### PR TITLE
[auto] Translate JAVA API Reference to German

### DIFF
--- a/german/java/_index.md
+++ b/german/java/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Aspose.Font für Java"
+type: docs
+weight: 11
+url: /de/java/
+description: "Aspose.Font für Java API-Referenzen enthalten Beispiele, Code‑Snippets und API‑Dokumentation. Sie bieten Pakete, Klassen, Schnittstellen und weitere API‑Details."
+is_root: true
+---
+## Packages
+| Paket | Beschreibung |
+| --- | --- |
+| [com.aspose.font](./com.aspose.font) | Das **com.aspose.font** ist ein Root‑Paket für alle Klassen, die sich mit Schriftarten befassen. |
+| [com.aspose.font.textutils](./com.aspose.font.textutils) | Das **com.aspose.font.text.utils**‑Paket stellt Klassen und Schnittstellen für die Textverarbeitung bereit. |

--- a/german/java/com.aspose.font.textutils/_index.md
+++ b/german/java/com.aspose.font.textutils/_index.md
@@ -1,0 +1,32 @@
+---
+title: "com.aspose.font.textutils"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Das com.aspose.font.text.utils-Paket stellt Klassen und Schnittstellen für die Textverarbeitung bereit."
+type: docs
+weight: 11
+url: /de/java/com.aspose.font.textutils/
+---
+
+Das **com.aspose.font.text.utils**‑Paket stellt Klassen und Schnittstellen für die Textverarbeitung bereit.
+
+
+## Klassen
+
+| Klasse | Beschreibung |
+| --- | --- |
+| [TextUtilsFactory](../com.aspose.font.textutils/textutilsfactory) | Bietet Funktionalität zum Abrufen von Erstellern von Textdienstobjekten |
+
+## Schnittstellen
+
+| Schnittstelle | Beschreibung |
+| --- | --- |
+| [IFontMorseDecoder](../com.aspose.font.textutils/ifontmorsedecoder) | Deklariert Funktionalität zum Dekodieren von Morsecode in Glyphen der angegebenen Schriftart. |
+| [IFontMorseEncoder](../com.aspose.font.textutils/ifontmorseencoder) | Deklariert Funktionalität zum Codieren von Text mittels Morsecode und gibt das Ergebnis als Schriftart-Glyphen zurück. |
+| [IMorseDecoder](../com.aspose.font.textutils/imorsedecoder) | Deklariert Funktionalität zum Entschlüsseln von Morsecode. |
+| [IMorseEncoder](../com.aspose.font.textutils/imorseencoder) | Deklariert Funktionalität zum Codieren von Text mittels Morsecode. |
+
+## Aufzählungen
+
+| Aufzählung | Beschreibung |
+| --- | --- |
+| [MorseAlphabets](../com.aspose.font.textutils/morsealphabets) | Stellt eine Menge von Alphabeten dar, die für Morsecode unterstützt werden |

--- a/german/java/com.aspose.font.textutils/ifontmorsedecoder/_index.md
+++ b/german/java/com.aspose.font.textutils/ifontmorsedecoder/_index.md
@@ -1,0 +1,180 @@
+---
+title: "IFontMorseDecoder"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Deklariert Funktionalität zum Dekodieren von Morsecode in Glyphen der angegebenen Schriftart."
+type: docs
+weight: 11
+url: /de/java/com.aspose.font.textutils/ifontmorsedecoder/
+---```
+public interface IFontMorseDecoder
+```
+
+Declares functionality to decode Morse code into glyphs of the specified font.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [decode(String morseText, IFont font)](#decode-java.lang.String-com.aspose.font.IFont-) | Deciphers Morse code into glyphs of the specified font. |
+| [decode(String morseText, IFont font, MorseAlphabets alphabet)](#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-) | Deciphers Morse code into glyphs of the specified font. |
+| [decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator)](#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-) | Deciphers Morse code into glyphs of the specified font. |
+| [decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-char-) | Deciphers Morse code into glyphs of the specified font. |
+| [decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)](#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-) | Deciphers Morse code and draws result in PNG-format. |
+| [decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet)](#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-) | Deciphers Morse code and draws result in PNG-format. |
+| [decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator)](#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-) | Deciphers Morse code and draws result in PNG-format. |
+| [decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-char-) | Deciphers Morse code and draws result in PNG-format. |
+### decode(String morseText, IFont font) {#decode-java.lang.String-com.aspose.font.IFont-}
+```
+public abstract GlyphId[] decode(String morseText, IFont font)
+```
+
+
+Deciphers Morse code into glyphs of the specified font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs (glyph identifiers) related to decoded text.
+### decode(String morseText, IFont font, MorseAlphabets alphabet) {#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract GlyphId[] decode(String morseText, IFont font, MorseAlphabets alphabet)
+```
+
+
+Deciphers Morse code into glyphs of the specified font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs (glyph identifiers) related to decoded text.
+### decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator) {#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract GlyphId[] decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Deciphers Morse code into glyphs of the specified font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs (glyph identifiers) related to decoded text.
+### decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract GlyphId[] decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Deciphers Morse code into glyphs of the specified font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+| outputSeparator | char | Symbol used to separate words in decoded text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs (glyph identifiers) related to decoded text.
+### decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth) {#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-}
+```
+public abstract InputStream decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)
+```
+
+
+Deciphers Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+
+**Returns:**
+java.io.InputStream - Decoded text in PNG-format as stream of bytes.
+### decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet) {#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract InputStream decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet)
+```
+
+
+Deciphers Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+java.io.InputStream - Decoded text in PNG-format as stream of bytes.
+### decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator) {#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract InputStream decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Deciphers Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.io.InputStream - Decoded text in PNG-format as stream of bytes.
+### decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract InputStream decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Deciphers Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+| outputSeparator | char | Symbol used to separate words in decoded text. |
+
+**Returns:**
+java.io.InputStream - Decoded text in PNG-format as stream of bytes.

--- a/german/java/com.aspose.font.textutils/ifontmorseencoder/_index.md
+++ b/german/java/com.aspose.font.textutils/ifontmorseencoder/_index.md
@@ -1,0 +1,262 @@
+---
+title: "IFontMorseEncoder"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Deklariert Funktionalität zum Codieren von Text mittels Morsecode und gibt das Ergebnis als Schriftart-Glyphen zurück."
+type: docs
+weight: 12
+url: /de/java/com.aspose.font.textutils/ifontmorseencoder/
+---```
+public interface IFontMorseEncoder
+```
+
+Declares functionality to encode text by Morse code and get result as font glyphs.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [encode(String text, IFont font)](#encode-java.lang.String-com.aspose.font.IFont-) | Encodes text in Morse code and returns result as set of glyphs(glyphId). |
+| [encode(String text, IFont font, char inputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-char-) | Encodes text in Morse code and returns result as set of glyphs(glyphId). |
+| [encode(String text, IFont font, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-char-char-) | Encodes text in Morse code and returns result as set of glyphs(glyphId). |
+| [encode(String text, IFont font, MorseAlphabets alphabet)](#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-) | Encodes text by Morse code and returns result as set of glyphs(glyph identifiers). |
+| [encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-) | Encodes text by Morse code and returns result as set of glyphs(glyph identifiers). |
+| [encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-char-) | Encodes text by Morse code and returns result as set of glyphs(glyph identifiers). |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-) | Encodes text in Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-char-) | Encodes text in Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-char-char-) | Encodes text in Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-) | Encodes text by Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-) | Encodes text by Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-char-) | Encodes text by Morse code and draws result in PNG-format. |
+### encode(String text, IFont font) {#encode-java.lang.String-com.aspose.font.IFont-}
+```
+public abstract GlyphId[] encode(String text, IFont font)
+```
+
+
+Encodes text in Morse code and returns result as set of glyphs(glyphId). Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, char inputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-char-}
+```
+public abstract GlyphId[] encode(String text, IFont font, char inputSeparator)
+```
+
+
+Encodes text in Morse code and returns result as set of glyphs(glyphId). Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-char-char-}
+```
+public abstract GlyphId[] encode(String text, IFont font, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text in Morse code and returns result as set of glyphs(glyphId). Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, MorseAlphabets alphabet) {#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract GlyphId[] encode(String text, IFont font, MorseAlphabets alphabet)
+```
+
+
+Encodes text by Morse code and returns result as set of glyphs(glyph identifiers).
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract GlyphId[] encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Encodes text by Morse code and returns result as set of glyphs(glyph identifiers).
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract GlyphId[] encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text by Morse code and returns result as set of glyphs(glyph identifiers).
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)
+```
+
+
+Encodes text in Morse code and draws result in PNG-format. Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-char-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator)
+```
+
+
+Encodes text in Morse code and draws result in PNG-format. Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-char-char-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text in Morse code and draws result in PNG-format. Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet)
+```
+
+
+Encodes text by Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Encodes text by Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text by Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.

--- a/german/java/com.aspose.font.textutils/imorsedecoder/_index.md
+++ b/german/java/com.aspose.font.textutils/imorsedecoder/_index.md
@@ -1,0 +1,86 @@
+---
+title: "IMorseDecoder"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Deklariert Funktionalität zum Entschlüsseln von Morsecode."
+type: docs
+weight: 13
+url: /de/java/com.aspose.font.textutils/imorsedecoder/
+---```
+public interface IMorseDecoder
+```
+
+Declares functionality to decipher Morse code.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [decode(String morseText)](#decode-java.lang.String-) | Deciphers Morse code. |
+| [decode(String morseText, MorseAlphabets alphabet)](#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-) | Deciphers Morse code. |
+| [decode(String morseText, MorseAlphabets alphabet, char inputSeparator)](#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-) | Deciphers Morse code. |
+| [decode(String morseText, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-char-) | Deciphers Morse code. |
+### decode(String morseText) {#decode-java.lang.String-}
+```
+public abstract String decode(String morseText)
+```
+
+
+Deciphers Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+
+**Returns:**
+java.lang.String - Decoded text.
+### decode(String morseText, MorseAlphabets alphabet) {#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract String decode(String morseText, MorseAlphabets alphabet)
+```
+
+
+Deciphers Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+java.lang.String - Decoded text.
+### decode(String morseText, MorseAlphabets alphabet, char inputSeparator) {#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract String decode(String morseText, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Deciphers Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.lang.String - Decoded text.
+### decode(String morseText, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract String decode(String morseText, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Deciphers Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+| outputSeparator | char | Symbol used to separate words in decoded text. |
+
+**Returns:**
+java.lang.String - Decoded text.

--- a/german/java/com.aspose.font.textutils/imorseencoder/_index.md
+++ b/german/java/com.aspose.font.textutils/imorseencoder/_index.md
@@ -1,0 +1,121 @@
+---
+title: "IMorseEncoder"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Deklariert Funktionalität zum Codieren von Text mittels Morsecode."
+type: docs
+weight: 14
+url: /de/java/com.aspose.font.textutils/imorseencoder/
+---```
+public interface IMorseEncoder
+```
+
+Declares functionality to encode text by Morse code.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [encode(String text)](#encode-java.lang.String-) | Encodes text by Morse code. |
+| [encode(String text, char inputSeparator)](#encode-java.lang.String-char-) | Encodes text by Morse code. |
+| [encode(String text, char inputSeparator, char outputSeparator)](#encode-java.lang.String-char-char-) | Encodes text by Morse code. |
+| [encode(String text, MorseAlphabets alphabet)](#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-) | Encodes text by Morse code. |
+| [encode(String text, MorseAlphabets alphabet, char inputSeparator)](#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-) | Encodes text by Morse code. |
+| [encode(String text, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-char-) | Encodes text by Morse code. |
+### encode(String text) {#encode-java.lang.String-}
+```
+public abstract String encode(String text)
+```
+
+
+Encodes text by Morse code. Heuristic analysis is used to calculate the alphabet of the input text. The alphabet is selected by the first word.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+
+**Returns:**
+java.lang.String - Encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, char inputSeparator) {#encode-java.lang.String-char-}
+```
+public abstract String encode(String text, char inputSeparator)
+```
+
+
+Encodes text by Morse code. Heuristic analysis is used to calculate the alphabet of the input text. The alphabet is selected by the first word.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+java.lang.String - Encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, char inputSeparator, char outputSeparator) {#encode-java.lang.String-char-char-}
+```
+public abstract String encode(String text, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text by Morse code. Heuristic analysis is used to calculate the alphabet of the input text. The alphabet is selected by the first word.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.lang.String - Encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, MorseAlphabets alphabet) {#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract String encode(String text, MorseAlphabets alphabet)
+```
+
+
+Encodes text by Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+java.lang.String - Encoded text, ie "... --- ..." for the input text "SOS".
+### encode(String text, MorseAlphabets alphabet, char inputSeparator) {#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract String encode(String text, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Encodes text by Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+java.lang.String - Encoded text, ie "... --- ..." for the input text "SOS".
+### encode(String text, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract String encode(String text, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text by Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.lang.String - Encoded text, ie "... --- ..." for the input text "SOS".

--- a/german/java/com.aspose.font.textutils/morsealphabets/_index.md
+++ b/german/java/com.aspose.font.textutils/morsealphabets/_index.md
@@ -1,0 +1,304 @@
+---
+title: "MorseAlphabets"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Menge von Alphabeten dar, die für Morsecode unterstützt werden"
+type: docs
+weight: 15
+url: /de/java/com.aspose.font.textutils/morsealphabets/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum MorseAlphabets extends Enum<MorseAlphabets>
+```
+
+Stellt eine Menge von Alphabeten dar, die für Morsecode unterstützt werden
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [Arabic](#Arabic) | Das arabische Codealphabet. |
+| [Cyrillic](#Cyrillic) | Das kyrillische Codealphabet. |
+| [Greek](#Greek) | Das griechische Morse-Codealphabet. |
+| [Hebrew](#Hebrew) | Das hebräische Codealphabet. |
+| [Kurdish](#Kurdish) | Das kurdische Codealphabet. |
+| [Latin](#Latin) | Das lateinische Morse-Codealphabet. |
+| [Persian](#Persian) | Das persische (Farsi) Codealphabet. |
+| [Portuguese](#Portuguese) | Das portugiesische Codealphabet. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Arabic {#Arabic}
+```
+public static final MorseAlphabets Arabic
+```
+
+
+Das arabische Codealphabet.
+
+### Cyrillic {#Cyrillic}
+```
+public static final MorseAlphabets Cyrillic
+```
+
+
+Das kyrillische Codealphabet.
+
+### Greek {#Greek}
+```
+public static final MorseAlphabets Greek
+```
+
+
+Das griechische Morse-Codealphabet.
+
+### Hebrew {#Hebrew}
+```
+public static final MorseAlphabets Hebrew
+```
+
+
+Das hebräische Codealphabet.
+
+### Kurdish {#Kurdish}
+```
+public static final MorseAlphabets Kurdish
+```
+
+
+Das kurdische Codealphabet.
+
+### Latin {#Latin}
+```
+public static final MorseAlphabets Latin
+```
+
+
+Das lateinische Morse-Codealphabet.
+
+### Persian {#Persian}
+```
+public static final MorseAlphabets Persian
+```
+
+
+Das persische (Farsi) Codealphabet.
+
+### Portuguese {#Portuguese}
+```
+public static final MorseAlphabets Portuguese
+```
+
+
+Das portugiesische Codealphabet.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static MorseAlphabets valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[MorseAlphabets](../../com.aspose.font.textutils/morsealphabets)
+### values() {#values--}
+```
+public static MorseAlphabets[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.textutils.MorseAlphabets[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font.textutils/textutilsfactory/_index.md
+++ b/german/java/com.aspose.font.textutils/textutilsfactory/_index.md
@@ -1,0 +1,215 @@
+---
+title: "TextUtilsFactory"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Bietet Funktionalität zum Abrufen von Erstellern von Textdienstobjekten"
+type: docs
+weight: 10
+url: /de/java/com.aspose.font.textutils/textutilsfactory/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TextUtilsFactory
+```
+
+Bietet Funktionalität zum Abrufen von Erstellern von Textdienstobjekten
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [TextUtilsFactory()](#TextUtilsFactory--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontCharactersMerger(Font primaryFont, Font secondaryFont, FontType outType)](#getFontCharactersMerger-com.aspose.font.Font-com.aspose.font.Font-com.aspose.font.FontType-) |  |
+| [getFontMorseDecoder()](#getFontMorseDecoder--) | Liefert die  IFontMorseDecoder  Instanz. |
+| [getFontMorseEncoder()](#getFontMorseEncoder--) | Liefert die  IFontMorseEncoder  Instanz. |
+| [getMorseDecoder()](#getMorseDecoder--) | Liefert die  IMorseDecoder  Instanz. |
+| [getMorseEncoder()](#getMorseEncoder--) | Liefert die  IMorseEncoder  Instanz. |
+| [hashCode()](#hashCode--) |  |
+| [isCffSimpleFontMerging(Font primaryFont, Font secondaryFont, FontType outType)](#isCffSimpleFontMerging-com.aspose.font.Font-com.aspose.font.Font-com.aspose.font.FontType-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TextUtilsFactory() {#TextUtilsFactory--}
+```
+public TextUtilsFactory()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontCharactersMerger(Font primaryFont, Font secondaryFont, FontType outType) {#getFontCharactersMerger-com.aspose.font.Font-com.aspose.font.Font-com.aspose.font.FontType-}
+```
+public FontCharactersMerger getFontCharactersMerger(Font primaryFont, Font secondaryFont, FontType outType)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| primaryFont | [Font](../../com.aspose.font/font) |  |
+| secondaryFont | [Font](../../com.aspose.font/font) |  |
+| outType | [FontType](../../com.aspose.font/fonttype) |  |
+
+**Returns:**
+[FontCharactersMerger](../../com.aspose.font/fontcharactersmerger)
+### getFontMorseDecoder() {#getFontMorseDecoder--}
+```
+public IFontMorseDecoder getFontMorseDecoder()
+```
+
+
+Liefert die  IFontMorseDecoder  Instanz.
+
+**Returns:**
+[IFontMorseDecoder](../../com.aspose.font.textutils/ifontmorsedecoder) - The  IFontMorseDecoder  instance.
+### getFontMorseEncoder() {#getFontMorseEncoder--}
+```
+public IFontMorseEncoder getFontMorseEncoder()
+```
+
+
+Liefert die  IFontMorseEncoder  Instanz.
+
+**Returns:**
+[IFontMorseEncoder](../../com.aspose.font.textutils/ifontmorseencoder) - The  IFontMorseEncoder  instance.
+### getMorseDecoder() {#getMorseDecoder--}
+```
+public IMorseDecoder getMorseDecoder()
+```
+
+
+Liefert die  IMorseDecoder  Instanz.
+
+**Returns:**
+[IMorseDecoder](../../com.aspose.font.textutils/imorsedecoder) - The  IMorseDecoder  instance.
+### getMorseEncoder() {#getMorseEncoder--}
+```
+public IMorseEncoder getMorseEncoder()
+```
+
+
+Liefert die  IMorseEncoder  Instanz.
+
+**Returns:**
+[IMorseEncoder](../../com.aspose.font.textutils/imorseencoder) - The  IMorseEncoder  instance.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isCffSimpleFontMerging(Font primaryFont, Font secondaryFont, FontType outType) {#isCffSimpleFontMerging-com.aspose.font.Font-com.aspose.font.Font-com.aspose.font.FontType-}
+```
+public static boolean isCffSimpleFontMerging(Font primaryFont, Font secondaryFont, FontType outType)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| primaryFont | [Font](../../com.aspose.font/font) |  |
+| secondaryFont | [Font](../../com.aspose.font/font) |  |
+| outType | [FontType](../../com.aspose.font/fonttype) |  |
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/_index.md
+++ b/german/java/com.aspose.font/_index.md
@@ -1,0 +1,165 @@
+---
+title: "com.aspose.font"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Das com.aspose.font ist ein Root‑Paket für alle Klassen, die sich mit Schriftarten befassen."
+type: docs
+weight: 10
+url: /de/java/com.aspose.font/
+---
+
+Das **com.aspose.font** ist ein Root‑Paket für alle Klassen, die sich mit Schriftarten befassen.
+
+
+## Klassen
+
+| Klasse | Beschreibung |
+| --- | --- |
+| [AxisRecord](../com.aspose.font/axisrecord) | Stellt die Axis‑Record‑Struktur dar. |
+| [AxisValue](../com.aspose.font/axisvalue) | Stellt den AxisValue‑Datensatz dar. |
+| [AxisValueTableBase](../com.aspose.font/axisvaluetablebase) | Basisklasse für die Axis‑Value‑Table‑Struktur. |
+| [AxisValueTableFormat1](../com.aspose.font/axisvaluetableformat1) | Stellt das Axis‑Value‑Table‑Format 1 dar |
+| [AxisValueTableFormat2](../com.aspose.font/axisvaluetableformat2) | Stellt das Axis‑Value‑Table‑Format 2 dar |
+| [AxisValueTableFormat3](../com.aspose.font/axisvaluetableformat3) | Stellt das Axis‑Value‑Table‑Format 3 dar |
+| [AxisValueTableFormat4](../com.aspose.font/axisvaluetableformat4) | Stellt das Axis‑Value‑Table‑Format 4 dar |
+| [ByteContentStreamSource](../com.aspose.font/bytecontentstreamsource) | Stellt eine Stream‑Quelle dar, die auf dem \_content‑Stream basiert. |
+| [CffEncoding](../com.aspose.font/cffencoding) | Stellt die CFF \_font‑Kodierung dar. |
+| [CffFont](../com.aspose.font/cfffont) | Stellt das Compact Font Format (CFF) dar. |
+| [CffFontException](../com.aspose.font/cfffontexception) | Stellt eine allgemeine, verarbeitungsbezogene Ausnahme für Schriftarten im CFF‑Format dar. |
+| [CffFontMetrics](../com.aspose.font/cfffontmetrics) | Implementierung der CFF‑Schriftmetriken |
+| [CffFontsSettings](../com.aspose.font/cfffontssettings) | Stellt Einstellungen bereit, die für CFF‑Schriftarten gemein sind. |
+| [CffParsingException](../com.aspose.font/cffparsingexception) | Stellt eine Parse‑Ausnahme für Schriftarten im cff‑Format dar. |
+| [ClosePath](../com.aspose.font/closepath) | Stellt die ClosePath-Operation dar. |
+| [CompositeGlyph](../com.aspose.font/compositeglyph) | Stellt ein zusammengesetztes Schriftzeichen dar. |
+| [CompositeGlyphComponent](../com.aspose.font/compositeglyphcomponent) | Stellt ein zusammengesetztes Glyph-Komponente dar (Glyph mit Platzierungs-Matrix). |
+| [CompositeGlyphComponentList](../com.aspose.font/compositeglyphcomponentlist) | Stellt eine Liste von zusammengesetzten Glyph-Komponenten dar. |
+| [CompressionUtils](../com.aspose.font/compressionutils) | Bietet Hilfsmethoden für Kompression und Dekompression. |
+| [CurveTo](../com.aspose.font/curveto) | Stellt die CurveTo-Operation dar. |
+| [EncodingException](../com.aspose.font/encodingexception) | Stellt eine Kodierungs-Ausnahme dar. |
+| [FileSystemStreamSource](../com.aspose.font/filesystemstreamsource) | Stellt eine Stream-Quelle basierend auf dem Dateisystem dar. |
+| [Font](../com.aspose.font/font) | Stellt die Basisklasse Font dar. |
+| [FontAgrumentException](../com.aspose.font/fontagrumentexception) | Stellt eine Font-Argumentausnahme dar. |
+| [FontBBox](../com.aspose.font/fontbbox) | Stellt die Begrenzungsbox der Schriftart dar. |
+| [FontCharactersMerger](../com.aspose.font/fontcharactersmerger) | Deklariert Funktionalität zum Zusammenführen von Schriftarten verschiedener Typen. |
+| [FontConversionException](../com.aspose.font/fontconversionexception) | Stellt eine Font-Konvertierungs-Ausnahme dar. |
+| [FontCreationException](../com.aspose.font/fontcreationexception) | Stellt eine Font-Erstellungs-Ausnahme dar. |
+| [FontDefinition](../com.aspose.font/fontdefinition) | Stellt die Definition einer Font-Datei-Sammlung dar. |
+| [FontEnvironment](../com.aspose.font/fontenvironment) | Bietet Informationen über die aktuelle Umgebung und Plattform. |
+| [FontException](../com.aspose.font/fontexception) | Stellt eine allgemeine, mit der Font-Verarbeitung verbundene Ausnahme dar. |
+| [FontFactory](../com.aspose.font/fontfactory) | Enthält Funktionalität zum Öffnen von Schriftarten verschiedener Typen und weitere Methoden zur Erstellung verschiedener Objekte. |
+| [FontFileDefinition](../com.aspose.font/fontfiledefinition) | Stellt die Definition einer Font-Datei dar. |
+| [FontMergeException](../com.aspose.font/fontmergeexception) | Stellt eine Font-Zusammenführungs-Ausnahme dar. |
+| [FontMetrics](../com.aspose.font/fontmetrics) | Stellt Schriftmetriken dar. |
+| [FontNotSupportedOperationException](../com.aspose.font/fontnotsupportedoperationexception) | Stellt eine nicht unterstützte Operationsausnahme dar. |
+| [FontSpecificEncodings](../com.aspose.font/fontspecificencodings) | Stellt spezifische Kodierungen für verbraucherbewusste Schriftarten dar. |
+| [FontStyle](../com.aspose.font/fontstyle) | Aufzählung der Schriftstilarten |
+| [GaspRange](../com.aspose.font/gasprange) | Das Array von GaspRange-Datensätzen bietet empfohlene Verhaltensweisen für verschiedene ppem-Größen. |
+| [Glyph](../com.aspose.font/glyph) | Stellt ein Font-Glyph dar. |
+| [GlyphId](../com.aspose.font/glyphid) | Stellt Glyph-IDs dar, die im Font verfügbar sind. |
+| [GlyphIdList](../com.aspose.font/glyphidlist) | Stellt eine Glyph-ID-Liste dar. |
+| [GlyphOutlineRenderer](../com.aspose.font/glyphoutlinerenderer) | Stellt einen Glyph-Umriss-Renderer dar. |
+| [GlyphRendererBase](../com.aspose.font/glyphrendererbase) | Stellt die Basisklasse für Glyph-Renderer dar. |
+| [GlyphStringId](../com.aspose.font/glyphstringid) | Stellt eine String-Glyph-ID dar. |
+| [GlyphUInt32Id](../com.aspose.font/glyphuint32id) | Stellt eine Ganzzahl-Glyph-ID dar. |
+| [HelpersFactory](../com.aspose.font/helpersfactory) | Erstellt Objekte, die zum Namespace TtfHelpers gehören |
+| [IncorrectFontDataException](../com.aspose.font/incorrectfontdataexception) | Stellt Ausnahmen für Fälle dar, in denen einige Werte des Font-Objekts ungültig sind. |
+| [License](../com.aspose.font/license) | Stellt Methoden zum Lizenzieren der Komponente bereit. |
+| [LicenseFlags](../com.aspose.font/licenseflags) | Stellt einen Hilfs-Wrapper für Einbettungsflags aus der 'OS/2'-Tabelle (Feld fsType) dar. |
+| [LicenseRestrictionException](../com.aspose.font/licenserestrictionexception) | Stellt eine Ausnahme dar, die bei dem Versuch ausgelöst werden kann, eine Funktionalität auszuführen, die im Evaluierungsmodus eingeschränkt ist. |
+| [LineTo](../com.aspose.font/lineto) | Stellt die LineTo-Operation dar. |
+| [MSLanguageId](../com.aspose.font/mslanguageid) | Microsoft-Plattform-Sprach-ID-Aufzählung. |
+| [MacLanguageId](../com.aspose.font/maclanguageid) | Macintosh-Plattform-Sprach-ID-Aufzählung. |
+| [Metered](../com.aspose.font/metered) | Stellt Methoden zum Festlegen des gemessenen Schlüssels bereit. |
+| [MoveTo](../com.aspose.font/moveto) | Stellt die MoveTo-Operation dar. |
+| [MultiLanguageString](../com.aspose.font/multilanguagestring) | Stellt einen mehrsprachigen String dar. |
+| [NameId](../com.aspose.font/nameid) | Stellt die NameId-Aufzählung dar. |
+| [NameIndexDataProvider](../com.aspose.font/nameindexdataprovider) | Stellt Einstellungen bereit, die für CFF‑Schriftarten gemein sind. |
+| [NameRecord](../com.aspose.font/namerecord) | Stellt die NameRecord-Struktur der 'name'-Tabelle dar |
+| [NameToCodeMap](../com.aspose.font/nametocodemap) | Stellt die Namens-zu-Code-Zuordnung dar. |
+| [PathSegmentCollection](../com.aspose.font/pathsegmentcollection) | Stellt eine Sammlung von Pfadsegmenten dar. |
+| [RenderingUtils](../com.aspose.font/renderingutils) | Stellt Dienstprogrammmethoden für das Rendering bereit. |
+| [SegmentPath](../com.aspose.font/segmentpath) | Stellt den Rendering-Pfad dar. |
+| [StreamSource](../com.aspose.font/streamsource) | Definiert eine Möglichkeit, einen Dateistream zu erhalten, wenn er benötigt wird. |
+| [StringIndexDataProvider](../com.aspose.font/stringindexdataprovider) | Deklariert Funktionalität zum Zugriff auf die CFF String INDEX Struktur. |
+| [SvgConversionException](../com.aspose.font/svgconversionexception) | Stellt eine Font-Konvertierungsausnahme für das SVG-Format dar. |
+| [TopDictDataProvider](../com.aspose.font/topdictdataprovider) | Deklariert Funktionalität zum Lesen/Aktualisieren der CFF Top DICT Struktur. |
+| [TransformationMatrix](../com.aspose.font/transformationmatrix) | Represents 3x3 matrix | A B 0 |  | C D 0 |  | TX TY 1 | . |
+| [TtcFontFileDefinition](../com.aspose.font/ttcfontfiledefinition) | Stellt die Dateidefinition für die TTC Schriftart dar. |
+| [TtcFontSource](../com.aspose.font/ttcfontsource) | Stellt die TTC Schriftart-Quelle dar. |
+| [TtfCMapFormat0Table](../com.aspose.font/ttfcmapformat0table) | Stellt die Format0 CMap Untertabelle der TTF Schriftdatei dar. |
+| [TtfCMapFormat10Table](../com.aspose.font/ttfcmapformat10table) | Stellt die Format10 CMap Untertabelle der TTF Schriftdatei dar. |
+| [TtfCMapFormat12Table](../com.aspose.font/ttfcmapformat12table) | Stellt die Format8 CMap Untertabelle der TTF Schriftdatei dar. |
+| [TtfCMapFormat2Table](../com.aspose.font/ttfcmapformat2table) | Stellt die Format2 CMap Untertabelle der TTF Schriftdatei dar. |
+| [TtfCMapFormat4Table](../com.aspose.font/ttfcmapformat4table) | Stellt die Format4 CMap Untertabelle der TTF Schriftdatei dar. |
+| [TtfCMapFormat6Table](../com.aspose.font/ttfcmapformat6table) | Stellt die Format6 CMap Untertabelle der TTF Schriftdatei dar. |
+| [TtfCMapFormat8Table](../com.aspose.font/ttfcmapformat8table) | Stellt die Format8 CMap Untertabelle der TTF Schriftdatei dar. |
+| [TtfCMapFormatBaseTable](../com.aspose.font/ttfcmapformatbasetable) | Stellt die Basisklasse der CMap Untertabelle dar. |
+| [TtfCMapTable](../com.aspose.font/ttfcmaptable) | Stellt die "cmap" Tabelle der TTF Schriftdatei dar. |
+| [TtfCMapTable.TtfCMapSubtableDescription](../com.aspose.font/ttfcmaptable.ttfcmapsubtabledescription) | Bietet kurze Informationen über die CMap Untertabelle. |
+| [TtfCffTable](../com.aspose.font/ttfcfftable) | Stellt die "cff" Tabelle der TTF Schriftdatei dar. |
+| [TtfCvtTable](../com.aspose.font/ttfcvttable) | Stellt die Control Value Table (CVT) der TTF Schriftdatei dar. |
+| [TtfEncoding](../com.aspose.font/ttfencoding) | Stellt die TTF Schriftkodierung dar. |
+| [TtfEncodingParameters](../com.aspose.font/ttfencodingparameters) | Stellt die TTF Kodierungsparameter dar. |
+| [TtfFont](../com.aspose.font/ttffont) | Stellt die TrueType Schrift (TTF) dar. |
+| [TtfFontMetrics](../com.aspose.font/ttffontmetrics) | Stellt die TTF Schriftmetriken dar. |
+| [TtfFpgmTable](../com.aspose.font/ttffpgmtable) | Stellt die "fpgm" Tabelle der TTF Schriftdatei dar. |
+| [TtfGaspTable](../com.aspose.font/ttfgasptable) | Stellt die "gasp" Tabelle der TTF Schriftdatei dar. |
+| [TtfGlyfTable](../com.aspose.font/ttfglyftable) | Stellt die "glyf" Tabelle der TTF Schriftdatei dar. |
+| [TtfHeadTable](../com.aspose.font/ttfheadtable) | Stellt die "head" Tabelle der TTF Schriftdatei dar. |
+| [TtfHheaTable](../com.aspose.font/ttfhheatable) | Stellt die "hhea"-Tabelle der TTF-Schriftdatei dar. |
+| [TtfHmtxTable](../com.aspose.font/ttfhmtxtable) | Stellt die "hmtx"-Tabelle der TTF-Schriftdatei dar. |
+| [TtfHmtxTable.LongHorMetric](../com.aspose.font/ttfhmtxtable.longhormetric) | Stellt den Metrikdatensatz dar. |
+| [TtfHmtxTable.MetricList](../com.aspose.font/ttfhmtxtable.metriclist) | Stellt eine Liste von Metriken dar. |
+| [TtfLocaTable](../com.aspose.font/ttflocatable) | Stellt die "loca"-Tabelle der TTF-Schriftdatei dar. |
+| [TtfLocaTable.OffsetsList](../com.aspose.font/ttflocatable.offsetslist) | Stellt eine Liste von Glyphen-Offsets dar. |
+| [TtfLtshTable](../com.aspose.font/ttfltshtable) | Stellt die Linear-Threshold-Tabelle der TTF-Schriftdatei dar. |
+| [TtfMaxpTable](../com.aspose.font/ttfmaxptable) | Stellt die "maxp"-Tabelle der TTF-Schriftdatei dar |
+| [TtfNameTable](../com.aspose.font/ttfnametable) | Stellt die "name"-Tabelle der TTF-Schriftdatei dar. |
+| [TtfOs2Table](../com.aspose.font/ttfos2table) | Stellt die "OS/2"-Tabelle der TTF-Schriftdatei dar. |
+| [TtfPostTable](../com.aspose.font/ttfposttable) | Stellt die "post"-Tabelle der TTF-Schriftdatei dar |
+| [TtfPrepTable](../com.aspose.font/ttfpreptable) | Stellt die "prep"-Tabelle der TTF-Schriftdatei dar. |
+| [TtfStatTable](../com.aspose.font/ttfstattable) |  |
+| [TtfTableBase](../com.aspose.font/ttftablebase) | Stellt die TTF-Tabellendefinition dar. |
+| [TtfTableRepository](../com.aspose.font/ttftablerepository) | Repository der TTF-Tabellen |
+| [TtfVheaTable](../com.aspose.font/ttfvheatable) | Stellt die "hhea"-Tabelle der TTF-Schriftdatei dar. |
+| [TtfVmtxTable](../com.aspose.font/ttfvmtxtable) | Stellt die "vmtx"-Tabelle der TTF-Schriftdatei dar. |
+| [TtfVmtxTable.LongVerMetric](../com.aspose.font/ttfvmtxtable.longvermetric) | Stellt den vertikalen Metrikdatensatz dar. |
+| [Type1Encoding](../com.aspose.font/type1encoding) | Stellt die Type1-Schriftkodierung dar. |
+| [Type1Font](../com.aspose.font/type1font) | Stellt die Type1-Schrift dar. |
+| [Type1FontMetrics](../com.aspose.font/type1fontmetrics) | Stellt die Type1-Schriftmetriken dar. |
+| [Type1MetricFont](../com.aspose.font/type1metricfont) | Type1-Metrik-Schriftimplementierung. |
+| [Version16Dot16](../com.aspose.font/version16dot16) | Stellt den Version16Dot16-Datentyp dar |
+| [WoffFormatException](../com.aspose.font/woffformatexception) | Stellt eine mit der WOFF-Schriftverarbeitung zusammenhängende Ausnahme dar. |
+
+## Schnittstellen
+
+| Schnittstelle | Beschreibung |
+| --- | --- |
+| [ICffIndexDataProvider](../com.aspose.font/icffindexdataprovider) | Grundlegende Schnittstelle zum Zugriff auf INDEX-Strukturen von CFF-Schriften. |
+| [IEncodingParameters](../com.aspose.font/iencodingparameters) | Gemeinsame Schnittstelle zur Unterstützung von Kodierungsparametern. |
+| [IFont](../com.aspose.font/ifont) | Deklariert gemeinsame Funktionalität für alle Schriftformaten. |
+| [IFontCharactersMerger](../com.aspose.font/ifontcharactersmerger) | Deklariert Hilfsfunktionalität zum Zusammenführen von TrueType-Schriften. |
+| [IFontEncoding](../com.aspose.font/ifontencoding) | Definiert eine Schnittstelle für die Schriftkodierung. |
+| [IFontMetrics](../com.aspose.font/ifontmetrics) | Definiert eine Schnittstelle für Schriftmetriken-Werkzeuge. |
+| [IFontSaver](../com.aspose.font/ifontsaver) | Definiert eine Schnittstelle für die Schrift-Speicherfunktionalität. |
+| [IGlyphAccessor](../com.aspose.font/iglyphaccessor) | Definiert Funktionalität zum Abrufen angegebener Glyphenkennungen und Glyphen. |
+| [IGlyphOutlinePainter](../com.aspose.font/iglyphoutlinepainter) | Definiert eine Umriss-Methode zum Zeichnen von Glyphen. |
+| [IGlyphPainter](../com.aspose.font/iglyphpainter) | Definiert eine Methode zum Zeichnen von Glyphen. |
+| [IGlyphRenderer](../com.aspose.font/iglyphrenderer) | Schnittstelle zum Rendern von Glyphen. |
+| [IPathSegment](../com.aspose.font/ipathsegment) | Stellt die Schnittstelle eines beliebigen Pfadsegments dar. |
+| [ISupportsNameAddressing](../com.aspose.font/isupportsnameaddressing) | Definiert Mitglieder, die spezifisch für Kodierungen sind, die die Glyphen-Namensadressierung unterstützen |
+
+## Aufzählungen
+
+| Aufzählung | Beschreibung |
+| --- | --- |
+| [CffIndexProviderType](../com.aspose.font/cffindexprovidertype) | Gibt INDEX-Strukturen an, die von der Indexanbieter-Schnittstellenfamilie unterstützt werden. |
+| [CffUpdateStringIndexStrategy](../com.aspose.font/cffupdatestringindexstrategy) | Gibt an, wie Zeichenketten zum CFF String INDEX Speicher hinzugefügt werden. |
+| [FontSavingFormats](../com.aspose.font/fontsavingformats) | Gibt den Schrifttyp an. |
+| [FontType](../com.aspose.font/fonttype) | Gibt den Schrifttyp an. |
+| [GlyphIdType](../com.aspose.font/glyphidtype) | Gibt die Typen von Glyphen‑ID an. |
+| [GlyphState](../com.aspose.font/glyphstate) | Gibt den Glyphenstatus an. |
+| [MSPlatformSpecificId](../com.aspose.font/msplatformspecificid) | Stellt die Microsoft-Plattform PlatformSpecificId‑Aufzählung dar. |
+| [MacPlatformSpecificId](../com.aspose.font/macplatformspecificid) | Stellt die Macintosh-Plattform PlatformSpecificId‑Aufzählung dar. |
+| [PlatformId](../com.aspose.font/platformid) | Stellt die PlatformId‑Aufzählung dar. |
+| [RangeGaspBehaviorFlags](../com.aspose.font/rangegaspbehaviorflags) | Flags, die das gewünschte Verhalten des Rasterisierers beschreiben. |
+| [UnicodePlatformSpecificId](../com.aspose.font/unicodeplatformspecificid) | Stellt die Unicode-Plattform‑spezifische Aufzählung dar. |

--- a/german/java/com.aspose.font/axisrecord/_index.md
+++ b/german/java/com.aspose.font/axisrecord/_index.md
@@ -1,0 +1,177 @@
+---
+title: "AxisRecord"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Axis‑Record‑Struktur dar."
+type: docs
+weight: 10
+url: /de/java/com.aspose.font/axisrecord/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class AxisRecord
+```
+
+Stellt die Axis Record-Struktur dar. Spec: Der Axis Record liefert Informationen über eine einzelne Design-Achse.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [AxisRecord(String tag, int axisNameId, int axisOrdering)](#AxisRecord-java.lang.String-int-int-) | Konstruktor |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisNameId()](#getAxisNameId--) | Gibt das axisNameID-Feld zurück. |
+| [getAxisOrdering()](#getAxisOrdering--) | Gibt das axisOrdering-Feld zurück. |
+| [getClass()](#getClass--) |  |
+| [getTag()](#getTag--) | Gibt einen Tag zurück, der die Achse der Design-Variation identifiziert. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisRecord(String tag, int axisNameId, int axisOrdering) {#AxisRecord-java.lang.String-int-int-}
+```
+public AxisRecord(String tag, int axisNameId, int axisOrdering)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| tag | java.lang.String | Tag, spec: Ein Tag, der die Achse der Design-Variation identifiziert |
+| axisNameId | int | Die Namens-ID für Einträge in der 'name'-Tabelle, die eine Anzeigestring für diese Achse bereitstellen |
+| axisOrdering | int | Der Wert, den Anwendungen verwenden können, um die primäre Sortierung von Schriftartnamen zu bestimmen oder um Labels zu ordnen, wenn Familien- oder Schriftartnamen zusammengesetzt werden. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisNameId() {#getAxisNameId--}
+```
+public int getAxisNameId()
+```
+
+
+Gibt das axisNameID-Feld zurück. Spec: Das axisNameID-Feld liefert eine Namens-ID, die verwendet werden kann, um Zeichenketten aus der 'name'-Tabelle zu erhalten, die zur Bezeichnung der Achse in Benutzeroberflächen von Anwendungen genutzt werden können.
+
+**Returns:**
+int - Das axisNameID-Feld.
+### getAxisOrdering() {#getAxisOrdering--}
+```
+public int getAxisOrdering()
+```
+
+
+Gibt das axisOrdering-Feld zurück. Spec:A Wert, den Anwendungen verwenden können, um die primäre Sortierung von Schriftartnamen zu bestimmen oder um Labels zu ordnen, wenn Familien- und Schriftartnamen zusammengesetzt werden.
+
+**Returns:**
+int - Das axisOrdering-Feld.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getTag() {#getTag--}
+```
+public String getTag()
+```
+
+
+Gibt einen Tag zurück, der die Achse der Design-Variation identifiziert. Spec: Jeder Axis Record hat einen Tag, der die Achse bezeichnet. Tag-Werte müssen den Regeln für Achsen-Tags folgen, die im OpenType Design-Variation Axis Tag Registry beschrieben sind.
+
+**Returns:**
+java.lang.String - Ein Tag, der die Achse der Design-Variation identifiziert.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/axisvalue/_index.md
+++ b/german/java/com.aspose.font/axisvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: "AxisValue"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt den AxisValue‑Datensatz dar."
+type: docs
+weight: 11
+url: /de/java/com.aspose.font/axisvalue/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class AxisValue
+```
+
+Stellt den AxisValue‑Datensatz dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [AxisValue(int axisIndex, float value)](#AxisValue-int-float-) | Konstruktor |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisIndex()](#getAxisIndex--) | Ermittelt das Feld axisIndex. |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Ermittelt einen numerischen Wert für diesen Attributwert. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValue(int axisIndex, float value) {#AxisValue-int-float-}
+```
+public AxisValue(int axisIndex, float value)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| axisIndex | int | Nullbasierter Index in das Achsenaufzeichnungs-Array, der die Achse identifiziert, für die dieser Wert gilt. Muss kleiner sein als designAxisCount. |
+| Wert | float | Der numerische Wert für diesen Attributwert. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisIndex() {#getAxisIndex--}
+```
+public int getAxisIndex()
+```
+
+
+Ermittelt das Feld axisIndex. Spez.: Nullbasierter Index in das Achsenaufzeichnungs-Array, der die Achse identifiziert, für die dieser Wert gilt. Muss kleiner sein als designAxisCount.
+
+**Returns:**
+int - Das Feld axisIndex.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public float getValue()
+```
+
+
+Ermittelt einen numerischen Wert für diesen Attributwert.
+
+**Returns:**
+float - Ein numerischer Wert für diesen Attributwert.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/axisvaluetablebase/_index.md
+++ b/german/java/com.aspose.font/axisvaluetablebase/_index.md
@@ -1,0 +1,168 @@
+---
+title: "AxisValueTableBase"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Basisklasse für die Axis‑Value‑Table‑Struktur."
+type: docs
+weight: 12
+url: /de/java/com.aspose.font/axisvaluetablebase/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class AxisValueTableBase
+```
+
+Basisklasse für die Struktur der Achsenwerttabelle. Spezifikation: Achsenwerttabellen liefern Details zu einem bestimmten Stil-Attributwert auf einer bestimmten Achse der Designvariation oder einer Kombination von Designvariations-Achsenwerten und die Beziehung dieser Werte zu Bezeichnungen, die als Elemente in Subfamiliennamen verwendet werden.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Liefert das Flags‑Feld der Achsenwerttabelle. |
+| [getFormat()](#getFormat--) | Liefert den Formatbezeichner (Versionsnummer). |
+| [getValueName()](#getValueName--) | Liefert den Namen aus der 'name'-Tabelle, der eine Anzeigekette für diesen Attributwert bereitstellt. |
+| [getValueNameId()](#getValueNameId--) | Liefert die Namens‑ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Liefert das Flags‑Feld der Achsenwerttabelle.
+
+**Returns:**
+int - Das Feld für die Achsenwerttabellen-Flags.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Liefert den Formatbezeichner (Versionsnummer).
+
+**Returns:**
+int - Der Formatbezeichner (Versionsnummer).
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Liefert den Namen aus der 'name'-Tabelle, der eine Anzeigekette für diesen Attributwert bereitstellt.
+
+**Returns:**
+java.lang.String - Der Name aus der 'name'-Tabelle, der eine Anzeigekette für diesen Attributwert bereitstellt.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Liefert die Namens‑ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen.
+
+**Returns:**
+int - Die Namens-ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/axisvaluetableflags/_index.md
+++ b/german/java/com.aspose.font/axisvaluetableflags/_index.md
@@ -1,0 +1,259 @@
+---
+title: "TtfStatTable.AxisValueTableFlags"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Gibt Achsenwert-Tabellen-Flags an."
+type: docs
+weight: 10
+url: /de/java/com.aspose.font/ttfstattable.axisvaluetableflags/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum TtfStatTable.AxisValueTableFlags extends Enum<TtfStatTable.AxisValueTableFlags>
+```
+
+Gibt Achsenwert-Tabellen-Flags an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ElidableAxisValueName](#ElidableAxisValueName) | Wenn gesetzt, zeigt dies an, dass der Achsenwert den "normalen" Wert für die Achse darstellt und beim Zusammenstellen von Namenszeichenketten weggelassen werden kann. |
+| [OlderSiblingFontAttribute](#OlderSiblingFontAttribute) | Wenn gesetzt, liefert diese Achsenwerttabelle Achsenwertinformationen, die für andere Schriften derselben Schriftfamilie gelten. |
+| [Reserved](#Reserved) | Für zukünftige Verwendung reserviert |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ElidableAxisValueName {#ElidableAxisValueName}
+```
+public static final TtfStatTable.AxisValueTableFlags ElidableAxisValueName
+```
+
+
+Wenn gesetzt, zeigt dies an, dass der Achsenwert den "normalen" Wert für die Achse darstellt und beim Zusammenstellen von Namenszeichenketten weggelassen werden kann.
+
+### OlderSiblingFontAttribute {#OlderSiblingFontAttribute}
+```
+public static final TtfStatTable.AxisValueTableFlags OlderSiblingFontAttribute
+```
+
+
+Wenn gesetzt, liefert diese Achsenwerttabelle Achsenwertinformationen, die für andere Schriften derselben Schriftfamilie gelten. Sie wird verwendet, wenn die anderen Schriften früher veröffentlicht wurden und keine Informationen über Werte für bestimmte Achsen enthalten. Wenn neuere Versionen der anderen Schriften die Informationen selbst enthalten und vorhanden sind, wird diese Tabelle ignoriert.
+
+### Reserved {#Reserved}
+```
+public static final TtfStatTable.AxisValueTableFlags Reserved
+```
+
+
+Für zukünftige Verwendung reserviert
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static TtfStatTable.AxisValueTableFlags valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[AxisValueTableFlags](../../com.aspose.font/axisvaluetableflags)
+### values() {#values--}
+```
+public static TtfStatTable.AxisValueTableFlags[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.TtfStatTable.AxisValueTableFlags[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/axisvaluetableformat1/_index.md
+++ b/german/java/com.aspose.font/axisvaluetableformat1/_index.md
@@ -1,0 +1,211 @@
+---
+title: "AxisValueTableFormat1"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt das Axis‑Value‑Table‑Format 1 dar"
+type: docs
+weight: 13
+url: /de/java/com.aspose.font/axisvaluetableformat1/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.AxisValueTableBase](../../com.aspose.font/axisvaluetablebase)
+```
+public class AxisValueTableFormat1 extends AxisValueTableBase
+```
+
+Stellt das Axis‑Value‑Table‑Format 1 dar
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [AxisValueTableFormat1(int flags, int valueNameId, int axisIndex, float value)](#AxisValueTableFormat1-int-int-int-float-) | Konstruktor |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisIndex()](#getAxisIndex--) | Liefert den nullbasierten Index im Achsenaufzeichnungs‑Array, der die Achse der Designvariation identifiziert, für die die Achsenwerttabelle gilt. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Liefert das Flags‑Feld der Achsenwerttabelle. |
+| [getFormat()](#getFormat--) | Liefert den Formatbezeichner (Versionsnummer). |
+| [getValue()](#getValue--) | Der numerische Wert für diesen Attributwert. |
+| [getValueName()](#getValueName--) | Liefert den Namen aus der 'name'-Tabelle, der eine Anzeigekette für diesen Attributwert bereitstellt. |
+| [getValueNameId()](#getValueNameId--) | Liefert die Namens‑ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValueTableFormat1(int flags, int valueNameId, int axisIndex, float value) {#AxisValueTableFormat1-int-int-int-float-}
+```
+public AxisValueTableFormat1(int flags, int valueNameId, int axisIndex, float value)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| flags | int | Flags |
+| valueNameId | int | Die Namens‑ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen. |
+| axisIndex | int | Spez.: Nullbasierter Index im Achsenaufzeichnungs‑Array, der die Achse der Designvariation identifiziert, für die die Achsenwerttabelle gilt. Muss kleiner sein als designAxisCount. |
+| Wert | float | Der numerische Wert für diesen Attributwert. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisIndex() {#getAxisIndex--}
+```
+public int getAxisIndex()
+```
+
+
+Liefert den nullbasierten Index im Achsenaufzeichnungs‑Array, der die Achse der Designvariation identifiziert, für die die Achsenwerttabelle gilt.
+
+**Returns:**
+int - Nullbasierter Index in das Achsenaufzeichnungsarray, der die Achse der Designvariation identifiziert, für die die Achsenwerttabelle gilt.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Liefert das Flags‑Feld der Achsenwerttabelle.
+
+**Returns:**
+int - Das Feld für die Achsenwerttabellen-Flags.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Liefert den Formatbezeichner (Versionsnummer).
+
+**Returns:**
+int - Der Formatbezeichner (Versionsnummer).
+### getValue() {#getValue--}
+```
+public float getValue()
+```
+
+
+Der numerische Wert für diesen Attributwert.
+
+**Returns:**
+float - Der numerische Wert für diesen Attributwert.
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Liefert den Namen aus der 'name'-Tabelle, der eine Anzeigekette für diesen Attributwert bereitstellt.
+
+**Returns:**
+java.lang.String - Der Name aus der 'name'-Tabelle, der eine Anzeigekette für diesen Attributwert bereitstellt.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Liefert die Namens‑ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen.
+
+**Returns:**
+int - Die Namens-ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/axisvaluetableformat2/_index.md
+++ b/german/java/com.aspose.font/axisvaluetableformat2/_index.md
@@ -1,0 +1,235 @@
+---
+title: "AxisValueTableFormat2"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt das Axis‑Value‑Table‑Format 2 dar"
+type: docs
+weight: 14
+url: /de/java/com.aspose.font/axisvaluetableformat2/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.AxisValueTableBase](../../com.aspose.font/axisvaluetablebase)
+```
+public class AxisValueTableFormat2 extends AxisValueTableBase
+```
+
+Stellt das Axis‑Value‑Table‑Format 2 dar
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [AxisValueTableFormat2(int flags, int valueNameId, int axisIndex, float nominalValue, float rangeMinValue, float rangeMaxValue)](#AxisValueTableFormat2-int-int-int-float-float-float-) | Konstruktor |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisIndex()](#getAxisIndex--) | Gibt den nullbasierten Index im Achsenaufzeichnungs-Array zurück, der die Achse der Designvariation identifiziert, für die die Achsenwerttabelle gilt. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Liefert das Flags‑Feld der Achsenwerttabelle. |
+| [getFormat()](#getFormat--) | Liefert den Formatbezeichner (Versionsnummer). |
+| [getNominalValue()](#getNominalValue--) | Ein nominaler numerischer Wert |
+| [getRangeMaxValue()](#getRangeMaxValue--) | Der maximale Wert für einen Bereich, der mit der angegebenen Namens-ID verknüpft ist. |
+| [getRangeMinValue()](#getRangeMinValue--) | Der minimale Wert für einen Bereich, der mit der angegebenen Namens-ID verknüpft ist. |
+| [getValueName()](#getValueName--) | Liefert den Namen aus der 'name'-Tabelle, der eine Anzeigekette für diesen Attributwert bereitstellt. |
+| [getValueNameId()](#getValueNameId--) | Liefert die Namens‑ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValueTableFormat2(int flags, int valueNameId, int axisIndex, float nominalValue, float rangeMinValue, float rangeMaxValue) {#AxisValueTableFormat2-int-int-int-float-float-float-}
+```
+public AxisValueTableFormat2(int flags, int valueNameId, int axisIndex, float nominalValue, float rangeMinValue, float rangeMaxValue)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| flags | int | Flags |
+| valueNameId | int | Die Namens‑ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen. |
+| axisIndex | int | Spez.: Nullbasierter Index im Achsenaufzeichnungs‑Array, der die Achse der Designvariation identifiziert, für die die Achsenwerttabelle gilt. Muss kleiner sein als designAxisCount. |
+| nominalValue | float | Der nominale numerische Wert für diesen Attributwert. |
+| rangeMinValue | float | Der minimale Wert für einen Bereich, der mit der angegebenen Namens-ID verknüpft ist. |
+| rangeMaxValue | float | Der maximale Wert für einen Bereich, der mit der angegebenen Namens-ID verknüpft ist. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisIndex() {#getAxisIndex--}
+```
+public int getAxisIndex()
+```
+
+
+Gibt den nullbasierten Index im Achsenaufzeichnungs-Array zurück, der die Achse der Designvariation identifiziert, für die die Achsenwerttabelle gilt.
+
+**Returns:**
+int - Der nullbasierte Index im Achsenaufzeichnungsarray, der die Achse der Designvariation identifiziert, für die die Achsenwerttabelle gilt.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Liefert das Flags‑Feld der Achsenwerttabelle.
+
+**Returns:**
+int - Das Feld für die Achsenwerttabellen-Flags.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Liefert den Formatbezeichner (Versionsnummer).
+
+**Returns:**
+int - Der Formatbezeichner (Versionsnummer).
+### getNominalValue() {#getNominalValue--}
+```
+public float getNominalValue()
+```
+
+
+Ein nominaler numerischer Wert
+
+**Returns:**
+float - Ein nominaler numerischer Wert
+### getRangeMaxValue() {#getRangeMaxValue--}
+```
+public float getRangeMaxValue()
+```
+
+
+Der maximale Wert für einen Bereich, der mit der angegebenen Namens-ID verknüpft ist.
+
+**Returns:**
+float - Der maximale Wert für einen Bereich, der mit der angegebenen Namens-ID verknüpft ist.
+### getRangeMinValue() {#getRangeMinValue--}
+```
+public float getRangeMinValue()
+```
+
+
+Der minimale Wert für einen Bereich, der mit der angegebenen Namens-ID verknüpft ist.
+
+**Returns:**
+float - Der minimale Wert für einen Bereich, der mit der angegebenen Namens-ID verknüpft ist.
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Liefert den Namen aus der 'name'-Tabelle, der eine Anzeigekette für diesen Attributwert bereitstellt.
+
+**Returns:**
+java.lang.String - Der Name aus der 'name'-Tabelle, der eine Anzeigekette für diesen Attributwert bereitstellt.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Liefert die Namens‑ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen.
+
+**Returns:**
+int - Die Namens-ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/axisvaluetableformat3/_index.md
+++ b/german/java/com.aspose.font/axisvaluetableformat3/_index.md
@@ -1,0 +1,223 @@
+---
+title: "AxisValueTableFormat3"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt das Axis‑Value‑Table‑Format 3 dar"
+type: docs
+weight: 15
+url: /de/java/com.aspose.font/axisvaluetableformat3/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.AxisValueTableBase](../../com.aspose.font/axisvaluetablebase)
+```
+public class AxisValueTableFormat3 extends AxisValueTableBase
+```
+
+Stellt das Axis‑Value‑Table‑Format 3 dar
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [AxisValueTableFormat3(int flags, int valueNameId, int axisIndex, float value, float linkedValue)](#AxisValueTableFormat3-int-int-int-float-float-) | Konstruktor |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisIndex()](#getAxisIndex--) | Liefert den nullbasierten Index im Achsenaufzeichnungs‑Array, der die Achse der Designvariation identifiziert, für die die Achsenwerttabelle gilt. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Liefert das Flags‑Feld der Achsenwerttabelle. |
+| [getFormat()](#getFormat--) | Liefert den Formatbezeichner (Versionsnummer). |
+| [getLinkedValue()](#getLinkedValue--) | Der numerische Wert für eine stilgebundene Zuordnung von diesem Wert. |
+| [getValue()](#getValue--) | Der numerische Wert für diesen Attributwert. |
+| [getValueName()](#getValueName--) | Liefert den Namen aus der 'name'-Tabelle, der eine Anzeigekette für diesen Attributwert bereitstellt. |
+| [getValueNameId()](#getValueNameId--) | Liefert die Namens‑ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValueTableFormat3(int flags, int valueNameId, int axisIndex, float value, float linkedValue) {#AxisValueTableFormat3-int-int-int-float-float-}
+```
+public AxisValueTableFormat3(int flags, int valueNameId, int axisIndex, float value, float linkedValue)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| flags | int | Flags |
+| valueNameId | int | Die Namens‑ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen. |
+| axisIndex | int | Spez.: Nullbasierter Index im Achsenaufzeichnungs‑Array, der die Achse der Designvariation identifiziert, für die die Achsenwerttabelle gilt. Muss kleiner sein als designAxisCount. |
+| Wert | float | Der numerische Wert für diesen Attributwert. |
+| linkedValue | float | Der numerische Wert für eine stilgebundene Zuordnung von diesem Wert. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisIndex() {#getAxisIndex--}
+```
+public int getAxisIndex()
+```
+
+
+Liefert den nullbasierten Index im Achsenaufzeichnungs‑Array, der die Achse der Designvariation identifiziert, für die die Achsenwerttabelle gilt.
+
+**Returns:**
+int - Nullbasierter Index in das Achsenaufzeichnungsarray, der die Achse der Designvariation identifiziert, für die die Achsenwerttabelle gilt.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Liefert das Flags‑Feld der Achsenwerttabelle.
+
+**Returns:**
+int - Das Feld für die Achsenwerttabellen-Flags.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Liefert den Formatbezeichner (Versionsnummer).
+
+**Returns:**
+int - Der Formatbezeichner (Versionsnummer).
+### getLinkedValue() {#getLinkedValue--}
+```
+public float getLinkedValue()
+```
+
+
+Der numerische Wert für eine stilgebundene Zuordnung von diesem Wert.
+
+**Returns:**
+float - Der numerische Wert für eine stilbezogene Zuordnung von diesem Wert.
+### getValue() {#getValue--}
+```
+public float getValue()
+```
+
+
+Der numerische Wert für diesen Attributwert.
+
+**Returns:**
+float - Der numerische Wert für diesen Attributwert.
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Liefert den Namen aus der 'name'-Tabelle, der eine Anzeigekette für diesen Attributwert bereitstellt.
+
+**Returns:**
+java.lang.String - Der Name aus der 'name'-Tabelle, der eine Anzeigekette für diesen Attributwert bereitstellt.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Liefert die Namens‑ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen.
+
+**Returns:**
+int - Die Namens-ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/axisvaluetableformat4/_index.md
+++ b/german/java/com.aspose.font/axisvaluetableformat4/_index.md
@@ -1,0 +1,199 @@
+---
+title: "AxisValueTableFormat4"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt das Axis‑Value‑Table‑Format 4 dar"
+type: docs
+weight: 16
+url: /de/java/com.aspose.font/axisvaluetableformat4/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.AxisValueTableBase](../../com.aspose.font/axisvaluetablebase)
+```
+public class AxisValueTableFormat4 extends AxisValueTableBase
+```
+
+Stellt das Axis‑Value‑Table‑Format 4 dar
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [AxisValueTableFormat4(int flags, int valueNameId, AxisValue[] axisValues)](#AxisValueTableFormat4-int-int-com.aspose.font.AxisValue---) | Konstruktor |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisValues()](#getAxisValues--) | Array von AxisValue‑Datensätzen, die die Kombination von Achsenwerten bereitstellen, jeweils einer für jede beitragende Achse. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Liefert das Flags‑Feld der Achsenwerttabelle. |
+| [getFormat()](#getFormat--) | Liefert den Formatbezeichner (Versionsnummer). |
+| [getValueName()](#getValueName--) | Liefert den Namen aus der 'name'-Tabelle, der eine Anzeigekette für diesen Attributwert bereitstellt. |
+| [getValueNameId()](#getValueNameId--) | Liefert die Namens‑ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValueTableFormat4(int flags, int valueNameId, AxisValue[] axisValues) {#AxisValueTableFormat4-int-int-com.aspose.font.AxisValue---}
+```
+public AxisValueTableFormat4(int flags, int valueNameId, AxisValue[] axisValues)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| flags | int | Flags |
+| valueNameId | int | Die Namens‑ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen. |
+| axisValues | [AxisValue\[\]](../../com.aspose.font/axisvalue) | Array von AxisValue‑Datensätzen, die die Kombination von Achsenwerten bereitstellen, jeweils einer für jede beitragende Achse. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisValues() {#getAxisValues--}
+```
+public AxisValue[] getAxisValues()
+```
+
+
+Array von AxisValue‑Datensätzen, die die Kombination von Achsenwerten bereitstellen, jeweils einer für jede beitragende Achse.
+
+**Returns:**
+com.aspose.font.AxisValue[] - Array von AxisValue‑Datensätzen, die die Kombination von Achsenwerten bereitstellen, jeweils einer für jede beitragende Achse.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Liefert das Flags‑Feld der Achsenwerttabelle.
+
+**Returns:**
+int - Das Feld für die Achsenwerttabellen-Flags.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Liefert den Formatbezeichner (Versionsnummer).
+
+**Returns:**
+int - Der Formatbezeichner (Versionsnummer).
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Liefert den Namen aus der 'name'-Tabelle, der eine Anzeigekette für diesen Attributwert bereitstellt.
+
+**Returns:**
+java.lang.String - Der Name aus der 'name'-Tabelle, der eine Anzeigekette für diesen Attributwert bereitstellt.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Liefert die Namens‑ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen.
+
+**Returns:**
+int - Die Namens-ID für Einträge in der 'name'-Tabelle, die eine Anzeigekette für diesen Attributwert bereitstellen.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/bytecontentstreamsource/_index.md
+++ b/german/java/com.aspose.font/bytecontentstreamsource/_index.md
@@ -1,0 +1,200 @@
+---
+title: "ByteContentStreamSource"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Stream-Quelle basierend auf _content stream dar."
+type: docs
+weight: 17
+url: /de/java/com.aspose.font/bytecontentstreamsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.StreamSource](../../com.aspose.font/streamsource)
+```
+public class ByteContentStreamSource extends StreamSource
+```
+
+Stellt eine Stream‑Quelle dar, die auf dem \_content‑Stream basiert.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ByteContentStreamSource(byte[] fileContent)](#ByteContentStreamSource-byte---) | Initialisiert ein neues ByteContentStreamSource-Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Klonen des ByteContentStreamSource-Objekts. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontStream()](#getFontStream--) | Gibt den Font-Dateistream zurück. |
+| [getOffset()](#getOffset--) | Liefert den Offset innerhalb der Quelle. |
+| [hashCode()](#hashCode--) |  |
+| [mustCloseAfterUse()](#mustCloseAfterUse--) | Die Erben können verhindern, dass der Stream geschlossen wird. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOffset(long value)](#setOffset-long-) | Setzt den Offset innerhalb der Quelle. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ByteContentStreamSource(byte[] fileContent) {#ByteContentStreamSource-byte---}
+```
+public ByteContentStreamSource(byte[] fileContent)
+```
+
+
+Initialisiert ein neues ByteContentStreamSource-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fileContent | byte[] | Dateibytes. |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Klonen des ByteContentStreamSource-Objekts.
+
+**Returns:**
+java.lang.Object
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontStream() {#getFontStream--}
+```
+public InputStream getFontStream()
+```
+
+
+Gibt den Font-Dateistream zurück. Vergessen Sie nicht, den Stream nach der Verwendung zu schließen.
+
+**Returns:**
+java.io.InputStream - Font-Dateistream.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset innerhalb der Quelle.
+
+**Returns:**
+long - Offset innerhalb der Quelle.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### mustCloseAfterUse() {#mustCloseAfterUse--}
+```
+public boolean mustCloseAfterUse()
+```
+
+
+Die Erben können verhindern, dass der Stream geschlossen wird. Gibt true zurück, wenn die StreamSource den Stream nach der Verwendung schließen möchte. Andernfalls wird false zurückgegeben.
+
+**Returns:**
+boolean - true, wenn die StreamSource den Stream nach der Verwendung schließen möchte, sonst false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOffset(long value) {#setOffset-long-}
+```
+public void setOffset(long value)
+```
+
+
+Setzt den Offset innerhalb der Quelle.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long | Offset innerhalb der Quelle. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/cffencoding/_index.md
+++ b/german/java/com.aspose.font/cffencoding/_index.md
@@ -1,0 +1,256 @@
+---
+title: "CffEncoding"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die CFF _font-Kodierung dar."
+type: docs
+weight: 18
+url: /de/java/com.aspose.font/cffencoding/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFontEncoding](../../com.aspose.font/ifontencoding), [com.aspose.font.ISupportsNameAddressing](../../com.aspose.font/isupportsnameaddressing)
+```
+public class CffEncoding implements IFontEncoding, ISupportsNameAddressing
+```
+
+Stellt die CFF \_font‑Kodierung dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [decodeToGid(long charCode)](#decodeToGid-long-) | Liefert Gid für übergebenen charCode. |
+| [decodeToGidParameterized(IEncodingParameters parameters, long charCode)](#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-) | Parametrisierte Dekodiermethode. |
+| [encode(long gid, long charCode)](#encode-long-long-) | Kodiert den Glyph. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getNameToCharCodeIndex()](#getNameToCharCodeIndex--) | Gibt die Zuordnung von Namen zu Zeichencode‑Kodierung zurück. |
+| [getNameToGidIndex()](#getNameToGidIndex--) | Gibt die Zuordnung von Namen zu Zeichencode‑Kodierung zurück. |
+| [getNameToSidIndex()](#getNameToSidIndex--) | Gibt die Zuordnung von Namen zu Zeichencode‑Kodierung zurück. |
+| [getSidName(int sid)](#getSidName-int-) | Liefert Namen für die angegebene SID. |
+| [gidToUnicode(GlyphId gid)](#gidToUnicode-com.aspose.font.GlyphId-) | Dekodiert Gid zu Unicode. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [unicodeToGid(long unicode)](#unicodeToGid-long-) | Dekodiert ein Unicode-Zeichen und gibt die Glyph-ID zurück. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### decodeToGid(long charCode) {#decodeToGid-long-}
+```
+public GlyphId decodeToGid(long charCode)
+```
+
+
+Liefert Gid für übergebenen charCode. Diese Methode ist für CFF CIDFonts konzipiert, bei denen charCode einen gültigen CID-Wert darstellen muss. Glyph id ist eine eindeutige Nummer für ein Glyph, die vom \_font-Typ abhängt. CFF Font Glyph id kann eine Instanz der Klasse ( GlyphStringId ) oder der Klasse ( GlyphUInt32Id ) sein.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| charCode | long | Zeichencode (CID), für den ein Glyph-Identifikator ermittelt werden soll. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to CID passed.
+### decodeToGidParameterized(IEncodingParameters parameters, long charCode) {#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-}
+```
+public GlyphId decodeToGidParameterized(IEncodingParameters parameters, long charCode)
+```
+
+
+Parametrisierte Dekodiermethode. Nicht unterstützt für den CFF Font-Typ.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| parameters | [IEncodingParameters](../../com.aspose.font/iencodingparameters) | Implementierung des Interfaces IEncodingParameters. |
+| charCode | long | Zeichencode, für den der Glyph‑Bezeichner ermittelt werden soll. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to charCode passed.
+### encode(long gid, long charCode) {#encode-long-long-}
+```
+public void encode(long gid, long charCode)
+```
+
+
+Kodiert das Glyph. Nicht unterstützt für CFF Font-Typen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| gid | long | Glyph id |
+| charCode | long | CharCode, der mit der Glyph id verknüpft ist. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNameToCharCodeIndex() {#getNameToCharCodeIndex--}
+```
+public NameToCodeMap getNameToCharCodeIndex()
+```
+
+
+Gibt die Zuordnung von Namen zu Zeichencode‑Kodierung zurück. Hinweis: Zeichencode ist kein Unicode. Zeichencode ist ein Zeichen‑Index in der Font‑Kodierung „table“.
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - Name to character code encoding map.
+### getNameToGidIndex() {#getNameToGidIndex--}
+```
+public NameToCodeMap getNameToGidIndex()
+```
+
+
+Gibt die Zuordnung von Namen zu Zeichencode‑Kodierung zurück. Hinweis: Zeichencode ist kein Unicode. Zeichencode ist ein Zeichen‑Index in der Font‑Kodierung „table“.
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - Name to character code encoding map.
+### getNameToSidIndex() {#getNameToSidIndex--}
+```
+public NameToCodeMap getNameToSidIndex()
+```
+
+
+Gibt die Zuordnung von Namen zu Zeichencode‑Kodierung zurück. Hinweis: Zeichencode ist kein Unicode. Zeichencode ist ein Zeichen‑Index in der Font‑Kodierung „table“.
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - Name to character code encoding map.
+### getSidName(int sid) {#getSidName-int-}
+```
+public String getSidName(int sid)
+```
+
+
+Liefert Namen für die angegebene SID.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| sid | int | String‑Bezeichner. |
+
+**Returns:**
+java.lang.String – Name aus dem String‑INDEX, falls gefunden.
+### gidToUnicode(GlyphId gid) {#gidToUnicode-com.aspose.font.GlyphId-}
+```
+public long gidToUnicode(GlyphId gid)
+```
+
+
+Dekodiert Gid zu Unicode. Glyph id ist eine eindeutige Nummer für ein Glyph, die vom \_font‑Typ abhängt. CFF Font Glyph id kann eine Instanz der Klasse ( GlyphStringId ) oder der Klasse ( GlyphUInt32Id ) sein.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| gid | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑Bezeichner des zu dekodierenden Symbols. |
+
+**Returns:**
+long – Unicode‑Wert, der zur übergebenen Glyph‑Id gehört.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unicodeToGid(long unicode) {#unicodeToGid-long-}
+```
+public GlyphId unicodeToGid(long unicode)
+```
+
+
+Dekodiert ein Unicode und gibt die Glyph id zurück. Glyph id ist eine eindeutige Nummer für ein Glyph, die vom \_font‑Typ abhängt. CFF Font Glyph id kann eine Instanz der Klasse ( GlyphStringId ) oder der Klasse ( GlyphUInt32Id ) sein.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| unicode | long | Unicode, für den der Glyph‑Bezeichner ermittelt werden soll. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to unicode passed.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/cfffont/_index.md
+++ b/german/java/com.aspose.font/cfffont/_index.md
@@ -1,0 +1,604 @@
+---
+title: "CffFont"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt das Compact Font Format CFF dar."
+type: docs
+weight: 19
+url: /de/java/com.aspose.font/cfffont/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Font](../../com.aspose.font/font)
+```
+public class CffFont extends Font
+```
+
+Stellt das Compact Font Format (CFF) dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Konvertiert die Font in ein anderes Format. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Gibt ein Array aller Glyph-IDs zurück, die in der Font verfügbar sind. |
+| [getClass()](#getClass--) |  |
+| [getCommonFontsSettings()](#getCommonFontsSettings--) | Liest Einstellungen, die für CFF-Schriften gemeinsam sind. |
+| [getEncoding()](#getEncoding--) | Liefert Font‑Kodierung. |
+| [getFontDefinition()](#getFontDefinition--) | Liest Schriftdefinition. |
+| [getFontFamily()](#getFontFamily--) | Liefert Font‑Familie. |
+| [getFontName()](#getFontName--) | Liefert Font‑Face‑Name. |
+| [getFontNames()](#getFontNames--) | Liefert Font‑Namen. |
+| [getFontSaver()](#getFontSaver--) | Liefert Font‑Speicherfunktionalität. |
+| [getFontStyle()](#getFontStyle--) | Liefert Font‑Stil. |
+| [getFontType()](#getFontType--) | Liefert Font‑Typ. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Font‑Glyph‑Zugriff. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Gibt Glyph nach Glyph-ID zurück. |
+| [getGlyphById(String glyphName)](#getGlyphById-java.lang.String-) | Gibt Glyph nach Glyph-Namen zurück. |
+| [getGlyphById(long id)](#getGlyphById-long-) | Gibt Glyph nach Glyph-ID zurück. |
+| [getGlyphIdType()](#getGlyphIdType--) | Liefert Glyph-ID‑Typ‑Spezifikation. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Liest Glyphenrepräsentation für Text. |
+| [getIndexDataProvider(CffIndexProviderType indexType)](#getIndexDataProvider-com.aspose.font.CffIndexProviderType-) | Liest Anbieter für den angegebenen CFF INDEX-Strukturtyp. |
+| [getMetrics()](#getMetrics--) | Liefert Font‑Metriken. |
+| [getNumGlyphs()](#getNumGlyphs--) | Ermittelt die Anzahl der Glyphen im Font. |
+| [getPostscriptNames()](#getPostscriptNames--) | Liest Postscript-Schriftnamen. |
+| [getStyle()](#getStyle--) | Liefert Font‑Stil. |
+| [getTopDictDataProvider()](#getTopDictDataProvider--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isCidKeyedFont()](#isCidKeyedFont--) | Liest Wert, der anzeigt, dass die Schrift cid-gebunden ist. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Öffnet einen Font mithilfe eines FontDefinition-Objekts. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Öffnet einen Font mithilfe des Font-Typs und eines Byte-Arrays mit Font-Daten. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Öffnet einen Font mithilfe des Font-Typs und einer Stream-Quelle. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Öffnet einen Font mithilfe des Font-Typs und des Font-Dateinamens. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Speichert den Font im Originalformat. |
+| [save(String fileName)](#save-java.lang.String-) | Speichert den Font im Originalformat. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Speichert den Font im angegebenen Format. |
+| [setCommonFontsSettings(CffFontsSettings value)](#setCommonFontsSettings-com.aspose.font.CffFontsSettings-) | Legt Einstellungen fest, die für CFF-Schriften gemeinsam sind. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Der Setter für die Schriftfamilie ist noch nicht implementiert. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Der Setter für den Schriftartnamen ist noch nicht implementiert. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Der Setter für den Stil ist noch nicht implementiert. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public Font convert(FontType fontType)
+```
+
+
+Konvertiert den Font in ein anderes Format. Hinweis: Der TTF-Fonttyp wird derzeit nur unterstützt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Font-Formattyp, in den konvertiert werden soll. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public GlyphId[] getAllGlyphIds()
+```
+
+
+Gibt ein Array aller Glyph-IDs zurück, die in der Schrift verfügbar sind. Eine Glyph-ID ist eine eindeutige Nummer für ein Glyph, die vom Schrifttyp abhängt. Eine CFF-Schrift-Glyph-ID kann eine Instanz der Klasse ( GlyphStringId ) oder der Klasse ( GlyphUInt32Id ) sein.
+
+**Returns:**
+com.aspose.font.GlyphId[]
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCommonFontsSettings() {#getCommonFontsSettings--}
+```
+public CffFontsSettings getCommonFontsSettings()
+```
+
+
+Liest Einstellungen, die für CFF-Schriften gemeinsam sind. Diese Einstellungen werden in verschiedenen Szenarien verwendet und können für jede einzelne Schrift geändert werden.
+
+**Returns:**
+[CffFontsSettings](../../com.aspose.font/cfffontssettings) - Font definition.
+### getEncoding() {#getEncoding--}
+```
+public IFontEncoding getEncoding()
+```
+
+
+Liefert Font‑Kodierung.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public FontDefinition getFontDefinition()
+```
+
+
+Liest Schriftdefinition.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public String getFontFamily()
+```
+
+
+Liefert Font‑Familie.
+
+**Returns:**
+java.lang.String - Font‑Familie.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Liefert Font‑Face‑Name.
+
+**Returns:**
+java.lang.String - Font‑Face‑Name.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Liefert Font‑Namen.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Liefert Font‑Speicherfunktionalität.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public int getFontStyle()
+```
+
+
+Ermittelt den Font-Stil. Dies ist ein Wert, der berechnet und in einem generalisierten Typ dargestellt wird.
+
+**Returns:**
+int - Font-Stil. In der Regel eine Kombination von Konstanten‑Flag‑Werten der FontStyle‑Klasse oder 0.
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Liest Schrifttyp. Gibt den Wert FontType.CFF zurück.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Schriftzeichen-Glyph-Zugriff. Ruft Glyphs und Glyph-Identifikatoren ab.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public Glyph getGlyphById(GlyphId id)
+```
+
+
+Gibt ein Glyph anhand seiner Glyph-ID zurück. Eine Glyph-ID ist eine eindeutige Nummer für ein Glyph, die vom Schrifttyp abhängt. Eine CFF-Schrift-Glyph-ID kann eine Instanz der Klasse ( GlyphStringId ) oder der Klasse ( GlyphInt32Id ) sein.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | Glyph-ID. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(String glyphName) {#getGlyphById-java.lang.String-}
+```
+public Glyph getGlyphById(String glyphName)
+```
+
+
+Gibt Glyph nach Glyph-Namen zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphName | java.lang.String | Glyph-Name. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(long id) {#getGlyphById-long-}
+```
+public Glyph getGlyphById(long id)
+```
+
+
+Gibt Glyph nach Glyph-ID zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| id | long | Glyph-ID. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public GlyphIdType getGlyphIdType()
+```
+
+
+Liefert Glyph-ID‑Typ‑Spezifikation.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype) - Glyph id type specification.
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Liest Glyphenrepräsentation für Text.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| text | java.lang.String | Eingabetext. |
+
+**Returns:**
+com.aspose.font.GlyphId[] – GlyphId-Array.
+### getIndexDataProvider(CffIndexProviderType indexType) {#getIndexDataProvider-com.aspose.font.CffIndexProviderType-}
+```
+public ICffIndexDataProvider getIndexDataProvider(CffIndexProviderType indexType)
+```
+
+
+Liest Anbieter für den angegebenen CFF INDEX-Strukturtyp.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| indexType | [CffIndexProviderType](../../com.aspose.font/cffindexprovidertype) | Typ der INDEX-Struktur. |
+
+**Returns:**
+[ICffIndexDataProvider](../../com.aspose.font/icffindexdataprovider) - Implementation of ( ICffIndexDataProvider ) interface.
+### getMetrics() {#getMetrics--}
+```
+public IFontMetrics getMetrics()
+```
+
+
+Liefert Font‑Metriken.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Ermittelt die Anzahl der Glyphen im Font.
+
+**Returns:**
+int – Anzahl der Glyphs in der Schrift.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Liest Postscript-Schriftnamen.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names.
+### getStyle() {#getStyle--}
+```
+public String getStyle()
+```
+
+
+Ermittelt den Schriftstil. Dies ist ein Roh-String-Wert, der von der Schriftdatei bereitgestellt wird.
+
+**Returns:**
+java.lang.String – Schriftstil.
+### getTopDictDataProvider() {#getTopDictDataProvider--}
+```
+public TopDictDataProvider getTopDictDataProvider()
+```
+
+
+
+
+**Returns:**
+[TopDictDataProvider](../../com.aspose.font/topdictdataprovider)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isCidKeyedFont() {#isCidKeyedFont--}
+```
+public boolean isCidKeyedFont()
+```
+
+
+Liest Wert, der anzeigt, dass die Schrift cid-gebunden ist.
+
+**Returns:**
+boolean - Wert, der anzeigt, dass die Schrift cid-gebunden ist.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Öffnet einen Font mithilfe eines FontDefinition-Objekts.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Schriftdefinitions-Objekt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und eines Byte-Arrays mit Font-Daten.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fontData | byte[] | Byte-Array, aus dem die Schrift geladen wird. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und einer Stream-Quelle.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Stream-Quelle für die Schrift. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und des Font-Dateinamens.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fileName | java.lang.String | Schriftdateiname. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Speichert den Font im Originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Stream zum Speichern der Schrift. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Speichert den Font im Originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fileName | java.lang.String | Datei zum Speichern der Schrift. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Speichert den Font im angegebenen Format.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Stream zum Speichern der Schrift |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | gewünschtes Format |
+
+### setCommonFontsSettings(CffFontsSettings value) {#setCommonFontsSettings-com.aspose.font.CffFontsSettings-}
+```
+public void setCommonFontsSettings(CffFontsSettings value)
+```
+
+
+Legt Einstellungen fest, die für CFF-Schriften gemeinsam sind.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [CffFontsSettings](../../com.aspose.font/cfffontssettings) | Schriftdefinition. |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public void setFontFamily(String value)
+```
+
+
+Der Setter für die Schriftfamilie ist noch nicht implementiert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Neue Schriftfamilie. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public void setFontName(String value)
+```
+
+
+Der Setter für den Schriftartnamen ist noch nicht implementiert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Neuer Schriftartname. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public void setStyle(String value)
+```
+
+
+Der Setter für den Stil ist noch nicht implementiert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Neuer Schriftstil. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/cfffontexception/_index.md
+++ b/german/java/com.aspose.font/cfffontexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "CffFontException"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine allgemeine, verarbeitungsbezogene Ausnahme für Schriftarten im CFF‑Format dar."
+type: docs
+weight: 20
+url: /de/java/com.aspose.font/cfffontexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class CffFontException extends FontException
+```
+
+Stellt eine allgemeine, verarbeitungsbezogene Ausnahme für Schriftarten im CFF‑Format dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [CffFontException()](#CffFontException--) | Initialisiert ein neues CffFontException-Objekt. |
+| [CffFontException(String message)](#CffFontException-java.lang.String-) | Initialisiert ein neues CffFontException-Objekt. |
+| [CffFontException(String message, RuntimeException innerException)](#CffFontException-java.lang.String-java.lang.RuntimeException-) | Initialisiert ein neues CffFontException-Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CffFontException() {#CffFontException--}
+```
+public CffFontException()
+```
+
+
+Initialisiert ein neues CffFontException-Objekt.
+
+### CffFontException(String message) {#CffFontException-java.lang.String-}
+```
+public CffFontException(String message)
+```
+
+
+Initialisiert ein neues CffFontException-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+
+### CffFontException(String message, RuntimeException innerException) {#CffFontException-java.lang.String-java.lang.RuntimeException-}
+```
+public CffFontException(String message, RuntimeException innerException)
+```
+
+
+Initialisiert ein neues CffFontException-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+| innerException | java.lang.RuntimeException | Die Ausnahme, die die aktuelle Ausnahme verursacht. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/cfffontmetrics/_index.md
+++ b/german/java/com.aspose.font/cfffontmetrics/_index.md
@@ -1,0 +1,483 @@
+---
+title: "CffFontMetrics"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Implementierung der CFF‑Schriftmetriken"
+type: docs
+weight: 21
+url: /de/java/com.aspose.font/cfffontmetrics/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.FontMetrics](../../com.aspose.font/fontmetrics)
+```
+public class CffFontMetrics extends FontMetrics
+```
+
+Implementierung der CFF‑Schriftmetriken
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAscender()](#getAscender--) | Liefert den Ascender-Wert. |
+| [getAscender(double fontSize)](#getAscender-double-) | Gibt den Ascender für eine bestimmte Schriftgröße zurück. |
+| [getClass()](#getClass--) |  |
+| [getDescender()](#getDescender--) | Liefert den Descender-Wert. |
+| [getDescender(double fontSize)](#getDescender-double-) | Gibt den Descender für eine bestimmte Schriftgröße zurück. |
+| [getFontBBox()](#getFontBBox--) | Liefert den FontBBox-Wert. |
+| [getFontMatrix()](#getFontMatrix--) | Liefert den FontMatrix-Wert. |
+| [getFontMatrixForGlyph(GlyphId glyphId)](#getFontMatrixForGlyph-com.aspose.font.GlyphId-) | Berechnet die Transformationsmatrix für die durch die ID angegebene Glyph. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Gibt das Glyph-Bbox zurück. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Gibt die Glyph-Breite zurück. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Gibt den Kerning-Wert für das Glyph-Paar zurück. |
+| [getLineGap()](#getLineGap--) | Liest den LineGap-Wert. |
+| [getTypoAscender()](#getTypoAscender--) | Liest den TypoAscender-Wert. |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Gibt den typografischen Ascender für eine bestimmte Schriftgröße zurück. |
+| [getTypoDescender()](#getTypoDescender--) | Liest den TypoDescender-Wert. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Gibt den typografischen Descender für eine bestimmte Schriftgröße zurück. |
+| [getTypoLineGap()](#getTypoLineGap--) | Liest den TypoLineGap-Wert. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Gibt den Zeilenabstand für eine bestimmte Schriftgröße zurück. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Liest den UnitsPerEM-Wert. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Liest den IsFixedPitch-Wert. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Misst die Zeichenkette und gibt die Zeichenkettenbreite zurück. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAscender(double value)](#setAscender-double-) | Setzt den Ascender-Wert. |
+| [setDescender(double value)](#setDescender-double-) | Setzt den Descender-Wert. |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) |  |
+| [setTypoAscender(double value)](#setTypoAscender-double-) | Setzt den TypoAscender-Wert. |
+| [setTypoDescender(double value)](#setTypoDescender-double-) | Setzt den TypoDescender-Wert. |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) | Setzt den UnitsPerEM-Wert. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAscender() {#getAscender--}
+```
+public double getAscender()
+```
+
+
+Liefert den Ascender-Wert.
+
+**Returns:**
+double - Ascender-Wert.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public double getAscender(double fontSize)
+```
+
+
+Gibt den Ascender für eine bestimmte Schriftgröße zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Ascender-Wert.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescender() {#getDescender--}
+```
+public double getDescender()
+```
+
+
+Liefert den Descender-Wert.
+
+**Returns:**
+double - Descender-Wert.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public double getDescender(double fontSize)
+```
+
+
+Gibt den Descender für eine bestimmte Schriftgröße zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Descender-Wert.
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+Liefert den FontBBox-Wert.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - FontBBox value.
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+Liefert den FontMatrix-Wert.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - FontMatrix value.
+### getFontMatrixForGlyph(GlyphId glyphId) {#getFontMatrixForGlyph-com.aspose.font.GlyphId-}
+```
+public TransformationMatrix getFontMatrixForGlyph(GlyphId glyphId)
+```
+
+
+Berechnet die Transformationsmatrix für die durch die ID angegebene Glyph.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑Bezeichner. |
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - Glyph transformation matrix.
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Gibt das Glyph-Bbox zurück. Gibt FontBBox zurück, wenn das BBox für das Glyph nicht definiert war. Kann von spezifischen Font-Encoding-Erben überschrieben werden.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑Bezeichner. |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox.
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Gibt die Glyph-Breite zurück. Kann von spezifischen Font-Encoding-Erben überschrieben werden.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑Bezeichner. |
+
+**Returns:**
+double - Glyphenbreite.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Gibt den Kerning-Wert für das Glyph-Paar zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Erste Glyphe im Paar. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Schriftgröße. |
+
+**Returns:**
+double - Kerning-Wert.
+### getLineGap() {#getLineGap--}
+```
+public double getLineGap()
+```
+
+
+Liest den LineGap-Wert.
+
+**Returns:**
+double - LineGap-Wert.
+### getTypoAscender() {#getTypoAscender--}
+```
+public double getTypoAscender()
+```
+
+
+Liest den TypoAscender-Wert.
+
+**Returns:**
+double - TypoAscender-Wert.
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public double getTypoAscender(double fontSize)
+```
+
+
+Gibt den typografischen Ascender für eine bestimmte Schriftgröße zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Typografischer Aufsteigerwert.
+### getTypoDescender() {#getTypoDescender--}
+```
+public double getTypoDescender()
+```
+
+
+Liest den TypoDescender-Wert.
+
+**Returns:**
+double - TypoDescender-Wert.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public double getTypoDescender(double fontSize)
+```
+
+
+Gibt den typografischen Descender für eine bestimmte Schriftgröße zurück.
+
+param fontSize Schriftgröße.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double |  |
+
+**Returns:**
+double - Typografischer Abstiegwert.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public double getTypoLineGap()
+```
+
+
+Liest den TypoLineGap-Wert.
+
+**Returns:**
+double - TypoLineGap-Wert.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public double getTypoLineGap(double fontSize)
+```
+
+
+Gibt den Zeilenabstand für eine bestimmte Schriftgröße zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Zeilenabstandswert.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Liest den UnitsPerEM-Wert.
+
+**Returns:**
+long - UnitsPerEM-Wert.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+Liest den IsFixedPitch-Wert.
+
+**Returns:**
+boolean - IsFixedPitch-Wert.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public double measureString(String unicode, double fontSize)
+```
+
+
+Misst die Zeichenkette und gibt die Zeichenkettenbreite zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| unicode | java.lang.String | Unicode-Zeichenkette. |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Zeichenkettenbreite.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAscender(double value) {#setAscender-double-}
+```
+public void setAscender(double value)
+```
+
+
+Setzt den Ascender-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | Aufsteigerwert. |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public void setDescender(double value)
+```
+
+
+Setzt den Descender-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | Abstiegwert. |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Setzt die Glyph-Breite.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) |  |
+| Wert | double |  |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public void setTypoAscender(double value)
+```
+
+
+Setzt den TypoAscender-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | TypoAscender-Wert. |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public void setTypoDescender(double value)
+```
+
+
+Setzt den TypoDescender-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | TypoDescender-Wert. |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public void setUnitsPerEM(long value)
+```
+
+
+Setzt den UnitsPerEM-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long | UnitsPerEM-Wert. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/cfffontssettings/_index.md
+++ b/german/java/com.aspose.font/cfffontssettings/_index.md
@@ -1,0 +1,162 @@
+---
+title: "CffFontsSettings"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt Einstellungen bereit, die für CFF‑Schriftarten gemein sind."
+type: docs
+weight: 22
+url: /de/java/com.aspose.font/cfffontssettings/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class CffFontsSettings
+```
+
+Stellt Einstellungen bereit, die für CFF‑Schriftarten gemein sind.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [CffFontsSettings()](#CffFontsSettings--) | Konstruktor |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getUpdateStringsStrategy()](#getUpdateStringsStrategy--) | Gibt die Strategie zum Aktualisieren von Strings in der CFF String INDEX-Struktur zurück. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUpdateStringStrategy(CffUpdateStringIndexStrategy updateStringsStrategy)](#setUpdateStringStrategy-com.aspose.font.CffUpdateStringIndexStrategy-) | Gibt die Strategie zum Aktualisieren von Strings in der CFF String INDEX-Struktur an. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CffFontsSettings() {#CffFontsSettings--}
+```
+public CffFontsSettings()
+```
+
+
+Konstruktor
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUpdateStringsStrategy() {#getUpdateStringsStrategy--}
+```
+public CffUpdateStringIndexStrategy getUpdateStringsStrategy()
+```
+
+
+Gibt die Strategie zum Aktualisieren von Strings in der CFF String INDEX-Struktur zurück. Die Option AddStringAsIs wird standardmäßig verwendet.
+
+**Returns:**
+[CffUpdateStringIndexStrategy](../../com.aspose.font/cffupdatestringindexstrategy)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUpdateStringStrategy(CffUpdateStringIndexStrategy updateStringsStrategy) {#setUpdateStringStrategy-com.aspose.font.CffUpdateStringIndexStrategy-}
+```
+public void setUpdateStringStrategy(CffUpdateStringIndexStrategy updateStringsStrategy)
+```
+
+
+Gibt die Strategie zum Aktualisieren von Strings in der CFF String INDEX-Struktur an.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| updateStringsStrategy | [CffUpdateStringIndexStrategy](../../com.aspose.font/cffupdatestringindexstrategy) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/cffindexprovidertype/_index.md
+++ b/german/java/com.aspose.font/cffindexprovidertype/_index.md
@@ -1,0 +1,250 @@
+---
+title: "CffIndexProviderType"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Gibt INDEX-Strukturen an, die von der Indexanbieter-Schnittstellenfamilie unterstützt werden."
+type: docs
+weight: 133
+url: /de/java/com.aspose.font/cffindexprovidertype/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum CffIndexProviderType extends Enum<CffIndexProviderType>
+```
+
+Gibt INDEX-Strukturen an, die von der Indexanbieter-Schnittstellenfamilie unterstützt werden.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [NameIndex](#NameIndex) | Name INDEX |
+| [StringIndex](#StringIndex) | String INDEX |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NameIndex {#NameIndex}
+```
+public static final CffIndexProviderType NameIndex
+```
+
+
+Name INDEX
+
+### StringIndex {#StringIndex}
+```
+public static final CffIndexProviderType StringIndex
+```
+
+
+String INDEX
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static CffIndexProviderType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[CffIndexProviderType](../../com.aspose.font/cffindexprovidertype)
+### values() {#values--}
+```
+public static CffIndexProviderType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.CffIndexProviderType[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/cffparsingexception/_index.md
+++ b/german/java/com.aspose.font/cffparsingexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "CffParsingException"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Parse‑Ausnahme für Schriftarten im cff‑Format dar."
+type: docs
+weight: 23
+url: /de/java/com.aspose.font/cffparsingexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception), [com.aspose.font.CffFontException](../../com.aspose.font/cfffontexception)
+```
+public class CffParsingException extends CffFontException
+```
+
+Stellt eine Parse‑Ausnahme für Schriftarten im cff-Format dar. Die Ausnahme kann im Falle von Fehlern während des Schriftarten‑Parsing‑Vorgangs ausgelöst werden.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [CffParsingException()](#CffParsingException--) | Initialisiert ein neues  CffParsingException  Objekt. |
+| [CffParsingException(String message)](#CffParsingException-java.lang.String-) | Initialisiert ein neues  CffParsingException  Objekt. |
+| [CffParsingException(String message, RuntimeException innerException)](#CffParsingException-java.lang.String-java.lang.RuntimeException-) | Initialisiert ein neues  CffParsingException  Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CffParsingException() {#CffParsingException--}
+```
+public CffParsingException()
+```
+
+
+Initialisiert ein neues  CffParsingException  Objekt.
+
+### CffParsingException(String message) {#CffParsingException-java.lang.String-}
+```
+public CffParsingException(String message)
+```
+
+
+Initialisiert ein neues  CffParsingException  Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+
+### CffParsingException(String message, RuntimeException innerException) {#CffParsingException-java.lang.String-java.lang.RuntimeException-}
+```
+public CffParsingException(String message, RuntimeException innerException)
+```
+
+
+Initialisiert ein neues  CffParsingException  Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+| innerException | java.lang.RuntimeException | Die Ausnahme, die die aktuelle Ausnahme verursacht. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/cffupdatestringindexstrategy/_index.md
+++ b/german/java/com.aspose.font/cffupdatestringindexstrategy/_index.md
@@ -1,0 +1,250 @@
+---
+title: "CffUpdateStringIndexStrategy"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Gibt an, wie Zeichenketten zum CFF String INDEX Speicher hinzugefügt werden."
+type: docs
+weight: 134
+url: /de/java/com.aspose.font/cffupdatestringindexstrategy/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum CffUpdateStringIndexStrategy extends Enum<CffUpdateStringIndexStrategy>
+```
+
+Legt fest, wie Zeichenketten zum CFF String INDEX Speicher hinzugefügt werden. Wenn wir versuchen, eine Zeichenkette in den CFF String INDEX einzufügen, kann es vorkommen, dass diese Zeichenkette bereits im String INDEX vorhanden ist. Durch die Option SearchForDuplicates können wir eine Suche im String INDEX erzwingen, um zu erkennen, ob diese Zeichenkette bereits vorhanden ist oder nicht. Dieser Ansatz spart Speicherplatz in der String INDEX-Struktur, erfordert jedoch mehr Zeit zum Hinzufügen der Zeichenkette.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [AddStringAsIs](#AddStringAsIs) | Legt fest, dass beim Hinzufügen einer Zeichenkette keine Duplikatprüfungen durchgeführt werden sollen. |
+| [SearchForDuplicates](#SearchForDuplicates) | Legt fest, dass die Suche nach der hinzuzufügenden Zeichenkette in der String INDEX-Struktur durchgeführt werden soll, um das Hinzufügen von Duplikaten zu vermeiden. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AddStringAsIs {#AddStringAsIs}
+```
+public static final CffUpdateStringIndexStrategy AddStringAsIs
+```
+
+
+Legt fest, dass beim Hinzufügen einer Zeichenkette keine Duplikatprüfungen durchgeführt werden sollen. Dieser Ansatz ist schneller, kann jedoch zu ineffizienter Speichernutzung für den String INDEX führen.
+
+### SearchForDuplicates {#SearchForDuplicates}
+```
+public static final CffUpdateStringIndexStrategy SearchForDuplicates
+```
+
+
+Legt fest, dass die Suche nach der hinzuzufügenden Zeichenkette in der String INDEX-Struktur durchgeführt werden soll, um das Hinzufügen von Duplikaten zu vermeiden.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static CffUpdateStringIndexStrategy valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[CffUpdateStringIndexStrategy](../../com.aspose.font/cffupdatestringindexstrategy)
+### values() {#values--}
+```
+public static CffUpdateStringIndexStrategy[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.CffUpdateStringIndexStrategy[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/closepath/_index.md
+++ b/german/java/com.aspose.font/closepath/_index.md
@@ -1,0 +1,200 @@
+---
+title: "ClosePath"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die ClosePath-Operation dar."
+type: docs
+weight: 24
+url: /de/java/com.aspose.font/closepath/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IPathSegment](../../com.aspose.font/ipathsegment)
+```
+public class ClosePath implements IPathSegment
+```
+
+Stellt die ClosePath-Operation dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clone()](#clone--) | Erstellt ein neues Objekt, das eine Kopie der aktuellen Instanz ist. |
+| [copy()](#copy--) | Erstellt eine Kopie des Segmentobjekts. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getX()](#getX--) | Liefert die x‑Koordinate. |
+| [getY()](#getY--) | Liefert die y‑Koordinate. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [shift(double dx, double dy)](#shift-double-double-) | Führt Verschiebung um x- und y-Koordinaten durch. |
+| [toString()](#toString--) |  |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Transformiert Koordinaten mit der Transformationsmatrix. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Erstellt ein neues Objekt, das eine Kopie der aktuellen Instanz ist.
+
+**Returns:**
+java.lang.Object – Ein neues Objekt, das eine Kopie dieser Instanz ist.
+### copy() {#copy--}
+```
+public IPathSegment copy()
+```
+
+
+Erstellt eine Kopie des Segmentobjekts.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getX() {#getX--}
+```
+public double getX()
+```
+
+
+Liefert die x‑Koordinate.
+
+**Returns:**
+double - Koordinate x.
+### getY() {#getY--}
+```
+public double getY()
+```
+
+
+Liefert die y‑Koordinate.
+
+**Returns:**
+double - Koordinate y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public void shift(double dx, double dy)
+```
+
+
+Führt Verschiebung um x- und y-Koordinaten durch.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| dx | double | Wert dx. |
+| dy | double | Wert dy. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public void transform(TransformationMatrix matrix)
+```
+
+
+Transformiert Koordinaten mit der Transformationsmatrix.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Transformationsmatrix. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/compositeglyph/_index.md
+++ b/german/java/com.aspose.font/compositeglyph/_index.md
@@ -1,0 +1,245 @@
+---
+title: "CompositeGlyph"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt ein zusammengesetztes Schriftzeichen dar."
+type: docs
+weight: 25
+url: /de/java/com.aspose.font/compositeglyph/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Glyph](../../com.aspose.font/glyph)
+```
+public class CompositeGlyph extends Glyph
+```
+
+Stellt ein zusammengesetztes Schriftzeichen dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clone()](#clone--) | Gibt eine Kopie des Glyph zurück. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getComponents()](#getComponents--) | Liest Komponentenliste. |
+| [getGlyphBBox()](#getGlyphBBox--) | Liest das Glyph‑BBox. |
+| [getLeftSidebearingX()](#getLeftSidebearingX--) | Ermittelt die Glyph‑Seitenlage x‑Koordinate. |
+| [getLeftSidebearingY()](#getLeftSidebearingY--) | Ermittelt die Glyph‑Seitenlage y‑Koordinate. |
+| [getPath()](#getPath--) | Ermittelt den Glyph‑Pfad. |
+| [getSourceResolution()](#getSourceResolution--) | Ermittelt die Auflösung des Quellbefehlsatzes. |
+| [getState()](#getState--) | Ermittelt den Glyph‑Zustand. |
+| [getWidthVectorX()](#getWidthVectorX--) | Ermittelt den Glyph‑Breitenvektor. |
+| [getWidthVectorY()](#getWidthVectorY--) | Ermittelt den Glyph‑Breitenvektor. |
+| [hashCode()](#hashCode--) |  |
+| [isEmpty()](#isEmpty--) | Wahr, wenn das Glyph keine Zeichenanweisungen enthält. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Gibt eine Kopie des Glyph zurück.
+
+**Returns:**
+java.lang.Object - Kopie von Glyph
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getComponents() {#getComponents--}
+```
+public CompositeGlyphComponentList getComponents()
+```
+
+
+Liest Komponentenliste.
+
+**Returns:**
+[CompositeGlyphComponentList](../../com.aspose.font/compositeglyphcomponentlist) - Components list.
+### getGlyphBBox() {#getGlyphBBox--}
+```
+public FontBBox getGlyphBBox()
+```
+
+
+Liest das Glyph‑BBox.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox
+### getLeftSidebearingX() {#getLeftSidebearingX--}
+```
+public double getLeftSidebearingX()
+```
+
+
+Ermittelt die Glyph‑Seitenlage x‑Koordinate.
+
+**Returns:**
+double - Glyph‑Seitenlage x‑Koordinate.
+### getLeftSidebearingY() {#getLeftSidebearingY--}
+```
+public double getLeftSidebearingY()
+```
+
+
+Ermittelt die Glyph‑Seitenlage y‑Koordinate.
+
+**Returns:**
+double - Glyph‑Seitenlage y‑Koordinate.
+### getPath() {#getPath--}
+```
+public SegmentPath getPath()
+```
+
+
+Ermittelt den Glyph‑Pfad.
+
+**Returns:**
+[SegmentPath](../../com.aspose.font/segmentpath) - Glyph path.
+### getSourceResolution() {#getSourceResolution--}
+```
+public int getSourceResolution()
+```
+
+
+Ermittelt die Auflösung des Quellbefehlsatzes.
+
+**Returns:**
+int - Auflösung des Quellbefehlsatzes.
+### getState() {#getState--}
+```
+public GlyphState getState()
+```
+
+
+Ermittelt den Glyph‑Zustand.
+
+**Returns:**
+[GlyphState](../../com.aspose.font/glyphstate) - Glyph state.
+### getWidthVectorX() {#getWidthVectorX--}
+```
+public double getWidthVectorX()
+```
+
+
+Ermittelt den Glyph‑Breitenvektor. Koordinate x.
+
+**Returns:**
+double - Glyph‑Breitenvektor. Koordinate x.
+### getWidthVectorY() {#getWidthVectorY--}
+```
+public double getWidthVectorY()
+```
+
+
+Ermittelt den Glyph‑Breitenvektor. Koordinate y.
+
+**Returns:**
+double - Glyph‑Breitenvektor. Koordinate y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+Wahr, wenn das Glyph keine Zeichenanweisungen enthält.
+
+**Returns:**
+boolean - Wahr, wenn das Glyph keine Zeichenanweisungen enthält.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/compositeglyphcomponent/_index.md
+++ b/german/java/com.aspose.font/compositeglyphcomponent/_index.md
@@ -1,0 +1,146 @@
+---
+title: "CompositeGlyphComponent"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt ein zusammengesetztes Glyph-Komponenten-Glyph mit Platzierungsmatrix dar."
+type: docs
+weight: 26
+url: /de/java/com.aspose.font/compositeglyphcomponent/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class CompositeGlyphComponent
+```
+
+Stellt ein zusammengesetztes Glyph-Komponente dar (Glyph mit Platzierungs-Matrix).
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGlyph()](#getGlyph--) | Liest das Komponenten-Glyph. |
+| [getMatrix()](#getMatrix--) | Liest die Transformationsmatrix der Komponente. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyph() {#getGlyph--}
+```
+public Glyph getGlyph()
+```
+
+
+Liest das Komponenten-Glyph.
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - The component glyph.
+### getMatrix() {#getMatrix--}
+```
+public TransformationMatrix getMatrix()
+```
+
+
+Liest die Transformationsmatrix der Komponente.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - The component transformation matrix.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/compositeglyphcomponentlist/_index.md
+++ b/german/java/com.aspose.font/compositeglyphcomponentlist/_index.md
@@ -1,0 +1,565 @@
+---
+title: "CompositeGlyphComponentList"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Liste von zusammengesetzten Glyph-Komponenten dar."
+type: docs
+weight: 27
+url: /de/java/com.aspose.font/compositeglyphcomponentlist/
+---
+**Inheritance:**
+java.lang.Object, java.util.AbstractCollection, java.util.AbstractList, java.util.ArrayList
+```
+public class CompositeGlyphComponentList extends ArrayList<CompositeGlyphComponent>
+```
+
+Stellt eine Liste von zusammengesetzten Glyph-Komponenten dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>toArray(T[] arg0)](#-T-toArray-T---) |  |
+| [add(E arg0)](#add-E-) |  |
+| [add(int arg0, E arg1)](#add-int-E-) |  |
+| [addAll(int arg0, Collection<? extends E> arg1)](#addAll-int-java.util.Collection---extends-E--) |  |
+| [addAll(Collection<? extends E> arg0)](#addAll-java.util.Collection---extends-E--) |  |
+| [clear()](#clear--) |  |
+| [clone()](#clone--) |  |
+| [contains(Object arg0)](#contains-java.lang.Object-) |  |
+| [containsAll(Collection<?> arg0)](#containsAll-java.util.Collection----) |  |
+| [ensureCapacity(int arg0)](#ensureCapacity-int-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [forEach(Consumer<? super E> arg0)](#forEach-java.util.function.Consumer---super-E--) |  |
+| [get(int arg0)](#get-int-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object arg0)](#indexOf-java.lang.Object-) |  |
+| [isEmpty()](#isEmpty--) |  |
+| [iterator()](#iterator--) |  |
+| [lastIndexOf(Object arg0)](#lastIndexOf-java.lang.Object-) |  |
+| [listIterator()](#listIterator--) |  |
+| [listIterator(int arg0)](#listIterator-int-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(int arg0)](#remove-int-) |  |
+| [remove(Object arg0)](#remove-java.lang.Object-) |  |
+| [removeAll(Collection<?> arg0)](#removeAll-java.util.Collection----) |  |
+| [removeIf(Predicate<? super E> arg0)](#removeIf-java.util.function.Predicate---super-E--) |  |
+| [replaceAll(UnaryOperator<E> arg0)](#replaceAll-java.util.function.UnaryOperator-E--) |  |
+| [retainAll(Collection<?> arg0)](#retainAll-java.util.Collection----) |  |
+| [set(int arg0, E arg1)](#set-int-E-) |  |
+| [size()](#size--) |  |
+| [sort(Comparator<? super E> arg0)](#sort-java.util.Comparator---super-E--) |  |
+| [spliterator()](#spliterator--) |  |
+| [subList(int arg0, int arg1)](#subList-int-int-) |  |
+| [toArray()](#toArray--) |  |
+| [toString()](#toString--) |  |
+| [trimToSize()](#trimToSize--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>toArray(T[] arg0) {#-T-toArray-T---}
+```
+public T[] <T>toArray(T[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | T[] |  |
+
+**Returns:**
+T[]
+### add(E arg0) {#add-E-}
+```
+public boolean add(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+boolean
+### add(int arg0, E arg1) {#add-int-E-}
+```
+public void add(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+### addAll(int arg0, Collection<? extends E> arg1) {#addAll-int-java.util.Collection---extends-E--}
+```
+public boolean addAll(int arg0, Collection<? extends E> arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### addAll(Collection<? extends E> arg0) {#addAll-java.util.Collection---extends-E--}
+```
+public boolean addAll(Collection<? extends E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### contains(Object arg0) {#contains-java.lang.Object-}
+```
+public boolean contains(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### containsAll(Collection<?> arg0) {#containsAll-java.util.Collection----}
+```
+public boolean containsAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### ensureCapacity(int arg0) {#ensureCapacity-int-}
+```
+public void ensureCapacity(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### forEach(Consumer<? super E> arg0) {#forEach-java.util.function.Consumer---super-E--}
+```
+public void forEach(Consumer<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.function.Consumer<? super E> |  |
+
+### get(int arg0) {#get-int-}
+```
+public E get(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object arg0) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public Iterator<E> iterator()
+```
+
+
+
+
+**Returns:**
+java.util.Iterator<E>
+### lastIndexOf(Object arg0) {#lastIndexOf-java.lang.Object-}
+```
+public int lastIndexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### listIterator() {#listIterator--}
+```
+public ListIterator<E> listIterator()
+```
+
+
+
+
+**Returns:**
+java.util.ListIterator<E>
+### listIterator(int arg0) {#listIterator-int-}
+```
+public ListIterator<E> listIterator(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+java.util.ListIterator<E>
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(int arg0) {#remove-int-}
+```
+public E remove(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### remove(Object arg0) {#remove-java.lang.Object-}
+```
+public boolean remove(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### removeAll(Collection<?> arg0) {#removeAll-java.util.Collection----}
+```
+public boolean removeAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### removeIf(Predicate<? super E> arg0) {#removeIf-java.util.function.Predicate---super-E--}
+```
+public boolean removeIf(Predicate<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.function.Predicate<? super E> |  |
+
+**Returns:**
+boolean
+### replaceAll(UnaryOperator<E> arg0) {#replaceAll-java.util.function.UnaryOperator-E--}
+```
+public void replaceAll(UnaryOperator<E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.function.UnaryOperator<E> |  |
+
+### retainAll(Collection<?> arg0) {#retainAll-java.util.Collection----}
+```
+public boolean retainAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### set(int arg0, E arg1) {#set-int-E-}
+```
+public E set(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+**Returns:**
+E
+### size() {#size--}
+```
+public int size()
+```
+
+
+
+
+**Returns:**
+int
+### sort(Comparator<? super E> arg0) {#sort-java.util.Comparator---super-E--}
+```
+public void sort(Comparator<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.Comparator<? super E> |  |
+
+### spliterator() {#spliterator--}
+```
+public Spliterator<E> spliterator()
+```
+
+
+
+
+**Returns:**
+java.util.Spliterator<E>
+### subList(int arg0, int arg1) {#subList-int-int-}
+```
+public List<E> subList(int arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | int |  |
+
+**Returns:**
+java.util.List<E>
+### toArray() {#toArray--}
+```
+public Object[] toArray()
+```
+
+
+
+
+**Returns:**
+java.lang.Object[]
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### trimToSize() {#trimToSize--}
+```
+public void trimToSize()
+```
+
+
+
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/compressionutils/_index.md
+++ b/german/java/com.aspose.font/compressionutils/_index.md
@@ -1,0 +1,168 @@
+---
+title: "CompressionUtils"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Bietet Hilfsmethoden für Kompression und Dekompression."
+type: docs
+weight: 28
+url: /de/java/com.aspose.font/compressionutils/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class CompressionUtils
+```
+
+Bietet Hilfsmethoden für Kompression und Dekompression.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [CompressionUtils()](#CompressionUtils--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [decodeByBrotli(byte[] input)](#decodeByBrotli-byte---) | Dekomprimiert das angegebene Brotli-komprimierte Byte-Array. |
+| [encodeByBrotli(byte[] buff, int buffLength)](#encodeByBrotli-byte---int-) | Komprimiert das angegebene Byte-Array mit dem Brotli-Algorithmus. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CompressionUtils() {#CompressionUtils--}
+```
+public CompressionUtils()
+```
+
+
+### decodeByBrotli(byte[] input) {#decodeByBrotli-byte---}
+```
+public static byte[] decodeByBrotli(byte[] input)
+```
+
+
+Dekomprimiert das angegebene Brotli-komprimierte Byte-Array.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Eingabe | byte[] | Die komprimierten Daten. |
+
+**Returns:**
+byte[] - Das dekomprimierte Byte-Array.
+### encodeByBrotli(byte[] buff, int buffLength) {#encodeByBrotli-byte---int-}
+```
+public static byte[] encodeByBrotli(byte[] buff, int buffLength)
+```
+
+
+Komprimiert das angegebene Byte-Array mit dem Brotli-Algorithmus.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| buff | byte[] | Der Eingabepuffer zum Komprimieren. |
+| buffLength | int | Die Länge der zu komprimierenden Daten. |
+
+**Returns:**
+byte[] - Das komprimierte Byte-Array.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/curveto/_index.md
+++ b/german/java/com.aspose.font/curveto/_index.md
@@ -1,0 +1,244 @@
+---
+title: "CurveTo"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die CurveTo-Operation dar."
+type: docs
+weight: 29
+url: /de/java/com.aspose.font/curveto/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IPathSegment](../../com.aspose.font/ipathsegment)
+```
+public class CurveTo implements IPathSegment
+```
+
+Stellt die CurveTo-Operation dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clone()](#clone--) | Erstellt ein neues Objekt, das eine Kopie der aktuellen Instanz ist. |
+| [copy()](#copy--) | Erstellt eine Kopie des Segmentobjekts. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getX1()](#getX1--) | Liefert Koordinate x1. |
+| [getX2()](#getX2--) | Liefert Koordinate x2. |
+| [getX3()](#getX3--) | Liefert Koordinate x3. |
+| [getY1()](#getY1--) | Liefert Koordinate y1. |
+| [getY2()](#getY2--) | Liefert Koordinate y2. |
+| [getY3()](#getY3--) | Ruft die Koordinate y3 ab. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [shift(double dx, double dy)](#shift-double-double-) | Führt Verschiebung um x- und y-Koordinaten durch. |
+| [toString()](#toString--) |  |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Transformiert Koordinaten mit der Transformationsmatrix. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Erstellt ein neues Objekt, das eine Kopie der aktuellen Instanz ist.
+
+**Returns:**
+java.lang.Object – Ein neues Objekt, das eine Kopie dieser Instanz ist.
+### copy() {#copy--}
+```
+public IPathSegment copy()
+```
+
+
+Erstellt eine Kopie des Segmentobjekts.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getX1() {#getX1--}
+```
+public double getX1()
+```
+
+
+Liefert Koordinate x1.
+
+**Returns:**
+double – Koordinate x1.
+### getX2() {#getX2--}
+```
+public double getX2()
+```
+
+
+Liefert Koordinate x2.
+
+**Returns:**
+double – Koordinate x2.
+### getX3() {#getX3--}
+```
+public double getX3()
+```
+
+
+Liefert Koordinate x3.
+
+**Returns:**
+double – Koordinate x3.
+### getY1() {#getY1--}
+```
+public double getY1()
+```
+
+
+Liefert Koordinate y1.
+
+**Returns:**
+double – Koordinate y1.
+### getY2() {#getY2--}
+```
+public double getY2()
+```
+
+
+Liefert Koordinate y2.
+
+**Returns:**
+double – Koordinate y2.
+### getY3() {#getY3--}
+```
+public double getY3()
+```
+
+
+Ruft die Koordinate y3 ab.
+
+**Returns:**
+double – Koordinate y3.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public void shift(double dx, double dy)
+```
+
+
+Führt Verschiebung um x- und y-Koordinaten durch.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| dx | double | Wert dx. |
+| dy | double | Wert dy. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public void transform(TransformationMatrix matrix)
+```
+
+
+Transformiert Koordinaten mit der Transformationsmatrix.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Transformationsmatrix. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/encodingexception/_index.md
+++ b/german/java/com.aspose.font/encodingexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "EncodingException"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Kodierungs-Ausnahme dar."
+type: docs
+weight: 30
+url: /de/java/com.aspose.font/encodingexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class EncodingException extends FontException
+```
+
+Stellt eine Kodierungsausnahme dar. Die Ausnahme kann ausgelöst werden, wenn ein Problem mit der Kodierung/Dekodierung von Text auftritt.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [EncodingException()](#EncodingException--) | Initialisiert ein neues  EncodingException  Objekt. |
+| [EncodingException(String message)](#EncodingException-java.lang.String-) | Initialisiert ein neues  EncodingException  Objekt. |
+| [EncodingException(String message, RuntimeException innerException)](#EncodingException-java.lang.String-java.lang.RuntimeException-) | Initialisiert ein neues  EncodingException  Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EncodingException() {#EncodingException--}
+```
+public EncodingException()
+```
+
+
+Initialisiert ein neues  EncodingException  Objekt.
+
+### EncodingException(String message) {#EncodingException-java.lang.String-}
+```
+public EncodingException(String message)
+```
+
+
+Initialisiert ein neues  EncodingException  Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+
+### EncodingException(String message, RuntimeException innerException) {#EncodingException-java.lang.String-java.lang.RuntimeException-}
+```
+public EncodingException(String message, RuntimeException innerException)
+```
+
+
+Initialisiert ein neues  EncodingException  Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+| innerException | java.lang.RuntimeException | Die Ausnahme, die die aktuelle Ausnahme verursacht. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/filesystemstreamsource/_index.md
+++ b/german/java/com.aspose.font/filesystemstreamsource/_index.md
@@ -1,0 +1,225 @@
+---
+title: "FileSystemStreamSource"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Stream-Quelle basierend auf dem Dateisystem dar."
+type: docs
+weight: 31
+url: /de/java/com.aspose.font/filesystemstreamsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.StreamSource](../../com.aspose.font/streamsource)
+```
+public class FileSystemStreamSource extends StreamSource
+```
+
+Stellt eine Stream-Quelle basierend auf dem Dateisystem dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FileSystemStreamSource(String fileName)](#FileSystemStreamSource-java.lang.String-) | Initialisiert ein neues FileSystemStreamSource-Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Klont das FileSystemStreamSource-Objekt. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileName()](#getFileName--) | Liefert den Dateinamen. |
+| [getFontStream()](#getFontStream--) | Gibt den Font-Dateistream zurück. |
+| [getOffset()](#getOffset--) | Liefert den Offset innerhalb der Quelle. |
+| [hashCode()](#hashCode--) |  |
+| [mustCloseAfterUse()](#mustCloseAfterUse--) | Die Erben können verhindern, dass der Stream geschlossen wird. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFileName(String value)](#setFileName-java.lang.String-) | Setzt den Dateinamen. |
+| [setOffset(long value)](#setOffset-long-) | Setzt den Offset innerhalb der Quelle. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileSystemStreamSource(String fileName) {#FileSystemStreamSource-java.lang.String-}
+```
+public FileSystemStreamSource(String fileName)
+```
+
+
+Initialisiert ein neues FileSystemStreamSource-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fileName | java.lang.String | Dateiname. |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Klont das FileSystemStreamSource-Objekt.
+
+**Returns:**
+java.lang.Object – Kopie des FileSystemStreamSource-Objekts.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Liefert den Dateinamen.
+
+**Returns:**
+java.lang.String - Dateiname.
+### getFontStream() {#getFontStream--}
+```
+public InputStream getFontStream()
+```
+
+
+Gibt den Font-Dateistream zurück. Vergessen Sie nicht, den Stream nach der Verwendung zu schließen.
+
+**Returns:**
+java.io.InputStream - Font-Dateistream.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset innerhalb der Quelle.
+
+**Returns:**
+long - Offset innerhalb der Quelle.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### mustCloseAfterUse() {#mustCloseAfterUse--}
+```
+public boolean mustCloseAfterUse()
+```
+
+
+Die Erben können verhindern, dass der Stream geschlossen wird. Gibt true zurück, wenn die StreamSource den Stream nach der Verwendung schließen möchte. Andernfalls wird false zurückgegeben.
+
+**Returns:**
+boolean - true, wenn die StreamSource den Stream nach der Verwendung schließen möchte, sonst false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFileName(String value) {#setFileName-java.lang.String-}
+```
+public void setFileName(String value)
+```
+
+
+Setzt den Dateinamen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Dateiname. |
+
+### setOffset(long value) {#setOffset-long-}
+```
+public void setOffset(long value)
+```
+
+
+Setzt den Offset innerhalb der Quelle.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long | Offset innerhalb der Quelle. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/font/_index.md
+++ b/german/java/com.aspose.font/font/_index.md
@@ -1,0 +1,526 @@
+---
+title: "Schriftart"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Basisklasse Font dar."
+type: docs
+weight: 32
+url: /de/java/com.aspose.font/font/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFont](../../com.aspose.font/ifont), [com.aspose.font.IGlyphAccessor](../../com.aspose.font/iglyphaccessor), [com.aspose.font.IFontSaver](../../com.aspose.font/ifontsaver)
+```
+public abstract class Font implements IFont, IGlyphAccessor, IFontSaver
+```
+
+Stellt die Basisklasse Font dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Konvertiert die Font in ein anderes Format. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Gibt alle Glyphen-IDs zurück, die in der Schrift verfügbar sind. |
+| [getClass()](#getClass--) |  |
+| [getEncoding()](#getEncoding--) | Liefert Font‑Kodierung. |
+| [getFontDefinition()](#getFontDefinition--) | Liefert Font‑Definition. |
+| [getFontFamily()](#getFontFamily--) | Liefert Font‑Familie. |
+| [getFontName()](#getFontName--) | Liefert Font‑Face‑Name. |
+| [getFontNames()](#getFontNames--) | Liefert Font‑Namen. |
+| [getFontSaver()](#getFontSaver--) | Liefert Font‑Speicherfunktionalität. |
+| [getFontStyle()](#getFontStyle--) | Liefert Font‑Stil. |
+| [getFontType()](#getFontType--) | Liefert Font‑Typ. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Font‑Glyph‑Zugriff. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Gibt das Glyph anhand der Glyph‑ID zurück. |
+| [getGlyphIdType()](#getGlyphIdType--) | Glyph id Typenspezifikation. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Liest Glyphenrepräsentation für Text. |
+| [getMetrics()](#getMetrics--) | Liefert Font‑Metriken. |
+| [getNumGlyphs()](#getNumGlyphs--) | Ermittelt die Anzahl der Glyphen im Font. |
+| [getPostscriptNames()](#getPostscriptNames--) | Ermittelt PostScript-Schriftartenamen. |
+| [getStyle()](#getStyle--) | Liefert Font‑Stil. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Öffnet einen Font mithilfe eines FontDefinition-Objekts. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Öffnet einen Font mithilfe des Font-Typs und eines Byte-Arrays mit Font-Daten. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Öffnet einen Font mithilfe des Font-Typs und einer Stream-Quelle. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Öffnet einen Font mithilfe des Font-Typs und des Font-Dateinamens. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Speichert den Font im Originalformat. |
+| [save(String fileName)](#save-java.lang.String-) | Speichert den Font im Originalformat. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Speichert den Font im angegebenen Format. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Setzt die Font-Familie. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Setzt den Font-Face-Namen. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Setzt den Font-Stil. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public abstract Font convert(FontType fontType)
+```
+
+
+Konvertiert die Font in ein anderes Format.
+
+--------------------
+
+> ```
+> Note: TTF Font type is now supported only.
+> ```
+
+fontType Schriftformattyp, in den konvertiert werden soll.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) |  |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public abstract GlyphId[] getAllGlyphIds()
+```
+
+
+Gibt alle Glyphen-IDs zurück, die in der Schrift verfügbar sind. Eine Glyphen-ID ist eine eindeutige Nummer für eine Glyphe, die vom Schriftarttyp abhängt. Zum Beispiel: Die ID von Type1 ist ein Glyphenname, eine Instanz der Klasse ( GlyphStringId ). Die ID von TTF ist ein int-Index, eine Instanz der Klasse ( GlyphInt32Id ).
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyph‑Bezeichner.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncoding() {#getEncoding--}
+```
+public abstract IFontEncoding getEncoding()
+```
+
+
+Liefert Font‑Kodierung.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public abstract FontDefinition getFontDefinition()
+```
+
+
+Liefert Font‑Definition.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public abstract String getFontFamily()
+```
+
+
+Liefert Font‑Familie.
+
+**Returns:**
+java.lang.String - Font‑Familie.
+### getFontName() {#getFontName--}
+```
+public abstract String getFontName()
+```
+
+
+Liefert Font‑Face‑Name.
+
+**Returns:**
+java.lang.String - Font‑Face‑Name.
+### getFontNames() {#getFontNames--}
+```
+public abstract MultiLanguageString getFontNames()
+```
+
+
+Liefert Font‑Namen.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Liefert Font‑Speicherfunktionalität.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public abstract int getFontStyle()
+```
+
+
+Ermittelt den Font-Stil. Dies ist ein Wert, der berechnet und in einem generalisierten Typ dargestellt wird.
+
+**Returns:**
+int - Font-Stil. In der Regel eine Kombination von Konstanten‑Flag‑Werten der FontStyle‑Klasse oder 0.
+### getFontType() {#getFontType--}
+```
+public abstract FontType getFontType()
+```
+
+
+Liefert Font‑Typ.
+
+--------------------
+
+> ```
+> Type1, TrueType etc.
+> ```
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Schriftzeichen-Glyph-Zugriff. Ruft Glyphs und Glyph-Identifikatoren ab.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public abstract Glyph getGlyphById(GlyphId id)
+```
+
+
+Gibt die Glyphe anhand ihrer Glyphen-ID zurück. Eine Glyphen-ID ist eine eindeutige Nummer für eine Glyphe, die vom Schriftarttyp abhängt. GlyphId – abgeleitetes Objekt. Zum Beispiel: Die ID von Type1 ist ein Glyphenname, eine Instanz der Klasse ( GlyphStringId ). Die ID von TTF ist ein int-Index, eine Instanz der Klasse ( GlyphInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | Glyph-ID. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public abstract GlyphIdType getGlyphIdType()
+```
+
+
+Spezifikation des Glyphen-ID-Typs. Für Verbraucher, die den tatsächlichen Typ von 'bytes[]' kennen müssen.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype) - Id type specification
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Liest Glyphenrepräsentation für Text.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| text | java.lang.String | Eingabetext. |
+
+**Returns:**
+com.aspose.font.GlyphId[] – GlyphId-Array.
+### getMetrics() {#getMetrics--}
+```
+public abstract IFontMetrics getMetrics()
+```
+
+
+Liefert Font‑Metriken.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public abstract int getNumGlyphs()
+```
+
+
+Ermittelt die Anzahl der Glyphen im Font.
+
+**Returns:**
+int – Anzahl der Glyphs in der Schrift.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public abstract MultiLanguageString getPostscriptNames()
+```
+
+
+Ermittelt PostScript-Schriftartenamen.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript font names.
+### getStyle() {#getStyle--}
+```
+public abstract String getStyle()
+```
+
+
+Ermittelt den Schriftstil. Dies ist ein Roh-String-Wert, der von der Schriftdatei bereitgestellt wird.
+
+**Returns:**
+java.lang.String – Schriftstil.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Öffnet einen Font mithilfe eines FontDefinition-Objekts.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Schriftdefinitions-Objekt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und eines Byte-Arrays mit Font-Daten.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fontData | byte[] | Byte-Array, aus dem die Schrift geladen wird. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und einer Stream-Quelle.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Stream-Quelle für die Schrift. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und des Font-Dateinamens.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fileName | java.lang.String | Schriftdateiname. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Speichert den Font im Originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Stream zum Speichern der Schrift. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Speichert den Font im Originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fileName | java.lang.String | Datei zum Speichern der Schrift. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Speichert den Font im angegebenen Format.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Stream zum Speichern der Schrift |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | gewünschtes Format |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public abstract void setFontFamily(String value)
+```
+
+
+Setzt die Font-Familie.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Neue Schriftfamilie. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public abstract void setFontName(String value)
+```
+
+
+Setzt den Font-Face-Namen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Neuer Schriftartname. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public abstract void setStyle(String value)
+```
+
+
+Setzt Schriftstil. Dies ist ein Rohzeichenfolgenwert, der von der Schriftdatei bereitgestellt wird.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Neuer Schriftstil. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fontagrumentexception/_index.md
+++ b/german/java/com.aspose.font/fontagrumentexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontAgrumentException"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Font-Argumentausnahme dar."
+type: docs
+weight: 33
+url: /de/java/com.aspose.font/fontagrumentexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontAgrumentException extends FontException
+```
+
+Stellt die Font argument exception dar. Die Ausnahme kann ausgelöst werden, falls falsche Argumentverwendungen vorliegen.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FontAgrumentException()](#FontAgrumentException--) | Initialisiert ein neues FontAgrumentException-Objekt. |
+| [FontAgrumentException(String message)](#FontAgrumentException-java.lang.String-) | Initialisiert ein neues FontAgrumentException-Objekt. |
+| [FontAgrumentException(String message, RuntimeException innerException)](#FontAgrumentException-java.lang.String-java.lang.RuntimeException-) | Initialisiert ein neues FontAgrumentException-Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontAgrumentException() {#FontAgrumentException--}
+```
+public FontAgrumentException()
+```
+
+
+Initialisiert ein neues FontAgrumentException-Objekt.
+
+### FontAgrumentException(String message) {#FontAgrumentException-java.lang.String-}
+```
+public FontAgrumentException(String message)
+```
+
+
+Initialisiert ein neues FontAgrumentException-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+
+### FontAgrumentException(String message, RuntimeException innerException) {#FontAgrumentException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontAgrumentException(String message, RuntimeException innerException)
+```
+
+
+Initialisiert ein neues FontAgrumentException-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+| innerException | java.lang.RuntimeException | Die Ausnahme, die die aktuelle Ausnahme verursacht. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fontbbox/_index.md
+++ b/german/java/com.aspose.font/fontbbox/_index.md
@@ -1,0 +1,168 @@
+---
+title: "FontBBox"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Begrenzungsbox der Schriftart dar."
+type: docs
+weight: 34
+url: /de/java/com.aspose.font/fontbbox/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontBBox
+```
+
+Stellt die Begrenzungsbox der Schriftart dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getXMax()](#getXMax--) | Liefert den XMax-Wert. |
+| [getXMin()](#getXMin--) | Liest XMin-Wert. |
+| [getYMax()](#getYMax--) | Liest YMax-Wert. |
+| [getYMin()](#getYMin--) | Liest YMin-Wert. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getXMax() {#getXMax--}
+```
+public double getXMax()
+```
+
+
+Liefert den XMax-Wert.
+
+**Returns:**
+double - XMax-Wert.
+### getXMin() {#getXMin--}
+```
+public double getXMin()
+```
+
+
+Liest XMin-Wert.
+
+**Returns:**
+double - XMin-Wert.
+### getYMax() {#getYMax--}
+```
+public double getYMax()
+```
+
+
+Liest YMax-Wert.
+
+**Returns:**
+double - YMax-Wert.
+### getYMin() {#getYMin--}
+```
+public double getYMin()
+```
+
+
+Liest YMin-Wert.
+
+**Returns:**
+double - YMin-Wert.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fontcharactersmerger/_index.md
+++ b/german/java/com.aspose.font/fontcharactersmerger/_index.md
@@ -1,0 +1,200 @@
+---
+title: "FontCharactersMerger"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Deklariert Funktionalität zum Zusammenführen von Schriftarten verschiedener Typen."
+type: docs
+weight: 35
+url: /de/java/com.aspose.font/fontcharactersmerger/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class FontCharactersMerger
+```
+
+Deklariert die Funktionalität zum Zusammenführen von Schriften verschiedener Typen. Ein Schriftpaar wird für den Merge‑Vorgang benötigt. Eine Schrift dieses Paares wird als primär betrachtet. Das bedeutet, dass viele Eigenschaften der endgültig zusammengeführten Schrift, wie Metriken, Kodierungsstruktur und weitere, von dieser primären Schrift übernommen werden. Die andere Schrift dieses Paares (sekundär) liefert nur Glyphen für die endgültig zusammengeführte Schrift.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPrimaryFont()](#getPrimaryFont--) | Liest die primäre Schrift. |
+| [getSecondaryFont()](#getSecondaryFont--) | Erhält sekundäre Schriftart. |
+| [hashCode()](#hashCode--) |  |
+| [mergeFonts(GlyphId[] primaryFontGlyphs, GlyphId[] secondaryFontGlyphs, String newFontName)](#mergeFonts-com.aspose.font.GlyphId---com.aspose.font.GlyphId---java.lang.String-) | Führt Schriftarten basierend auf übergebenen Glyphenlisten zusammen. |
+| [mergeFonts(int[] primaryFontCharCodes, int[] secondaryFontCharCodes, String newFontName)](#mergeFonts-int---int---java.lang.String-) | Führt Schriftarten basierend auf übergebenen Zeichenkodierungslisten zusammen. |
+| [mergeFonts(Map<Integer,GlyphId> primaryFontDict, Map<Integer,GlyphId> secondaryFontDict, String newFontName)](#mergeFonts-java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.lang.String-) | Diese Methodenvariante ist für Fälle gedacht, in denen Sie Zeichencodes für Glyphen in der resultierenden Schriftart explizit festlegen möchten. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPrimaryFont() {#getPrimaryFont--}
+```
+public abstract Font getPrimaryFont()
+```
+
+
+Liest die primäre Schrift.
+
+**Returns:**
+[Font](../../com.aspose.font/font) - The primary font.
+### getSecondaryFont() {#getSecondaryFont--}
+```
+public abstract Font getSecondaryFont()
+```
+
+
+Erhält sekundäre Schriftart.
+
+**Returns:**
+[Font](../../com.aspose.font/font) - The secondary font.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### mergeFonts(GlyphId[] primaryFontGlyphs, GlyphId[] secondaryFontGlyphs, String newFontName) {#mergeFonts-com.aspose.font.GlyphId---com.aspose.font.GlyphId---java.lang.String-}
+```
+public abstract Font mergeFonts(GlyphId[] primaryFontGlyphs, GlyphId[] secondaryFontGlyphs, String newFontName)
+```
+
+
+Führt Schriftarten basierend auf übergebenen Glyphenlisten zusammen. Sucht für jede übergebene Glyphe nach einem Zeichencode und fügt den gefundenen Zeichencode mit der entsprechenden Glyphe in die neue resultierende Schriftart ein.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| primaryFontGlyphs | [GlyphId\[\]](../../com.aspose.font/glyphid) | Liste der Glyphen, die aus der primären Schriftart übernommen werden sollen. |
+| secondaryFontGlyphs | [GlyphId\[\]](../../com.aspose.font/glyphid) | Liste der Glyphen, die aus der sekundären Schriftart übernommen werden sollen. |
+| newFontName | java.lang.String | Gewünschter Name für die resultierende Schriftart. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Merged font
+### mergeFonts(int[] primaryFontCharCodes, int[] secondaryFontCharCodes, String newFontName) {#mergeFonts-int---int---java.lang.String-}
+```
+public abstract Font mergeFonts(int[] primaryFontCharCodes, int[] secondaryFontCharCodes, String newFontName)
+```
+
+
+Führt Schriftarten basierend auf übergebenen Zeichenkodierungslisten zusammen. Um die gewünschte resultierende Schriftart zu erstellen, übergeben Sie einfach die Symbolcodes aus den Originalschriftarten, die Sie in die resultierende Schriftart aufnehmen möchten. Glyphen, die zu den übergebenen Codes gehören, werden automatisch gefunden. Beispiel: Wenn Sie Glyphen für die Buchstaben A und B aus der ersten Schriftart und Glyphen für die Buchstaben C und D aus der zweiten Schriftart einbeziehen möchten, rufen Sie diese Methode wie folgt auf: `mergeFonts(new uint[] { 'A', 'B' }, new uint[] { 'C', 'D' }, "NewFont")`
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| primaryFontCharCodes | int[] | Codes, die aus der primären Schriftart übernommen werden sollen. |
+| secondaryFontCharCodes | int[] | Codes, die aus der sekundären Schriftart übernommen werden sollen. |
+| newFontName | java.lang.String | Gewünschter Name für die resultierende Schriftart. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Merged font.
+### mergeFonts(Map<Integer,GlyphId> primaryFontDict, Map<Integer,GlyphId> secondaryFontDict, String newFontName) {#mergeFonts-java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.lang.String-}
+```
+public abstract Font mergeFonts(Map<Integer,GlyphId> primaryFontDict, Map<Integer,GlyphId> secondaryFontDict, String newFontName)
+```
+
+
+Diese Methodenvariante ist für Fälle gedacht, in denen Sie Zeichencodes für Glyphen in der resultierenden Schriftart explizit festlegen möchten. Es ist nicht zwingend erforderlich, dass der für die bereitgestellte Glyphe angegebene Code in der Originalschriftart enthalten ist. Der Zweck des übergebenen Codes besteht darin, ihn mit dem entsprechenden Glyphen‑Identifikator in der resultierenden Schriftart zu verknüpfen. Daher lautet die Regel zur Verarbeitung jedes Paars, das über den Wörterbuchparameter [code, glyph identifier] übergeben wird: Es wird nur der Glyphen‑Identifikator aus der Originalschriftart genommen und anschließend mit dem entsprechenden Code in der resultierenden Schriftart verknüpft. Dies kann hilfreich sein, wenn einige Codes der ersten Schriftart mit denselben Codes der zweiten Schriftart kollidieren.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| primaryFontDict | java.util.Map<java.lang.Integer,com.aspose.font.GlyphId> | Wörterbuch mit Paaren [symbol code, glyph identifier] aus der primären Schriftart. |
+| secondaryFontDict | java.util.Map<java.lang.Integer,com.aspose.font.GlyphId> | Wörterbuch mit Paaren [symbol code, glyph identifier] aus der sekundären Schriftart. |
+| newFontName | java.lang.String | Gewünschter Name für die resultierende Schriftart. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Merged font.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fontconversionexception/_index.md
+++ b/german/java/com.aspose.font/fontconversionexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontConversionException"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Font-Konvertierungs-Ausnahme dar."
+type: docs
+weight: 36
+url: /de/java/com.aspose.font/fontconversionexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontConversionException extends FontException
+```
+
+Stellt eine Font-Konvertierungsausnahme dar. Die Ausnahme kann im Falle von Fehlern während des Font-Konvertierungsprozesses ausgelöst werden.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FontConversionException()](#FontConversionException--) | Initialisiert ein neues  FontConversionException  Objekt. |
+| [FontConversionException(String message)](#FontConversionException-java.lang.String-) | Initialisiert ein neues  FontConversionException  Objekt. |
+| [FontConversionException(String message, RuntimeException innerException)](#FontConversionException-java.lang.String-java.lang.RuntimeException-) | Initialisiert ein neues  FontConversionException  Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontConversionException() {#FontConversionException--}
+```
+public FontConversionException()
+```
+
+
+Initialisiert ein neues  FontConversionException  Objekt.
+
+### FontConversionException(String message) {#FontConversionException-java.lang.String-}
+```
+public FontConversionException(String message)
+```
+
+
+Initialisiert ein neues  FontConversionException  Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+
+### FontConversionException(String message, RuntimeException innerException) {#FontConversionException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontConversionException(String message, RuntimeException innerException)
+```
+
+
+Initialisiert ein neues  FontConversionException  Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+| innerException | java.lang.RuntimeException | Die Ausnahme, die die aktuelle Ausnahme verursacht. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fontcreationexception/_index.md
+++ b/german/java/com.aspose.font/fontcreationexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontCreationException"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Font-Erstellungs-Ausnahme dar."
+type: docs
+weight: 37
+url: /de/java/com.aspose.font/fontcreationexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontCreationException extends FontException
+```
+
+Stellt eine Font-Erstellungsausnahme dar. Die Ausnahme kann ausgelöst werden, falls Fehler während des Font-Erstellungsprozesses auftreten.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FontCreationException()](#FontCreationException--) | Initialisiert ein neues FontCreationException-Objekt. |
+| [FontCreationException(String message)](#FontCreationException-java.lang.String-) | Initialisiert ein neues FontCreationException-Objekt. |
+| [FontCreationException(String message, RuntimeException innerException)](#FontCreationException-java.lang.String-java.lang.RuntimeException-) | Initialisiert ein neues FontCreationException-Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontCreationException() {#FontCreationException--}
+```
+public FontCreationException()
+```
+
+
+Initialisiert ein neues FontCreationException-Objekt.
+
+### FontCreationException(String message) {#FontCreationException-java.lang.String-}
+```
+public FontCreationException(String message)
+```
+
+
+Initialisiert ein neues FontCreationException-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+
+### FontCreationException(String message, RuntimeException innerException) {#FontCreationException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontCreationException(String message, RuntimeException innerException)
+```
+
+
+Initialisiert ein neues FontCreationException-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+| innerException | java.lang.RuntimeException | Die Ausnahme, die die aktuelle Ausnahme verursacht. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fontdefinition/_index.md
+++ b/german/java/com.aspose.font/fontdefinition/_index.md
@@ -1,0 +1,390 @@
+---
+title: "FontDefinition"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Definition einer Font-Datei-Sammlung dar."
+type: docs
+weight: 38
+url: /de/java/com.aspose.font/fontdefinition/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontDefinition
+```
+
+Stellt die Definition eines Font-Dateisatzes dar. Diese Klasse enthält Felder, die nicht mit internen Font-Daten zusammenhängen. Diese Felder beschreiben die Font-Platzierung und weitere Daten, die zum Laden einer Font aus einer Font-Quelle (Datei, Speicher usw.) erforderlich sind.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FontDefinition(FontType fontType, String fileExtension, StreamSource streamSource)](#FontDefinition-com.aspose.font.FontType-java.lang.String-com.aspose.font.StreamSource-) | Erstellt eine Einzeldatei-Font-Definition. |
+| [FontDefinition(FontType fontType, StreamSource streamSource)](#FontDefinition-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Erstellt eine Einzeldatei-Font-Definition. |
+| [FontDefinition(String fontName, FontType fontType, String fileExtension, StreamSource streamSource)](#FontDefinition-java.lang.String-com.aspose.font.FontType-java.lang.String-com.aspose.font.StreamSource-) | Erstellt eine Einzeldatei-Font-Definition. |
+| [FontDefinition(FontType fontType, FontFileDefinition fileDefinition)](#FontDefinition-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-) | Erstellt eine Einzeldatei-Font-Definition. |
+| [FontDefinition(String fontName, FontType fontType, FontFileDefinition fileDefinition)](#FontDefinition-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-) | Erstellt eine Einzeldatei-Font-Definition. |
+| [FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition fileDefinition)](#FontDefinition-java.lang.String-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-) | Erstellt eine Einzeldatei-Font-Definition. |
+| [FontDefinition(FontType fontType, FontFileDefinition[] fileDefinitions)](#FontDefinition-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---) | Erstellt eine Mehrdatei-Font-Definition. |
+| [FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition[] fileDefinitions)](#FontDefinition-java.lang.String-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---) | Erstellt eine Mehrdatei-Font-Definition. |
+| [FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition fileDefinition)](#FontDefinition-com.aspose.font.MultiLanguageString-com.aspose.font.MultiLanguageString-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-) | Erstellt eine Mehrdatei-Font-Definition. |
+| [FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition[] fileDefinitions)](#FontDefinition-com.aspose.font.MultiLanguageString-com.aspose.font.MultiLanguageString-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---) | Erstellt eine Mehrdatei-Font-Definition. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileDefinitions()](#getFileDefinitions--) | Ruft die Sammlung von Dateidefinitionen ab. |
+| [getFontName()](#getFontName--) | Gibt den Font-Namen zurück. |
+| [getFontNames()](#getFontNames--) | Ruft Font-Namen als ein  MultiLanguageString  ab. |
+| [getFontType()](#getFontType--) | Liefert Font‑Typ. |
+| [getPostscriptName()](#getPostscriptName--) | Ruft den Postscript-Font-Namen ab. |
+| [getPostscriptNames()](#getPostscriptNames--) | Ruft Postscript-Font-Namen als ein  MultiLanguageString  ab. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(StreamSource source, FontType fontType)](#open-com.aspose.font.StreamSource-com.aspose.font.FontType-) | Gibt die FontDefinition für die Font-Stream-Quelle und den Font-Typ zurück. |
+| [open(String fileName, FontType fontType)](#open-java.lang.String-com.aspose.font.FontType-) | Gibt die FontDefinition für die Font-Datei und den Font-Typ zurück. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontDefinition(FontType fontType, String fileExtension, StreamSource streamSource) {#FontDefinition-com.aspose.font.FontType-java.lang.String-com.aspose.font.StreamSource-}
+```
+public FontDefinition(FontType fontType, String fileExtension, StreamSource streamSource)
+```
+
+
+Erstellt eine Einzeldatei-Font-Definition.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fileExtension | java.lang.String | Font-Dateierweiterung. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Font-Stream-Quelle. |
+
+### FontDefinition(FontType fontType, StreamSource streamSource) {#FontDefinition-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public FontDefinition(FontType fontType, StreamSource streamSource)
+```
+
+
+Erstellt eine Einzeldatei-Font-Definition.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Font-Stream-Quelle. |
+
+### FontDefinition(String fontName, FontType fontType, String fileExtension, StreamSource streamSource) {#FontDefinition-java.lang.String-com.aspose.font.FontType-java.lang.String-com.aspose.font.StreamSource-}
+```
+public FontDefinition(String fontName, FontType fontType, String fileExtension, StreamSource streamSource)
+```
+
+
+Erstellt eine Einzeldatei-Font-Definition.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontName | java.lang.String | Schriftartname. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fileExtension | java.lang.String | Font-Dateierweiterung. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Font-Stream-Quelle. |
+
+### FontDefinition(FontType fontType, FontFileDefinition fileDefinition) {#FontDefinition-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-}
+```
+public FontDefinition(FontType fontType, FontFileDefinition fileDefinition)
+```
+
+
+Erstellt eine Einzeldatei-Font-Definition.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fileDefinition | [FontFileDefinition](../../com.aspose.font/fontfiledefinition) | FontFileDefinition. |
+
+### FontDefinition(String fontName, FontType fontType, FontFileDefinition fileDefinition) {#FontDefinition-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-}
+```
+public FontDefinition(String fontName, FontType fontType, FontFileDefinition fileDefinition)
+```
+
+
+Erstellt eine Einzeldatei-Font-Definition.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontName | java.lang.String | Schriftartname. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fileDefinition | [FontFileDefinition](../../com.aspose.font/fontfiledefinition) | FontFileDefinition. |
+
+### FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition fileDefinition) {#FontDefinition-java.lang.String-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-}
+```
+public FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition fileDefinition)
+```
+
+
+Erstellt eine Einzeldatei-Font-Definition.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontName | java.lang.String | Schriftartname. |
+| postscriptName | java.lang.String | Postscript-Font-Name. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fileDefinition | [FontFileDefinition](../../com.aspose.font/fontfiledefinition) | FontFileDefinition. |
+
+### FontDefinition(FontType fontType, FontFileDefinition[] fileDefinitions) {#FontDefinition-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---}
+```
+public FontDefinition(FontType fontType, FontFileDefinition[] fileDefinitions)
+```
+
+
+Erstellt eine Mehrdatei-Font-Definition.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fileDefinitions | [FontFileDefinition\[\]](../../com.aspose.font/fontfiledefinition) | Array von FontFileDefinition-Objekten. |
+
+### FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition[] fileDefinitions) {#FontDefinition-java.lang.String-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---}
+```
+public FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition[] fileDefinitions)
+```
+
+
+Erstellt eine Mehrdatei-Font-Definition.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontName | java.lang.String | Schriftartname. |
+| postscriptName | java.lang.String | Postscript-Font-Name. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fileDefinitions | [FontFileDefinition\[\]](../../com.aspose.font/fontfiledefinition) | Array von FontFileDefinition-Objekten. |
+
+### FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition fileDefinition) {#FontDefinition-com.aspose.font.MultiLanguageString-com.aspose.font.MultiLanguageString-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-}
+```
+public FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition fileDefinition)
+```
+
+
+Erstellt eine Mehrdatei-Font-Definition.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Font-Namen. |
+| postscriptNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Postscript-Font-Namen. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fileDefinition | [FontFileDefinition](../../com.aspose.font/fontfiledefinition) | FontFileDefinition. |
+
+### FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition[] fileDefinitions) {#FontDefinition-com.aspose.font.MultiLanguageString-com.aspose.font.MultiLanguageString-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---}
+```
+public FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition[] fileDefinitions)
+```
+
+
+Erstellt eine Mehrdatei-Font-Definition.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Font-Namen. |
+| postscriptNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Postscript-Font-Namen. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fileDefinitions | [FontFileDefinition\[\]](../../com.aspose.font/fontfiledefinition) | Array von FontFileDefinition-Objekten. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileDefinitions() {#getFileDefinitions--}
+```
+public FontFileDefinition[] getFileDefinitions()
+```
+
+
+Ruft die Sammlung von Dateidefinitionen ab.
+
+**Returns:**
+com.aspose.font.FontFileDefinition[] - Sammlung von Dateidefinitionen.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Gibt den Font-Namen zurück.
+
+**Returns:**
+java.lang.String - Schriftartname.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Ruft Font-Namen als ein  MultiLanguageString  ab.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names as a  MultiLanguageString .
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Liefert Font‑Typ.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getPostscriptName() {#getPostscriptName--}
+```
+public String getPostscriptName()
+```
+
+
+Ruft den Postscript-Font-Namen ab.
+
+**Returns:**
+java.lang.String - Postscript-Font-Name.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Ruft Postscript-Font-Namen als ein  MultiLanguageString  ab.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names as a  MultiLanguageString .
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(StreamSource source, FontType fontType) {#open-com.aspose.font.StreamSource-com.aspose.font.FontType-}
+```
+public static FontDefinition open(StreamSource source, FontType fontType)
+```
+
+
+Gibt die FontDefinition für die Font-Stream-Quelle und den Font-Typ zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| source | [StreamSource](../../com.aspose.font/streamsource) | Font-Stream-Quelle. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - FontDefinition.
+### open(String fileName, FontType fontType) {#open-java.lang.String-com.aspose.font.FontType-}
+```
+public static FontDefinition open(String fileName, FontType fontType)
+```
+
+
+Gibt die FontDefinition für die Font-Datei und den Font-Typ zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fileName | java.lang.String | Schriftdateiname. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - FontDefinition.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fontenvironment/_index.md
+++ b/german/java/com.aspose.font/fontenvironment/_index.md
@@ -1,0 +1,193 @@
+---
+title: "FontEnvironment"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Bietet Informationen über die aktuelle Umgebung und Plattform."
+type: docs
+weight: 39
+url: /de/java/com.aspose.font/fontenvironment/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontEnvironment
+```
+
+Bietet Informationen über die aktuelle Umgebung und Plattform.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCffCommonFontsSettings()](#getCffCommonFontsSettings--) | Gemeinsame Einstellungen für CFF-Schriften. |
+| [getClass()](#getClass--) |  |
+| [getCurrent()](#getCurrent--) | Liest die aktuelle Umgebung. |
+| [getCurrentPlatformId()](#getCurrentPlatformId--) | Liest die aktuelle Plattform-ID. |
+| [getFontSpecificEncodings()](#getFontSpecificEncodings--) | Speichert spezifische Kodierungen für verbraucherbewusste Schriften. |
+| [getStrictness()](#getStrictness--) | Einige Schriften können unerwartete Daten, nicht spezifizierte Funktionen oder grob beschnittene Bereiche enthalten. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setStrictness(FontEnvironment.ParsingStrictness value)](#setStrictness-com.aspose.font.FontEnvironment.ParsingStrictness-) | Einige Schriften können unerwartete Daten, nicht spezifizierte Funktionen oder grob beschnittene Bereiche enthalten. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCffCommonFontsSettings() {#getCffCommonFontsSettings--}
+```
+public static CffFontsSettings getCffCommonFontsSettings()
+```
+
+
+Gemeinsame Einstellungen für CFF-Schriften.
+
+**Returns:**
+[CffFontsSettings](../../com.aspose.font/cfffontssettings)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCurrent() {#getCurrent--}
+```
+public static FontEnvironment getCurrent()
+```
+
+
+Liest die aktuelle Umgebung.
+
+**Returns:**
+[FontEnvironment](../../com.aspose.font/fontenvironment) - Current environment.
+### getCurrentPlatformId() {#getCurrentPlatformId--}
+```
+public int getCurrentPlatformId()
+```
+
+
+Liest die aktuelle Plattform-ID.
+
+**Returns:**
+int – aktuelle Plattform-ID.
+### getFontSpecificEncodings() {#getFontSpecificEncodings--}
+```
+public FontSpecificEncodings getFontSpecificEncodings()
+```
+
+
+Speichert spezifische Kodierungen für verbraucherbewusste Schriften. Zum Beispiel verwendet PDF spezifische Kodierungen für Adobe Symbol und ZapfDingbats.
+
+**Returns:**
+[FontSpecificEncodings](../../com.aspose.font/fontspecificencodings) - Specific encodings for consumer-aware Fonts.
+### getStrictness() {#getStrictness--}
+```
+public FontEnvironment.ParsingStrictness getStrictness()
+```
+
+
+Einige Schriften können unerwartete Daten, nicht spezifizierte Funktionen oder grob beschnittene Bereiche enthalten. Eine tolerante Einstellung wird für Verbraucher empfohlen, die jede Schrift öffnen möchten, ungeachtet möglicher Unzulänglichkeiten der Schrift. Interne Schriftstrukturen sind nicht garantiert konsistent. Eine strenge Einstellung wird für Verbraucher empfohlen, die überwiegend gültige und solide Schriften öffnen möchten.
+
+**Returns:**
+[ParsingStrictness](../../com.aspose.font/parsingstrictness) - Strictness.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setStrictness(FontEnvironment.ParsingStrictness value) {#setStrictness-com.aspose.font.FontEnvironment.ParsingStrictness-}
+```
+public void setStrictness(FontEnvironment.ParsingStrictness value)
+```
+
+
+Einige Schriften können unerwartete Daten, nicht spezifizierte Funktionen oder grob beschnittene Bereiche enthalten. Eine tolerante Einstellung wird für Verbraucher empfohlen, die jede Schrift öffnen möchten, ungeachtet möglicher Unzulänglichkeiten der Schrift. Interne Schriftstrukturen sind nicht garantiert konsistent. Eine strenge Einstellung wird für Verbraucher empfohlen, die überwiegend gültige und solide Schriften öffnen möchten.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ParsingStrictness](../../com.aspose.font/parsingstrictness) | Striktheit. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fontexception/_index.md
+++ b/german/java/com.aspose.font/fontexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontException"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine allgemeine, mit der Font-Verarbeitung verbundene Ausnahme dar."
+type: docs
+weight: 40
+url: /de/java/com.aspose.font/fontexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException
+```
+public class FontException extends IllegalStateException
+```
+
+Stellt eine allgemeine, mit der Font-Verarbeitung verbundene Ausnahme dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FontException()](#FontException--) | Initialisiert ein neues  FontException  Objekt. |
+| [FontException(String message)](#FontException-java.lang.String-) | Initialisiert ein neues  FontException  Objekt. |
+| [FontException(String message, RuntimeException innerException)](#FontException-java.lang.String-java.lang.RuntimeException-) | Initialisiert ein neues  FontException  Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontException() {#FontException--}
+```
+public FontException()
+```
+
+
+Initialisiert ein neues  FontException  Objekt.
+
+### FontException(String message) {#FontException-java.lang.String-}
+```
+public FontException(String message)
+```
+
+
+Initialisiert ein neues  FontException  Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+
+### FontException(String message, RuntimeException innerException) {#FontException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontException(String message, RuntimeException innerException)
+```
+
+
+Initialisiert ein neues  FontException  Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+| innerException | java.lang.RuntimeException | Die Ausnahme, die die aktuelle Ausnahme verursacht. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fontfactory/_index.md
+++ b/german/java/com.aspose.font/fontfactory/_index.md
@@ -1,0 +1,204 @@
+---
+title: "FontFactory"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Enthält Funktionen zum Öffnen von Schriftarten verschiedener Typen und weitere Methoden zum Erstellen verschiedener Objekte."
+type: docs
+weight: 41
+url: /de/java/com.aspose.font/fontfactory/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontFactory
+```
+
+Enthält Funktionalität zum Öffnen von Schriftarten verschiedener Typen und weitere Methoden zur Erstellung verschiedener Objekte.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FontFactory()](#FontFactory--) | Konstruktor |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Öffnet einen Font mithilfe eines FontDefinition-Objekts. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Öffnet einen Font mithilfe des Font-Typs und eines Byte-Arrays mit Font-Daten. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Öffnet einen Font mithilfe des Font-Typs und einer Stream-Quelle. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Öffnet einen Font mithilfe des Font-Typs und des Font-Dateinamens. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontFactory() {#FontFactory--}
+```
+public FontFactory()
+```
+
+
+Konstruktor
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public Font open(FontDefinition fontDefinition)
+```
+
+
+Öffnet einen Font mithilfe eines FontDefinition-Objekts.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Schriftdefinitions-Objekt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public Font open(FontType fontType, byte[] fontData)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und eines Byte-Arrays mit Font-Daten.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fontData | byte[] | Byte-Array, aus dem die Schrift geladen wird. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und einer Stream-Quelle.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Stream-Quelle für die Schrift. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public Font open(FontType fontType, String fileName)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und des Font-Dateinamens.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fileName | java.lang.String | Schriftdateiname. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fontfiledefinition/_index.md
+++ b/german/java/com.aspose.font/fontfiledefinition/_index.md
@@ -1,0 +1,231 @@
+---
+title: "FontFileDefinition"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Definition einer Font-Datei dar."
+type: docs
+weight: 42
+url: /de/java/com.aspose.font/fontfiledefinition/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontFileDefinition
+```
+
+Stellt die Definition einer Font-Datei dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FontFileDefinition(StreamSource streamSource)](#FontFileDefinition-com.aspose.font.StreamSource-) | Erstellt eine Dateidefinition, die ausschließlich den Dateiinhalt verwendet. |
+| [FontFileDefinition(String fileExtension, StreamSource streamSource)](#FontFileDefinition-java.lang.String-com.aspose.font.StreamSource-) | Erstellt eine Dateidefinition, die ausschließlich den Dateiinhalt verwendet. |
+| [FontFileDefinition(String fileExtension, StreamSource streamSource, long offset)](#FontFileDefinition-java.lang.String-com.aspose.font.StreamSource-long-) | Erstellt eine Dateidefinition, die ausschließlich den Dateiinhalt verwendet. |
+| [FontFileDefinition(File fontFile)](#FontFileDefinition-java.io.File-) | Erstellt eine Dateidefinition unter Verwendung der Schriftdatei (repräsentiert durch File) und des Dateiinhalts. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileExtension()](#getFileExtension--) | Liefert Dateierweiterung. |
+| [getFileName()](#getFileName--) | Liefert Dateinamen. |
+| [getOffset()](#getOffset--) | Liefert Offset innerhalb des Streams. |
+| [getStreamSource()](#getStreamSource--) | Liefert die Stream-Quelle. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontFileDefinition(StreamSource streamSource) {#FontFileDefinition-com.aspose.font.StreamSource-}
+```
+public FontFileDefinition(StreamSource streamSource)
+```
+
+
+Erstellt eine Dateidefinition, die ausschließlich den Dateiinhalt verwendet.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Font-Stream-Quelle. |
+
+### FontFileDefinition(String fileExtension, StreamSource streamSource) {#FontFileDefinition-java.lang.String-com.aspose.font.StreamSource-}
+```
+public FontFileDefinition(String fileExtension, StreamSource streamSource)
+```
+
+
+Erstellt eine Dateidefinition, die ausschließlich den Dateiinhalt verwendet.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fileExtension | java.lang.String | Font-Dateierweiterung. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Font-Stream-Quelle. |
+
+### FontFileDefinition(String fileExtension, StreamSource streamSource, long offset) {#FontFileDefinition-java.lang.String-com.aspose.font.StreamSource-long-}
+```
+public FontFileDefinition(String fileExtension, StreamSource streamSource, long offset)
+```
+
+
+Erstellt eine Dateidefinition, die ausschließlich den Dateiinhalt verwendet.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fileExtension | java.lang.String | Font-Dateierweiterung. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Font-Stream-Quelle. |
+| Versatz | long | Versatz zu den Schriftartdaten in der Stream-Quelle. |
+
+### FontFileDefinition(File fontFile) {#FontFileDefinition-java.io.File-}
+```
+public FontFileDefinition(File fontFile)
+```
+
+
+Erstellt eine Dateidefinition unter Verwendung der Schriftdatei (repräsentiert durch File) und des Dateiinhalts.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontFile | java.io.File | Dateiobjekt. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileExtension() {#getFileExtension--}
+```
+public String getFileExtension()
+```
+
+
+Liefert Dateierweiterung.
+
+**Returns:**
+java.lang.String - Dateierweiterung.
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Liefert Dateinamen.
+
+**Returns:**
+java.lang.String - Dateiname.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert Offset innerhalb des Streams.
+
+**Returns:**
+long - Versatz innerhalb des Streams.
+### getStreamSource() {#getStreamSource--}
+```
+public StreamSource getStreamSource()
+```
+
+
+Liefert die Stream-Quelle.
+
+**Returns:**
+[StreamSource](../../com.aspose.font/streamsource) - The stream source.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fontmergeexception/_index.md
+++ b/german/java/com.aspose.font/fontmergeexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontMergeException"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Font-Zusammenführungs-Ausnahme dar."
+type: docs
+weight: 43
+url: /de/java/com.aspose.font/fontmergeexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontMergeException extends FontException
+```
+
+Stellt eine Font‑Merge‑Ausnahme dar. Die Ausnahme kann bei Fehlern während des Zusammenführens von Schriften ausgelöst werden.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FontMergeException()](#FontMergeException--) | Initialisiert ein neues  FontMergeException  Objekt. |
+| [FontMergeException(String message)](#FontMergeException-java.lang.String-) | Initialisiert ein neues  FontMergeException  Objekt. |
+| [FontMergeException(String message, RuntimeException innerException)](#FontMergeException-java.lang.String-java.lang.RuntimeException-) | Initialisiert ein neues  FontMergeException  Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontMergeException() {#FontMergeException--}
+```
+public FontMergeException()
+```
+
+
+Initialisiert ein neues  FontMergeException  Objekt.
+
+### FontMergeException(String message) {#FontMergeException-java.lang.String-}
+```
+public FontMergeException(String message)
+```
+
+
+Initialisiert ein neues  FontMergeException  Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+
+### FontMergeException(String message, RuntimeException innerException) {#FontMergeException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontMergeException(String message, RuntimeException innerException)
+```
+
+
+Initialisiert ein neues  FontMergeException  Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+| innerException | java.lang.RuntimeException | Die Ausnahme, die die aktuelle Ausnahme verursacht. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fontmetrics/_index.md
+++ b/german/java/com.aspose.font/fontmetrics/_index.md
@@ -1,0 +1,470 @@
+---
+title: "FontMetrics"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt Schriftmetriken dar."
+type: docs
+weight: 44
+url: /de/java/com.aspose.font/fontmetrics/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFontMetrics](../../com.aspose.font/ifontmetrics)
+```
+public abstract class FontMetrics implements IFontMetrics
+```
+
+Stellt Schriftmetriken dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAscender()](#getAscender--) | Liefert den Ascender-Wert. |
+| [getAscender(double fontSize)](#getAscender-double-) | Gibt den Ascender für eine bestimmte Schriftgröße zurück. |
+| [getClass()](#getClass--) |  |
+| [getDescender()](#getDescender--) | Liefert den Descender-Wert. |
+| [getDescender(double fontSize)](#getDescender-double-) | Gibt den Descender für eine bestimmte Schriftgröße zurück. |
+| [getFontBBox()](#getFontBBox--) | Liefert den FontBBox-Wert. |
+| [getFontMatrix()](#getFontMatrix--) | Liefert den FontMatrix-Wert. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Gibt das Glyph-Bbox zurück. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Gibt die Glyph-Breite zurück. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Gibt den Kerning-Wert für das Glyph-Paar zurück. |
+| [getLineGap()](#getLineGap--) | Liest den LineGap-Wert. |
+| [getTypoAscender()](#getTypoAscender--) | Liest den TypoAscender-Wert. |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Gibt den typografischen Ascender für eine bestimmte Schriftgröße zurück. |
+| [getTypoDescender()](#getTypoDescender--) | Liest den TypoDescender-Wert. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Gibt den typografischen Descender für eine bestimmte Schriftgröße zurück. |
+| [getTypoLineGap()](#getTypoLineGap--) | Liest den TypoLineGap-Wert. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Gibt den Zeilenabstand für eine bestimmte Schriftgröße zurück. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Liest den UnitsPerEM-Wert. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Liest den IsFixedPitch-Wert. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Misst die Zeichenkette und gibt die Zeichenkettenbreite zurück. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAscender(double value)](#setAscender-double-) | Setzt den Ascender-Wert. |
+| [setDescender(double value)](#setDescender-double-) | Setzt den Descender-Wert. |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) | Setzt die Glyph-Breite. |
+| [setTypoAscender(double value)](#setTypoAscender-double-) | Setzt den TypoAscender-Wert. |
+| [setTypoDescender(double value)](#setTypoDescender-double-) | Setzt den TypoDescender-Wert. |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) | Setzt den UnitsPerEM-Wert. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAscender() {#getAscender--}
+```
+public double getAscender()
+```
+
+
+Liefert den Ascender-Wert.
+
+**Returns:**
+double - Ascender-Wert.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public double getAscender(double fontSize)
+```
+
+
+Gibt den Ascender für eine bestimmte Schriftgröße zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Ascender-Wert.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescender() {#getDescender--}
+```
+public double getDescender()
+```
+
+
+Liefert den Descender-Wert.
+
+**Returns:**
+double - Descender-Wert.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public double getDescender(double fontSize)
+```
+
+
+Gibt den Descender für eine bestimmte Schriftgröße zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Descender-Wert.
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+Liefert den FontBBox-Wert.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - FontBBox value.
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+Liefert den FontMatrix-Wert.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - FontMatrix value.
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Gibt das Glyph-Bbox zurück. Gibt FontBBox zurück, wenn das BBox für das Glyph nicht definiert war. Kann von spezifischen Font-Encoding-Erben überschrieben werden.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑Bezeichner. |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox.
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Gibt die Glyphenbreite zurück. Kann von spezifischen Schriftkodierungs-Erben überschrieben werden.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑Bezeichner. |
+
+**Returns:**
+double - Glyphenbreite.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Gibt den Kerning-Wert für das Glyph-Paar zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Erste Glyphe im Paar. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Schriftgröße. |
+
+**Returns:**
+double - Kerning-Wert.
+### getLineGap() {#getLineGap--}
+```
+public double getLineGap()
+```
+
+
+Liest den LineGap-Wert.
+
+**Returns:**
+double - LineGap-Wert.
+### getTypoAscender() {#getTypoAscender--}
+```
+public double getTypoAscender()
+```
+
+
+Liest den TypoAscender-Wert.
+
+**Returns:**
+double - TypoAscender-Wert.
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public double getTypoAscender(double fontSize)
+```
+
+
+Gibt den typografischen Ascender für eine bestimmte Schriftgröße zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Typografischer Aufsteigerwert.
+### getTypoDescender() {#getTypoDescender--}
+```
+public double getTypoDescender()
+```
+
+
+Liest den TypoDescender-Wert.
+
+**Returns:**
+double - TypoDescender-Wert.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public double getTypoDescender(double fontSize)
+```
+
+
+Gibt den typografischen Descender für eine bestimmte Schriftgröße zurück.
+
+param fontSize Schriftgröße.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double |  |
+
+**Returns:**
+double - Typografischer Abstiegwert.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public double getTypoLineGap()
+```
+
+
+Liest den TypoLineGap-Wert.
+
+**Returns:**
+double - TypoLineGap-Wert.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public double getTypoLineGap(double fontSize)
+```
+
+
+Gibt den Zeilenabstand für eine bestimmte Schriftgröße zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Zeilenabstandswert.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Liest den UnitsPerEM-Wert.
+
+**Returns:**
+long - UnitsPerEM-Wert.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+Liest den IsFixedPitch-Wert.
+
+**Returns:**
+boolean - IsFixedPitch-Wert.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public abstract double measureString(String unicode, double fontSize)
+```
+
+
+Misst die Zeichenkette und gibt die Zeichenkettenbreite zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| unicode | java.lang.String | Unicode-Zeichenkette. |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Zeichenkettenbreite.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAscender(double value) {#setAscender-double-}
+```
+public void setAscender(double value)
+```
+
+
+Setzt den Ascender-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | Aufsteigerwert. |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public void setDescender(double value)
+```
+
+
+Setzt den Descender-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | Abstiegwert. |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public abstract void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Setzt die Glyph-Breite.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑Bezeichner. |
+| Wert | double | Neue Breite. |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public void setTypoAscender(double value)
+```
+
+
+Setzt den TypoAscender-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | TypoAscender-Wert. |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public void setTypoDescender(double value)
+```
+
+
+Setzt den TypoDescender-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | TypoDescender-Wert. |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public void setUnitsPerEM(long value)
+```
+
+
+Setzt den UnitsPerEM-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long | UnitsPerEM-Wert. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fontnotsupportedoperationexception/_index.md
+++ b/german/java/com.aspose.font/fontnotsupportedoperationexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontNotSupportedOperationException"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine nicht unterstützte Operationsausnahme dar."
+type: docs
+weight: 45
+url: /de/java/com.aspose.font/fontnotsupportedoperationexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontNotSupportedOperationException extends FontException
+```
+
+Stellt eine nicht unterstützte Operationsausnahme dar. Die Ausnahme kann ausgelöst werden, wenn eine Operation für einen bestimmten Schriftarttyp nicht unterstützt wird.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FontNotSupportedOperationException()](#FontNotSupportedOperationException--) | Initialisiert ein neues FontNotSupportedOperationException-Objekt. |
+| [FontNotSupportedOperationException(String message)](#FontNotSupportedOperationException-java.lang.String-) | Initialisiert ein neues FontNotSupportedOperationException-Objekt. |
+| [FontNotSupportedOperationException(String message, RuntimeException innerException)](#FontNotSupportedOperationException-java.lang.String-java.lang.RuntimeException-) | Initialisiert ein neues FontNotSupportedOperationException-Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontNotSupportedOperationException() {#FontNotSupportedOperationException--}
+```
+public FontNotSupportedOperationException()
+```
+
+
+Initialisiert ein neues FontNotSupportedOperationException-Objekt.
+
+### FontNotSupportedOperationException(String message) {#FontNotSupportedOperationException-java.lang.String-}
+```
+public FontNotSupportedOperationException(String message)
+```
+
+
+Initialisiert ein neues FontNotSupportedOperationException-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+
+### FontNotSupportedOperationException(String message, RuntimeException innerException) {#FontNotSupportedOperationException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontNotSupportedOperationException(String message, RuntimeException innerException)
+```
+
+
+Initialisiert ein neues FontNotSupportedOperationException-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+| innerException | java.lang.RuntimeException | Die Ausnahme, die die aktuelle Ausnahme verursacht. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fontsavingformats/_index.md
+++ b/german/java/com.aspose.font/fontsavingformats/_index.md
@@ -1,0 +1,277 @@
+---
+title: "FontSavingFormats"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Gibt den Schrifttyp an."
+type: docs
+weight: 135
+url: /de/java/com.aspose.font/fontsavingformats/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum FontSavingFormats extends Enum<FontSavingFormats>
+```
+
+Gibt den Schrifttyp an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [OTF](#OTF) | OpenType-Schrift. |
+| [SVG](#SVG) | SVG(Scalable Vector Graphics) Schriftartformat |
+| [TTF](#TTF) | TTF (TrueType) Schriftartformat. |
+| [WOFF](#WOFF) | WOFF(Web Open Font Format). |
+| [WOFF2](#WOFF2) | WOFF-Dateiformat 2.0 |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OTF {#OTF}
+```
+public static final FontSavingFormats OTF
+```
+
+
+OpenType-Schrift. Das OpenType-Schriftformat ist eine Erweiterung des TrueType-Schriftformats und fügt Unterstützung für PostScript-Schriftdaten hinzu.
+
+### SVG {#SVG}
+```
+public static final FontSavingFormats SVG
+```
+
+
+SVG(Scalable Vector Graphics) Schriftartformat
+
+### TTF {#TTF}
+```
+public static final FontSavingFormats TTF
+```
+
+
+TTF (TrueType) Schriftartformat.
+
+### WOFF {#WOFF}
+```
+public static final FontSavingFormats WOFF
+```
+
+
+WOFF(Web Open Font Format).
+
+### WOFF2 {#WOFF2}
+```
+public static final FontSavingFormats WOFF2
+```
+
+
+WOFF-Dateiformat 2.0
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static FontSavingFormats valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[FontSavingFormats](../../com.aspose.font/fontsavingformats)
+### values() {#values--}
+```
+public static FontSavingFormats[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.FontSavingFormats[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fontspecificencodings/_index.md
+++ b/german/java/com.aspose.font/fontspecificencodings/_index.md
@@ -1,0 +1,139 @@
+---
+title: "FontSpecificEncodings"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt spezifische Kodierungen für verbraucherbewusste Schriftarten dar."
+type: docs
+weight: 46
+url: /de/java/com.aspose.font/fontspecificencodings/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontSpecificEncodings
+```
+
+Stellt spezifische Kodierungen für verbraucherbewusste Schriftarten dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [registerEncoding(String fontName, String[] encoding)](#registerEncoding-java.lang.String-java.lang.String---) | Registriere Kodierung für verbraucherbewusste Fonts. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### registerEncoding(String fontName, String[] encoding) {#registerEncoding-java.lang.String-java.lang.String---}
+```
+public void registerEncoding(String fontName, String[] encoding)
+```
+
+
+Registriere Kodierung für verbraucherbewusste Fonts.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontName | java.lang.String | Schriftartname. |
+| Kodierung | java.lang.String[] | Kodierung. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fontstyle/_index.md
+++ b/german/java/com.aspose.font/fontstyle/_index.md
@@ -1,0 +1,155 @@
+---
+title: "FontStyle"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Aufzählung der Schriftstilarten"
+type: docs
+weight: 47
+url: /de/java/com.aspose.font/fontstyle/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class FontStyle
+```
+
+Aufzählung der Schriftstilarten
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [Bold](#Bold) | Gibt den fetten Schriftschnitt an. |
+| [Italic](#Italic) | Gibt den kursiven Schriftschnitt an. |
+| [Regular](#Regular) | Gibt den normalen Schriftschnitt an. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Bold {#Bold}
+```
+public static final int Bold
+```
+
+
+Gibt den fetten Schriftschnitt an.
+
+### Italic {#Italic}
+```
+public static final int Italic
+```
+
+
+Gibt den kursiven Schriftschnitt an.
+
+### Regular {#Regular}
+```
+public static final int Regular
+```
+
+
+Gibt den normalen Schriftschnitt an.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/fonttype/_index.md
+++ b/german/java/com.aspose.font/fonttype/_index.md
@@ -1,0 +1,268 @@
+---
+title: "FontType"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Gibt den Schrifttyp an."
+type: docs
+weight: 136
+url: /de/java/com.aspose.font/fonttype/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum FontType extends Enum<FontType>
+```
+
+Gibt den Schrifttyp an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CFF](#CFF) | CFF (Compact Font Format) Schriftarttyp. |
+| [OTF](#OTF) | OpenType-Schrift. |
+| [TTF](#TTF) | TTF (TrueType) Schriftart und zugehörig. |
+| [Type1](#Type1) | Type1-Schriftarttyp. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CFF {#CFF}
+```
+public static final FontType CFF
+```
+
+
+CFF (Compact Font Format) Schriftarttyp.
+
+### OTF {#OTF}
+```
+public static final FontType OTF
+```
+
+
+OpenType-Schrift. Das OpenType-Schriftformat ist eine Erweiterung des TrueType-Schriftformats und fügt Unterstützung für PostScript-Schriftdaten hinzu.
+
+### TTF {#TTF}
+```
+public static final FontType TTF
+```
+
+
+TTF (TrueType) Schriftart und zugehörig.
+
+### Type1 {#Type1}
+```
+public static final FontType Type1
+```
+
+
+Type1-Schriftarttyp.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static FontType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype)
+### values() {#values--}
+```
+public static FontType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.FontType[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/gasprange/_index.md
+++ b/german/java/com.aspose.font/gasprange/_index.md
@@ -1,0 +1,163 @@
+---
+title: "GaspRange"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Das Array von GaspRange-Datensätzen bietet empfohlene Verhaltensweisen für verschiedene ppem-Größen."
+type: docs
+weight: 48
+url: /de/java/com.aspose.font/gasprange/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class GaspRange
+```
+
+Das Array von GaspRange-Datensätzen bietet empfohlene Verhaltensweisen für verschiedene ppem-Größen.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [GaspRange(int rangeMaxPPEM, AsFoEnumSet<RangeGaspBehaviorFlags> rangeGaspBehaviorFlags)](#GaspRange-int-com.aspose.font.util.AsFoEnumSet-com.aspose.font.RangeGaspBehaviorFlags--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getRangeGaspBehaviorFlags()](#getRangeGaspBehaviorFlags--) | Liefert die Flags, die das gewünschte Rasterizer-Verhalten beschreiben. |
+| [getRangeMaxPPEM()](#getRangeMaxPPEM--) | Liefert die obere Grenze des Bereichs in PPEM. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GaspRange(int rangeMaxPPEM, AsFoEnumSet<RangeGaspBehaviorFlags> rangeGaspBehaviorFlags) {#GaspRange-int-com.aspose.font.util.AsFoEnumSet-com.aspose.font.RangeGaspBehaviorFlags--}
+```
+public GaspRange(int rangeMaxPPEM, AsFoEnumSet<RangeGaspBehaviorFlags> rangeGaspBehaviorFlags)
+```
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| rangeMaxPPEM | int |  |
+| rangeGaspBehaviorFlags | com.aspose.font.util.AsFoEnumSet<com.aspose.font.RangeGaspBehaviorFlags> |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getRangeGaspBehaviorFlags() {#getRangeGaspBehaviorFlags--}
+```
+public AsFoEnumSet<RangeGaspBehaviorFlags> getRangeGaspBehaviorFlags()
+```
+
+
+Liefert die Flags, die das gewünschte Rasterizer-Verhalten beschreiben.
+
+**Returns:**
+[AsFoEnumSet](../../com.aspose.font.util/asfoenumset) - The flags describing desired rasterizer behavior.
+### getRangeMaxPPEM() {#getRangeMaxPPEM--}
+```
+public int getRangeMaxPPEM()
+```
+
+
+Liefert die obere Grenze des Bereichs in PPEM.
+
+**Returns:**
+int - Die obere Grenze des Bereichs in PPEM.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/glyph/_index.md
+++ b/german/java/com.aspose.font/glyph/_index.md
@@ -1,0 +1,237 @@
+---
+title: "Glyph"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt ein Font-Glyph dar."
+type: docs
+weight: 49
+url: /de/java/com.aspose.font/glyph/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Cloneable
+```
+public class Glyph implements Cloneable
+```
+
+Stellt ein Font-Glyph dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clone()](#clone--) | Gibt eine Kopie des Glyph zurück. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGlyphBBox()](#getGlyphBBox--) | Liest das Glyph‑BBox. |
+| [getLeftSidebearingX()](#getLeftSidebearingX--) | Ermittelt die Glyph‑Seitenlage x‑Koordinate. |
+| [getLeftSidebearingY()](#getLeftSidebearingY--) | Ermittelt die Glyph‑Seitenlage y‑Koordinate. |
+| [getPath()](#getPath--) | Ermittelt den Glyph‑Pfad. |
+| [getSourceResolution()](#getSourceResolution--) | Ermittelt die Auflösung des Quellbefehlsatzes. |
+| [getState()](#getState--) | Ermittelt den Glyph‑Zustand. |
+| [getWidthVectorX()](#getWidthVectorX--) | Ermittelt den Glyph‑Breitenvektor. |
+| [getWidthVectorY()](#getWidthVectorY--) | Ermittelt den Glyph‑Breitenvektor. |
+| [hashCode()](#hashCode--) |  |
+| [isEmpty()](#isEmpty--) | Wahr, wenn das Glyph keine Zeichenanweisungen enthält. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Gibt eine Kopie des Glyph zurück.
+
+**Returns:**
+java.lang.Object - Kopie des Glyphs.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphBBox() {#getGlyphBBox--}
+```
+public FontBBox getGlyphBBox()
+```
+
+
+Liest das Glyph‑BBox.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox
+### getLeftSidebearingX() {#getLeftSidebearingX--}
+```
+public double getLeftSidebearingX()
+```
+
+
+Ermittelt die Glyph‑Seitenlage x‑Koordinate.
+
+**Returns:**
+double - Glyph‑Seitenlage x‑Koordinate.
+### getLeftSidebearingY() {#getLeftSidebearingY--}
+```
+public double getLeftSidebearingY()
+```
+
+
+Ermittelt die Glyph‑Seitenlage y‑Koordinate.
+
+**Returns:**
+double - Glyph‑Seitenlage y‑Koordinate.
+### getPath() {#getPath--}
+```
+public SegmentPath getPath()
+```
+
+
+Ermittelt den Glyph‑Pfad.
+
+**Returns:**
+[SegmentPath](../../com.aspose.font/segmentpath) - Glyph path.
+### getSourceResolution() {#getSourceResolution--}
+```
+public int getSourceResolution()
+```
+
+
+Ermittelt die Auflösung des Quellbefehlsatzes.
+
+**Returns:**
+int - Auflösung des Quellbefehlsatzes.
+### getState() {#getState--}
+```
+public GlyphState getState()
+```
+
+
+Ermittelt den Glyph‑Zustand.
+
+**Returns:**
+[GlyphState](../../com.aspose.font/glyphstate) - Glyph state.
+### getWidthVectorX() {#getWidthVectorX--}
+```
+public double getWidthVectorX()
+```
+
+
+Ermittelt den Glyph‑Breitenvektor. Koordinate x.
+
+**Returns:**
+double - Glyph‑Breitenvektor. Koordinate x.
+### getWidthVectorY() {#getWidthVectorY--}
+```
+public double getWidthVectorY()
+```
+
+
+Ermittelt den Glyph‑Breitenvektor. Koordinate y.
+
+**Returns:**
+double - Glyph‑Breitenvektor. Koordinate y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+Wahr, wenn das Glyph keine Zeichenanweisungen enthält.
+
+**Returns:**
+boolean - Wahr, wenn das Glyph keine Zeichenanweisungen enthält.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/glyphid/_index.md
+++ b/german/java/com.aspose.font/glyphid/_index.md
@@ -1,0 +1,180 @@
+---
+title: "GlyphId"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt Glyph-IDs dar, die in der Schriftart verfügbar sind."
+type: docs
+weight: 50
+url: /de/java/com.aspose.font/glyphid/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class GlyphId
+```
+
+Stellt Glyph-IDs dar, die in der Schriftart verfügbar sind. Eine Glyph-ID ist eine eindeutige Nummer für ein Glyph, die vom Schriftarttyp abhängt. Zum Beispiel: Die ID von Type1 ist ein Glyph-Name, eine Instanz der Klasse ( GlyphStringId ). Die ID von TTF ist ein int-Index, eine Instanz der Klasse ( GlyphUInt32Id ).
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Gibt true zurück, wenn zwei Glyph-IDs ungleich sind. |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) | Gibt den Hashcode des Objekts zurück. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(GlyphId obj1, Object obj2)](#op-Equality-com.aspose.font.GlyphId-java.lang.Object-) | Gibt true zurück, wenn zwei Glyph-IDs gleich sind. |
+| [op_Inequality(GlyphId obj1, Object obj2)](#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-) | Gibt true zurück, wenn zwei Glyph-IDs ungleich sind. |
+| [toGlyphStringId()](#toGlyphStringId--) | Virtueller Cast zu GlyphStringId. |
+| [toGlyphUInt32Id()](#toGlyphUInt32Id--) | Virtuelle Umwandlung zu GlyphUInt32Id. |
+| [toString()](#toString--) | Gibt die String-Darstellung der Glyph-ID zurück. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Gibt true zurück, wenn zwei Glyph-IDs ungleich sind.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj | java.lang.Object | Glyph-Identifikator zum Vergleichen. |
+
+**Returns:**
+boolean - Vergleichsergebnis.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public abstract int hashCode()
+```
+
+
+Gibt den Hashcode des Objekts zurück.
+
+**Returns:**
+int - Hashcode des Objekts.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(GlyphId obj1, Object obj2) {#op-Equality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Equality(GlyphId obj1, Object obj2)
+```
+
+
+Gibt true zurück, wenn zwei Glyph-IDs gleich sind.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Erster Glyph-Bezeichner zum Vergleichen. |
+| obj2 | java.lang.Object | Zweiter Glyph-Bezeichner zum Vergleichen. |
+
+**Returns:**
+boolean - Vergleichsergebnis.
+### op_Inequality(GlyphId obj1, Object obj2) {#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Inequality(GlyphId obj1, Object obj2)
+```
+
+
+Gibt true zurück, wenn zwei Glyph-IDs ungleich sind.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Erster Glyph-Bezeichner zum Vergleichen. |
+| obj2 | java.lang.Object | Zweiter Glyph-Bezeichner zum Vergleichen. |
+
+**Returns:**
+boolean - Vergleichsergebnis.
+### toGlyphStringId() {#toGlyphStringId--}
+```
+public GlyphStringId toGlyphStringId()
+```
+
+
+Virtueller Cast zu GlyphStringId. GlyphStringId überschreibt, um eine Instanz zurückzugeben.
+
+**Returns:**
+[GlyphStringId](../../com.aspose.font/glyphstringid) - null
+### toGlyphUInt32Id() {#toGlyphUInt32Id--}
+```
+public GlyphUInt32Id toGlyphUInt32Id()
+```
+
+
+Virtuelle Umwandlung zu GlyphUInt32Id. GlyphUInt32Id überschreibt, um die Instanz zurückzugeben.
+
+**Returns:**
+[GlyphUInt32Id](../../com.aspose.font/glyphuint32id) - null
+### toString() {#toString--}
+```
+public abstract String toString()
+```
+
+
+Gibt die String-Darstellung der Glyph-ID zurück.
+
+**Returns:**
+java.lang.String - Glyph-Bezeichner
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/glyphidlist/_index.md
+++ b/german/java/com.aspose.font/glyphidlist/_index.md
@@ -1,0 +1,613 @@
+---
+title: "GlyphIdList"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Glyph-ID-Liste dar."
+type: docs
+weight: 51
+url: /de/java/com.aspose.font/glyphidlist/
+---
+**Inheritance:**
+java.lang.Object, java.util.AbstractCollection, java.util.AbstractList, java.util.ArrayList
+```
+public class GlyphIdList extends ArrayList<GlyphId>
+```
+
+Stellt eine Glyph-ID-Liste dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>toArray(T[] arg0)](#-T-toArray-T---) |  |
+| [add(E arg0)](#add-E-) |  |
+| [add(GlyphId glyphId)](#add-com.aspose.font.GlyphId-) | Fügt der Liste eine Glyph‑ID hinzu. |
+| [add(int arg0, E arg1)](#add-int-E-) |  |
+| [addAll(int arg0, Collection<? extends E> arg1)](#addAll-int-java.util.Collection---extends-E--) |  |
+| [addAll(Collection<? extends E> arg0)](#addAll-java.util.Collection---extends-E--) |  |
+| [clear()](#clear--) | Leert die Liste. |
+| [clone()](#clone--) |  |
+| [contains(GlyphId glyphId)](#contains-com.aspose.font.GlyphId-) | Gibt true zurück, falls die Glyph-ID in der Liste ist. |
+| [contains(Object arg0)](#contains-java.lang.Object-) |  |
+| [containsAll(Collection<?> arg0)](#containsAll-java.util.Collection----) |  |
+| [ensureCapacity(int arg0)](#ensureCapacity-int-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [forEach(Consumer<? super E> arg0)](#forEach-java.util.function.Consumer---super-E--) |  |
+| [get(int index)](#get-int-) | Gibt die Glyph-ID nach dem Index zurück. |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object arg0)](#indexOf-java.lang.Object-) |  |
+| [isEmpty()](#isEmpty--) |  |
+| [iterator()](#iterator--) |  |
+| [lastIndexOf(Object arg0)](#lastIndexOf-java.lang.Object-) |  |
+| [listIterator()](#listIterator--) |  |
+| [listIterator(int arg0)](#listIterator-int-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(GlyphId glyphId)](#remove-com.aspose.font.GlyphId-) | Entfernt die Glyph-ID aus der Liste. |
+| [remove(int arg0)](#remove-int-) |  |
+| [remove(Object arg0)](#remove-java.lang.Object-) |  |
+| [removeAll(Collection<?> arg0)](#removeAll-java.util.Collection----) |  |
+| [removeIf(Predicate<? super E> arg0)](#removeIf-java.util.function.Predicate---super-E--) |  |
+| [replaceAll(UnaryOperator<E> arg0)](#replaceAll-java.util.function.UnaryOperator-E--) |  |
+| [retainAll(Collection<?> arg0)](#retainAll-java.util.Collection----) |  |
+| [set(int arg0, E arg1)](#set-int-E-) |  |
+| [size()](#size--) |  |
+| [sort(Comparator<? super E> arg0)](#sort-java.util.Comparator---super-E--) |  |
+| [spliterator()](#spliterator--) |  |
+| [subList(int arg0, int arg1)](#subList-int-int-) |  |
+| [toArray()](#toArray--) |  |
+| [toString()](#toString--) |  |
+| [trimToSize()](#trimToSize--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>toArray(T[] arg0) {#-T-toArray-T---}
+```
+public T[] <T>toArray(T[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | T[] |  |
+
+**Returns:**
+T[]
+### add(E arg0) {#add-E-}
+```
+public boolean add(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+boolean
+### add(GlyphId glyphId) {#add-com.aspose.font.GlyphId-}
+```
+public boolean add(GlyphId glyphId)
+```
+
+
+Fügt der Liste eine Glyph‑ID hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph-Identifikator |
+
+**Returns:**
+boolean
+### add(int arg0, E arg1) {#add-int-E-}
+```
+public void add(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+### addAll(int arg0, Collection<? extends E> arg1) {#addAll-int-java.util.Collection---extends-E--}
+```
+public boolean addAll(int arg0, Collection<? extends E> arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### addAll(Collection<? extends E> arg0) {#addAll-java.util.Collection---extends-E--}
+```
+public boolean addAll(Collection<? extends E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Leert die Liste.
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### contains(GlyphId glyphId) {#contains-com.aspose.font.GlyphId-}
+```
+public boolean contains(GlyphId glyphId)
+```
+
+
+Gibt true zurück, falls die Glyph-ID in der Liste ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph-Identifikator |
+
+**Returns:**
+boolean - true, falls die Glyph-ID in der Liste ist, sonst false
+### contains(Object arg0) {#contains-java.lang.Object-}
+```
+public boolean contains(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### containsAll(Collection<?> arg0) {#containsAll-java.util.Collection----}
+```
+public boolean containsAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### ensureCapacity(int arg0) {#ensureCapacity-int-}
+```
+public void ensureCapacity(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### forEach(Consumer<? super E> arg0) {#forEach-java.util.function.Consumer---super-E--}
+```
+public void forEach(Consumer<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.function.Consumer<? super E> |  |
+
+### get(int index) {#get-int-}
+```
+public GlyphId get(int index)
+```
+
+
+Gibt die Glyph-ID nach dem Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index der Glyph in der Liste |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object arg0) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public Iterator<E> iterator()
+```
+
+
+
+
+**Returns:**
+java.util.Iterator<E>
+### lastIndexOf(Object arg0) {#lastIndexOf-java.lang.Object-}
+```
+public int lastIndexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### listIterator() {#listIterator--}
+```
+public ListIterator<E> listIterator()
+```
+
+
+
+
+**Returns:**
+java.util.ListIterator<E>
+### listIterator(int arg0) {#listIterator-int-}
+```
+public ListIterator<E> listIterator(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+java.util.ListIterator<E>
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(GlyphId glyphId) {#remove-com.aspose.font.GlyphId-}
+```
+public boolean remove(GlyphId glyphId)
+```
+
+
+Entfernt die Glyph-ID aus der Liste.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph-Identifikator |
+
+**Returns:**
+boolean - true, wenn das Element erfolgreich entfernt wurde; sonst false
+### remove(int arg0) {#remove-int-}
+```
+public E remove(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### remove(Object arg0) {#remove-java.lang.Object-}
+```
+public boolean remove(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### removeAll(Collection<?> arg0) {#removeAll-java.util.Collection----}
+```
+public boolean removeAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### removeIf(Predicate<? super E> arg0) {#removeIf-java.util.function.Predicate---super-E--}
+```
+public boolean removeIf(Predicate<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.function.Predicate<? super E> |  |
+
+**Returns:**
+boolean
+### replaceAll(UnaryOperator<E> arg0) {#replaceAll-java.util.function.UnaryOperator-E--}
+```
+public void replaceAll(UnaryOperator<E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.function.UnaryOperator<E> |  |
+
+### retainAll(Collection<?> arg0) {#retainAll-java.util.Collection----}
+```
+public boolean retainAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### set(int arg0, E arg1) {#set-int-E-}
+```
+public E set(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+**Returns:**
+E
+### size() {#size--}
+```
+public int size()
+```
+
+
+
+
+**Returns:**
+int
+### sort(Comparator<? super E> arg0) {#sort-java.util.Comparator---super-E--}
+```
+public void sort(Comparator<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.Comparator<? super E> |  |
+
+### spliterator() {#spliterator--}
+```
+public Spliterator<E> spliterator()
+```
+
+
+
+
+**Returns:**
+java.util.Spliterator<E>
+### subList(int arg0, int arg1) {#subList-int-int-}
+```
+public List<E> subList(int arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | int |  |
+
+**Returns:**
+java.util.List<E>
+### toArray() {#toArray--}
+```
+public Object[] toArray()
+```
+
+
+
+
+**Returns:**
+java.lang.Object[]
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### trimToSize() {#trimToSize--}
+```
+public void trimToSize()
+```
+
+
+
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/glyphidtype/_index.md
+++ b/german/java/com.aspose.font/glyphidtype/_index.md
@@ -1,0 +1,250 @@
+---
+title: "GlyphIdType"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Gibt die Typen von Glyphen‑ID an."
+type: docs
+weight: 137
+url: /de/java/com.aspose.font/glyphidtype/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum GlyphIdType extends Enum<GlyphIdType>
+```
+
+Gibt die Typen von Glyphen‑ID an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ASCIIStringName](#ASCIIStringName) | ASCII-Zeichenkette Glyphenname. |
+| [Int32Index](#Int32Index) | Ganzzahliger Glyphenindex. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ASCIIStringName {#ASCIIStringName}
+```
+public static final GlyphIdType ASCIIStringName
+```
+
+
+ASCII-Zeichenkette Glyphenname.
+
+### Int32Index {#Int32Index}
+```
+public static final GlyphIdType Int32Index
+```
+
+
+Ganzzahliger Glyphenindex.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static GlyphIdType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype)
+### values() {#values--}
+```
+public static GlyphIdType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.GlyphIdType[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/glyphoutlinerenderer/_index.md
+++ b/german/java/com.aspose.font/glyphoutlinerenderer/_index.md
@@ -1,0 +1,238 @@
+---
+title: "GlyphOutlineRenderer"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt einen Glyph-Umriss-Renderer dar."
+type: docs
+weight: 52
+url: /de/java/com.aspose.font/glyphoutlinerenderer/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.GlyphRendererBase](../../com.aspose.font/glyphrendererbase)
+```
+public class GlyphOutlineRenderer extends GlyphRendererBase
+```
+
+Stellt einen Glyph-Umriss-Renderer dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [GlyphOutlineRenderer(IGlyphOutlinePainter painter)](#GlyphOutlineRenderer-com.aspose.font.IGlyphOutlinePainter-) | Initialisiert ein neues GlyphOutlineRenderer-Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [renderGlyph(IFont font, GlyphId glyphId)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-) | Rendert das Glyph. |
+| [renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Rendert das Glyph, ein Ziel dieser überladenen Version – zur Verwendung mit einem Cache für Glyphs. |
+| [renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-) | Rendert das Glyph. |
+| [renderGlyph(IFont font, long glyphIndex)](#renderGlyph-com.aspose.font.IFont-long-) | Rendert das Glyph |
+| [renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-) | Rendert das Glyph. |
+| [renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Rendert das Glyph mit einem unabhängigen Glyph-Pfad. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlyphOutlineRenderer(IGlyphOutlinePainter painter) {#GlyphOutlineRenderer-com.aspose.font.IGlyphOutlinePainter-}
+```
+public GlyphOutlineRenderer(IGlyphOutlinePainter painter)
+```
+
+
+Initialisiert ein neues GlyphOutlineRenderer-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| painter | [IGlyphOutlinePainter](../../com.aspose.font/iglyphoutlinepainter) | Glyph-Maler. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### renderGlyph(IFont font, GlyphId glyphId) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId)
+```
+
+
+Rendert das Glyph.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Die Schrift, die das Glyph enthält. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physikalischer Glyph-Index innerhalb der Schrift. Hinweis: Dies ist kein Unicode. |
+
+### renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Rendert das Glyph, ein Ziel dieser überladenen Version – zur Verwendung mit einem Cache für Glyphs.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Die Schrift, die das Glyph enthält. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physikalischer Glyph-Index innerhalb der Schrift. Hinweis: Dies ist kein Unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glyph zum Rendern. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix, die auf Glyph-Koordinaten angewendet wird. |
+
+### renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Rendert das Glyph.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Die Schrift, die das Glyph enthält. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physikalischer Glyph-Index innerhalb der Schrift. Hinweis: Dies ist kein Unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix, die auf Glyph-Koordinaten angewendet wird. |
+
+### renderGlyph(IFont font, long glyphIndex) {#renderGlyph-com.aspose.font.IFont-long-}
+```
+public void renderGlyph(IFont font, long glyphIndex)
+```
+
+
+Rendert das Glyph
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Die Schrift, die das Glyph enthält. |
+| glyphIndex | long | Physikalischer Glyph-Index innerhalb der Schrift. Hinweis: Dies ist kein Unicode. |
+
+### renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Rendert das Glyph.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Die Schrift, die das Glyph enthält. |
+| glyphIndex | long | Physikalischer Glyph-Index innerhalb der Schrift. Hinweis: Dies ist kein Unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix, die auf Glyph-Koordinaten angewendet wird. |
+
+### renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public void renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Rendert das Glyph mit einem unabhängigen Glyph-Pfad. Die RenderGlyph()-Funktionsfamilie ändert den Glyph-Pfad beim Rendern. Das führt dazu, dass das Glyph erneut geladen werden muss. Diese Funktion verwendet eine Kopie des Glyph-Pfads und ändert den ursprünglichen Glyph-Pfad nicht, sodass dasselbe Glyph mehrfach verwendet werden kann. Diese Version der Funktion ist für die Verwendung mit einem Glyph-Cache vorgesehen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Die Schrift, die das Glyph enthält. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physikalischer Glyph-Index innerhalb der Schrift. Hinweis: Dies ist kein Unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glyph zum Rendern. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix, die auf Glyph-Koordinaten angewendet wird. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/glyphrendererbase/_index.md
+++ b/german/java/com.aspose.font/glyphrendererbase/_index.md
@@ -1,0 +1,223 @@
+---
+title: "GlyphRendererBase"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Basisklasse für Glyph-Renderer dar."
+type: docs
+weight: 53
+url: /de/java/com.aspose.font/glyphrendererbase/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IGlyphRenderer](../../com.aspose.font/iglyphrenderer)
+```
+public abstract class GlyphRendererBase implements IGlyphRenderer
+```
+
+Stellt die Basisklasse für Glyph-Renderer dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [renderGlyph(IFont font, GlyphId glyphId)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-) | Rendert das Glyph. |
+| [renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Rendert das Glyph, ein Ziel dieser überladenen Version – zur Verwendung mit einem Cache für Glyphs. |
+| [renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-) | Rendert das Glyph. |
+| [renderGlyph(IFont font, long glyphIndex)](#renderGlyph-com.aspose.font.IFont-long-) | Rendert das Glyph |
+| [renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-) | Rendert das Glyph. |
+| [renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Rendert das Glyph mit einem unabhängigen Glyph-Pfad. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### renderGlyph(IFont font, GlyphId glyphId) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId)
+```
+
+
+Rendert das Glyph.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Die Schrift, die das Glyph enthält. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physikalischer Glyph-Index innerhalb der Schrift. Hinweis: Dies ist kein Unicode. |
+
+### renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Rendert das Glyph, ein Ziel dieser überladenen Version – zur Verwendung mit einem Cache für Glyphs.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Die Schrift, die das Glyph enthält. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physikalischer Glyph-Index innerhalb der Schrift. Hinweis: Dies ist kein Unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glyph zum Rendern. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix, die auf Glyph-Koordinaten angewendet wird. |
+
+### renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Rendert das Glyph.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Die Schrift, die das Glyph enthält. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physikalischer Glyph-Index innerhalb der Schrift. Hinweis: Dies ist kein Unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix, die auf Glyph-Koordinaten angewendet wird. |
+
+### renderGlyph(IFont font, long glyphIndex) {#renderGlyph-com.aspose.font.IFont-long-}
+```
+public void renderGlyph(IFont font, long glyphIndex)
+```
+
+
+Rendert das Glyph
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Die Schrift, die das Glyph enthält. |
+| glyphIndex | long | Physikalischer Glyph-Index innerhalb der Schrift. Hinweis: Dies ist kein Unicode. |
+
+### renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Rendert das Glyph.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Die Schrift, die das Glyph enthält. |
+| glyphIndex | long | Physikalischer Glyph-Index innerhalb der Schrift. Hinweis: Dies ist kein Unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix, die auf Glyph-Koordinaten angewendet wird. |
+
+### renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public void renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Rendert das Glyph mit einem unabhängigen Glyph-Pfad. Die RenderGlyph()-Funktionsfamilie ändert den Glyph-Pfad beim Rendern. Das führt dazu, dass das Glyph erneut geladen werden muss. Diese Funktion verwendet eine Kopie des Glyph-Pfads und ändert den ursprünglichen Glyph-Pfad nicht, sodass dasselbe Glyph mehrfach verwendet werden kann. Diese Version der Funktion ist für die Verwendung mit einem Glyph-Cache vorgesehen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Die Schrift, die das Glyph enthält. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physikalischer Glyph-Index innerhalb der Schrift. Hinweis: Dies ist kein Unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glyph zum Rendern. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix, die auf Glyph-Koordinaten angewendet wird. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/glyphstate/_index.md
+++ b/german/java/com.aspose.font/glyphstate/_index.md
@@ -1,0 +1,250 @@
+---
+title: "GlyphState"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Gibt den Glyphenstatus an."
+type: docs
+weight: 138
+url: /de/java/com.aspose.font/glyphstate/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum GlyphState extends Enum<GlyphState>
+```
+
+Gibt den Glyphenstatus an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ParsedWithErrors](#ParsedWithErrors) | Glyph wurde mit Fehlern geparst. |
+| [Success](#Success) | Glyph wurde erfolgreich geparst. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ParsedWithErrors {#ParsedWithErrors}
+```
+public static final GlyphState ParsedWithErrors
+```
+
+
+Glyph wurde mit Fehlern geparst.
+
+### Success {#Success}
+```
+public static final GlyphState Success
+```
+
+
+Glyph wurde erfolgreich geparst.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static GlyphState valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[GlyphState](../../com.aspose.font/glyphstate)
+### values() {#values--}
+```
+public static GlyphState[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.GlyphState[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/glyphstringid/_index.md
+++ b/german/java/com.aspose.font/glyphstringid/_index.md
@@ -1,0 +1,234 @@
+---
+title: "GlyphStringId"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine String-Glyph-ID dar."
+type: docs
+weight: 54
+url: /de/java/com.aspose.font/glyphstringid/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.GlyphId](../../com.aspose.font/glyphid)
+```
+public class GlyphStringId extends GlyphId
+```
+
+Stellt eine String-Glyph-ID dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [GlyphStringId(String value)](#GlyphStringId-java.lang.String-) | Initialisiert ein neues GlyphStringID-Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Gibt true zurück, wenn die Zeichenketten-IDs gleich sind. |
+| [getClass()](#getClass--) |  |
+| [getNotDefId()](#getNotDefId--) | Liefert nicht definierte Glyph-ID. |
+| [getValue()](#getValue--) | Liefert Zeichenkettenwert. |
+| [hashCode()](#hashCode--) | Implementierung von GetHashCode. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(GlyphId obj1, Object obj2)](#op-Equality-com.aspose.font.GlyphId-java.lang.Object-) | Gibt true zurück, wenn zwei Glyph-IDs gleich sind. |
+| [op_Inequality(GlyphId obj1, Object obj2)](#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-) | Gibt true zurück, wenn zwei Glyph-IDs ungleich sind. |
+| [setValue(String value)](#setValue-java.lang.String-) | Setzt Zeichenkettenwert. |
+| [toGlyphStringId()](#toGlyphStringId--) | Konvertiere GlyphId zu GlyphStringId |
+| [toGlyphUInt32Id()](#toGlyphUInt32Id--) | Virtuelle Umwandlung zu GlyphUInt32Id. |
+| [toString()](#toString--) | Gibt den Zeichenkettenwert der Glyph-ID zurück. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlyphStringId(String value) {#GlyphStringId-java.lang.String-}
+```
+public GlyphStringId(String value)
+```
+
+
+Initialisiert ein neues GlyphStringID-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Glyph‑Bezeichner. |
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Gibt true zurück, wenn die Zeichenketten-IDs gleich sind.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj | java.lang.Object | Glyph-Zeichenkettenbezeichner zum Vergleichen mit. |
+
+**Returns:**
+boolean - Vergleichsergebnis
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNotDefId() {#getNotDefId--}
+```
+public static GlyphStringId getNotDefId()
+```
+
+
+Liefert nicht definierte Glyph-ID.
+
+**Returns:**
+[GlyphStringId](../../com.aspose.font/glyphstringid) - Not defined glyph id.
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Liefert Zeichenkettenwert.
+
+**Returns:**
+java.lang.String - Zeichenkettenwert.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Implementierung von GetHashCode.
+
+**Returns:**
+int - Hashcode des Objekts.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(GlyphId obj1, Object obj2) {#op-Equality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Equality(GlyphId obj1, Object obj2)
+```
+
+
+Gibt true zurück, wenn zwei Glyph-IDs gleich sind.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Erster Glyph-Bezeichner zum Vergleichen. |
+| obj2 | java.lang.Object | Zweiter Glyph-Bezeichner zum Vergleichen. |
+
+**Returns:**
+boolean - Vergleichsergebnis.
+### op_Inequality(GlyphId obj1, Object obj2) {#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Inequality(GlyphId obj1, Object obj2)
+```
+
+
+Gibt true zurück, wenn zwei Glyph-IDs ungleich sind.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Erster Glyph-Bezeichner zum Vergleichen. |
+| obj2 | java.lang.Object | Zweiter Glyph-Bezeichner zum Vergleichen. |
+
+**Returns:**
+boolean - Vergleichsergebnis.
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Setzt Zeichenkettenwert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Zeichenkettenwert. |
+
+### toGlyphStringId() {#toGlyphStringId--}
+```
+public GlyphStringId toGlyphStringId()
+```
+
+
+Konvertiere GlyphId zu GlyphStringId
+
+**Returns:**
+[GlyphStringId](../../com.aspose.font/glyphstringid) - this
+### toGlyphUInt32Id() {#toGlyphUInt32Id--}
+```
+public GlyphUInt32Id toGlyphUInt32Id()
+```
+
+
+Virtuelle Umwandlung zu GlyphUInt32Id. GlyphUInt32Id überschreibt, um die Instanz zurückzugeben.
+
+**Returns:**
+[GlyphUInt32Id](../../com.aspose.font/glyphuint32id) - null
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+Gibt den Zeichenkettenwert der Glyph-ID zurück.
+
+**Returns:**
+java.lang.String - Glyph-Bezeichner.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/glyphuint32id/_index.md
+++ b/german/java/com.aspose.font/glyphuint32id/_index.md
@@ -1,0 +1,268 @@
+---
+title: "GlyphUInt32Id"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Ganzzahl-Glyph-ID dar."
+type: docs
+weight: 55
+url: /de/java/com.aspose.font/glyphuint32id/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.GlyphId](../../com.aspose.font/glyphid)
+```
+public class GlyphUInt32Id extends GlyphId
+```
+
+Stellt eine Ganzzahl-Glyph-ID dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [GlyphUInt32Id(long value)](#GlyphUInt32Id-long-) | Initialisiert ein neues GlyphUInt32Id-Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Gibt true zurück, wenn die IDs gleich sind. |
+| [getClass()](#getClass--) |  |
+| [getNotDefId()](#getNotDefId--) | Liefert nicht definierte Glyph-ID. |
+| [getValue()](#getValue--) | Liefert den int-Wert der ID. |
+| [hashCode()](#hashCode--) | Implementierung von GetHashCode. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(GlyphId obj1, Object obj2)](#op-Equality-com.aspose.font.GlyphId-java.lang.Object-) | Gibt true zurück, wenn zwei Glyph-IDs gleich sind. |
+| [op_Equality(GlyphUInt32Id obj1, Object obj2)](#op-Equality-com.aspose.font.GlyphUInt32Id-java.lang.Object-) | Implementierung des Gleichheitsoperators. |
+| [op_Inequality(GlyphId obj1, Object obj2)](#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-) | Gibt true zurück, wenn zwei Glyph-IDs ungleich sind. |
+| [op_Inequality(GlyphUInt32Id obj1, Object obj2)](#op-Inequality-com.aspose.font.GlyphUInt32Id-java.lang.Object-) | Implementierung des Ungleichheitsoperators. |
+| [setValue(long value)](#setValue-long-) | Setzt den int-Wert der ID. |
+| [toGlyphStringId()](#toGlyphStringId--) | Virtueller Cast zu GlyphStringId. |
+| [toGlyphUInt32Id()](#toGlyphUInt32Id--) | Cast GlyphId zu GlyphUInt32Id |
+| [toString()](#toString--) | Liefert die String-Darstellung des ganzzahligen Werts. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlyphUInt32Id(long value) {#GlyphUInt32Id-long-}
+```
+public GlyphUInt32Id(long value)
+```
+
+
+Initialisiert ein neues GlyphUInt32Id-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long | Glyph‑Bezeichner. |
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Gibt true zurück, wenn die IDs gleich sind.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj | java.lang.Object | Glyph-Bezeichner zum Vergleich mit |
+
+**Returns:**
+boolean - Vergleichsergebnis
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNotDefId() {#getNotDefId--}
+```
+public static GlyphUInt32Id getNotDefId()
+```
+
+
+Liefert nicht definierte Glyph-ID.
+
+**Returns:**
+[GlyphUInt32Id](../../com.aspose.font/glyphuint32id) - Not defined glyph id.
+### getValue() {#getValue--}
+```
+public long getValue()
+```
+
+
+Liefert den int-Wert der ID.
+
+**Returns:**
+long - Int-Wert der ID.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Implementierung von GetHashCode.
+
+**Returns:**
+int - Hashcode des Objekts
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(GlyphId obj1, Object obj2) {#op-Equality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Equality(GlyphId obj1, Object obj2)
+```
+
+
+Gibt true zurück, wenn zwei Glyph-IDs gleich sind.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Erster Glyph-Bezeichner zum Vergleichen. |
+| obj2 | java.lang.Object | Zweiter Glyph-Bezeichner zum Vergleichen. |
+
+**Returns:**
+boolean - Vergleichsergebnis.
+### op_Equality(GlyphUInt32Id obj1, Object obj2) {#op-Equality-com.aspose.font.GlyphUInt32Id-java.lang.Object-}
+```
+public static boolean op_Equality(GlyphUInt32Id obj1, Object obj2)
+```
+
+
+Implementierung des Gleichheitsoperators.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj1 | [GlyphUInt32Id](../../com.aspose.font/glyphuint32id) | erster Glyph-Bezeichner zum Vergleich |
+| obj2 | java.lang.Object | zweiter Glyph-Bezeichner zum Vergleich |
+
+**Returns:**
+boolean - Vergleichsergebnis
+### op_Inequality(GlyphId obj1, Object obj2) {#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Inequality(GlyphId obj1, Object obj2)
+```
+
+
+Gibt true zurück, wenn zwei Glyph-IDs ungleich sind.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Erster Glyph-Bezeichner zum Vergleichen. |
+| obj2 | java.lang.Object | Zweiter Glyph-Bezeichner zum Vergleichen. |
+
+**Returns:**
+boolean - Vergleichsergebnis.
+### op_Inequality(GlyphUInt32Id obj1, Object obj2) {#op-Inequality-com.aspose.font.GlyphUInt32Id-java.lang.Object-}
+```
+public static boolean op_Inequality(GlyphUInt32Id obj1, Object obj2)
+```
+
+
+Implementierung des Ungleichheitsoperators.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj1 | [GlyphUInt32Id](../../com.aspose.font/glyphuint32id) | erster Glyph-Bezeichner zum Vergleich |
+| obj2 | java.lang.Object | zweiter Glyph-Bezeichner zum Vergleich |
+
+**Returns:**
+boolean - Vergleichsergebnis
+### setValue(long value) {#setValue-long-}
+```
+public void setValue(long value)
+```
+
+
+Setzt den int-Wert der ID.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long | Int-Wert der ID. |
+
+### toGlyphStringId() {#toGlyphStringId--}
+```
+public GlyphStringId toGlyphStringId()
+```
+
+
+Virtueller Cast zu GlyphStringId. GlyphStringId überschreibt, um eine Instanz zurückzugeben.
+
+**Returns:**
+[GlyphStringId](../../com.aspose.font/glyphstringid) - null
+### toGlyphUInt32Id() {#toGlyphUInt32Id--}
+```
+public GlyphUInt32Id toGlyphUInt32Id()
+```
+
+
+Cast GlyphId zu GlyphUInt32Id
+
+**Returns:**
+[GlyphUInt32Id](../../com.aspose.font/glyphuint32id) - this
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+Liefert die String-Darstellung des ganzzahligen Werts.
+
+**Returns:**
+java.lang.String - Glyph-Bezeichner
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/helpersfactory/_index.md
+++ b/german/java/com.aspose.font/helpersfactory/_index.md
@@ -1,0 +1,141 @@
+---
+title: "HelpersFactory"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Erstellt Objekte, die zum Namespace TtfHelpers gehören"
+type: docs
+weight: 56
+url: /de/java/com.aspose.font/helpersfactory/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class HelpersFactory
+```
+
+Erstellt Objekte, die zum Namespace TtfHelpers gehören
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontCharactersMerger(TtfFont font1, TtfFont font2)](#getFontCharactersMerger-com.aspose.font.TtfFont-com.aspose.font.TtfFont-) | Erstellt eine IFontCharactersMerger‑Instanz |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontCharactersMerger(TtfFont font1, TtfFont font2) {#getFontCharactersMerger-com.aspose.font.TtfFont-com.aspose.font.TtfFont-}
+```
+public static IFontCharactersMerger getFontCharactersMerger(TtfFont font1, TtfFont font2)
+```
+
+
+Erstellt eine IFontCharactersMerger‑Instanz
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font1 | [TtfFont](../../com.aspose.font/ttffont) | Erste Schrift zum Zusammenführen, diese Schrift wird als primäre Schrift betrachtet |
+| font2 | [TtfFont](../../com.aspose.font/ttffont) | Zweite Schrift zum Zusammenführen |
+
+**Returns:**
+[IFontCharactersMerger](../../com.aspose.font/ifontcharactersmerger) -  IFontCharactersMerger  instance
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/icffindexdataprovider/_index.md
+++ b/german/java/com.aspose.font/icffindexdataprovider/_index.md
@@ -1,0 +1,38 @@
+---
+title: "ICffIndexDataProvider"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Grundlegende Schnittstelle zum Zugriff auf INDEX-Strukturen von CFF-Schriften."
+type: docs
+weight: 120
+url: /de/java/com.aspose.font/icffindexdataprovider/
+---```
+public interface ICffIndexDataProvider
+```
+
+Basic interface for accessing INDEX structures of CFF fonts.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getCount()](#getCount--) | The number of objects in the CFF INDEX structure. |
+| [getRawBytes()](#getRawBytes--) | Gets all the bytes of the CFF INDEX structure. |
+### getCount() {#getCount--}
+```
+public abstract int getCount()
+```
+
+
+The number of objects in the CFF INDEX structure.
+
+**Returns:**
+int
+### getRawBytes() {#getRawBytes--}
+```
+public abstract byte[] getRawBytes()
+```
+
+
+Gets all the bytes of the CFF INDEX structure.
+
+**Returns:**
+byte[] - Bytes of the CFF INDEX structure

--- a/german/java/com.aspose.font/iencodingparameters/_index.md
+++ b/german/java/com.aspose.font/iencodingparameters/_index.md
@@ -1,0 +1,12 @@
+---
+title: "IEncodingParameters"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Gemeinsame Schnittstelle zur Unterstützung von Kodierungsparametern."
+type: docs
+weight: 121
+url: /de/java/com.aspose.font/iencodingparameters/
+---```
+public interface IEncodingParameters
+```
+
+Common interface to support encoding parameters. Some font types can have multiple encoding algorithms/maps. So, this interface should be used to create concrete font encoding parameters.

--- a/german/java/com.aspose.font/ifont/_index.md
+++ b/german/java/com.aspose.font/ifont/_index.md
@@ -1,0 +1,223 @@
+---
+title: "IFont"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Deklariert gemeinsame Funktionalität für alle Schriftformaten."
+type: docs
+weight: 122
+url: /de/java/com.aspose.font/ifont/
+---```
+public interface IFont
+```
+
+Declares common functionality for all font formats. Implemented by Font classes.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Converts the Font into another format. |
+| [getEncoding()](#getEncoding--) | Gets Font encoding. |
+| [getFontDefinition()](#getFontDefinition--) | Gets Font definition. |
+| [getFontFamily()](#getFontFamily--) | Gets Font family. |
+| [getFontName()](#getFontName--) | Gets Font face name. |
+| [getFontNames()](#getFontNames--) | Gets Font names. |
+| [getFontSaver()](#getFontSaver--) | Gets Font save functionality. |
+| [getFontStyle()](#getFontStyle--) | Gets Font style. |
+| [getFontType()](#getFontType--) | Gets Font type. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Gets Font glyph accessor. |
+| [getMetrics()](#getMetrics--) | Gets Font metrics. |
+| [getNumGlyphs()](#getNumGlyphs--) | Gets number of glyphs in the Font. |
+| [getPostscriptNames()](#getPostscriptNames--) | Gets postscript Font names. |
+| [getStyle()](#getStyle--) | Gets Font style. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Sets Font family. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Sets Font face name. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Sets Font style. |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public abstract Font convert(FontType fontType)
+```
+
+
+Converts the Font into another format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | type to convert to font into |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - font converted into format specified
+### getEncoding() {#getEncoding--}
+```
+public abstract IFontEncoding getEncoding()
+```
+
+
+Gets Font encoding.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public abstract FontDefinition getFontDefinition()
+```
+
+
+Gets Font definition.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public abstract String getFontFamily()
+```
+
+
+Gets Font family.
+
+**Returns:**
+java.lang.String - Font family.
+### getFontName() {#getFontName--}
+```
+public abstract String getFontName()
+```
+
+
+Gets Font face name.
+
+**Returns:**
+java.lang.String - Font face name.
+### getFontNames() {#getFontNames--}
+```
+public abstract MultiLanguageString getFontNames()
+```
+
+
+Gets Font names.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public abstract IFontSaver getFontSaver()
+```
+
+
+Gets Font save functionality.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public abstract int getFontStyle()
+```
+
+
+Gets Font style. This is a value computed and represented in generalized type.
+
+**Returns:**
+int - Font style. Usually, a combination of FontStyle class constant flag values or 0.
+### getFontType() {#getFontType--}
+```
+public abstract FontType getFontType()
+```
+
+
+Gets Font type.
+
+--------------------
+
+> ```
+> Type1, TrueType etc.
+> ```
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public abstract IGlyphAccessor getGlyphAccessor()
+```
+
+
+Gets Font glyph accessor. Retrieves glyphs and glyph identifiers.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getMetrics() {#getMetrics--}
+```
+public abstract IFontMetrics getMetrics()
+```
+
+
+Gets Font metrics.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public abstract int getNumGlyphs()
+```
+
+
+Gets number of glyphs in the Font.
+
+**Returns:**
+int - Number of glyphs in the Font..
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public abstract MultiLanguageString getPostscriptNames()
+```
+
+
+Gets postscript Font names.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names.
+### getStyle() {#getStyle--}
+```
+public abstract String getStyle()
+```
+
+
+Gets Font style. This is a raw string value provided by Font file.
+
+**Returns:**
+java.lang.String - Font style.
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public abstract void setFontFamily(String value)
+```
+
+
+Sets Font family.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | java.lang.String | New Font family. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public abstract void setFontName(String value)
+```
+
+
+Sets Font face name.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | java.lang.String | New Font face name. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public abstract void setStyle(String value)
+```
+
+
+Sets Font style. This is a raw string value provided by Font file.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | java.lang.String | New Font style. |
+

--- a/german/java/com.aspose.font/ifontcharactersmerger/_index.md
+++ b/german/java/com.aspose.font/ifontcharactersmerger/_index.md
@@ -1,0 +1,70 @@
+---
+title: "IFontCharactersMerger"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Deklariert Hilfsfunktionalität zum Zusammenführen von TrueType-Schriften."
+type: docs
+weight: 123
+url: /de/java/com.aspose.font/ifontcharactersmerger/
+---```
+public interface IFontCharactersMerger
+```
+
+Declares helpers functionality to merge TrueType fonts. Font which is passed by parameter font1 considered as primary. It means that many characteristics, related to final merged font, such as metrics, encoding structure and others, will be taken from this primary font.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [mergeFonts(GlyphId[] font1Glyphs, GlyphId[] font2Glyphs, String newFontName)](#mergeFonts-com.aspose.font.GlyphId---com.aspose.font.GlyphId---java.lang.String-) | Merges fonts based on glyphs lists passed. |
+| [mergeFonts(int[] font1CharCodes, int[] font2CharCodes, String newFontName)](#mergeFonts-int---int---java.lang.String-) | Merges fonts based on character codes lists passed. |
+| [mergeFonts(Map<Integer,GlyphId> font1Dict, Map<Integer,GlyphId> font2Dict, String newFontName)](#mergeFonts-java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.lang.String-) | This method version designed for cases when you want to set character codes for glyphs in resultant font explicitly. |
+### mergeFonts(GlyphId[] font1Glyphs, GlyphId[] font2Glyphs, String newFontName) {#mergeFonts-com.aspose.font.GlyphId---com.aspose.font.GlyphId---java.lang.String-}
+```
+public abstract TtfFont mergeFonts(GlyphId[] font1Glyphs, GlyphId[] font2Glyphs, String newFontName)
+```
+
+
+Merges fonts based on glyphs lists passed. Searches for a character code for every glyph passed and add found character code with correspondent glyph into resultant new font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font1Glyphs | [GlyphId\[\]](../../com.aspose.font/glyphid) | List of glyphs from first font |
+| font2Glyphs | [GlyphId\[\]](../../com.aspose.font/glyphid) | List of glyphs from second font |
+| newFontName | java.lang.String | Desired name for resultant font |
+
+**Returns:**
+[TtfFont](../../com.aspose.font/ttffont) - Merged font
+### mergeFonts(int[] font1CharCodes, int[] font2CharCodes, String newFontName) {#mergeFonts-int---int---java.lang.String-}
+```
+public abstract TtfFont mergeFonts(int[] font1CharCodes, int[] font2CharCodes, String newFontName)
+```
+
+
+Merges fonts based on character codes lists passed. To create desired resultant font just pass symbol codes from original fonts you want to include into resultant font. Glyphs related to codes passed will be found automatically. For example, if you want to include into resultant font glyphs related to letters A and B from first font and glyphs, related to letters C and D from second font, just call this method like this:  MergeFonts(new uint[] \{ 'A', 'B' \}, new uint[] \{ 'C', 'D' \}, "NewFont") 
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font1CharCodes | int[] | Codes to take from first font |
+| font2CharCodes | int[] | Codes to take from second font |
+| newFontName | java.lang.String | Desired name for resultant font |
+
+**Returns:**
+[TtfFont](../../com.aspose.font/ttffont) - Merged font
+### mergeFonts(Map<Integer,GlyphId> font1Dict, Map<Integer,GlyphId> font2Dict, String newFontName) {#mergeFonts-java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.lang.String-}
+```
+public abstract TtfFont mergeFonts(Map<Integer,GlyphId> font1Dict, Map<Integer,GlyphId> font2Dict, String newFontName)
+```
+
+
+This method version designed for cases when you want to set character codes for glyphs in resultant font explicitly. It's not mandatory that code for glyph you provided is included in original font. The sense of code passed is that it will be associated with correspondent glyph identifier in resultant font. So, rule to process every pair passed by dictionary parameter[code, glyph ideitifier] is that only glyph identifer will be taken from original font and then it will be linked with correspondent code in resultant font. It can be helpful when some codes from first font conflict with same codes from second font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font1Dict | java.util.Map<java.lang.Integer,com.aspose.font.GlyphId> | Dictionary with pairs [symbol code, glyph identifier] from first font |
+| font2Dict | java.util.Map<java.lang.Integer,com.aspose.font.GlyphId> | Dictionary with pairs [symbol code, glyph identifier] from second font |
+| newFontName | java.lang.String | Desired name for resultant font |
+
+**Returns:**
+[TtfFont](../../com.aspose.font/ttffont) - Merged font

--- a/german/java/com.aspose.font/ifontencoding/_index.md
+++ b/german/java/com.aspose.font/ifontencoding/_index.md
@@ -1,0 +1,96 @@
+---
+title: "IFontEncoding"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Definiert eine Schnittstelle für die Schriftkodierung."
+type: docs
+weight: 124
+url: /de/java/com.aspose.font/ifontencoding/
+---```
+public interface IFontEncoding
+```
+
+Defines an interface for Font encoding.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [decodeToGid(long charCode)](#decodeToGid-long-) | Decodes a character code and returns glyph id. |
+| [decodeToGidParameterized(IEncodingParameters parameters, long charCode)](#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-) | Parameterized decode method. |
+| [encode(long gid, long charCode)](#encode-long-long-) | Encodes the glyph. |
+| [gidToUnicode(GlyphId gid)](#gidToUnicode-com.aspose.font.GlyphId-) | Decodes Gid to unicode. |
+| [unicodeToGid(long unicode)](#unicodeToGid-long-) | Decodes a unicode and returns glyph id. |
+### decodeToGid(long charCode) {#decodeToGid-long-}
+```
+public abstract GlyphId decodeToGid(long charCode)
+```
+
+
+Decodes a character code and returns glyph id. Glyph id is a unique number for a glyph, which is font type dependent. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| charCode | long | Character code to get glyph identifier for. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to charCode passed.
+### decodeToGidParameterized(IEncodingParameters parameters, long charCode) {#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-}
+```
+public abstract GlyphId decodeToGidParameterized(IEncodingParameters parameters, long charCode)
+```
+
+
+Parameterized decode method. Some font types can have multiple encoding algorithms/maps. So,  IEncodingParameters  interface is used to create concrete font encoding parameters.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| parameters | [IEncodingParameters](../../com.aspose.font/iencodingparameters) | Implementation of  IEncodingParameters  interface. |
+| charCode | long | Character code to get glyph identifier for. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to char code passed.
+### encode(long gid, long charCode) {#encode-long-long-}
+```
+public abstract void encode(long gid, long charCode)
+```
+
+
+Encodes the glyph. For TTF Fonts the charCode is unicode.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| gid | long | Glyph id. |
+| charCode | long | Character code associated with the glyph id. |
+
+### gidToUnicode(GlyphId gid) {#gidToUnicode-com.aspose.font.GlyphId-}
+```
+public abstract long gidToUnicode(GlyphId gid)
+```
+
+
+Decodes Gid to unicode. Glyph id is a unique number for a glyph, which is font type dependent. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| gid | [GlyphId](../../com.aspose.font/glyphid) | Glyph identifier of symbol to decode. |
+
+**Returns:**
+long - Unicode value related to glyph id passed.
+### unicodeToGid(long unicode) {#unicodeToGid-long-}
+```
+public abstract GlyphId unicodeToGid(long unicode)
+```
+
+
+Decodes a unicode and returns glyph id. Glyph id is a unique number for a glyph, which is font type dependent. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| unicode | long | Unicode to get glyph identifier for. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to unicode passed.

--- a/german/java/com.aspose.font/ifontmetrics/_index.md
+++ b/german/java/com.aspose.font/ifontmetrics/_index.md
@@ -1,0 +1,357 @@
+---
+title: "IFontMetrics"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Definiert eine Schnittstelle für Schriftmetriken-Werkzeuge."
+type: docs
+weight: 125
+url: /de/java/com.aspose.font/ifontmetrics/
+---```
+public interface IFontMetrics
+```
+
+Defines an interface for Font metrics tools.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getAscender()](#getAscender--) | Gets ascender value of the Font in font units. |
+| [getAscender(double fontSize)](#getAscender-double-) | Returns ascender for specific Font size. |
+| [getDescender()](#getDescender--) | Gets descender value of the Font in font units. |
+| [getDescender(double fontSize)](#getDescender-double-) | Returns descender for specific Font size. |
+| [getFontBBox()](#getFontBBox--) | Gets Font bounding box. |
+| [getFontMatrix()](#getFontMatrix--) | Gets Font transformation matrix. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Returns glyph BBox. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Returns glyph width. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Returns kerning value for the glyph pair. |
+| [getLineGap()](#getLineGap--) | Gets LineGap value of the Font in Font units. |
+| [getTypoAscender()](#getTypoAscender--) | Gets typographic ascender value of the Font in font units |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Returns typographic ascender for specific Font size. |
+| [getTypoDescender()](#getTypoDescender--) | Gets typographic descender value of the Font in Font units. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Returns typographic descender for specific Font size. |
+| [getTypoLineGap()](#getTypoLineGap--) | Gets typographic LineGap value of the Font in Font units. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Returns line gap for specific Font size. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Gets Gets units per em. |
+| [isFixedPitch()](#isFixedPitch--) | True, if the Font is monospaced. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Measures string and returns string width. |
+| [setAscender(double value)](#setAscender-double-) |  |
+| [setDescender(double value)](#setDescender-double-) |  |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) | Specifies glyph width. |
+| [setTypoAscender(double value)](#setTypoAscender-double-) |  |
+| [setTypoDescender(double value)](#setTypoDescender-double-) |  |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) |  |
+### getAscender() {#getAscender--}
+```
+public abstract double getAscender()
+```
+
+
+Gets ascender value of the Font in font units.
+
+**Returns:**
+double - Ascender value of the Font in font units.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public abstract double getAscender(double fontSize)
+```
+
+
+Returns ascender for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Ascender value.
+### getDescender() {#getDescender--}
+```
+public abstract double getDescender()
+```
+
+
+Gets descender value of the Font in font units.
+
+**Returns:**
+double - Descender value of the Font in font units.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public abstract double getDescender(double fontSize)
+```
+
+
+Returns descender for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Descender value.
+### getFontBBox() {#getFontBBox--}
+```
+public abstract FontBBox getFontBBox()
+```
+
+
+Gets Font bounding box.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Font bounding box.
+### getFontMatrix() {#getFontMatrix--}
+```
+public abstract TransformationMatrix getFontMatrix()
+```
+
+
+Gets Font transformation matrix.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - Font transformation matrix.
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public abstract FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Returns glyph BBox.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | glyph identifier |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - glyph BBox
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public abstract double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Returns glyph width.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph identifier. |
+
+**Returns:**
+double - Glyph width.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public abstract double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Returns kerning value for the glyph pair.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | First glyph in pair. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Font size. |
+
+**Returns:**
+double - Kerning value.
+### getLineGap() {#getLineGap--}
+```
+public abstract double getLineGap()
+```
+
+
+Gets LineGap value of the Font in Font units.
+
+**Returns:**
+double - LineGap value of the Font in Font units.
+### getTypoAscender() {#getTypoAscender--}
+```
+public abstract double getTypoAscender()
+```
+
+
+Gets typographic ascender value of the Font in font units
+
+**Returns:**
+double - Typographic ascender value of the Font in font units
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public abstract double getTypoAscender(double fontSize)
+```
+
+
+Returns typographic ascender for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Typographic ascender value.
+### getTypoDescender() {#getTypoDescender--}
+```
+public abstract double getTypoDescender()
+```
+
+
+Gets typographic descender value of the Font in Font units.
+
+**Returns:**
+double - Typographic descender value of the Font in Font units.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public abstract double getTypoDescender(double fontSize)
+```
+
+
+Returns typographic descender for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Typographic descender value.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public abstract double getTypoLineGap()
+```
+
+
+Gets typographic LineGap value of the Font in Font units.
+
+**Returns:**
+double - Typographic LineGap value of the Font in Font units.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public abstract double getTypoLineGap(double fontSize)
+```
+
+
+Returns line gap for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Line gap value.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public abstract long getUnitsPerEM()
+```
+
+
+Gets Gets units per em.
+
+**Returns:**
+long - Units per em.
+### isFixedPitch() {#isFixedPitch--}
+```
+public abstract boolean isFixedPitch()
+```
+
+
+True, if the Font is monospaced.
+
+**Returns:**
+boolean - True, if the Font is monospaced.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public abstract double measureString(String unicode, double fontSize)
+```
+
+
+Measures string and returns string width.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| unicode | java.lang.String | Unicode string. |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - String width.
+### setAscender(double value) {#setAscender-double-}
+```
+public abstract void setAscender(double value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | double |  |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public abstract void setDescender(double value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | double |  |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public abstract void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Specifies glyph width.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph identifier. |
+| value | double | Glyph width value. |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public abstract void setTypoAscender(double value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | double |  |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public abstract void setTypoDescender(double value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | double |  |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public abstract void setUnitsPerEM(long value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | long |  |
+

--- a/german/java/com.aspose.font/ifontsaver/_index.md
+++ b/german/java/com.aspose.font/ifontsaver/_index.md
@@ -1,0 +1,59 @@
+---
+title: "IFontSaver"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Definiert eine Schnittstelle für die Schrift-Speicherfunktionalität."
+type: docs
+weight: 126
+url: /de/java/com.aspose.font/ifontsaver/
+---```
+public interface IFontSaver
+```
+
+Defines an interface for Font save functionality.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Saves the Font into original format. |
+| [save(String fileName)](#save-java.lang.String-) | Saves the Font into original format. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Saves the Font into format specified. |
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public abstract void save(OutputStream stream)
+```
+
+
+Saves the Font into original format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| stream | java.io.OutputStream | stream to save font |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public abstract void save(String fileName)
+```
+
+
+Saves the Font into original format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fileName | java.lang.String | file to save font |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public abstract void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Saves the Font into format specified.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| stream | java.io.OutputStream | stream to save font |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | desired format |
+

--- a/german/java/com.aspose.font/iglyphaccessor/_index.md
+++ b/german/java/com.aspose.font/iglyphaccessor/_index.md
@@ -1,0 +1,70 @@
+---
+title: "IGlyphAccessor"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Definiert Funktionalität zum Abrufen angegebener Glyphenkennungen und Glyphen."
+type: docs
+weight: 127
+url: /de/java/com.aspose.font/iglyphaccessor/
+---```
+public interface IGlyphAccessor
+```
+
+Defines functionality to retrieve specified glyph identifiers and glyphs.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Returns all glyph ids, available in the Font. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Returns glyph by glyph id. |
+| [getGlyphIdType()](#getGlyphIdType--) | Glyph id type specification. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Get glyphs representation for text. |
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public abstract GlyphId[] getAllGlyphIds()
+```
+
+
+Returns all glyph ids, available in the Font. Glyph id is a unique number for a glyph, which is font type dependent. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyph identifiers.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public abstract Glyph getGlyphById(GlyphId id)
+```
+
+
+Returns glyph by glyph id. Glyph id is a unique number for a glyph, which is font type dependent. GlyphId - derived object. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | glyph ID. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public abstract GlyphIdType getGlyphIdType()
+```
+
+
+Glyph id type specification.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype) - Id type specification.
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public abstract GlyphId[] getGlyphsForText(String text)
+```
+
+
+Get glyphs representation for text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Input text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - GlyphId array.

--- a/german/java/com.aspose.font/iglyphoutlinepainter/_index.md
+++ b/german/java/com.aspose.font/iglyphoutlinepainter/_index.md
@@ -1,0 +1,70 @@
+---
+title: "IGlyphOutlinePainter"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Definiert eine Umriss-Methode zum Zeichnen von Glyphen."
+type: docs
+weight: 128
+url: /de/java/com.aspose.font/iglyphoutlinepainter/
+---
+**All Implemented Interfaces:**
+[com.aspose.font.IGlyphPainter](../../com.aspose.font/iglyphpainter)
+```
+public interface IGlyphOutlinePainter extends IGlyphPainter
+```
+
+Definiert eine Umriss-Methode zum Zeichnen von Glyphen.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [closePath()](#closePath--) | Verarbeitet ClosePath-Operation. |
+| [curveTo(CurveTo curveTo)](#curveTo-com.aspose.font.CurveTo-) | Verarbeitet CurveTo-Operation. |
+| [lineTo(LineTo lineTo)](#lineTo-com.aspose.font.LineTo-) | Verarbeitet LineTo-Operation. |
+| [moveTo(MoveTo moveTo)](#moveTo-com.aspose.font.MoveTo-) | Führt MoveTo-Operation aus. |
+### closePath() {#closePath--}
+```
+public abstract void closePath()
+```
+
+
+Verarbeitet ClosePath-Operation.
+
+### curveTo(CurveTo curveTo) {#curveTo-com.aspose.font.CurveTo-}
+```
+public abstract void curveTo(CurveTo curveTo)
+```
+
+
+Verarbeitet CurveTo-Operation.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| curveTo | [CurveTo](../../com.aspose.font/curveto) | CurveTo-Referenz |
+
+### lineTo(LineTo lineTo) {#lineTo-com.aspose.font.LineTo-}
+```
+public abstract void lineTo(LineTo lineTo)
+```
+
+
+Verarbeitet LineTo-Operation.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| lineTo | [LineTo](../../com.aspose.font/lineto) | LineTo-Referenz |
+
+### moveTo(MoveTo moveTo) {#moveTo-com.aspose.font.MoveTo-}
+```
+public abstract void moveTo(MoveTo moveTo)
+```
+
+
+Führt MoveTo-Operation aus.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| moveTo | [MoveTo](../../com.aspose.font/moveto) | MoveTo-Referenz |
+

--- a/german/java/com.aspose.font/iglyphpainter/_index.md
+++ b/german/java/com.aspose.font/iglyphpainter/_index.md
@@ -1,0 +1,12 @@
+---
+title: "IGlyphPainter"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Definiert eine Methode zum Zeichnen von Glyphen."
+type: docs
+weight: 129
+url: /de/java/com.aspose.font/iglyphpainter/
+---```
+public interface IGlyphPainter
+```
+
+Defines a way to draw glyphs.

--- a/german/java/com.aspose.font/iglyphrenderer/_index.md
+++ b/german/java/com.aspose.font/iglyphrenderer/_index.md
@@ -1,0 +1,112 @@
+---
+title: "IGlyphRenderer"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Schnittstelle zum Rendern von Glyphen."
+type: docs
+weight: 130
+url: /de/java/com.aspose.font/iglyphrenderer/
+---```
+public interface IGlyphRenderer
+```
+
+Interface used to render glyphs.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [renderGlyph(IFont font, GlyphId glyphId)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-) | Renders glyph. |
+| [renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renders glyph, an objective of this overloaded version - to be used with cache for glyphs. |
+| [renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-) | Renders glyph. |
+| [renderGlyph(IFont font, long glyphIndex)](#renderGlyph-com.aspose.font.IFont-long-) | Renders glyph. |
+| [renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-) | Renders glyph. |
+| [renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renders glyph using independent glyph path. |
+### renderGlyph(IFont font, GlyphId glyphId) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-}
+```
+public abstract void renderGlyph(IFont font, GlyphId glyphId)
+```
+
+
+Renders glyph.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physical glyph index inside font. Note that this is not a unicode. |
+
+### renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public abstract void renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renders glyph, an objective of this overloaded version - to be used with cache for glyphs.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physical glyph index inside font. Note that this is not a unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glyph to render. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix that is applied to glyph coordinates. |
+
+### renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-}
+```
+public abstract void renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renders glyph.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physical glyph index inside font. Note that this is not a unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix that is applied to glyph coordinates. |
+
+### renderGlyph(IFont font, long glyphIndex) {#renderGlyph-com.aspose.font.IFont-long-}
+```
+public abstract void renderGlyph(IFont font, long glyphIndex)
+```
+
+
+Renders glyph.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphIndex | long | Physical glyph index inside font. Note that this is not a unicode. |
+
+### renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-}
+```
+public abstract void renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renders glyph.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphIndex | long | Physical glyph index inside font. Note that this is not a unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix that is applied to glyph coordinates. |
+
+### renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public abstract void renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renders glyph using independent glyph path. RenderGlyph() function family changes glyph path on rendering. It then leads to necessity reload this glyph again. This function uses copy of glyph path and doesn't changes original glyph path, so the same glyph could be reused multiple times. This version of function is intended for use with cache of glyphs.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physical glyph index inside font. Note that this is not a unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glyph to render. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix that is applied to glyph coordinates. |
+

--- a/german/java/com.aspose.font/incorrectfontdataexception/_index.md
+++ b/german/java/com.aspose.font/incorrectfontdataexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "IncorrectFontDataException"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt Ausnahmen für Fälle dar, in denen einige Werte des Font-Objekts ungültig sind."
+type: docs
+weight: 57
+url: /de/java/com.aspose.font/incorrectfontdataexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class IncorrectFontDataException extends FontException
+```
+
+Stellt Ausnahmen für Fälle dar, in denen einige Werte des Font-Objekts ungültig sind.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [IncorrectFontDataException()](#IncorrectFontDataException--) | Initialisiert ein neues FontAgrumentException-Objekt. |
+| [IncorrectFontDataException(String message)](#IncorrectFontDataException-java.lang.String-) | Initialisiert ein neues FontAgrumentException-Objekt. |
+| [IncorrectFontDataException(String message, RuntimeException innerException)](#IncorrectFontDataException-java.lang.String-java.lang.RuntimeException-) | Initialisiert ein neues FontAgrumentException-Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IncorrectFontDataException() {#IncorrectFontDataException--}
+```
+public IncorrectFontDataException()
+```
+
+
+Initialisiert ein neues FontAgrumentException-Objekt.
+
+### IncorrectFontDataException(String message) {#IncorrectFontDataException-java.lang.String-}
+```
+public IncorrectFontDataException(String message)
+```
+
+
+Initialisiert ein neues FontAgrumentException-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+
+### IncorrectFontDataException(String message, RuntimeException innerException) {#IncorrectFontDataException-java.lang.String-java.lang.RuntimeException-}
+```
+public IncorrectFontDataException(String message, RuntimeException innerException)
+```
+
+
+Initialisiert ein neues FontAgrumentException-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+| innerException | java.lang.RuntimeException | Die Ausnahme, die die aktuelle Ausnahme verursacht. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ipathsegment/_index.md
+++ b/german/java/com.aspose.font/ipathsegment/_index.md
@@ -1,0 +1,59 @@
+---
+title: "IPathSegment"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Schnittstelle eines beliebigen Pfadsegments dar."
+type: docs
+weight: 131
+url: /de/java/com.aspose.font/ipathsegment/
+---
+**All Implemented Interfaces:**
+java.lang.Cloneable
+```
+public interface IPathSegment extends Cloneable
+```
+
+Stellt die Schnittstelle eines beliebigen Pfadsegments dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [copy()](#copy--) | Erstellt eine Kopie des Segmentobjekts. |
+| [shift(double dx, double dy)](#shift-double-double-) | Führt Verschiebung um x- und y-Koordinaten durch. |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Transformiert Koordinaten mit der Transformationsmatrix. |
+### copy() {#copy--}
+```
+public abstract IPathSegment copy()
+```
+
+
+Erstellt eine Kopie des Segmentobjekts.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public abstract void shift(double dx, double dy)
+```
+
+
+Führt Verschiebung um x- und y-Koordinaten durch.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| dx | double | Wert dx. |
+| dy | double | Wert dy. |
+
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public abstract void transform(TransformationMatrix matrix)
+```
+
+
+Transformiert Koordinaten mit der Transformationsmatrix.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Transformationsmatrix. |
+

--- a/german/java/com.aspose.font/isupportsnameaddressing/_index.md
+++ b/german/java/com.aspose.font/isupportsnameaddressing/_index.md
@@ -1,0 +1,27 @@
+---
+title: "ISupportsNameAddressing"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Definiert Mitglieder, die spezifisch für Kodierungen sind, die die Glyphen-Namensadressierung unterstützen"
+type: docs
+weight: 132
+url: /de/java/com.aspose.font/isupportsnameaddressing/
+---```
+public interface ISupportsNameAddressing
+```
+
+Defines members that are specific to encodings that support glyph name addressing
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getNameToCharCodeIndex()](#getNameToCharCodeIndex--) | Returns name to code map object. |
+### getNameToCharCodeIndex() {#getNameToCharCodeIndex--}
+```
+public abstract NameToCodeMap getNameToCharCodeIndex()
+```
+
+
+Returns name to code map object.
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - name to code map object.

--- a/german/java/com.aspose.font/license/_index.md
+++ b/german/java/com.aspose.font/license/_index.md
@@ -1,0 +1,193 @@
+---
+title: "Lizenz"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt Methoden zum Lizenzieren der Komponente bereit."
+type: docs
+weight: 58
+url: /de/java/com.aspose.font/license/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class License
+```
+
+Stellt Methoden zum Lizenzieren der Komponente bereit.
+
+In diesem Beispiel wird versucht, eine Lizenzdatei mit dem Namen MyLicense.lic im Ordner zu finden, der die Komponente enthält, im Ordner, der die aufrufende Assembly enthält, im Ordner der Einstieg‑Assembly und anschließend in den eingebetteten Ressourcen der aufrufenden Assembly.
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [License()](#License--) | Initialisiert eine neue Instanz dieser Klasse. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLicense(InputStream stream)](#setLicense-java.io.InputStream-) | Lizenziert die Komponente. |
+| [setLicense(String licenseName)](#setLicense-java.lang.String-) | Lizenziert die Komponente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### License() {#License--}
+```
+public License()
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse.
+
+In diesem Beispiel wird versucht, eine Lizenzdatei mit dem Namen MyLicense.lic im Ordner zu finden, der die Komponente enthält, im Ordner, der die aufrufende Assembly enthält, im Ordner der Einstieg‑Assembly und anschließend in den eingebetteten Ressourcen der aufrufenden Assembly.
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLicense(InputStream stream) {#setLicense-java.io.InputStream-}
+```
+public void setLicense(InputStream stream)
+```
+
+
+Lizenziert die Komponente.
+
+Ein Stream, der die Lizenz enthält.
+
+Verwenden Sie diese Methode, um eine Lizenz aus einem Stream zu laden.
+
+License license = new License();
+license.setLicense(myStream);
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.InputStream | Lizenz-Stream |
+
+### setLicense(String licenseName) {#setLicense-java.lang.String-}
+```
+public void setLicense(String licenseName)
+```
+
+
+Lizenziert die Komponente.
+
+Versucht, die Lizenz an den folgenden Orten zu finden:
+
+1. Expliziter Pfad.
+
+2. Der Ordner der Komponenten‑Jar‑Datei.
+
+In diesem Beispiel wird versucht, eine Lizenzdatei mit dem Namen MyLicense.lic im Ordner zu finden, der die Komponente enthält, im Ordner, der die aufrufende Assembly enthält, im Ordner der Einstieg‑Assembly und anschließend in den eingebetteten Ressourcen der aufrufenden Assembly.
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| licenseName | java.lang.String | Kann ein voller oder kurzer Dateiname oder der Name einer eingebetteten Ressource sein. Verwenden Sie einen leeren String, um in den Evaluierungsmodus zu wechseln. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/licenseflags/_index.md
+++ b/german/java/com.aspose.font/licenseflags/_index.md
@@ -1,0 +1,223 @@
+---
+title: "LicenseFlags"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt einen Hilfs-Wrapper für Einbettungs-Flags aus dem OS/2-Tabellenfeld fsType dar."
+type: docs
+weight: 59
+url: /de/java/com.aspose.font/licenseflags/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class LicenseFlags
+```
+
+Stellt einen Hilfs-Wrapper für Einbettungsflags aus der 'OS/2'-Tabelle (Feld fsType) dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFSType()](#getFSType--) | Liefert den rohen fsType-Wert aus der OS/2-Tabelle oder 0, falls dieses Feld in der Tabelle nicht existiert. |
+| [hashCode()](#hashCode--) |  |
+| [isBitmapOnlyEmbedding()](#isBitmapOnlyEmbedding--) | Ermittelt, ob fsType das BitmapOnly-Einbetten zulässt. |
+| [isEditableEmbedding()](#isEditableEmbedding--) | Ermittelt, ob fsType das Editable-Einbetten zulässt. |
+| [isFSTypeAbsent()](#isFSTypeAbsent--) | Gibt true zurück, wenn das fsType-Flag in der 'OS/2'-Tabelle fehlt. |
+| [isInstallableEmbedding()](#isInstallableEmbedding--) | Ermittelt, ob fsType Installable-Einbetten zulässt. |
+| [isNoSubsettingEmbedding()](#isNoSubsettingEmbedding--) | Ermittelt, ob fsType NoSubsetting-Einbetten zulässt. |
+| [isPreviewAndPrintEmbedding()](#isPreviewAndPrintEmbedding--) | Ermittelt, ob fsType Preview- und Print-Einbetten zulässt. |
+| [isReservedType()](#isReservedType--) | Ermittelt, ob das reservierte Bit (Bit 0) für fsType gesetzt ist. |
+| [isRestrictedLicenseEmbedding()](#isRestrictedLicenseEmbedding--) | Ermittelt, ob fsType Restricted License-Einbetten ist. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFSType() {#getFSType--}
+```
+public int getFSType()
+```
+
+
+Liefert den rohen fsType-Wert aus der OS/2-Tabelle oder 0, falls dieses Feld in der Tabelle nicht existiert.
+
+**Returns:**
+int - Rohwert von fsType aus der OS/2-Tabelle oder 0, falls dieses Feld in der Tabelle nicht existiert.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isBitmapOnlyEmbedding() {#isBitmapOnlyEmbedding--}
+```
+public boolean isBitmapOnlyEmbedding()
+```
+
+
+Ermittelt, ob fsType das BitmapOnly-Einbetten zulässt.
+
+**Returns:**
+boolean - Ermittelt, ob fsType BitmapOnly-Einbetten zulässt.
+### isEditableEmbedding() {#isEditableEmbedding--}
+```
+public boolean isEditableEmbedding()
+```
+
+
+Ermittelt, ob fsType das Editable-Einbetten zulässt.
+
+**Returns:**
+boolean - Erkennt, ob fsType Editable-Einbettung erlaubt.
+### isFSTypeAbsent() {#isFSTypeAbsent--}
+```
+public boolean isFSTypeAbsent()
+```
+
+
+Gibt true zurück, wenn das fsType-Flag in der 'OS/2'-Tabelle fehlt.
+
+**Returns:**
+boolean - Wahr, wenn das fsType-Flag in der 'OS/2'-Tabelle fehlt.
+### isInstallableEmbedding() {#isInstallableEmbedding--}
+```
+public boolean isInstallableEmbedding()
+```
+
+
+Ermittelt, ob fsType Installable-Einbetten zulässt.
+
+**Returns:**
+boolean - Erkennt, ob fsType Installable-Einbettung ist.
+### isNoSubsettingEmbedding() {#isNoSubsettingEmbedding--}
+```
+public boolean isNoSubsettingEmbedding()
+```
+
+
+Ermittelt, ob fsType NoSubsetting-Einbetten zulässt.
+
+**Returns:**
+boolean - Erkennt, ob fsType NoSubsetting-Einbettung erlaubt.
+### isPreviewAndPrintEmbedding() {#isPreviewAndPrintEmbedding--}
+```
+public boolean isPreviewAndPrintEmbedding()
+```
+
+
+Ermittelt, ob fsType Preview- und Print-Einbetten zulässt.
+
+**Returns:**
+boolean - Erkennt, ob fsType Preview- und Print-Einbettung erlaubt.
+### isReservedType() {#isReservedType--}
+```
+public boolean isReservedType()
+```
+
+
+Ermittelt, ob das reservierte Bit (Bit 0) für fsType gesetzt ist.
+
+**Returns:**
+boolean - Erkennt, ob das reservierte Bit (Bit 0) für fsType gesetzt ist.
+### isRestrictedLicenseEmbedding() {#isRestrictedLicenseEmbedding--}
+```
+public boolean isRestrictedLicenseEmbedding()
+```
+
+
+Ermittelt, ob fsType Restricted License-Einbetten ist.
+
+**Returns:**
+boolean - Erkennt, ob fsType Restricted License-Einbettung ist.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/licenserestrictionexception/_index.md
+++ b/german/java/com.aspose.font/licenserestrictionexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "LicenseRestrictionException"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Ausnahme dar, die bei dem Versuch ausgelöst werden kann, eine Funktionalität auszuführen, die im Evaluierungsmodus eingeschränkt ist."
+type: docs
+weight: 60
+url: /de/java/com.aspose.font/licenserestrictionexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class LicenseRestrictionException extends FontException
+```
+
+Stellt eine Ausnahme dar, die bei dem Versuch ausgelöst werden kann, eine Funktionalität auszuführen, die im Evaluierungsmodus eingeschränkt ist.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [LicenseRestrictionException()](#LicenseRestrictionException--) | Initialisiert ein neues FontCreationException-Objekt. |
+| [LicenseRestrictionException(String message)](#LicenseRestrictionException-java.lang.String-) | Initialisiert ein neues FontCreationException-Objekt. |
+| [LicenseRestrictionException(String message, RuntimeException innerException)](#LicenseRestrictionException-java.lang.String-java.lang.RuntimeException-) | Initialisiert ein neues FontCreationException-Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LicenseRestrictionException() {#LicenseRestrictionException--}
+```
+public LicenseRestrictionException()
+```
+
+
+Initialisiert ein neues FontCreationException-Objekt.
+
+### LicenseRestrictionException(String message) {#LicenseRestrictionException-java.lang.String-}
+```
+public LicenseRestrictionException(String message)
+```
+
+
+Initialisiert ein neues FontCreationException-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+
+### LicenseRestrictionException(String message, RuntimeException innerException) {#LicenseRestrictionException-java.lang.String-java.lang.RuntimeException-}
+```
+public LicenseRestrictionException(String message, RuntimeException innerException)
+```
+
+
+Initialisiert ein neues FontCreationException-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+| innerException | java.lang.RuntimeException | Die Ausnahme, die die aktuelle Ausnahme verursacht. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/linespacingtype/_index.md
+++ b/german/java/com.aspose.font/linespacingtype/_index.md
@@ -1,0 +1,250 @@
+---
+title: "RenderingUtils.LineSpacingType"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Zeilenabstandstyp."
+type: docs
+weight: 10
+url: /de/java/com.aspose.font/renderingutils.linespacingtype/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum RenderingUtils.LineSpacingType extends Enum<RenderingUtils.LineSpacingType>
+```
+
+Zeilenabstandstyp. Anzahl von Pixeln oder Prozentsatz der Schriftgröße.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [PercentOfFontHeight](#PercentOfFontHeight) | Der Wert des Zeilenabstands wird in Prozent der Schriftgröße festgelegt. |
+| [Pixels](#Pixels) | Der Wert des Zeilenabstands wird in Pixeln festgelegt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PercentOfFontHeight {#PercentOfFontHeight}
+```
+public static final RenderingUtils.LineSpacingType PercentOfFontHeight
+```
+
+
+Der Wert des Zeilenabstands wird in Prozent der Schriftgröße festgelegt.
+
+### Pixels {#Pixels}
+```
+public static final RenderingUtils.LineSpacingType Pixels
+```
+
+
+Der Wert des Zeilenabstands wird in Pixeln festgelegt.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static RenderingUtils.LineSpacingType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[LineSpacingType](../../com.aspose.font/linespacingtype)
+### values() {#values--}
+```
+public static RenderingUtils.LineSpacingType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.RenderingUtils.LineSpacingType[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/lineto/_index.md
+++ b/german/java/com.aspose.font/lineto/_index.md
@@ -1,0 +1,200 @@
+---
+title: "LineTo"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die LineTo-Operation dar."
+type: docs
+weight: 61
+url: /de/java/com.aspose.font/lineto/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IPathSegment](../../com.aspose.font/ipathsegment)
+```
+public class LineTo implements IPathSegment
+```
+
+Stellt die LineTo-Operation dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clone()](#clone--) | Erstellt ein neues Objekt, das eine Kopie der aktuellen Instanz ist. |
+| [copy()](#copy--) | Erstellt eine Kopie des Segmentobjekts. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getX()](#getX--) | Liefert die x‑Koordinate. |
+| [getY()](#getY--) | Liefert die y‑Koordinate. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [shift(double dx, double dy)](#shift-double-double-) | Führt Verschiebung um x- und y-Koordinaten durch. |
+| [toString()](#toString--) |  |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Transformiert Koordinaten mit der Transformationsmatrix. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Erstellt ein neues Objekt, das eine Kopie der aktuellen Instanz ist.
+
+**Returns:**
+java.lang.Object – Ein neues Objekt, das eine Kopie dieser Instanz ist.
+### copy() {#copy--}
+```
+public IPathSegment copy()
+```
+
+
+Erstellt eine Kopie des Segmentobjekts.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getX() {#getX--}
+```
+public double getX()
+```
+
+
+Liefert die x‑Koordinate.
+
+**Returns:**
+double - Koordinate x.
+### getY() {#getY--}
+```
+public double getY()
+```
+
+
+Liefert die y‑Koordinate.
+
+**Returns:**
+double - Koordinate y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public void shift(double dx, double dy)
+```
+
+
+Führt Verschiebung um x- und y-Koordinaten durch.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| dx | double | Wert dx. |
+| dy | double | Wert dy. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public void transform(TransformationMatrix matrix)
+```
+
+
+Transformiert Koordinaten mit der Transformationsmatrix.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Transformationsmatrix. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/longhormetric/_index.md
+++ b/german/java/com.aspose.font/longhormetric/_index.md
@@ -1,0 +1,185 @@
+---
+title: "TtfHmtxTable.LongHorMetric"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt den Metrikdatensatz dar."
+type: docs
+weight: 10
+url: /de/java/com.aspose.font/ttfhmtxtable.longhormetric/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static class TtfHmtxTable.LongHorMetric
+```
+
+Stellt den Metrikdatensatz dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [LongHorMetric()](#LongHorMetric--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clone()](#clone--) |  |
+| [equals(TtfHmtxTable.LongHorMetric obj1, TtfHmtxTable.LongHorMetric obj2)](#equals-com.aspose.font.TtfHmtxTable.LongHorMetric-com.aspose.font.TtfHmtxTable.LongHorMetric-) |  |
+| [equals(Object obj)](#equals-java.lang.Object-) |  |
+| [getAdvanceWidth()](#getAdvanceWidth--) | Liefert den Vorschubbreitenwert. |
+| [getClass()](#getClass--) |  |
+| [getLeftSideBearing()](#getLeftSideBearing--) | Liefert den Wert des linken Seitenabstands. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LongHorMetric() {#LongHorMetric--}
+```
+public LongHorMetric()
+```
+
+
+### clone() {#clone--}
+```
+public TtfHmtxTable.LongHorMetric clone()
+```
+
+
+
+
+**Returns:**
+[LongHorMetric](../../com.aspose.font/longhormetric)
+### equals(TtfHmtxTable.LongHorMetric obj1, TtfHmtxTable.LongHorMetric obj2) {#equals-com.aspose.font.TtfHmtxTable.LongHorMetric-com.aspose.font.TtfHmtxTable.LongHorMetric-}
+```
+public static boolean equals(TtfHmtxTable.LongHorMetric obj1, TtfHmtxTable.LongHorMetric obj2)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj1 | [LongHorMetric](../../com.aspose.font/longhormetric) |  |
+| obj2 | [LongHorMetric](../../com.aspose.font/longhormetric) |  |
+
+**Returns:**
+boolean
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdvanceWidth() {#getAdvanceWidth--}
+```
+public int getAdvanceWidth()
+```
+
+
+Liefert den Vorschubbreitenwert.
+
+**Returns:**
+int - Vorschubbreitenwert.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLeftSideBearing() {#getLeftSideBearing--}
+```
+public short getLeftSideBearing()
+```
+
+
+Liefert den Wert des linken Seitenabstands.
+
+**Returns:**
+short - Wert des linken Seitenrandes.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/longvermetric/_index.md
+++ b/german/java/com.aspose.font/longvermetric/_index.md
@@ -1,0 +1,185 @@
+---
+title: "TtfVmtxTable.LongVerMetric"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt den vertikalen Metrikdatensatz dar."
+type: docs
+weight: 10
+url: /de/java/com.aspose.font/ttfvmtxtable.longvermetric/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static class TtfVmtxTable.LongVerMetric
+```
+
+Stellt den vertikalen Metrikdatensatz dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [LongVerMetric()](#LongVerMetric--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clone()](#clone--) |  |
+| [equals(TtfVmtxTable.LongVerMetric obj1, TtfVmtxTable.LongVerMetric obj2)](#equals-com.aspose.font.TtfVmtxTable.LongVerMetric-com.aspose.font.TtfVmtxTable.LongVerMetric-) |  |
+| [equals(Object obj)](#equals-java.lang.Object-) |  |
+| [getAdvanceHeight()](#getAdvanceHeight--) | Ermittelt den Vorwärts‑Höhenwert. |
+| [getClass()](#getClass--) |  |
+| [getTopSideBearing()](#getTopSideBearing--) | Ermittelt den oberen Seitenabstandswert. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LongVerMetric() {#LongVerMetric--}
+```
+public LongVerMetric()
+```
+
+
+### clone() {#clone--}
+```
+public TtfVmtxTable.LongVerMetric clone()
+```
+
+
+
+
+**Returns:**
+[LongVerMetric](../../com.aspose.font/longvermetric)
+### equals(TtfVmtxTable.LongVerMetric obj1, TtfVmtxTable.LongVerMetric obj2) {#equals-com.aspose.font.TtfVmtxTable.LongVerMetric-com.aspose.font.TtfVmtxTable.LongVerMetric-}
+```
+public static boolean equals(TtfVmtxTable.LongVerMetric obj1, TtfVmtxTable.LongVerMetric obj2)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj1 | [LongVerMetric](../../com.aspose.font/longvermetric) |  |
+| obj2 | [LongVerMetric](../../com.aspose.font/longvermetric) |  |
+
+**Returns:**
+boolean
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdvanceHeight() {#getAdvanceHeight--}
+```
+public int getAdvanceHeight()
+```
+
+
+Ermittelt den Vorwärts‑Höhenwert.
+
+**Returns:**
+int - Der Vorwärts‑Höhenwert.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getTopSideBearing() {#getTopSideBearing--}
+```
+public short getTopSideBearing()
+```
+
+
+Ermittelt den oberen Seitenabstandswert.
+
+**Returns:**
+short - Der Wert des oberen Seitenabstands.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/maclanguageid/_index.md
+++ b/german/java/com.aspose.font/maclanguageid/_index.md
@@ -1,0 +1,1201 @@
+---
+title: "MacLanguageId"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Macintosh-Plattform-Sprach-ID-Aufzählung."
+type: docs
+weight: 63
+url: /de/java/com.aspose.font/maclanguageid/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class MacLanguageId
+```
+
+Macintosh-Plattform-Sprach-ID-Aufzählung.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [Afrikaans](#Afrikaans) | Afrikaans LanguageId-Wert |
+| [Albanian](#Albanian) | Albanian LanguageId-Wert |
+| [Amharic](#Amharic) | Amharic LanguageId-Wert |
+| [Arabic](#Arabic) | Arabic LanguageId-Wert |
+| [Armenian](#Armenian) | Armenian LanguageId-Wert |
+| [Assamese](#Assamese) | Assamese LanguageId-Wert |
+| [Aymara](#Aymara) | Aymara LanguageId Wert |
+| [Azerbaijani_Arabic](#Azerbaijani-Arabic) | Aserbaidschanisch (Arabische Schrift) LanguageId Wert |
+| [Azerbaijani_Cyrillic](#Azerbaijani-Cyrillic) | Aserbaidschanisch (Kyrillische Schrift) LanguageId Wert |
+| [Azerbaijani_Roman](#Azerbaijani-Roman) | Aserbaidschanisch (Lateinische Schrift) LanguageId Wert |
+| [Basque](#Basque) | Baskisch LanguageId Wert |
+| [Bengali](#Bengali) | Bengalisch LanguageId Wert |
+| [Breton](#Breton) | Bretonisch LanguageId Wert |
+| [Bulgarian](#Bulgarian) | Bulgarisch LanguageId Wert |
+| [Burmese](#Burmese) | Birmanisch LanguageId Wert |
+| [Byelorussian](#Byelorussian) | Belarussisch LanguageId Wert |
+| [Catalan](#Catalan) | Katalanisch LanguageId Wert |
+| [Chinese_Simplified](#Chinese-Simplified) | Chinesisch (Vereinfacht) LanguageId Wert |
+| [Chinese_Traditional](#Chinese-Traditional) | Chinesisch (Traditionell) LanguageId Wert |
+| [Croatian](#Croatian) | Kroatisch LanguageId Wert |
+| [Czech](#Czech) | Tschechisch LanguageId Wert |
+| [Danish](#Danish) | Dänisch LanguageId Wert |
+| [Dutch](#Dutch) | Niederländisch LanguageId Wert |
+| [Dzongkha](#Dzongkha) | Dzongkha LanguageId Wert |
+| [English](#English) | Englisch LanguageId Wert |
+| [Esperanto](#Esperanto) | Esperanto LanguageId Wert |
+| [Estonian](#Estonian) | Estnisch LanguageId Wert |
+| [Faroese](#Faroese) | Färöisch LanguageId Wert |
+| [Farsi_Persian](#Farsi-Persian) | Farsi/Persisch LanguageId Wert |
+| [Finnish](#Finnish) | Finnisch LanguageId Wert |
+| [Flemish](#Flemish) | Flämisch LanguageId Wert |
+| [French](#French) | Französisch LanguageId Wert |
+| [Galician](#Galician) | Galicisch LanguageId Wert |
+| [Galla](#Galla) | Galla LanguageId Wert |
+| [Georgian](#Georgian) | Georgisch LanguageId Wert |
+| [German](#German) | Deutsch LanguageId Wert |
+| [Greek](#Greek) | Griechisch LanguageId Wert |
+| [Greek_Polytonic](#Greek-Polytonic) | Griechisch (polytonisch) LanguageId Wert |
+| [Greenlandic](#Greenlandic) | Grönländisch LanguageId Wert |
+| [Guarani](#Guarani) | Guaraní LanguageId Wert |
+| [Gujarati](#Gujarati) | Gujarati LanguageId Wert |
+| [Hebrew](#Hebrew) | Hebräisch LanguageId Wert |
+| [Hindi](#Hindi) | Hindi LanguageId Wert |
+| [Hungarian](#Hungarian) | Ungarisch LanguageId Wert |
+| [Icelandic](#Icelandic) | Isländisch LanguageId Wert |
+| [Indonesian](#Indonesian) | Indonesisch LanguageId Wert |
+| [Inuktitut](#Inuktitut) | Inuktitut LanguageId Wert |
+| [Irish_Gaelic](#Irish-Gaelic) | Irisch Gälisch LanguageId Wert |
+| [Irish_Gaelic_WDA](#Irish-Gaelic-WDA) | Irisch Gälisch (mit Punkt darüber) LanguageId Wert |
+| [Italian](#Italian) | Italienisch LanguageId Wert |
+| [Japanese](#Japanese) | Japanisch LanguageId Wert |
+| [Javanese](#Javanese) | Javanisch (Römische Schrift) LanguageId Wert |
+| [Kannada](#Kannada) | Kannada LanguageId Wert |
+| [Kashmiri](#Kashmiri) | Kaschmiri LanguageId Wert |
+| [Kazakh](#Kazakh) | Kasachisch LanguageId Wert |
+| [Khmer](#Khmer) | Khmer LanguageId Wert |
+| [Kinyarwanda_Ruanda](#Kinyarwanda-Ruanda) | Kinyarwanda/Ruanda LanguageId Wert |
+| [Kirghiz](#Kirghiz) | Kirgisisch LanguageId Wert |
+| [Korean](#Korean) | Koreanisch LanguageId Wert |
+| [Kurdish](#Kurdish) | Kurdisch LanguageId Wert |
+| [Lao](#Lao) | Laotisch LanguageId Wert |
+| [Latin](#Latin) | Latein LanguageId Wert |
+| [Latvian](#Latvian) | Lettisch LanguageId Wert |
+| [Lithuanian](#Lithuanian) | Litauisch LanguageId Wert |
+| [Macedonian](#Macedonian) | Mazedonisch LanguageId Wert |
+| [Malagasy](#Malagasy) | Madagassisch LanguageId Wert |
+| [Malay_Arabic](#Malay-Arabic) | Malaiisch (arabische Schrift) LanguageId Wert |
+| [Malay_Roman](#Malay-Roman) | Malaiisch (lateinische Schrift) LanguageId Wert |
+| [Malayalam](#Malayalam) | Malayalam LanguageId Wert |
+| [Maltese](#Maltese) | Maltesisch LanguageId Wert |
+| [Manx_Gaelic](#Manx-Gaelic) | Manx-Gälisch LanguageId Wert |
+| [Marathi](#Marathi) | Marathi LanguageId Wert |
+| [Moldavian](#Moldavian) | Moldauisch LanguageId Wert |
+| [Mongolian_Cyrillic](#Mongolian-Cyrillic) | Mongolisch (kyrillische Schrift) LanguageId Wert |
+| [Mongolian_Mongolian](#Mongolian-Mongolian) | Mongolisch (mongolische Schrift) LanguageId Wert |
+| [Nepali](#Nepali) | Nepalesisch LanguageId Wert |
+| [Norwegian](#Norwegian) | Norwegisch LanguageId Wert |
+| [Nyanja_Chewa](#Nyanja-Chewa) | Nyanja/Chewa LanguageId Wert |
+| [Oriya](#Oriya) | Oriya LanguageId Wert |
+| [Pashto](#Pashto) | Paschtunisch LanguageId Wert |
+| [Polish](#Polish) | Polnisch LanguageId Wert |
+| [Portuguese](#Portuguese) | Portugiesisch LanguageId Wert |
+| [Punjabi](#Punjabi) | Punjabi LanguageId Wert |
+| [Quechua](#Quechua) | Quechua LanguageId Wert |
+| [Romanian](#Romanian) | Rumänisch LanguageId Wert |
+| [Rundi](#Rundi) | Rundi LanguageId Wert |
+| [Russian](#Russian) | Russisch LanguageId Wert |
+| [Sami](#Sami) | Samisch LanguageId Wert |
+| [Sanskrit](#Sanskrit) | Sanskrit LanguageId Wert |
+| [Scottish_Gaelic](#Scottish-Gaelic) | Schottisch-Gälisch LanguageId Wert |
+| [Serbian](#Serbian) | Serbisch LanguLanguageIdageID Wert |
+| [Sindhi](#Sindhi) | Sindhi LanguageId Wert |
+| [Sinhalese](#Sinhalese) | Singhalesisch LanguageId Wert |
+| [Slovak](#Slovak) | Slowakisch LanguageId Wert |
+| [Slovenian](#Slovenian) | Slowenisch LanguageId Wert |
+| [Somali](#Somali) | Somali LanguageId Wert |
+| [Spanish](#Spanish) | Spanisch LanguageId Wert |
+| [Sundanese](#Sundanese) | Sundanesisch (Römische Schrift) LanguageId Wert |
+| [Swahili](#Swahili) | Swahili LanguageId Wert |
+| [Swedish](#Swedish) | Schwedisch LanguageId Wert |
+| [Tagalog](#Tagalog) | Tagalog LanguageId Wert |
+| [Tajiki](#Tajiki) | Tadschikisch LanguageId Wert |
+| [Tamil](#Tamil) | Tamil LanguagLanguageIdeID Wert |
+| [Tatar](#Tatar) | Tatarisch LanguageId Wert |
+| [Telugu](#Telugu) | Telugu LanguageId Wert |
+| [Thai](#Thai) | Thailändisch LanguageId Wert |
+| [Tibetan](#Tibetan) | tibetischer LanguageId-Wert |
+| [Tigrinya](#Tigrinya) | tigrinischer LanguageId-Wert |
+| [Tongan](#Tongan) | tongaischer LanguageId-Wert |
+| [Turkish](#Turkish) | türkischer LanguageId-Wert |
+| [Turkmen](#Turkmen) | turkmenischer LanguageId-Wert |
+| [Uighur](#Uighur) | uigurischer LanguageId-Wert |
+| [Ukrainian](#Ukrainian) | ukrainischer LanguageId-Wert |
+| [Urdu](#Urdu) | urdu LanguageId-Wert |
+| [Uzbek](#Uzbek) | usbekischer LanguageId-Wert |
+| [Vietnamese](#Vietnamese) | vietnamesischer LanguageId-Wert |
+| [Welsh](#Welsh) | walisischer LanguageId-Wert |
+| [Yiddish](#Yiddish) | jiddischer LanguageId-Wert |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getId()](#getId--) | Gib den ganzzahligen Wert zurück. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Afrikaans {#Afrikaans}
+```
+public static final MacLanguageId Afrikaans
+```
+
+
+Afrikaans LanguageId-Wert
+
+### Albanian {#Albanian}
+```
+public static final MacLanguageId Albanian
+```
+
+
+Albanian LanguageId-Wert
+
+### Amharic {#Amharic}
+```
+public static final MacLanguageId Amharic
+```
+
+
+Amharic LanguageId-Wert
+
+### Arabic {#Arabic}
+```
+public static final MacLanguageId Arabic
+```
+
+
+Arabic LanguageId-Wert
+
+### Armenian {#Armenian}
+```
+public static final MacLanguageId Armenian
+```
+
+
+Armenian LanguageId-Wert
+
+### Assamese {#Assamese}
+```
+public static final MacLanguageId Assamese
+```
+
+
+Assamese LanguageId-Wert
+
+### Aymara {#Aymara}
+```
+public static final MacLanguageId Aymara
+```
+
+
+Aymara LanguageId Wert
+
+### Azerbaijani_Arabic {#Azerbaijani-Arabic}
+```
+public static final MacLanguageId Azerbaijani_Arabic
+```
+
+
+Aserbaidschanisch (Arabische Schrift) LanguageId Wert
+
+### Azerbaijani_Cyrillic {#Azerbaijani-Cyrillic}
+```
+public static final MacLanguageId Azerbaijani_Cyrillic
+```
+
+
+Aserbaidschanisch (Kyrillische Schrift) LanguageId Wert
+
+### Azerbaijani_Roman {#Azerbaijani-Roman}
+```
+public static final MacLanguageId Azerbaijani_Roman
+```
+
+
+Aserbaidschanisch (Lateinische Schrift) LanguageId Wert
+
+### Basque {#Basque}
+```
+public static final MacLanguageId Basque
+```
+
+
+Baskisch LanguageId Wert
+
+### Bengali {#Bengali}
+```
+public static final MacLanguageId Bengali
+```
+
+
+Bengalisch LanguageId Wert
+
+### Breton {#Breton}
+```
+public static final MacLanguageId Breton
+```
+
+
+Bretonisch LanguageId Wert
+
+### Bulgarian {#Bulgarian}
+```
+public static final MacLanguageId Bulgarian
+```
+
+
+Bulgarisch LanguageId Wert
+
+### Burmese {#Burmese}
+```
+public static final MacLanguageId Burmese
+```
+
+
+Birmanisch LanguageId Wert
+
+### Byelorussian {#Byelorussian}
+```
+public static final MacLanguageId Byelorussian
+```
+
+
+Belarussisch LanguageId Wert
+
+### Catalan {#Catalan}
+```
+public static final MacLanguageId Catalan
+```
+
+
+Katalanisch LanguageId Wert
+
+### Chinese_Simplified {#Chinese-Simplified}
+```
+public static final MacLanguageId Chinese_Simplified
+```
+
+
+Chinesisch (Vereinfacht) LanguageId Wert
+
+### Chinese_Traditional {#Chinese-Traditional}
+```
+public static final MacLanguageId Chinese_Traditional
+```
+
+
+Chinesisch (Traditionell) LanguageId Wert
+
+### Croatian {#Croatian}
+```
+public static final MacLanguageId Croatian
+```
+
+
+Kroatisch LanguageId Wert
+
+### Czech {#Czech}
+```
+public static final MacLanguageId Czech
+```
+
+
+Tschechisch LanguageId Wert
+
+### Danish {#Danish}
+```
+public static final MacLanguageId Danish
+```
+
+
+Dänisch LanguageId Wert
+
+### Dutch {#Dutch}
+```
+public static final MacLanguageId Dutch
+```
+
+
+Niederländisch LanguageId Wert
+
+### Dzongkha {#Dzongkha}
+```
+public static final MacLanguageId Dzongkha
+```
+
+
+Dzongkha LanguageId Wert
+
+### English {#English}
+```
+public static final MacLanguageId English
+```
+
+
+Englisch LanguageId Wert
+
+### Esperanto {#Esperanto}
+```
+public static final MacLanguageId Esperanto
+```
+
+
+Esperanto LanguageId Wert
+
+### Estonian {#Estonian}
+```
+public static final MacLanguageId Estonian
+```
+
+
+Estnisch LanguageId Wert
+
+### Faroese {#Faroese}
+```
+public static final MacLanguageId Faroese
+```
+
+
+Färöisch LanguageId Wert
+
+### Farsi_Persian {#Farsi-Persian}
+```
+public static final MacLanguageId Farsi_Persian
+```
+
+
+Farsi/Persisch LanguageId Wert
+
+### Finnish {#Finnish}
+```
+public static final MacLanguageId Finnish
+```
+
+
+Finnisch LanguageId Wert
+
+### Flemish {#Flemish}
+```
+public static final MacLanguageId Flemish
+```
+
+
+Flämisch LanguageId Wert
+
+### French {#French}
+```
+public static final MacLanguageId French
+```
+
+
+Französisch LanguageId Wert
+
+### Galician {#Galician}
+```
+public static final MacLanguageId Galician
+```
+
+
+Galicisch LanguageId Wert
+
+### Galla {#Galla}
+```
+public static final MacLanguageId Galla
+```
+
+
+Galla LanguageId Wert
+
+### Georgian {#Georgian}
+```
+public static final MacLanguageId Georgian
+```
+
+
+Georgisch LanguageId Wert
+
+### German {#German}
+```
+public static final MacLanguageId German
+```
+
+
+Deutsch LanguageId Wert
+
+### Greek {#Greek}
+```
+public static final MacLanguageId Greek
+```
+
+
+Griechisch LanguageId Wert
+
+### Greek_Polytonic {#Greek-Polytonic}
+```
+public static final MacLanguageId Greek_Polytonic
+```
+
+
+Griechisch (polytonisch) LanguageId Wert
+
+### Greenlandic {#Greenlandic}
+```
+public static final MacLanguageId Greenlandic
+```
+
+
+Grönländisch LanguageId Wert
+
+### Guarani {#Guarani}
+```
+public static final MacLanguageId Guarani
+```
+
+
+Guaraní LanguageId Wert
+
+### Gujarati {#Gujarati}
+```
+public static final MacLanguageId Gujarati
+```
+
+
+Gujarati LanguageId Wert
+
+### Hebrew {#Hebrew}
+```
+public static final MacLanguageId Hebrew
+```
+
+
+Hebräisch LanguageId Wert
+
+### Hindi {#Hindi}
+```
+public static final MacLanguageId Hindi
+```
+
+
+Hindi LanguageId Wert
+
+### Hungarian {#Hungarian}
+```
+public static final MacLanguageId Hungarian
+```
+
+
+Ungarisch LanguageId Wert
+
+### Icelandic {#Icelandic}
+```
+public static final MacLanguageId Icelandic
+```
+
+
+Isländisch LanguageId Wert
+
+### Indonesian {#Indonesian}
+```
+public static final MacLanguageId Indonesian
+```
+
+
+Indonesisch LanguageId Wert
+
+### Inuktitut {#Inuktitut}
+```
+public static final MacLanguageId Inuktitut
+```
+
+
+Inuktitut LanguageId Wert
+
+### Irish_Gaelic {#Irish-Gaelic}
+```
+public static final MacLanguageId Irish_Gaelic
+```
+
+
+Irisch Gälisch LanguageId Wert
+
+### Irish_Gaelic_WDA {#Irish-Gaelic-WDA}
+```
+public static final MacLanguageId Irish_Gaelic_WDA
+```
+
+
+Irisch Gälisch (mit Punkt darüber) LanguageId Wert
+
+### Italian {#Italian}
+```
+public static final MacLanguageId Italian
+```
+
+
+Italienisch LanguageId Wert
+
+### Japanese {#Japanese}
+```
+public static final MacLanguageId Japanese
+```
+
+
+Japanisch LanguageId Wert
+
+### Javanese {#Javanese}
+```
+public static final MacLanguageId Javanese
+```
+
+
+Javanisch (Römische Schrift) LanguageId Wert
+
+### Kannada {#Kannada}
+```
+public static final MacLanguageId Kannada
+```
+
+
+Kannada LanguageId Wert
+
+### Kashmiri {#Kashmiri}
+```
+public static final MacLanguageId Kashmiri
+```
+
+
+Kaschmiri LanguageId Wert
+
+### Kazakh {#Kazakh}
+```
+public static final MacLanguageId Kazakh
+```
+
+
+Kasachisch LanguageId Wert
+
+### Khmer {#Khmer}
+```
+public static final MacLanguageId Khmer
+```
+
+
+Khmer LanguageId Wert
+
+### Kinyarwanda_Ruanda {#Kinyarwanda-Ruanda}
+```
+public static final MacLanguageId Kinyarwanda_Ruanda
+```
+
+
+Kinyarwanda/Ruanda LanguageId Wert
+
+### Kirghiz {#Kirghiz}
+```
+public static final MacLanguageId Kirghiz
+```
+
+
+Kirgisisch LanguageId Wert
+
+### Korean {#Korean}
+```
+public static final MacLanguageId Korean
+```
+
+
+Koreanisch LanguageId Wert
+
+### Kurdish {#Kurdish}
+```
+public static final MacLanguageId Kurdish
+```
+
+
+Kurdisch LanguageId Wert
+
+### Lao {#Lao}
+```
+public static final MacLanguageId Lao
+```
+
+
+Laotisch LanguageId Wert
+
+### Latin {#Latin}
+```
+public static final MacLanguageId Latin
+```
+
+
+Latein LanguageId Wert
+
+### Latvian {#Latvian}
+```
+public static final MacLanguageId Latvian
+```
+
+
+Lettisch LanguageId Wert
+
+### Lithuanian {#Lithuanian}
+```
+public static final MacLanguageId Lithuanian
+```
+
+
+Litauisch LanguageId Wert
+
+### Macedonian {#Macedonian}
+```
+public static final MacLanguageId Macedonian
+```
+
+
+Mazedonisch LanguageId Wert
+
+### Malagasy {#Malagasy}
+```
+public static final MacLanguageId Malagasy
+```
+
+
+Madagassisch LanguageId Wert
+
+### Malay_Arabic {#Malay-Arabic}
+```
+public static final MacLanguageId Malay_Arabic
+```
+
+
+Malaiisch (arabische Schrift) LanguageId Wert
+
+### Malay_Roman {#Malay-Roman}
+```
+public static final MacLanguageId Malay_Roman
+```
+
+
+Malaiisch (lateinische Schrift) LanguageId Wert
+
+### Malayalam {#Malayalam}
+```
+public static final MacLanguageId Malayalam
+```
+
+
+Malayalam LanguageId Wert
+
+### Maltese {#Maltese}
+```
+public static final MacLanguageId Maltese
+```
+
+
+Maltesisch LanguageId Wert
+
+### Manx_Gaelic {#Manx-Gaelic}
+```
+public static final MacLanguageId Manx_Gaelic
+```
+
+
+Manx-Gälisch LanguageId Wert
+
+### Marathi {#Marathi}
+```
+public static final MacLanguageId Marathi
+```
+
+
+Marathi LanguageId Wert
+
+### Moldavian {#Moldavian}
+```
+public static final MacLanguageId Moldavian
+```
+
+
+Moldauisch LanguageId Wert
+
+### Mongolian_Cyrillic {#Mongolian-Cyrillic}
+```
+public static final MacLanguageId Mongolian_Cyrillic
+```
+
+
+Mongolisch (kyrillische Schrift) LanguageId Wert
+
+### Mongolian_Mongolian {#Mongolian-Mongolian}
+```
+public static final MacLanguageId Mongolian_Mongolian
+```
+
+
+Mongolisch (mongolische Schrift) LanguageId Wert
+
+### Nepali {#Nepali}
+```
+public static final MacLanguageId Nepali
+```
+
+
+Nepalesisch LanguageId Wert
+
+### Norwegian {#Norwegian}
+```
+public static final MacLanguageId Norwegian
+```
+
+
+Norwegisch LanguageId Wert
+
+### Nyanja_Chewa {#Nyanja-Chewa}
+```
+public static final MacLanguageId Nyanja_Chewa
+```
+
+
+Nyanja/Chewa LanguageId Wert
+
+### Oriya {#Oriya}
+```
+public static final MacLanguageId Oriya
+```
+
+
+Oriya LanguageId Wert
+
+### Pashto {#Pashto}
+```
+public static final MacLanguageId Pashto
+```
+
+
+Paschtunisch LanguageId Wert
+
+### Polish {#Polish}
+```
+public static final MacLanguageId Polish
+```
+
+
+Polnisch LanguageId Wert
+
+### Portuguese {#Portuguese}
+```
+public static final MacLanguageId Portuguese
+```
+
+
+Portugiesisch LanguageId Wert
+
+### Punjabi {#Punjabi}
+```
+public static final MacLanguageId Punjabi
+```
+
+
+Punjabi LanguageId Wert
+
+### Quechua {#Quechua}
+```
+public static final MacLanguageId Quechua
+```
+
+
+Quechua LanguageId Wert
+
+### Romanian {#Romanian}
+```
+public static final MacLanguageId Romanian
+```
+
+
+Rumänisch LanguageId Wert
+
+### Rundi {#Rundi}
+```
+public static final MacLanguageId Rundi
+```
+
+
+Rundi LanguageId Wert
+
+### Russian {#Russian}
+```
+public static final MacLanguageId Russian
+```
+
+
+Russisch LanguageId Wert
+
+### Sami {#Sami}
+```
+public static final MacLanguageId Sami
+```
+
+
+Samisch LanguageId Wert
+
+### Sanskrit {#Sanskrit}
+```
+public static final MacLanguageId Sanskrit
+```
+
+
+Sanskrit LanguageId Wert
+
+### Scottish_Gaelic {#Scottish-Gaelic}
+```
+public static final MacLanguageId Scottish_Gaelic
+```
+
+
+Schottisch-Gälisch LanguageId Wert
+
+### Serbian {#Serbian}
+```
+public static final MacLanguageId Serbian
+```
+
+
+Serbisch LanguLanguageIdageID Wert
+
+### Sindhi {#Sindhi}
+```
+public static final MacLanguageId Sindhi
+```
+
+
+Sindhi LanguageId Wert
+
+### Sinhalese {#Sinhalese}
+```
+public static final MacLanguageId Sinhalese
+```
+
+
+Singhalesisch LanguageId Wert
+
+### Slovak {#Slovak}
+```
+public static final MacLanguageId Slovak
+```
+
+
+Slowakisch LanguageId Wert
+
+### Slovenian {#Slovenian}
+```
+public static final MacLanguageId Slovenian
+```
+
+
+Slowenisch LanguageId Wert
+
+### Somali {#Somali}
+```
+public static final MacLanguageId Somali
+```
+
+
+Somali LanguageId Wert
+
+### Spanish {#Spanish}
+```
+public static final MacLanguageId Spanish
+```
+
+
+Spanisch LanguageId Wert
+
+### Sundanese {#Sundanese}
+```
+public static final MacLanguageId Sundanese
+```
+
+
+Sundanesisch (Römische Schrift) LanguageId Wert
+
+### Swahili {#Swahili}
+```
+public static final MacLanguageId Swahili
+```
+
+
+Swahili LanguageId Wert
+
+### Swedish {#Swedish}
+```
+public static final MacLanguageId Swedish
+```
+
+
+Schwedisch LanguageId Wert
+
+### Tagalog {#Tagalog}
+```
+public static final MacLanguageId Tagalog
+```
+
+
+Tagalog LanguageId Wert
+
+### Tajiki {#Tajiki}
+```
+public static final MacLanguageId Tajiki
+```
+
+
+Tadschikisch LanguageId Wert
+
+### Tamil {#Tamil}
+```
+public static final MacLanguageId Tamil
+```
+
+
+Tamil LanguagLanguageIdeID Wert
+
+### Tatar {#Tatar}
+```
+public static final MacLanguageId Tatar
+```
+
+
+Tatarisch LanguageId Wert
+
+### Telugu {#Telugu}
+```
+public static final MacLanguageId Telugu
+```
+
+
+Telugu LanguageId Wert
+
+### Thai {#Thai}
+```
+public static final MacLanguageId Thai
+```
+
+
+Thailändisch LanguageId Wert
+
+### Tibetan {#Tibetan}
+```
+public static final MacLanguageId Tibetan
+```
+
+
+tibetischer LanguageId-Wert
+
+### Tigrinya {#Tigrinya}
+```
+public static final MacLanguageId Tigrinya
+```
+
+
+tigrinischer LanguageId-Wert
+
+### Tongan {#Tongan}
+```
+public static final MacLanguageId Tongan
+```
+
+
+tongaischer LanguageId-Wert
+
+### Turkish {#Turkish}
+```
+public static final MacLanguageId Turkish
+```
+
+
+türkischer LanguageId-Wert
+
+### Turkmen {#Turkmen}
+```
+public static final MacLanguageId Turkmen
+```
+
+
+turkmenischer LanguageId-Wert
+
+### Uighur {#Uighur}
+```
+public static final MacLanguageId Uighur
+```
+
+
+uigurischer LanguageId-Wert
+
+### Ukrainian {#Ukrainian}
+```
+public static final MacLanguageId Ukrainian
+```
+
+
+ukrainischer LanguageId-Wert
+
+### Urdu {#Urdu}
+```
+public static final MacLanguageId Urdu
+```
+
+
+urdu LanguageId-Wert
+
+### Uzbek {#Uzbek}
+```
+public static final MacLanguageId Uzbek
+```
+
+
+usbekischer LanguageId-Wert
+
+### Vietnamese {#Vietnamese}
+```
+public static final MacLanguageId Vietnamese
+```
+
+
+vietnamesischer LanguageId-Wert
+
+### Welsh {#Welsh}
+```
+public static final MacLanguageId Welsh
+```
+
+
+walisischer LanguageId-Wert
+
+### Yiddish {#Yiddish}
+```
+public static final MacLanguageId Yiddish
+```
+
+
+jiddischer LanguageId-Wert
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getId() {#getId--}
+```
+public int getId()
+```
+
+
+Gib den ganzzahligen Wert zurück.
+
+**Returns:**
+int - Der ganzzahlige Wert.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/macplatformspecificid/_index.md
+++ b/german/java/com.aspose.font/macplatformspecificid/_index.md
@@ -1,0 +1,529 @@
+---
+title: "MacPlatformSpecificId"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Macintosh-Plattform PlatformSpecificId‑Aufzählung dar."
+type: docs
+weight: 140
+url: /de/java/com.aspose.font/macplatformspecificid/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum MacPlatformSpecificId extends Enum<MacPlatformSpecificId>
+```
+
+Stellt die Macintosh-Plattform PlatformSpecificId‑Aufzählung dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [Arabic](#Arabic) | Arabischer plattformspezifischer Wert. |
+| [Armenian](#Armenian) | Armenischer plattformspezifischer Wert. |
+| [Bengali](#Bengali) | Bengalischer plattformspezifischer Wert. |
+| [Burmese](#Burmese) | Burmesischer plattformspezifischer Wert. |
+| [Devanagari](#Devanagari) | Devanagari plattformspezifischer Wert. |
+| [Geez](#Geez) | Geez plattformspezifischer Wert. |
+| [Georgian](#Georgian) | Georgischer plattformspezifischer Wert. |
+| [Greek](#Greek) | Griechischer plattformspezifischer Wert. |
+| [Gujarati](#Gujarati) | Gujarati plattformspezifischer Wert. |
+| [Gurmukhi](#Gurmukhi) | Gurmukhi plattformspezifischer Wert. |
+| [Hebrew](#Hebrew) | Hebräischer plattformspezifischer Wert. |
+| [Japanese](#Japanese) | Japanischer plattformspezifischer Wert. |
+| [Kannada](#Kannada) | Kannada plattformspezifischer Wert. |
+| [Khmer](#Khmer) | Khmer plattformspezifischer Wert. |
+| [Korean](#Korean) | Koreanischer plattformspezifischer Wert. |
+| [Laotian](#Laotian) | Laotischer plattformspezifischer Wert. |
+| [Malayalam](#Malayalam) | Malayalam plattformspezifischer Wert. |
+| [Mongolian](#Mongolian) | Mongolischer plattformspezifischer Wert. |
+| [Oriya](#Oriya) | Oriya plattformspezifischer Wert. |
+| [RSymbol](#RSymbol) | RSymbol plattformspezifischer Wert. |
+| [Roman](#Roman) | Römischer plattformspezifischer Wert. |
+| [Russian](#Russian) | Russischer plattformspezifischer Wert. |
+| [Simplified_Chinese](#Simplified-Chinese) | Vereinfachtes Chinesisch plattformspezifischer Wert. |
+| [Sindhi](#Sindhi) | Sindhi plattformspezifischer Wert. |
+| [Sinhalese](#Sinhalese) | Singhalesischer plattformspezifischer Wert. |
+| [Slavic](#Slavic) | Slawischer plattformspezifischer Wert. |
+| [Tamil](#Tamil) | Tamilischer plattformspezifischer Wert. |
+| [Telugu](#Telugu) | Telugu plattformspezifischer Wert. |
+| [Thai](#Thai) | Thailändischer plattformspezifischer Wert. |
+| [Tibetan](#Tibetan) | Tibetischer plattformspezifischer Wert. |
+| [Traditional_Chinese](#Traditional-Chinese) | Traditioneller chinesischer plattformspezifischer Wert. |
+| [Uninterpreted](#Uninterpreted) | Nicht interpretierter plattformspezifischer Wert. |
+| [Vietnamese](#Vietnamese) | Vietnamesischer plattformspezifischer Wert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Arabic {#Arabic}
+```
+public static final MacPlatformSpecificId Arabic
+```
+
+
+Arabischer plattformspezifischer Wert.
+
+### Armenian {#Armenian}
+```
+public static final MacPlatformSpecificId Armenian
+```
+
+
+Armenischer plattformspezifischer Wert.
+
+### Bengali {#Bengali}
+```
+public static final MacPlatformSpecificId Bengali
+```
+
+
+Bengalischer plattformspezifischer Wert.
+
+### Burmese {#Burmese}
+```
+public static final MacPlatformSpecificId Burmese
+```
+
+
+Burmesischer plattformspezifischer Wert.
+
+### Devanagari {#Devanagari}
+```
+public static final MacPlatformSpecificId Devanagari
+```
+
+
+Devanagari plattformspezifischer Wert.
+
+### Geez {#Geez}
+```
+public static final MacPlatformSpecificId Geez
+```
+
+
+Geez plattformspezifischer Wert.
+
+### Georgian {#Georgian}
+```
+public static final MacPlatformSpecificId Georgian
+```
+
+
+Georgischer plattformspezifischer Wert.
+
+### Greek {#Greek}
+```
+public static final MacPlatformSpecificId Greek
+```
+
+
+Griechischer plattformspezifischer Wert.
+
+### Gujarati {#Gujarati}
+```
+public static final MacPlatformSpecificId Gujarati
+```
+
+
+Gujarati plattformspezifischer Wert.
+
+### Gurmukhi {#Gurmukhi}
+```
+public static final MacPlatformSpecificId Gurmukhi
+```
+
+
+Gurmukhi plattformspezifischer Wert.
+
+### Hebrew {#Hebrew}
+```
+public static final MacPlatformSpecificId Hebrew
+```
+
+
+Hebräischer plattformspezifischer Wert.
+
+### Japanese {#Japanese}
+```
+public static final MacPlatformSpecificId Japanese
+```
+
+
+Japanischer plattformspezifischer Wert.
+
+### Kannada {#Kannada}
+```
+public static final MacPlatformSpecificId Kannada
+```
+
+
+Kannada plattformspezifischer Wert.
+
+### Khmer {#Khmer}
+```
+public static final MacPlatformSpecificId Khmer
+```
+
+
+Khmer plattformspezifischer Wert.
+
+### Korean {#Korean}
+```
+public static final MacPlatformSpecificId Korean
+```
+
+
+Koreanischer plattformspezifischer Wert.
+
+### Laotian {#Laotian}
+```
+public static final MacPlatformSpecificId Laotian
+```
+
+
+Laotischer plattformspezifischer Wert.
+
+### Malayalam {#Malayalam}
+```
+public static final MacPlatformSpecificId Malayalam
+```
+
+
+Malayalam plattformspezifischer Wert.
+
+### Mongolian {#Mongolian}
+```
+public static final MacPlatformSpecificId Mongolian
+```
+
+
+Mongolischer plattformspezifischer Wert.
+
+### Oriya {#Oriya}
+```
+public static final MacPlatformSpecificId Oriya
+```
+
+
+Oriya plattformspezifischer Wert.
+
+### RSymbol {#RSymbol}
+```
+public static final MacPlatformSpecificId RSymbol
+```
+
+
+RSymbol plattformspezifischer Wert.
+
+### Roman {#Roman}
+```
+public static final MacPlatformSpecificId Roman
+```
+
+
+Römischer plattformspezifischer Wert.
+
+### Russian {#Russian}
+```
+public static final MacPlatformSpecificId Russian
+```
+
+
+Russischer plattformspezifischer Wert.
+
+### Simplified_Chinese {#Simplified-Chinese}
+```
+public static final MacPlatformSpecificId Simplified_Chinese
+```
+
+
+Vereinfachtes Chinesisch plattformspezifischer Wert.
+
+### Sindhi {#Sindhi}
+```
+public static final MacPlatformSpecificId Sindhi
+```
+
+
+Sindhi plattformspezifischer Wert.
+
+### Sinhalese {#Sinhalese}
+```
+public static final MacPlatformSpecificId Sinhalese
+```
+
+
+Singhalesischer plattformspezifischer Wert.
+
+### Slavic {#Slavic}
+```
+public static final MacPlatformSpecificId Slavic
+```
+
+
+Slawischer plattformspezifischer Wert.
+
+### Tamil {#Tamil}
+```
+public static final MacPlatformSpecificId Tamil
+```
+
+
+Tamilischer plattformspezifischer Wert.
+
+### Telugu {#Telugu}
+```
+public static final MacPlatformSpecificId Telugu
+```
+
+
+Telugu plattformspezifischer Wert.
+
+### Thai {#Thai}
+```
+public static final MacPlatformSpecificId Thai
+```
+
+
+Thailändischer plattformspezifischer Wert.
+
+### Tibetan {#Tibetan}
+```
+public static final MacPlatformSpecificId Tibetan
+```
+
+
+Tibetischer plattformspezifischer Wert.
+
+### Traditional_Chinese {#Traditional-Chinese}
+```
+public static final MacPlatformSpecificId Traditional_Chinese
+```
+
+
+Traditioneller chinesischer plattformspezifischer Wert.
+
+### Uninterpreted {#Uninterpreted}
+```
+public static final MacPlatformSpecificId Uninterpreted
+```
+
+
+Nicht interpretierter plattformspezifischer Wert.
+
+### Vietnamese {#Vietnamese}
+```
+public static final MacPlatformSpecificId Vietnamese
+```
+
+
+Vietnamesischer plattformspezifischer Wert.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static MacPlatformSpecificId valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[MacPlatformSpecificId](../../com.aspose.font/macplatformspecificid)
+### values() {#values--}
+```
+public static MacPlatformSpecificId[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.MacPlatformSpecificId[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/metered/_index.md
+++ b/german/java/com.aspose.font/metered/_index.md
@@ -1,0 +1,185 @@
+---
+title: "Gemessen"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt Methoden zum Festlegen des gemessenen Schlüssels bereit."
+type: docs
+weight: 64
+url: /de/java/com.aspose.font/metered/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class Metered
+```
+
+Stellt Methoden zum Festlegen des gemessenen Schlüssels bereit.
+
+--------------------
+
+In diesem Beispiel wird versucht, den gemessenen öffentlichen und privaten Schlüssel zu setzen.
+
+```
+The component jar file:
+  
+ 	Metered metered = new Metered();
+ 	matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Metered()](#Metered--) | Initialisiert eine neue Instanz dieser Klasse. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getConsumptionCredit()](#getConsumptionCredit--) | Ruft das Verbrauchsguthaben ab. |
+| [getConsumptionQuantity()](#getConsumptionQuantity--) | Ruft die Dateigröße des Verbrauchs ab. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setMeteredKey(String publicKey, String privateKey)](#setMeteredKey-java.lang.String-java.lang.String-) | Setzt den gemessenen öffentlichen und privaten Schlüssel. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Metered() {#Metered--}
+```
+public Metered()
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConsumptionCredit() {#getConsumptionCredit--}
+```
+public static double getConsumptionCredit()
+```
+
+
+Ruft das Verbrauchsguthaben ab.
+
+**Returns:**
+double - Verbrauchsmenge
+### getConsumptionQuantity() {#getConsumptionQuantity--}
+```
+public static double getConsumptionQuantity()
+```
+
+
+Ruft die Dateigröße des Verbrauchs ab.
+
+**Returns:**
+double - Verbrauchsmenge
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setMeteredKey(String publicKey, String privateKey) {#setMeteredKey-java.lang.String-java.lang.String-}
+```
+public void setMeteredKey(String publicKey, String privateKey)
+```
+
+
+Setzt den gemessenen öffentlichen und privaten Schlüssel.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| publicKey | java.lang.String | öffentlicher Schlüssel |
+| privateKey | java.lang.String | privater Schlüssel |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/metriclist/_index.md
+++ b/german/java/com.aspose.font/metriclist/_index.md
@@ -1,0 +1,162 @@
+---
+title: "TtfHmtxTable.MetricList"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Liste von Metriken dar."
+type: docs
+weight: 11
+url: /de/java/com.aspose.font/ttfhmtxtable.metriclist/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static class TtfHmtxTable.MetricList
+```
+
+Stellt eine Liste von Metriken dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int glyphIndex)](#get-int-) | Liefert Metriken nach Glyphenindex. |
+| [getClass()](#getClass--) |  |
+| [getRawList()](#getRawList--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [size()](#size--) | Liefert die Anzahl der Metriken. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int glyphIndex) {#get-int-}
+```
+public TtfHmtxTable.LongHorMetric get(int glyphIndex)
+```
+
+
+Liefert Metriken nach Glyphenindex.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphIndex | int | Glyphenindex, für den Metriken abgerufen werden sollen. |
+
+**Returns:**
+[LongHorMetric](../../com.aspose.font/longhormetric) - Metrics record.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getRawList() {#getRawList--}
+```
+public System.Collections.Generic.List<TtfHmtxTable.LongHorMetric> getRawList()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List<com.aspose.font.TtfHmtxTable.LongHorMetric>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+Liefert die Anzahl der Metriken.
+
+**Returns:**
+int – Anzahl der Metriken.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/moveto/_index.md
+++ b/german/java/com.aspose.font/moveto/_index.md
@@ -1,0 +1,200 @@
+---
+title: "MoveTo"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die MoveTo-Operation dar."
+type: docs
+weight: 65
+url: /de/java/com.aspose.font/moveto/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IPathSegment](../../com.aspose.font/ipathsegment)
+```
+public class MoveTo implements IPathSegment
+```
+
+Stellt die MoveTo-Operation dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clone()](#clone--) | Erstellt ein neues Objekt, das eine Kopie der aktuellen Instanz ist. |
+| [copy()](#copy--) | Erstellt eine Kopie des Segmentobjekts. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getX()](#getX--) | Liefert die x‑Koordinate. |
+| [getY()](#getY--) | Liefert die y‑Koordinate. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [shift(double dx, double dy)](#shift-double-double-) | Führt Verschiebung um x- und y-Koordinaten durch. |
+| [toString()](#toString--) |  |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Transformiert Koordinaten mit der Transformationsmatrix. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Erstellt ein neues Objekt, das eine Kopie der aktuellen Instanz ist.
+
+**Returns:**
+java.lang.Object – Ein neues Objekt, das eine Kopie dieser Instanz ist.
+### copy() {#copy--}
+```
+public IPathSegment copy()
+```
+
+
+Erstellt eine Kopie des Segmentobjekts.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getX() {#getX--}
+```
+public double getX()
+```
+
+
+Liefert die x‑Koordinate.
+
+**Returns:**
+double - Koordinate x.
+### getY() {#getY--}
+```
+public double getY()
+```
+
+
+Liefert die y‑Koordinate.
+
+**Returns:**
+double - Koordinate y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public void shift(double dx, double dy)
+```
+
+
+Führt Verschiebung um x- und y-Koordinaten durch.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| dx | double | Wert dx. |
+| dy | double | Wert dy. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public void transform(TransformationMatrix matrix)
+```
+
+
+Transformiert Koordinaten mit der Transformationsmatrix.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Transformationsmatrix. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/mslanguageid/_index.md
+++ b/german/java/com.aspose.font/mslanguageid/_index.md
@@ -1,0 +1,1984 @@
+---
+title: "MSLanguageId"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Microsoft-Plattform-Sprach-ID-Aufzählung."
+type: docs
+weight: 62
+url: /de/java/com.aspose.font/mslanguageid/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class MSLanguageId
+```
+
+Microsoft-Plattform-Sprach-ID-Aufzählung.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [Afrikaans](#Afrikaans) | Afrikaans (Region: Südafrika, SA) LanguageId-Wert |
+| [Albanian](#Albanian) | Albanisch (Region: Albania, SQI) LanguageId-Wert |
+| [Alsatian](#Alsatian) | Elsässisch (Region: France) LanguageId-Wert |
+| [Amharic](#Amharic) | Amharisch (Region: Ethiopia) LanguageId-Wert |
+| [Arabic_Algeria](#Arabic-Algeria) | Arabisch (Region: Algeria) LanguageId-Wert |
+| [Arabic_Bahrain](#Arabic-Bahrain) | Arabisch (Region: Bahrain) LanguageId-Wert |
+| [Arabic_Egypt](#Arabic-Egypt) | Arabisch (Region: Egypt) LanguageId-Wert |
+| [Arabic_Iraq](#Arabic-Iraq) | Arabisch (Region: Iraq) LanguageId-Wert |
+| [Arabic_Jordan](#Arabic-Jordan) | Arabisch (Region: Jordan) LanguageId-Wert |
+| [Arabic_Kuwait](#Arabic-Kuwait) | Arabisch (Region: Kuwait) LanguageId-Wert |
+| [Arabic_Lebanon](#Arabic-Lebanon) | Arabisch (Region: Lebanon) LanguageId-Wert |
+| [Arabic_Libya](#Arabic-Libya) | Arabisch (Region: Libya) LanguageId-Wert |
+| [Arabic_Morocco](#Arabic-Morocco) | Arabisch (Region: Morocco) LanguageId-Wert |
+| [Arabic_Oman](#Arabic-Oman) | Arabisch (Region: Oman) LanguageId-Wert |
+| [Arabic_Qatar](#Arabic-Qatar) | Arabisch (Region: Qatar) LanguageId-Wert |
+| [Arabic_Saudi_Arabia](#Arabic-Saudi-Arabia) | Arabisch (Region: Saudi Arabia) LanguageId-Wert |
+| [Arabic_Syria](#Arabic-Syria) | Arabisch (Region: Syria) LanguageId-Wert |
+| [Arabic_Tunisia](#Arabic-Tunisia) | Arabisch (Region: Tunisia) LanguageId-Wert |
+| [Arabic_U_A_E](#Arabic-U-A-E) | Arabisch (Region: U.A.E.) |
+| [Arabic_Yemen](#Arabic-Yemen) | Arabisch (Region: Yemen) LanguageId-Wert |
+| [Armenian](#Armenian) | Armenisch (Region: Armenia) LanguageId-Wert |
+| [Assamese](#Assamese) | Assamesisch (Region: India) LanguageId-Wert |
+| [Azeri_Cyrillic](#Azeri-Cyrillic) | Aserbaidschanisch (Kyrillisch, Region: Azerbaijan) LanguageId-Wert |
+| [Azeri_Latin](#Azeri-Latin) | Aserbaidschanisch (Lateinisch, Region: Azerbaijan) LanguageId-Wert |
+| [Bashkir](#Bashkir) | Baschkirisch (Region: Russia) LanguageId-Wert |
+| [Basque](#Basque) | Baskisch (Region: Basque, EUQ) LanguageId-Wert |
+| [Belarusian](#Belarusian) | Belarussisch (Region: Belarus, BEL) LanguageId-Wert |
+| [Bengali_Bangladesh](#Bengali-Bangladesh) | Bengalisch (Region: Bangladesch) LanguageId-Wert |
+| [Bengali_India](#Bengali-India) | Bengalisch (Region: Indien) LanguageId-Wert |
+| [Bosnian_Cyrillic](#Bosnian-Cyrillic) | Bosnisch (Kyrillisch, Region: Bosnien und Herzegowina) LanguageId-Wert |
+| [Bosnian_Latin](#Bosnian-Latin) | Bosnisch (Lateinisch, Region: Bosnien und Herzegowina) LanguageId-Wert |
+| [Breton](#Breton) | Bretonisch (Region: Frankreich) LanguageId-Wert |
+| [Bulgarian](#Bulgarian) | Bulgarisch (Region: Bulgarien, BGR) LanguageId-Wert |
+| [Catalan](#Catalan) | Katalanisch (Region: Katalonien, CAT) LanguageId-Wert |
+| [Chinese_Hong_Kong](#Chinese-Hong-Kong) | Chinesisch (Region: Hongkong S.A.R.) |
+| [Chinese_Macao](#Chinese-Macao) | Chinesisch (Region: Macau S.A.R.) |
+| [Chinese_PRC](#Chinese-PRC) | Chinesisch (Region: Volksrepublik China) LanguageId-Wert |
+| [Chinese_Singapore](#Chinese-Singapore) | Chinesisch (Region: Singapur) LanguageId-Wert |
+| [Chinese_Taiwan](#Chinese-Taiwan) | Chinesisch (Region: Taiwan) LanguageId-Wert |
+| [Corsican](#Corsican) | Korsisch (Region: Frankreich) LanguageId-Wert |
+| [Croatian](#Croatian) | Kroatisch (Region: Kroatien, SHL) LanguageId-Wert |
+| [Croatian_Latin](#Croatian-Latin) | Kroatisch (Lateinisch, Region: Bosnien und Herzegowina) LanguageId-Wert |
+| [Czech](#Czech) | Tschechisch (Region: Tschechien, CSY) LanguageId-Wert |
+| [Danish](#Danish) | Dänisch (Region: Dänemark, DAN) LanguageId-Wert |
+| [Dari](#Dari) | Dari (Region: Afghanistan) LanguageId-Wert |
+| [Divehi](#Divehi) | Divehi (Region: Malediven) LanguageId-Wert |
+| [Dutch_Belgium](#Dutch-Belgium) | Niederländisch (Flämisch, Region: Belgien, NLB) LanguageId-Wert |
+| [Dutch_Netherlands](#Dutch-Netherlands) | Niederländisch (Standard, Region: Niederlande, NLD) LanguageId-Wert |
+| [English_Australia](#English-Australia) | Englisch (Australisch, Region: Australien, ENA) LanguageId-Wert |
+| [English_Belize](#English-Belize) | Englisch (Region: Belize) LanguageId-Wert |
+| [English_Canada](#English-Canada) | Englisch (Kanadisch, Region: Kanada, ENC) LanguageId-Wert |
+| [English_Caribbean](#English-Caribbean) | Englisch (Region: Caribbean) LanguageId Wert |
+| [English_India](#English-India) | Englisch (Region: India) LanguageId Wert |
+| [English_Ireland](#English-Ireland) | Englisch (Region: Ireland, ENI) LanguageId Wert |
+| [English_Jamaica](#English-Jamaica) | Englisch (Region: Jamaica) LanguageId Wert |
+| [English_Malaysia](#English-Malaysia) | Englisch (Region: Malaysia) LanguageId Wert |
+| [English_New_Zealand](#English-New-Zealand) | Englisch (Region: New Zealand, ENZ) LanguageId Wert |
+| [English_ROP](#English-ROP) | Englisch (Region: Republic of the Philippines, ROP) LanguageId Wert |
+| [English_Singapore](#English-Singapore) | Englisch (Region: Singapore) LanguageId Wert |
+| [English_South_Africa](#English-South-Africa) | Englisch (Region: South Africa, SA) LanguageId Wert |
+| [English_TT](#English-TT) | Englisch (Region: Trinidad and Tobago, TT) LanguageId Wert |
+| [English_United_Kingdom](#English-United-Kingdom) | Englisch (Britisch, Region: United Kingdom, ENG) LanguageId Wert |
+| [English_United_States](#English-United-States) | Englisch (Amerikanisch, Region: United States, ENU) LanguageId Wert |
+| [English_Zimbabwe](#English-Zimbabwe) | Englisch (Region: Zimbabwe) LanguageId Wert |
+| [Estonian](#Estonian) | Estnisch (Region: Estonia, ETI) LanguageId Wert |
+| [Faroese](#Faroese) | Färöisch (Region: Faroe Islands) LanguageId Wert |
+| [Filipino](#Filipino) | Filipino (Region: Philippines) LanguageId Wert |
+| [Finnish](#Finnish) | Finnisch (Region: Finland, FIN) LanguageId Wert |
+| [French_Belgium](#French-Belgium) | Französisch (Belgisch, Region: Belgium, FRB) LanguageId Wert |
+| [French_Canada](#French-Canada) | Französisch (Kanadisch, Region: Canada, FRC) LanguageId Wert |
+| [French_France](#French-France) | Französisch (Standard, Region: France, FRA) LanguageId Wert |
+| [French_Luxembourg](#French-Luxembourg) | Französisch (Region: Luxembourg, FRL) LanguageId Wert |
+| [French_MC](#French-MC) | Französisch (Region: Principality of Monaco, MC) LanguageId Wert |
+| [French_Switzerland](#French-Switzerland) | Französisch (Schweizerisch, Region: Switzerland, FRS) LanguageId Wert |
+| [Frisian](#Frisian) | Friesisch (Region: Netherlands, NLD) LanguageId Wert |
+| [Galician](#Galician) | Galicisch (Region: Galician) LanguageId Wert |
+| [Georgian](#Georgian) | Georgisch (Region: Georgien) LanguageId Wert |
+| [German_Austria](#German-Austria) | Deutsch (Österreichisch, Region: Österreich, DEA) LanguageId Wert |
+| [German_Germany](#German-Germany) | Deutsch (Standard, Region: Deutschland, DEU) LanguageId Wert |
+| [German_Liechtenstein](#German-Liechtenstein) | Deutsch (Region: Liechtenstein, DEC) LanguageId Wert |
+| [German_Luxembourg](#German-Luxembourg) | Deutsch (Region: Luxemburg, DEL) LanguageId Wert |
+| [German_Switzerland](#German-Switzerland) | Deutsch (Schweizerisch, Region: Schweiz, DES) LanguageId Wert |
+| [Greek](#Greek) | Griechisch (Region: Griechenland, ELL) LanguageId Wert |
+| [Greenlandic](#Greenlandic) | Grönländisch (Region: Grönland) LanguageId Wert |
+| [Gujarati](#Gujarati) | Gujarati (Region: Indien) LanguageId Wert |
+| [Hausa](#Hausa) | Hausa (Lateinisch, Region: Nigeria) LanguageId Wert |
+| [Hebrew](#Hebrew) | Hebräisch (Region: Israel) LanguageId Wert |
+| [Hindi](#Hindi) | Hindi (Region: Indien) LanguageId Wert |
+| [Hungarian](#Hungarian) | Ungarisch (Region: Ungarn, HUN) LanguageId Wert |
+| [Icelandic](#Icelandic) | Isländisch (Region: Island, ISL) LanguageId Wert |
+| [Igbo](#Igbo) | Igbo (Region: Nigeria) LanguageId Wert |
+| [Indonesian](#Indonesian) | Indonesisch (Region: Indonesien) LanguageId Wert |
+| [Inuktitut](#Inuktitut) | Inuktitut (Region: Kanada) LanguageId Wert |
+| [Inuktitut_Latin](#Inuktitut-Latin) | Inuktitut (Lateinisch, Region: Kanada) LanguageId Wert |
+| [Irish](#Irish) | Irisch (Region: Irland) LanguageId Wert |
+| [Italian_Italy](#Italian-Italy) | Italienisch (Standard, Region: Italien, ITA) LanguageId Wert |
+| [Italian_Switzerland](#Italian-Switzerland) | Italienisch (Schweizerisch, Region: Schweiz, ITS) LanguageId Wert |
+| [Japanese](#Japanese) | Japanisch (Region: Japan) LanguageId Wert |
+| [Kannada](#Kannada) | Kannada (Region: Indien) LanguageId Wert |
+| [Kazakh](#Kazakh) | Kasachisch (Region: Kasachstan) LanguageId Wert |
+| [Khmer](#Khmer) | Khmer (Region: Kambodscha) LanguageId Wert |
+| [Kiche](#Kiche) | K’iche (Region: Guatemala) LanguageId Wert |
+| [Kinyarwanda](#Kinyarwanda) | Kinyarwanda (Region: Ruanda) LanguageId Wert |
+| [Kiswahili](#Kiswahili) | Kiswahili (Region: Kenia) LanguageId Wert |
+| [Konkani](#Konkani) | Konkani (Region: Indien) LanguageId Wert |
+| [Korean](#Korean) | Koreanisch (Region: Korea) LanguageId Wert |
+| [Kyrgyz](#Kyrgyz) | Kirgisisch (Region: Kirgisistan) LanguageId Wert |
+| [Lao](#Lao) | Laotisch (Region: Lao P.D.R.) |
+| [Latvian](#Latvian) | Lettisch (Region: Lettland, LVI) LanguageId Wert |
+| [Lithuanian](#Lithuanian) | Litauisch (Region: Litauen, LTH) LanguageId Wert |
+| [Lower_Sorbian](#Lower-Sorbian) | Niedersorbisch (Region: Deutschland) LanguageId Wert |
+| [Luxembourgish](#Luxembourgish) | Luxemburgisch (Region: Luxemburg) LanguageId Wert |
+| [Macedonian](#Macedonian) | Mazedonisch (Region: Nordmazedonien) LanguageId Wert |
+| [Malay_Brunei_Darussalam](#Malay-Brunei-Darussalam) | Malaiisch (Region: Brunei Darussalam) LanguageId Wert |
+| [Malay_Malaysia](#Malay-Malaysia) | Malaiisch (Region: Malaysia) LanguageId Wert |
+| [Malayalam](#Malayalam) | Malayalam (Region: Indien) LanguageId Wert |
+| [Maltese](#Maltese) | Maltesisch (Region: Malta) LanguageId Wert |
+| [Maori](#Maori) | Maori (Region: Neuseeland) LanguageId Wert |
+| [Mapudungun](#Mapudungun) | Mapudungun (Region: Chile) LanguageId Wert |
+| [Marathi](#Marathi) | Marathi (Region: Indien) LanguageId Wert |
+| [Mohawk](#Mohawk) | Mohawk (Region: Mohawk) LanguageId Wert |
+| [Mongolian_Cyrillic](#Mongolian-Cyrillic) | Mongolisch (Kyrillisch, Region: Mongolei) LanguageId Wert |
+| [Mongolian_Traditional](#Mongolian-Traditional) | Mongolisch (Traditionell, Region: Volksrepublik China) LanguageId Wert |
+| [Nepali](#Nepali) | Nepalesisch (Region: Nepal) LanguageId Wert |
+| [Norwegian_Bokmal](#Norwegian-Bokmal) | Norwegisch (Bokmål, Region: Norwegen, NOR) LanguageId Wert |
+| [Norwegian_Nynorsk](#Norwegian-Nynorsk) | Norwegisch (Nynorsk, Region: Norwegen, NON) LanguageId Wert |
+| [Occitan](#Occitan) | Okzitanisch (Region: Frankreich) LanguageId Wert |
+| [Odia](#Odia) | Odia (früher Oriya, Region: Indien) LanguageId Wert |
+| [Pashto](#Pashto) | Paschtunisch (Region: Afghanistan) LanguageId Wert |
+| [Polish](#Polish) | Polnisch (Region: Polen, PLK) LanguageId Wert |
+| [Portuguese_Brazil](#Portuguese-Brazil) | Portugiesisch (Brasilianisch, Region: Brasilien, PTB) LanguageId Wert |
+| [Portuguese_Portugal](#Portuguese-Portugal) | Portugiesisch (Standard, Region: Portugal, PTG) LanguageId Wert |
+| [Punjabi](#Punjabi) | Panjabi (Region: Indien) LanguageId Wert |
+| [Quechua_Bolivia](#Quechua-Bolivia) | Quechua (Region: Bolivien) LanguageId Wert |
+| [Quechua_Ecuador](#Quechua-Ecuador) | Quechua (Region: Ecuador) LanguageId Wert |
+| [Quechua_Peru](#Quechua-Peru) | Quechua (Region: Peru) LanguageId Wert |
+| [Romanian](#Romanian) | Rumänisch (Region: Rumänien, ROM) LanguageId Wert |
+| [Romansh](#Romansh) | Rätoromanisch (Region: Schweiz) LanguageId Wert |
+| [Russian](#Russian) | Russisch (Region: Russland, RUS) LanguageId Wert |
+| [Sami_Inari](#Sami-Inari) | Samisch (Inari, Region: Finnland) LanguageId Wert |
+| [Sami_Lule_Norway](#Sami-Lule-Norway) | Samisch (Lule, Region: Norwegen) LanguageId Wert |
+| [Sami_Lule_Sweden](#Sami-Lule-Sweden) | Samisch (Lule, Region: Schweden) LanguageId Wert |
+| [Sami_Northern_Finland](#Sami-Northern-Finland) | Samisch (Nördlich, Region: Finnland) LanguageId Wert |
+| [Sami_Northern_Norway](#Sami-Northern-Norway) | Samisch (Nördlich, Region: Norwegen) LanguageId Wert |
+| [Sami_Northern_Sweden](#Sami-Northern-Sweden) | Samisch (Nördlich, Region: Schweden) LanguageId Wert |
+| [Sami_Skolt](#Sami-Skolt) | Samisch (Skolt, Region: Finnland) LanguageId Wert |
+| [Sami_Southern_Norway](#Sami-Southern-Norway) | Samisch (Südlich, Region: Norwegen) LanguageId Wert |
+| [Sami_Southern_Sweden](#Sami-Southern-Sweden) | Samisch (Südlich, Region: Schweden) LanguageId Wert |
+| [Sanskrit](#Sanskrit) | Sanskrit (Region: Indien) LanguageId Wert |
+| [Serbian_Cyrillic_BIH](#Serbian-Cyrillic-BIH) | Serbisch (Kyrillisch, Region: Bosnien und Herzegowina) LanguageId Wert |
+| [Serbian_Cyrillic_Serbia](#Serbian-Cyrillic-Serbia) | Serbisch (Kyrillisch, Region: Serbien) LanguageId Wert |
+| [Serbian_Latin_BIH](#Serbian-Latin-BIH) | Serbisch (Latein, Region: Bosnien und Herzegowina) LanguageId-Wert |
+| [Serbian_Latin_Serbia](#Serbian-Latin-Serbia) | Serbisch (Latein, Region: Serbien) LanguageId-Wert |
+| [Sesotho_Sa_Leboa](#Sesotho-Sa-Leboa) | Sesotho sa Leboa (Nord‑Sotho, Region: Südafrika, SA) LanguageId-Wert |
+| [Setswana](#Setswana) | Setswana (Region: Südafrika, SA) LanguageId-Wert |
+| [Sinhala](#Sinhala) | Singhalesisch (Region: Sri Lanka) LanguageId-Wert |
+| [Slovak](#Slovak) | Slowakisch (Region: Slowakei, SKY) LanguageId-Wert |
+| [Slovenian](#Slovenian) | Slowenisch (Region: Slowenien, SLV) LanguageId-Wert |
+| [Spanish_Argentina](#Spanish-Argentina) | Spanisch (Region: Argentinien) LanguageId-Wert |
+| [Spanish_Bolivia](#Spanish-Bolivia) | Spanisch (Region: Bolivien) LanguageId-Wert |
+| [Spanish_Chile](#Spanish-Chile) | Spanisch (Region: Chile) LanguageId-Wert |
+| [Spanish_Colombia](#Spanish-Colombia) | Spanisch (Region: Kolumbien) LanguageId-Wert |
+| [Spanish_Costa_Rica](#Spanish-Costa-Rica) | Spanisch (Region: Costa Rica) LanguageId-Wert |
+| [Spanish_Dominican_Republic](#Spanish-Dominican-Republic) | Spanisch (Region: Dominikanische Republik) LanguageId-Wert |
+| [Spanish_Ecuador](#Spanish-Ecuador) | Spanisch (Region: Ecuador) LanguageId-Wert |
+| [Spanish_El_Salvador](#Spanish-El-Salvador) | Spanisch (Region: El Salvador) LanguageId-Wert |
+| [Spanish_Guatemala](#Spanish-Guatemala) | Spanisch (Region: Guatemala) LanguageId-Wert |
+| [Spanish_Honduras](#Spanish-Honduras) | Spanisch (Region: Honduras) LanguageId-Wert |
+| [Spanish_Mexico](#Spanish-Mexico) | Spanisch (Mexikanisch, Region: Mexiko, ESM) LanguageId-Wert |
+| [Spanish_Modern_Sort](#Spanish-Modern-Sort) | Spanisch (Moderne Sortierung, Region: Spanien, ESN) LanguageId-Wert |
+| [Spanish_Nicaragua](#Spanish-Nicaragua) | Spanisch (Region: Nicaragua) LanguageId-Wert |
+| [Spanish_Panama](#Spanish-Panama) | Spanisch (Region: Panama) LanguageId-Wert |
+| [Spanish_Paraguay](#Spanish-Paraguay) | Spanisch (Region: Paraguay) LanguageId-Wert |
+| [Spanish_Peru](#Spanish-Peru) | Spanisch (Region: Peru) LanguageId-Wert |
+| [Spanish_Puerto_Rico](#Spanish-Puerto-Rico) | Spanisch (Region: Puerto Rico) LanguageId-Wert |
+| [Spanish_Traditional_Sort](#Spanish-Traditional-Sort) | Spanisch (Traditionelle Sortierung, Region: Spanien, ESP) LanguageId-Wert |
+| [Spanish_United_States](#Spanish-United-States) | Spanisch (Region: Vereinigte Staaten) LanguageId value |
+| [Spanish_Uruguay](#Spanish-Uruguay) | Spanisch (Region: Uruguay) LanguageId value |
+| [Spanish_Venezuela](#Spanish-Venezuela) | Spanisch (Region: Venezuela) LanguageId value |
+| [Swedish_Finland](#Swedish-Finland) | Schwedisch (Region: Finnland) LanguageId value |
+| [Swedish_Sweden](#Swedish-Sweden) | Schwedisch (Region: Schweden, SVE) LanguageId value |
+| [Syriac](#Syriac) | Syrisch (Region: Syrien) LanguageId value |
+| [Tajik](#Tajik) | Tadschikisch (Kyrillisch, Region: Tadschikistan) LanguageId value |
+| [Tamazight](#Tamazight) | Tamazight (Lateinisch, Region: Algerien) LanguageId value |
+| [Tamil](#Tamil) | Tamilisch (Region: Indien) LanguageId value |
+| [Tatar](#Tatar) | Tatarisch (Region: Russland) LanguageId value |
+| [Telugu](#Telugu) | Telugu (Region: Indien) LanguageId value |
+| [Thai](#Thai) | Thailändisch (Region: Thailand) LanguageId value |
+| [Tibetan](#Tibetan) | Tibetisch (Region: VR China) LanguageId value |
+| [Turkish](#Turkish) | Türkisch (Region: Türkei, TRK) LanguageId value |
+| [Turkmen](#Turkmen) | Turkmenisch (Region: Turkmenistan) LanguageId value |
+| [Uighur](#Uighur) | Uigurisch (Region: VR China) LanguageId value |
+| [Ukrainian](#Ukrainian) | Ukrainisch (Region: Ukraine, UKR) LanguageId value |
+| [Upper_Sorbian](#Upper-Sorbian) | Obersorbisch (Region: Deutschland) LanguageId value |
+| [Urdu](#Urdu) | Urdu (Region: Islamische Republik Pakistan) LanguageId value |
+| [Uzbek_Cyrillic](#Uzbek-Cyrillic) | Usbekisch (Kyrillisch, Region: Usbekistan) LanguageId value |
+| [Uzbek_Latin](#Uzbek-Latin) | Usbekisch (Lateinisch, Region: Usbekistan) LanguageId value |
+| [Vietnamese](#Vietnamese) | Vietnamesisch (Region: Vietnam) LanguageId value |
+| [Welsh](#Welsh) | Walisisch (Region: Vereinigtes Königreich) LanguageId value |
+| [Wolof](#Wolof) | Wolof (Region: Senegal) LanguageId value |
+| [Yakut](#Yakut) | Jakutisch (Region: Russland) LanguageId value |
+| [Yi](#Yi) | Yi (Region: VR China) LanguageId-Wert |
+| [Yoruba](#Yoruba) | Yoruba (Region: Nigeria) LanguageId-Wert |
+| [isiXhosa](#isiXhosa) | isiXhosa (Region: Südafrika, SA) LanguageId-Wert |
+| [isiZulu](#isiZulu) | isiZulu (Region: Südafrika, SA) LanguageId-Wert |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getId()](#getId--) | Gib den ganzzahligen Wert zurück. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Afrikaans {#Afrikaans}
+```
+public static final MSLanguageId Afrikaans
+```
+
+
+Afrikaans (Region: Südafrika, SA) LanguageId-Wert
+
+### Albanian {#Albanian}
+```
+public static final MSLanguageId Albanian
+```
+
+
+Albanisch (Region: Albania, SQI) LanguageId-Wert
+
+### Alsatian {#Alsatian}
+```
+public static final MSLanguageId Alsatian
+```
+
+
+Elsässisch (Region: France) LanguageId-Wert
+
+### Amharic {#Amharic}
+```
+public static final MSLanguageId Amharic
+```
+
+
+Amharisch (Region: Ethiopia) LanguageId-Wert
+
+### Arabic_Algeria {#Arabic-Algeria}
+```
+public static final MSLanguageId Arabic_Algeria
+```
+
+
+Arabisch (Region: Algeria) LanguageId-Wert
+
+### Arabic_Bahrain {#Arabic-Bahrain}
+```
+public static final MSLanguageId Arabic_Bahrain
+```
+
+
+Arabisch (Region: Bahrain) LanguageId-Wert
+
+### Arabic_Egypt {#Arabic-Egypt}
+```
+public static final MSLanguageId Arabic_Egypt
+```
+
+
+Arabisch (Region: Egypt) LanguageId-Wert
+
+### Arabic_Iraq {#Arabic-Iraq}
+```
+public static final MSLanguageId Arabic_Iraq
+```
+
+
+Arabisch (Region: Iraq) LanguageId-Wert
+
+### Arabic_Jordan {#Arabic-Jordan}
+```
+public static final MSLanguageId Arabic_Jordan
+```
+
+
+Arabisch (Region: Jordan) LanguageId-Wert
+
+### Arabic_Kuwait {#Arabic-Kuwait}
+```
+public static final MSLanguageId Arabic_Kuwait
+```
+
+
+Arabisch (Region: Kuwait) LanguageId-Wert
+
+### Arabic_Lebanon {#Arabic-Lebanon}
+```
+public static final MSLanguageId Arabic_Lebanon
+```
+
+
+Arabisch (Region: Lebanon) LanguageId-Wert
+
+### Arabic_Libya {#Arabic-Libya}
+```
+public static final MSLanguageId Arabic_Libya
+```
+
+
+Arabisch (Region: Libya) LanguageId-Wert
+
+### Arabic_Morocco {#Arabic-Morocco}
+```
+public static final MSLanguageId Arabic_Morocco
+```
+
+
+Arabisch (Region: Morocco) LanguageId-Wert
+
+### Arabic_Oman {#Arabic-Oman}
+```
+public static final MSLanguageId Arabic_Oman
+```
+
+
+Arabisch (Region: Oman) LanguageId-Wert
+
+### Arabic_Qatar {#Arabic-Qatar}
+```
+public static final MSLanguageId Arabic_Qatar
+```
+
+
+Arabisch (Region: Qatar) LanguageId-Wert
+
+### Arabic_Saudi_Arabia {#Arabic-Saudi-Arabia}
+```
+public static final MSLanguageId Arabic_Saudi_Arabia
+```
+
+
+Arabisch (Region: Saudi Arabia) LanguageId-Wert
+
+### Arabic_Syria {#Arabic-Syria}
+```
+public static final MSLanguageId Arabic_Syria
+```
+
+
+Arabisch (Region: Syria) LanguageId-Wert
+
+### Arabic_Tunisia {#Arabic-Tunisia}
+```
+public static final MSLanguageId Arabic_Tunisia
+```
+
+
+Arabisch (Region: Tunisia) LanguageId-Wert
+
+### Arabic_U_A_E {#Arabic-U-A-E}
+```
+public static final MSLanguageId Arabic_U_A_E
+```
+
+
+Arabisch (Region: VAE) LanguageId-Wert
+
+### Arabic_Yemen {#Arabic-Yemen}
+```
+public static final MSLanguageId Arabic_Yemen
+```
+
+
+Arabisch (Region: Yemen) LanguageId-Wert
+
+### Armenian {#Armenian}
+```
+public static final MSLanguageId Armenian
+```
+
+
+Armenisch (Region: Armenia) LanguageId-Wert
+
+### Assamese {#Assamese}
+```
+public static final MSLanguageId Assamese
+```
+
+
+Assamesisch (Region: India) LanguageId-Wert
+
+### Azeri_Cyrillic {#Azeri-Cyrillic}
+```
+public static final MSLanguageId Azeri_Cyrillic
+```
+
+
+Aserbaidschanisch (Kyrillisch, Region: Azerbaijan) LanguageId-Wert
+
+### Azeri_Latin {#Azeri-Latin}
+```
+public static final MSLanguageId Azeri_Latin
+```
+
+
+Aserbaidschanisch (Lateinisch, Region: Azerbaijan) LanguageId-Wert
+
+### Bashkir {#Bashkir}
+```
+public static final MSLanguageId Bashkir
+```
+
+
+Baschkirisch (Region: Russia) LanguageId-Wert
+
+### Basque {#Basque}
+```
+public static final MSLanguageId Basque
+```
+
+
+Baskisch (Region: Basque, EUQ) LanguageId-Wert
+
+### Belarusian {#Belarusian}
+```
+public static final MSLanguageId Belarusian
+```
+
+
+Belarussisch (Region: Belarus, BEL) LanguageId-Wert
+
+### Bengali_Bangladesh {#Bengali-Bangladesh}
+```
+public static final MSLanguageId Bengali_Bangladesh
+```
+
+
+Bengalisch (Region: Bangladesch) LanguageId-Wert
+
+### Bengali_India {#Bengali-India}
+```
+public static final MSLanguageId Bengali_India
+```
+
+
+Bengalisch (Region: Indien) LanguageId-Wert
+
+### Bosnian_Cyrillic {#Bosnian-Cyrillic}
+```
+public static final MSLanguageId Bosnian_Cyrillic
+```
+
+
+Bosnisch (Kyrillisch, Region: Bosnien und Herzegowina) LanguageId-Wert
+
+### Bosnian_Latin {#Bosnian-Latin}
+```
+public static final MSLanguageId Bosnian_Latin
+```
+
+
+Bosnisch (Lateinisch, Region: Bosnien und Herzegowina) LanguageId-Wert
+
+### Breton {#Breton}
+```
+public static final MSLanguageId Breton
+```
+
+
+Bretonisch (Region: Frankreich) LanguageId-Wert
+
+### Bulgarian {#Bulgarian}
+```
+public static final MSLanguageId Bulgarian
+```
+
+
+Bulgarisch (Region: Bulgarien, BGR) LanguageId-Wert
+
+### Catalan {#Catalan}
+```
+public static final MSLanguageId Catalan
+```
+
+
+Katalanisch (Region: Katalonien, CAT) LanguageId-Wert
+
+### Chinese_Hong_Kong {#Chinese-Hong-Kong}
+```
+public static final MSLanguageId Chinese_Hong_Kong
+```
+
+
+Chinesisch (Region: Hongkong SAR) LanguageId-Wert
+
+### Chinese_Macao {#Chinese-Macao}
+```
+public static final MSLanguageId Chinese_Macao
+```
+
+
+Chinesisch (Region: Macau SAR) LanguageId-Wert
+
+### Chinese_PRC {#Chinese-PRC}
+```
+public static final MSLanguageId Chinese_PRC
+```
+
+
+Chinesisch (Region: Volksrepublik China) LanguageId-Wert
+
+### Chinese_Singapore {#Chinese-Singapore}
+```
+public static final MSLanguageId Chinese_Singapore
+```
+
+
+Chinesisch (Region: Singapur) LanguageId-Wert
+
+### Chinese_Taiwan {#Chinese-Taiwan}
+```
+public static final MSLanguageId Chinese_Taiwan
+```
+
+
+Chinesisch (Region: Taiwan) LanguageId-Wert
+
+### Corsican {#Corsican}
+```
+public static final MSLanguageId Corsican
+```
+
+
+Korsisch (Region: Frankreich) LanguageId-Wert
+
+### Croatian {#Croatian}
+```
+public static final MSLanguageId Croatian
+```
+
+
+Kroatisch (Region: Kroatien, SHL) LanguageId-Wert
+
+### Croatian_Latin {#Croatian-Latin}
+```
+public static final MSLanguageId Croatian_Latin
+```
+
+
+Kroatisch (Lateinisch, Region: Bosnien und Herzegowina) LanguageId-Wert
+
+### Czech {#Czech}
+```
+public static final MSLanguageId Czech
+```
+
+
+Tschechisch (Region: Tschechien, CSY) LanguageId-Wert
+
+### Danish {#Danish}
+```
+public static final MSLanguageId Danish
+```
+
+
+Dänisch (Region: Dänemark, DAN) LanguageId-Wert
+
+### Dari {#Dari}
+```
+public static final MSLanguageId Dari
+```
+
+
+Dari (Region: Afghanistan) LanguageId-Wert
+
+### Divehi {#Divehi}
+```
+public static final MSLanguageId Divehi
+```
+
+
+Divehi (Region: Malediven) LanguageId-Wert
+
+### Dutch_Belgium {#Dutch-Belgium}
+```
+public static final MSLanguageId Dutch_Belgium
+```
+
+
+Niederländisch (Flämisch, Region: Belgien, NLB) LanguageId-Wert
+
+### Dutch_Netherlands {#Dutch-Netherlands}
+```
+public static final MSLanguageId Dutch_Netherlands
+```
+
+
+Niederländisch (Standard, Region: Niederlande, NLD) LanguageId-Wert
+
+### English_Australia {#English-Australia}
+```
+public static final MSLanguageId English_Australia
+```
+
+
+Englisch (Australisch, Region: Australien, ENA) LanguageId-Wert
+
+### English_Belize {#English-Belize}
+```
+public static final MSLanguageId English_Belize
+```
+
+
+Englisch (Region: Belize) LanguageId-Wert
+
+### English_Canada {#English-Canada}
+```
+public static final MSLanguageId English_Canada
+```
+
+
+Englisch (Kanadisch, Region: Kanada, ENC) LanguageId-Wert
+
+### English_Caribbean {#English-Caribbean}
+```
+public static final MSLanguageId English_Caribbean
+```
+
+
+Englisch (Region: Caribbean) LanguageId Wert
+
+### English_India {#English-India}
+```
+public static final MSLanguageId English_India
+```
+
+
+Englisch (Region: India) LanguageId Wert
+
+### English_Ireland {#English-Ireland}
+```
+public static final MSLanguageId English_Ireland
+```
+
+
+Englisch (Region: Ireland, ENI) LanguageId Wert
+
+### English_Jamaica {#English-Jamaica}
+```
+public static final MSLanguageId English_Jamaica
+```
+
+
+Englisch (Region: Jamaica) LanguageId Wert
+
+### English_Malaysia {#English-Malaysia}
+```
+public static final MSLanguageId English_Malaysia
+```
+
+
+Englisch (Region: Malaysia) LanguageId Wert
+
+### English_New_Zealand {#English-New-Zealand}
+```
+public static final MSLanguageId English_New_Zealand
+```
+
+
+Englisch (Region: New Zealand, ENZ) LanguageId Wert
+
+### English_ROP {#English-ROP}
+```
+public static final MSLanguageId English_ROP
+```
+
+
+Englisch (Region: Republic of the Philippines, ROP) LanguageId Wert
+
+### English_Singapore {#English-Singapore}
+```
+public static final MSLanguageId English_Singapore
+```
+
+
+Englisch (Region: Singapore) LanguageId Wert
+
+### English_South_Africa {#English-South-Africa}
+```
+public static final MSLanguageId English_South_Africa
+```
+
+
+Englisch (Region: South Africa, SA) LanguageId Wert
+
+### English_TT {#English-TT}
+```
+public static final MSLanguageId English_TT
+```
+
+
+Englisch (Region: Trinidad and Tobago, TT) LanguageId Wert
+
+### English_United_Kingdom {#English-United-Kingdom}
+```
+public static final MSLanguageId English_United_Kingdom
+```
+
+
+Englisch (Britisch, Region: United Kingdom, ENG) LanguageId Wert
+
+### English_United_States {#English-United-States}
+```
+public static final MSLanguageId English_United_States
+```
+
+
+Englisch (Amerikanisch, Region: United States, ENU) LanguageId Wert
+
+### English_Zimbabwe {#English-Zimbabwe}
+```
+public static final MSLanguageId English_Zimbabwe
+```
+
+
+Englisch (Region: Zimbabwe) LanguageId Wert
+
+### Estonian {#Estonian}
+```
+public static final MSLanguageId Estonian
+```
+
+
+Estnisch (Region: Estonia, ETI) LanguageId Wert
+
+### Faroese {#Faroese}
+```
+public static final MSLanguageId Faroese
+```
+
+
+Färöisch (Region: Faroe Islands) LanguageId Wert
+
+### Filipino {#Filipino}
+```
+public static final MSLanguageId Filipino
+```
+
+
+Filipino (Region: Philippines) LanguageId Wert
+
+### Finnish {#Finnish}
+```
+public static final MSLanguageId Finnish
+```
+
+
+Finnisch (Region: Finland, FIN) LanguageId Wert
+
+### French_Belgium {#French-Belgium}
+```
+public static final MSLanguageId French_Belgium
+```
+
+
+Französisch (Belgisch, Region: Belgium, FRB) LanguageId Wert
+
+### French_Canada {#French-Canada}
+```
+public static final MSLanguageId French_Canada
+```
+
+
+Französisch (Kanadisch, Region: Canada, FRC) LanguageId Wert
+
+### French_France {#French-France}
+```
+public static final MSLanguageId French_France
+```
+
+
+Französisch (Standard, Region: France, FRA) LanguageId Wert
+
+### French_Luxembourg {#French-Luxembourg}
+```
+public static final MSLanguageId French_Luxembourg
+```
+
+
+Französisch (Region: Luxembourg, FRL) LanguageId Wert
+
+### French_MC {#French-MC}
+```
+public static final MSLanguageId French_MC
+```
+
+
+Französisch (Region: Principality of Monaco, MC) LanguageId Wert
+
+### French_Switzerland {#French-Switzerland}
+```
+public static final MSLanguageId French_Switzerland
+```
+
+
+Französisch (Schweizerisch, Region: Switzerland, FRS) LanguageId Wert
+
+### Frisian {#Frisian}
+```
+public static final MSLanguageId Frisian
+```
+
+
+Friesisch (Region: Netherlands, NLD) LanguageId Wert
+
+### Galician {#Galician}
+```
+public static final MSLanguageId Galician
+```
+
+
+Galicisch (Region: Galician) LanguageId Wert
+
+### Georgian {#Georgian}
+```
+public static final MSLanguageId Georgian
+```
+
+
+Georgisch (Region: Georgien) LanguageId Wert
+
+### German_Austria {#German-Austria}
+```
+public static final MSLanguageId German_Austria
+```
+
+
+Deutsch (Österreichisch, Region: Österreich, DEA) LanguageId Wert
+
+### German_Germany {#German-Germany}
+```
+public static final MSLanguageId German_Germany
+```
+
+
+Deutsch (Standard, Region: Deutschland, DEU) LanguageId Wert
+
+### German_Liechtenstein {#German-Liechtenstein}
+```
+public static final MSLanguageId German_Liechtenstein
+```
+
+
+Deutsch (Region: Liechtenstein, DEC) LanguageId Wert
+
+### German_Luxembourg {#German-Luxembourg}
+```
+public static final MSLanguageId German_Luxembourg
+```
+
+
+Deutsch (Region: Luxemburg, DEL) LanguageId Wert
+
+### German_Switzerland {#German-Switzerland}
+```
+public static final MSLanguageId German_Switzerland
+```
+
+
+Deutsch (Schweizerisch, Region: Schweiz, DES) LanguageId Wert
+
+### Greek {#Greek}
+```
+public static final MSLanguageId Greek
+```
+
+
+Griechisch (Region: Griechenland, ELL) LanguageId Wert
+
+### Greenlandic {#Greenlandic}
+```
+public static final MSLanguageId Greenlandic
+```
+
+
+Grönländisch (Region: Grönland) LanguageId Wert
+
+### Gujarati {#Gujarati}
+```
+public static final MSLanguageId Gujarati
+```
+
+
+Gujarati (Region: Indien) LanguageId Wert
+
+### Hausa {#Hausa}
+```
+public static final MSLanguageId Hausa
+```
+
+
+Hausa (Lateinisch, Region: Nigeria) LanguageId Wert
+
+### Hebrew {#Hebrew}
+```
+public static final MSLanguageId Hebrew
+```
+
+
+Hebräisch (Region: Israel) LanguageId Wert
+
+### Hindi {#Hindi}
+```
+public static final MSLanguageId Hindi
+```
+
+
+Hindi (Region: Indien) LanguageId Wert
+
+### Hungarian {#Hungarian}
+```
+public static final MSLanguageId Hungarian
+```
+
+
+Ungarisch (Region: Ungarn, HUN) LanguageId Wert
+
+### Icelandic {#Icelandic}
+```
+public static final MSLanguageId Icelandic
+```
+
+
+Isländisch (Region: Island, ISL) LanguageId Wert
+
+### Igbo {#Igbo}
+```
+public static final MSLanguageId Igbo
+```
+
+
+Igbo (Region: Nigeria) LanguageId Wert
+
+### Indonesian {#Indonesian}
+```
+public static final MSLanguageId Indonesian
+```
+
+
+Indonesisch (Region: Indonesien) LanguageId Wert
+
+### Inuktitut {#Inuktitut}
+```
+public static final MSLanguageId Inuktitut
+```
+
+
+Inuktitut (Region: Kanada) LanguageId Wert
+
+### Inuktitut_Latin {#Inuktitut-Latin}
+```
+public static final MSLanguageId Inuktitut_Latin
+```
+
+
+Inuktitut (Lateinisch, Region: Kanada) LanguageId Wert
+
+### Irish {#Irish}
+```
+public static final MSLanguageId Irish
+```
+
+
+Irisch (Region: Irland) LanguageId Wert
+
+### Italian_Italy {#Italian-Italy}
+```
+public static final MSLanguageId Italian_Italy
+```
+
+
+Italienisch (Standard, Region: Italien, ITA) LanguageId Wert
+
+### Italian_Switzerland {#Italian-Switzerland}
+```
+public static final MSLanguageId Italian_Switzerland
+```
+
+
+Italienisch (Schweizerisch, Region: Schweiz, ITS) LanguageId Wert
+
+### Japanese {#Japanese}
+```
+public static final MSLanguageId Japanese
+```
+
+
+Japanisch (Region: Japan) LanguageId Wert
+
+### Kannada {#Kannada}
+```
+public static final MSLanguageId Kannada
+```
+
+
+Kannada (Region: Indien) LanguageId Wert
+
+### Kazakh {#Kazakh}
+```
+public static final MSLanguageId Kazakh
+```
+
+
+Kasachisch (Region: Kasachstan) LanguageId Wert
+
+### Khmer {#Khmer}
+```
+public static final MSLanguageId Khmer
+```
+
+
+Khmer (Region: Kambodscha) LanguageId Wert
+
+### Kiche {#Kiche}
+```
+public static final MSLanguageId Kiche
+```
+
+
+K’iche (Region: Guatemala) LanguageId Wert
+
+### Kinyarwanda {#Kinyarwanda}
+```
+public static final MSLanguageId Kinyarwanda
+```
+
+
+Kinyarwanda (Region: Ruanda) LanguageId Wert
+
+### Kiswahili {#Kiswahili}
+```
+public static final MSLanguageId Kiswahili
+```
+
+
+Kiswahili (Region: Kenia) LanguageId Wert
+
+### Konkani {#Konkani}
+```
+public static final MSLanguageId Konkani
+```
+
+
+Konkani (Region: Indien) LanguageId Wert
+
+### Korean {#Korean}
+```
+public static final MSLanguageId Korean
+```
+
+
+Koreanisch (Region: Korea) LanguageId Wert
+
+### Kyrgyz {#Kyrgyz}
+```
+public static final MSLanguageId Kyrgyz
+```
+
+
+Kirgisisch (Region: Kirgisistan) LanguageId Wert
+
+### Lao {#Lao}
+```
+public static final MSLanguageId Lao
+```
+
+
+Laotisch (Region: Laos PDR) LanguageId-Wert
+
+### Latvian {#Latvian}
+```
+public static final MSLanguageId Latvian
+```
+
+
+Lettisch (Region: Lettland, LVI) LanguageId Wert
+
+### Lithuanian {#Lithuanian}
+```
+public static final MSLanguageId Lithuanian
+```
+
+
+Litauisch (Region: Litauen, LTH) LanguageId Wert
+
+### Lower_Sorbian {#Lower-Sorbian}
+```
+public static final MSLanguageId Lower_Sorbian
+```
+
+
+Niedersorbisch (Region: Deutschland) LanguageId Wert
+
+### Luxembourgish {#Luxembourgish}
+```
+public static final MSLanguageId Luxembourgish
+```
+
+
+Luxemburgisch (Region: Luxemburg) LanguageId Wert
+
+### Macedonian {#Macedonian}
+```
+public static final MSLanguageId Macedonian
+```
+
+
+Mazedonisch (Region: Nordmazedonien) LanguageId Wert
+
+### Malay_Brunei_Darussalam {#Malay-Brunei-Darussalam}
+```
+public static final MSLanguageId Malay_Brunei_Darussalam
+```
+
+
+Malaiisch (Region: Brunei Darussalam) LanguageId Wert
+
+### Malay_Malaysia {#Malay-Malaysia}
+```
+public static final MSLanguageId Malay_Malaysia
+```
+
+
+Malaiisch (Region: Malaysia) LanguageId Wert
+
+### Malayalam {#Malayalam}
+```
+public static final MSLanguageId Malayalam
+```
+
+
+Malayalam (Region: Indien) LanguageId Wert
+
+### Maltese {#Maltese}
+```
+public static final MSLanguageId Maltese
+```
+
+
+Maltesisch (Region: Malta) LanguageId Wert
+
+### Maori {#Maori}
+```
+public static final MSLanguageId Maori
+```
+
+
+Maori (Region: Neuseeland) LanguageId Wert
+
+### Mapudungun {#Mapudungun}
+```
+public static final MSLanguageId Mapudungun
+```
+
+
+Mapudungun (Region: Chile) LanguageId Wert
+
+### Marathi {#Marathi}
+```
+public static final MSLanguageId Marathi
+```
+
+
+Marathi (Region: Indien) LanguageId Wert
+
+### Mohawk {#Mohawk}
+```
+public static final MSLanguageId Mohawk
+```
+
+
+Mohawk (Region: Mohawk) LanguageId Wert
+
+### Mongolian_Cyrillic {#Mongolian-Cyrillic}
+```
+public static final MSLanguageId Mongolian_Cyrillic
+```
+
+
+Mongolisch (Kyrillisch, Region: Mongolei) LanguageId Wert
+
+### Mongolian_Traditional {#Mongolian-Traditional}
+```
+public static final MSLanguageId Mongolian_Traditional
+```
+
+
+Mongolisch (Traditionell, Region: Volksrepublik China) LanguageId Wert
+
+### Nepali {#Nepali}
+```
+public static final MSLanguageId Nepali
+```
+
+
+Nepalesisch (Region: Nepal) LanguageId Wert
+
+### Norwegian_Bokmal {#Norwegian-Bokmal}
+```
+public static final MSLanguageId Norwegian_Bokmal
+```
+
+
+Norwegisch (Bokmål, Region: Norwegen, NOR) LanguageId Wert
+
+### Norwegian_Nynorsk {#Norwegian-Nynorsk}
+```
+public static final MSLanguageId Norwegian_Nynorsk
+```
+
+
+Norwegisch (Nynorsk, Region: Norwegen, NON) LanguageId Wert
+
+### Occitan {#Occitan}
+```
+public static final MSLanguageId Occitan
+```
+
+
+Okzitanisch (Region: Frankreich) LanguageId Wert
+
+### Odia {#Odia}
+```
+public static final MSLanguageId Odia
+```
+
+
+Odia (früher Oriya, Region: Indien) LanguageId Wert
+
+### Pashto {#Pashto}
+```
+public static final MSLanguageId Pashto
+```
+
+
+Paschtunisch (Region: Afghanistan) LanguageId Wert
+
+### Polish {#Polish}
+```
+public static final MSLanguageId Polish
+```
+
+
+Polnisch (Region: Polen, PLK) LanguageId Wert
+
+### Portuguese_Brazil {#Portuguese-Brazil}
+```
+public static final MSLanguageId Portuguese_Brazil
+```
+
+
+Portugiesisch (Brasilianisch, Region: Brasilien, PTB) LanguageId Wert
+
+### Portuguese_Portugal {#Portuguese-Portugal}
+```
+public static final MSLanguageId Portuguese_Portugal
+```
+
+
+Portugiesisch (Standard, Region: Portugal, PTG) LanguageId Wert
+
+### Punjabi {#Punjabi}
+```
+public static final MSLanguageId Punjabi
+```
+
+
+Panjabi (Region: Indien) LanguageId Wert
+
+### Quechua_Bolivia {#Quechua-Bolivia}
+```
+public static final MSLanguageId Quechua_Bolivia
+```
+
+
+Quechua (Region: Bolivien) LanguageId Wert
+
+### Quechua_Ecuador {#Quechua-Ecuador}
+```
+public static final MSLanguageId Quechua_Ecuador
+```
+
+
+Quechua (Region: Ecuador) LanguageId Wert
+
+### Quechua_Peru {#Quechua-Peru}
+```
+public static final MSLanguageId Quechua_Peru
+```
+
+
+Quechua (Region: Peru) LanguageId Wert
+
+### Romanian {#Romanian}
+```
+public static final MSLanguageId Romanian
+```
+
+
+Rumänisch (Region: Rumänien, ROM) LanguageId Wert
+
+### Romansh {#Romansh}
+```
+public static final MSLanguageId Romansh
+```
+
+
+Rätoromanisch (Region: Schweiz) LanguageId Wert
+
+### Russian {#Russian}
+```
+public static final MSLanguageId Russian
+```
+
+
+Russisch (Region: Russland, RUS) LanguageId Wert
+
+### Sami_Inari {#Sami-Inari}
+```
+public static final MSLanguageId Sami_Inari
+```
+
+
+Samisch (Inari, Region: Finnland) LanguageId Wert
+
+### Sami_Lule_Norway {#Sami-Lule-Norway}
+```
+public static final MSLanguageId Sami_Lule_Norway
+```
+
+
+Samisch (Lule, Region: Norwegen) LanguageId Wert
+
+### Sami_Lule_Sweden {#Sami-Lule-Sweden}
+```
+public static final MSLanguageId Sami_Lule_Sweden
+```
+
+
+Samisch (Lule, Region: Schweden) LanguageId Wert
+
+### Sami_Northern_Finland {#Sami-Northern-Finland}
+```
+public static final MSLanguageId Sami_Northern_Finland
+```
+
+
+Samisch (Nördlich, Region: Finnland) LanguageId Wert
+
+### Sami_Northern_Norway {#Sami-Northern-Norway}
+```
+public static final MSLanguageId Sami_Northern_Norway
+```
+
+
+Samisch (Nördlich, Region: Norwegen) LanguageId Wert
+
+### Sami_Northern_Sweden {#Sami-Northern-Sweden}
+```
+public static final MSLanguageId Sami_Northern_Sweden
+```
+
+
+Samisch (Nördlich, Region: Schweden) LanguageId Wert
+
+### Sami_Skolt {#Sami-Skolt}
+```
+public static final MSLanguageId Sami_Skolt
+```
+
+
+Samisch (Skolt, Region: Finnland) LanguageId Wert
+
+### Sami_Southern_Norway {#Sami-Southern-Norway}
+```
+public static final MSLanguageId Sami_Southern_Norway
+```
+
+
+Samisch (Südlich, Region: Norwegen) LanguageId Wert
+
+### Sami_Southern_Sweden {#Sami-Southern-Sweden}
+```
+public static final MSLanguageId Sami_Southern_Sweden
+```
+
+
+Samisch (Südlich, Region: Schweden) LanguageId Wert
+
+### Sanskrit {#Sanskrit}
+```
+public static final MSLanguageId Sanskrit
+```
+
+
+Sanskrit (Region: Indien) LanguageId Wert
+
+### Serbian_Cyrillic_BIH {#Serbian-Cyrillic-BIH}
+```
+public static final MSLanguageId Serbian_Cyrillic_BIH
+```
+
+
+Serbisch (Kyrillisch, Region: Bosnien und Herzegowina) LanguageId Wert
+
+### Serbian_Cyrillic_Serbia {#Serbian-Cyrillic-Serbia}
+```
+public static final MSLanguageId Serbian_Cyrillic_Serbia
+```
+
+
+Serbisch (Kyrillisch, Region: Serbien) LanguageId Wert
+
+### Serbian_Latin_BIH {#Serbian-Latin-BIH}
+```
+public static final MSLanguageId Serbian_Latin_BIH
+```
+
+
+Serbisch (Latein, Region: Bosnien und Herzegowina) LanguageId-Wert
+
+### Serbian_Latin_Serbia {#Serbian-Latin-Serbia}
+```
+public static final MSLanguageId Serbian_Latin_Serbia
+```
+
+
+Serbisch (Latein, Region: Serbien) LanguageId-Wert
+
+### Sesotho_Sa_Leboa {#Sesotho-Sa-Leboa}
+```
+public static final MSLanguageId Sesotho_Sa_Leboa
+```
+
+
+Sesotho sa Leboa (Nord‑Sotho, Region: Südafrika, SA) LanguageId-Wert
+
+### Setswana {#Setswana}
+```
+public static final MSLanguageId Setswana
+```
+
+
+Setswana (Region: Südafrika, SA) LanguageId-Wert
+
+### Sinhala {#Sinhala}
+```
+public static final MSLanguageId Sinhala
+```
+
+
+Singhalesisch (Region: Sri Lanka) LanguageId-Wert
+
+### Slovak {#Slovak}
+```
+public static final MSLanguageId Slovak
+```
+
+
+Slowakisch (Region: Slowakei, SKY) LanguageId-Wert
+
+### Slovenian {#Slovenian}
+```
+public static final MSLanguageId Slovenian
+```
+
+
+Slowenisch (Region: Slowenien, SLV) LanguageId-Wert
+
+### Spanish_Argentina {#Spanish-Argentina}
+```
+public static final MSLanguageId Spanish_Argentina
+```
+
+
+Spanisch (Region: Argentinien) LanguageId-Wert
+
+### Spanish_Bolivia {#Spanish-Bolivia}
+```
+public static final MSLanguageId Spanish_Bolivia
+```
+
+
+Spanisch (Region: Bolivien) LanguageId-Wert
+
+### Spanish_Chile {#Spanish-Chile}
+```
+public static final MSLanguageId Spanish_Chile
+```
+
+
+Spanisch (Region: Chile) LanguageId-Wert
+
+### Spanish_Colombia {#Spanish-Colombia}
+```
+public static final MSLanguageId Spanish_Colombia
+```
+
+
+Spanisch (Region: Kolumbien) LanguageId-Wert
+
+### Spanish_Costa_Rica {#Spanish-Costa-Rica}
+```
+public static final MSLanguageId Spanish_Costa_Rica
+```
+
+
+Spanisch (Region: Costa Rica) LanguageId-Wert
+
+### Spanish_Dominican_Republic {#Spanish-Dominican-Republic}
+```
+public static final MSLanguageId Spanish_Dominican_Republic
+```
+
+
+Spanisch (Region: Dominikanische Republik) LanguageId-Wert
+
+### Spanish_Ecuador {#Spanish-Ecuador}
+```
+public static final MSLanguageId Spanish_Ecuador
+```
+
+
+Spanisch (Region: Ecuador) LanguageId-Wert
+
+### Spanish_El_Salvador {#Spanish-El-Salvador}
+```
+public static final MSLanguageId Spanish_El_Salvador
+```
+
+
+Spanisch (Region: El Salvador) LanguageId-Wert
+
+### Spanish_Guatemala {#Spanish-Guatemala}
+```
+public static final MSLanguageId Spanish_Guatemala
+```
+
+
+Spanisch (Region: Guatemala) LanguageId-Wert
+
+### Spanish_Honduras {#Spanish-Honduras}
+```
+public static final MSLanguageId Spanish_Honduras
+```
+
+
+Spanisch (Region: Honduras) LanguageId-Wert
+
+### Spanish_Mexico {#Spanish-Mexico}
+```
+public static final MSLanguageId Spanish_Mexico
+```
+
+
+Spanisch (Mexikanisch, Region: Mexiko, ESM) LanguageId-Wert
+
+### Spanish_Modern_Sort {#Spanish-Modern-Sort}
+```
+public static final MSLanguageId Spanish_Modern_Sort
+```
+
+
+Spanisch (Moderne Sortierung, Region: Spanien, ESN) LanguageId-Wert
+
+### Spanish_Nicaragua {#Spanish-Nicaragua}
+```
+public static final MSLanguageId Spanish_Nicaragua
+```
+
+
+Spanisch (Region: Nicaragua) LanguageId-Wert
+
+### Spanish_Panama {#Spanish-Panama}
+```
+public static final MSLanguageId Spanish_Panama
+```
+
+
+Spanisch (Region: Panama) LanguageId-Wert
+
+### Spanish_Paraguay {#Spanish-Paraguay}
+```
+public static final MSLanguageId Spanish_Paraguay
+```
+
+
+Spanisch (Region: Paraguay) LanguageId-Wert
+
+### Spanish_Peru {#Spanish-Peru}
+```
+public static final MSLanguageId Spanish_Peru
+```
+
+
+Spanisch (Region: Peru) LanguageId-Wert
+
+### Spanish_Puerto_Rico {#Spanish-Puerto-Rico}
+```
+public static final MSLanguageId Spanish_Puerto_Rico
+```
+
+
+Spanisch (Region: Puerto Rico) LanguageId-Wert
+
+### Spanish_Traditional_Sort {#Spanish-Traditional-Sort}
+```
+public static final MSLanguageId Spanish_Traditional_Sort
+```
+
+
+Spanisch (Traditionelle Sortierung, Region: Spanien, ESP) LanguageId-Wert
+
+### Spanish_United_States {#Spanish-United-States}
+```
+public static final MSLanguageId Spanish_United_States
+```
+
+
+Spanisch (Region: Vereinigte Staaten) LanguageId value
+
+### Spanish_Uruguay {#Spanish-Uruguay}
+```
+public static final MSLanguageId Spanish_Uruguay
+```
+
+
+Spanisch (Region: Uruguay) LanguageId value
+
+### Spanish_Venezuela {#Spanish-Venezuela}
+```
+public static final MSLanguageId Spanish_Venezuela
+```
+
+
+Spanisch (Region: Venezuela) LanguageId value
+
+### Swedish_Finland {#Swedish-Finland}
+```
+public static final MSLanguageId Swedish_Finland
+```
+
+
+Schwedisch (Region: Finnland) LanguageId value
+
+### Swedish_Sweden {#Swedish-Sweden}
+```
+public static final MSLanguageId Swedish_Sweden
+```
+
+
+Schwedisch (Region: Schweden, SVE) LanguageId value
+
+### Syriac {#Syriac}
+```
+public static final MSLanguageId Syriac
+```
+
+
+Syrisch (Region: Syrien) LanguageId value
+
+### Tajik {#Tajik}
+```
+public static final MSLanguageId Tajik
+```
+
+
+Tadschikisch (Kyrillisch, Region: Tadschikistan) LanguageId value
+
+### Tamazight {#Tamazight}
+```
+public static final MSLanguageId Tamazight
+```
+
+
+Tamazight (Lateinisch, Region: Algerien) LanguageId value
+
+### Tamil {#Tamil}
+```
+public static final MSLanguageId Tamil
+```
+
+
+Tamilisch (Region: Indien) LanguageId value
+
+### Tatar {#Tatar}
+```
+public static final MSLanguageId Tatar
+```
+
+
+Tatarisch (Region: Russland) LanguageId value
+
+### Telugu {#Telugu}
+```
+public static final MSLanguageId Telugu
+```
+
+
+Telugu (Region: Indien) LanguageId value
+
+### Thai {#Thai}
+```
+public static final MSLanguageId Thai
+```
+
+
+Thailändisch (Region: Thailand) LanguageId value
+
+### Tibetan {#Tibetan}
+```
+public static final MSLanguageId Tibetan
+```
+
+
+Tibetisch (Region: VR China) LanguageId value
+
+### Turkish {#Turkish}
+```
+public static final MSLanguageId Turkish
+```
+
+
+Türkisch (Region: Türkei, TRK) LanguageId value
+
+### Turkmen {#Turkmen}
+```
+public static final MSLanguageId Turkmen
+```
+
+
+Turkmenisch (Region: Turkmenistan) LanguageId value
+
+### Uighur {#Uighur}
+```
+public static final MSLanguageId Uighur
+```
+
+
+Uigurisch (Region: VR China) LanguageId value
+
+### Ukrainian {#Ukrainian}
+```
+public static final MSLanguageId Ukrainian
+```
+
+
+Ukrainisch (Region: Ukraine, UKR) LanguageId value
+
+### Upper_Sorbian {#Upper-Sorbian}
+```
+public static final MSLanguageId Upper_Sorbian
+```
+
+
+Obersorbisch (Region: Deutschland) LanguageId value
+
+### Urdu {#Urdu}
+```
+public static final MSLanguageId Urdu
+```
+
+
+Urdu (Region: Islamische Republik Pakistan) LanguageId value
+
+### Uzbek_Cyrillic {#Uzbek-Cyrillic}
+```
+public static final MSLanguageId Uzbek_Cyrillic
+```
+
+
+Usbekisch (Kyrillisch, Region: Usbekistan) LanguageId value
+
+### Uzbek_Latin {#Uzbek-Latin}
+```
+public static final MSLanguageId Uzbek_Latin
+```
+
+
+Usbekisch (Lateinisch, Region: Usbekistan) LanguageId value
+
+### Vietnamese {#Vietnamese}
+```
+public static final MSLanguageId Vietnamese
+```
+
+
+Vietnamesisch (Region: Vietnam) LanguageId value
+
+### Welsh {#Welsh}
+```
+public static final MSLanguageId Welsh
+```
+
+
+Walisisch (Region: Vereinigtes Königreich) LanguageId value
+
+### Wolof {#Wolof}
+```
+public static final MSLanguageId Wolof
+```
+
+
+Wolof (Region: Senegal) LanguageId value
+
+### Yakut {#Yakut}
+```
+public static final MSLanguageId Yakut
+```
+
+
+Jakutisch (Region: Russland) LanguageId value
+
+### Yi {#Yi}
+```
+public static final MSLanguageId Yi
+```
+
+
+Yi (Region: VR China) LanguageId-Wert
+
+### Yoruba {#Yoruba}
+```
+public static final MSLanguageId Yoruba
+```
+
+
+Yoruba (Region: Nigeria) LanguageId-Wert
+
+### isiXhosa {#isiXhosa}
+```
+public static final MSLanguageId isiXhosa
+```
+
+
+isiXhosa (Region: Südafrika, SA) LanguageId-Wert
+
+### isiZulu {#isiZulu}
+```
+public static final MSLanguageId isiZulu
+```
+
+
+isiZulu (Region: Südafrika, SA) LanguageId-Wert
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getId() {#getId--}
+```
+public int getId()
+```
+
+
+Gib den ganzzahligen Wert zurück.
+
+**Returns:**
+int - Der ganzzahlige Wert.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/msplatformspecificid/_index.md
+++ b/german/java/com.aspose.font/msplatformspecificid/_index.md
@@ -1,0 +1,331 @@
+---
+title: "MSPlatformSpecificId"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Microsoft-Plattform PlatformSpecificId‑Aufzählung dar."
+type: docs
+weight: 139
+url: /de/java/com.aspose.font/msplatformspecificid/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum MSPlatformSpecificId extends Enum<MSPlatformSpecificId>
+```
+
+Stellt die Microsoft-Plattform PlatformSpecificId‑Aufzählung dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [Big5](#Big5) | Big5 MS MSPlatformSpecificId. |
+| [Johab](#Johab) | Johab MS MSPlatformSpecificId. |
+| [PRC](#PRC) | PRC MS MSPlatformSpecificId. |
+| [Reserved1](#Reserved1) | Reserved1 MS MSPlatformSpecificId. |
+| [Reserved2](#Reserved2) | Reserved2 MS MSPlatformSpecificId. |
+| [Reserved3](#Reserved3) | Reserved3 MS MSPlatformSpecificId. |
+| [ShiftJIS](#ShiftJIS) | ShiftJIS MS MSPlatformSpecificId. |
+| [Symbol](#Symbol) | Symbol MS MSPlatformSpecificId. |
+| [Unicode_BMP_UCS2](#Unicode-BMP-UCS2) | Unicode BMP (UCS2) MS PlatformSpecificId. |
+| [Unicode_UCS4](#Unicode-UCS4) | Unicode\_UCS4 MS MSPlatformSpecificId. |
+| [Wansung](#Wansung) | Wansung MS MSPlatformSpecificId. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Big5 {#Big5}
+```
+public static final MSPlatformSpecificId Big5
+```
+
+
+Big5 MS MSPlatformSpecificId.
+
+### Johab {#Johab}
+```
+public static final MSPlatformSpecificId Johab
+```
+
+
+Johab MS MSPlatformSpecificId.
+
+### PRC {#PRC}
+```
+public static final MSPlatformSpecificId PRC
+```
+
+
+PRC MS MSPlatformSpecificId.
+
+### Reserved1 {#Reserved1}
+```
+public static final MSPlatformSpecificId Reserved1
+```
+
+
+Reserved1 MS MSPlatformSpecificId.
+
+### Reserved2 {#Reserved2}
+```
+public static final MSPlatformSpecificId Reserved2
+```
+
+
+Reserved2 MS MSPlatformSpecificId.
+
+### Reserved3 {#Reserved3}
+```
+public static final MSPlatformSpecificId Reserved3
+```
+
+
+Reserved3 MS MSPlatformSpecificId.
+
+### ShiftJIS {#ShiftJIS}
+```
+public static final MSPlatformSpecificId ShiftJIS
+```
+
+
+ShiftJIS MS MSPlatformSpecificId.
+
+### Symbol {#Symbol}
+```
+public static final MSPlatformSpecificId Symbol
+```
+
+
+Symbol MS MSPlatformSpecificId.
+
+### Unicode_BMP_UCS2 {#Unicode-BMP-UCS2}
+```
+public static final MSPlatformSpecificId Unicode_BMP_UCS2
+```
+
+
+Unicode BMP (UCS2) MS PlatformSpecificId.
+
+### Unicode_UCS4 {#Unicode-UCS4}
+```
+public static final MSPlatformSpecificId Unicode_UCS4
+```
+
+
+Unicode\_UCS4 MS MSPlatformSpecificId.
+
+### Wansung {#Wansung}
+```
+public static final MSPlatformSpecificId Wansung
+```
+
+
+Wansung MS MSPlatformSpecificId.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static MSPlatformSpecificId valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[MSPlatformSpecificId](../../com.aspose.font/msplatformspecificid)
+### values() {#values--}
+```
+public static MSPlatformSpecificId[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.MSPlatformSpecificId[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/multilanguagestring/_index.md
+++ b/german/java/com.aspose.font/multilanguagestring/_index.md
@@ -1,0 +1,296 @@
+---
+title: "MultiLanguageString"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt einen mehrsprachigen String dar."
+type: docs
+weight: 66
+url: /de/java/com.aspose.font/multilanguagestring/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class MultiLanguageString
+```
+
+Stellt einen mehrsprachigen String dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [MultiLanguageString()](#MultiLanguageString--) | Erstellt eine leere mehrsprachige Zeichenkette. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addLanguageString(String str, int languageId)](#addLanguageString-java.lang.String-int-) | Fügt eine Zeichenkette einer bestimmten Sprache hinzu. |
+| [containsString(String str)](#containsString-java.lang.String-) | Gibt true zurück, wenn die Zeichenkette in allen Sprachzeichenketten enthalten ist. |
+| [equals(Object objToCompare)](#equals-java.lang.Object-) | Gibt true zurück, wenn die Objekte als gleich betrachtet werden. |
+| [getAllLanguageIds()](#getAllLanguageIds--) | Ermittelt Sprachkennungen für alle Zeichenketten oder ein leeres Array, wenn keine Zeichenketten vorhanden sind. |
+| [getAllStrings()](#getAllStrings--) | Gibt alle Zeichenketten aller Sprachen zurück. |
+| [getClass()](#getClass--) |  |
+| [getEnglishString()](#getEnglishString--) | Gibt die englische Zeichenkette zurück, falls gefunden. |
+| [getStringForLanguageId(int languageId)](#getStringForLanguageId-int-) | Gibt die zur übergebenen Sprachkennung gehörende Zeichenkette zurück, falls gefunden. |
+| [hashCode()](#hashCode--) | Implementierung von GetHashCode. |
+| [isEmpty()](#isEmpty--) | True, wenn MultiLanguageString keine Sprachzeichenketten enthält. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(MultiLanguageString obj1, String obj2)](#op-Equality-com.aspose.font.MultiLanguageString-java.lang.String-) | Implementierung des Gleichheitsoperators. |
+| [op_Equality(String obj1, MultiLanguageString obj2)](#op-Equality-java.lang.String-com.aspose.font.MultiLanguageString-) | Implementierung des Gleichheitsoperators. |
+| [op_Inequality(MultiLanguageString obj1, String obj2)](#op-Inequality-com.aspose.font.MultiLanguageString-java.lang.String-) | Implementierung des Ungleichheitsoperators. |
+| [op_Inequality(String obj1, MultiLanguageString obj2)](#op-Inequality-java.lang.String-com.aspose.font.MultiLanguageString-) | Implementierung des Ungleichheitsoperators. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MultiLanguageString() {#MultiLanguageString--}
+```
+public MultiLanguageString()
+```
+
+
+Erstellt eine leere mehrsprachige Zeichenkette.
+
+### addLanguageString(String str, int languageId) {#addLanguageString-java.lang.String-int-}
+```
+public void addLanguageString(String str, int languageId)
+```
+
+
+Fügt eine Zeichenkette einer bestimmten Sprache hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| str | java.lang.String | Zeichenkette zum Hinzufügen |
+| languageId | int | Sprachkennung |
+
+### containsString(String str) {#containsString-java.lang.String-}
+```
+public boolean containsString(String str)
+```
+
+
+Gibt true zurück, wenn die Zeichenkette in allen Sprachzeichenketten enthalten ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| str | java.lang.String | Zeichenkette zum Prüfen. |
+
+**Returns:**
+boolean - True, wenn die Zeichenkette in allen Sprachzeichenketten enthalten ist.
+### equals(Object objToCompare) {#equals-java.lang.Object-}
+```
+public boolean equals(Object objToCompare)
+```
+
+
+Gibt true zurück, wenn die Objekte als gleich betrachtet werden.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| objToCompare | java.lang.Object | Objekt zum Vergleichen mit |
+
+**Returns:**
+boolean - Vergleichsergebnis
+### getAllLanguageIds() {#getAllLanguageIds--}
+```
+public int[] getAllLanguageIds()
+```
+
+
+Ermittelt Sprachkennungen für alle Zeichenketten oder ein leeres Array, wenn keine Zeichenketten vorhanden sind.
+
+**Returns:**
+int[] - Array mit Sprachkennungen oder leeres Array, wenn keine Zeichenketten vorhanden sind.
+### getAllStrings() {#getAllStrings--}
+```
+public String[] getAllStrings()
+```
+
+
+Gibt alle Zeichenketten aller Sprachen zurück.
+
+**Returns:**
+java.lang.String[] - Array aller Zeichenketten aller Sprachen.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEnglishString() {#getEnglishString--}
+```
+public String getEnglishString()
+```
+
+
+Gibt die englische Zeichenkette zurück, wenn gefunden. Andernfalls wird die erste nicht-englische Zeichenkette zurückgegeben.
+
+**Returns:**
+java.lang.String - Englische Zeichenkette, wenn gefunden, sonst die erste nicht-englische Zeichenkette.
+### getStringForLanguageId(int languageId) {#getStringForLanguageId-int-}
+```
+public String getStringForLanguageId(int languageId)
+```
+
+
+Gibt die zu der übergebenen Sprachkennung gehörende Zeichenkette zurück, falls gefunden. Andernfalls leere Zeichenkette.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| languageId | int | Sprachkennung. |
+
+**Returns:**
+java.lang.String - Zeichenkette, die zur übergebenen Sprachkennung gehört, falls gefunden. Andernfalls leere Zeichenkette.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Implementierung von GetHashCode.
+
+**Returns:**
+int - Hashcode des Objekts
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+True, wenn MultiLanguageString keine Sprachzeichenketten enthält.
+
+**Returns:**
+boolean - Wahr, wenn MultiLanguageString keine Zeichenketten von Sprachen hat.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(MultiLanguageString obj1, String obj2) {#op-Equality-com.aspose.font.MultiLanguageString-java.lang.String-}
+```
+public static boolean op_Equality(MultiLanguageString obj1, String obj2)
+```
+
+
+Implementierung des Gleichheitsoperators.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj1 | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | erstes Objekt zum Vergleichen |
+| obj2 | java.lang.String | zweites Objekt zum Vergleichen |
+
+**Returns:**
+boolean - Vergleichsergebnis
+### op_Equality(String obj1, MultiLanguageString obj2) {#op-Equality-java.lang.String-com.aspose.font.MultiLanguageString-}
+```
+public static boolean op_Equality(String obj1, MultiLanguageString obj2)
+```
+
+
+Implementierung des Gleichheitsoperators.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj1 | java.lang.String | Zeichenkette zum Vergleichen |
+| obj2 | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | mehrsprachige Zeichenkette zum Vergleichen |
+
+**Returns:**
+boolean - Vergleichsergebnis
+### op_Inequality(MultiLanguageString obj1, String obj2) {#op-Inequality-com.aspose.font.MultiLanguageString-java.lang.String-}
+```
+public static boolean op_Inequality(MultiLanguageString obj1, String obj2)
+```
+
+
+Implementierung des Ungleichheitsoperators.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj1 | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Zeichenkette zum Vergleichen |
+| obj2 | java.lang.String | mehrsprachige Zeichenkette zum Vergleichen |
+
+**Returns:**
+boolean - Vergleichsergebnis
+### op_Inequality(String obj1, MultiLanguageString obj2) {#op-Inequality-java.lang.String-com.aspose.font.MultiLanguageString-}
+```
+public static boolean op_Inequality(String obj1, MultiLanguageString obj2)
+```
+
+
+Implementierung des Ungleichheitsoperators.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj1 | java.lang.String | Zeichenkette zum Vergleichen |
+| obj2 | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | mehrsprachige Zeichenkette zum Vergleichen |
+
+**Returns:**
+boolean - Vergleichsergebnis
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/nameid/_index.md
+++ b/german/java/com.aspose.font/nameid/_index.md
@@ -1,0 +1,380 @@
+---
+title: "NameId"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die NameId-Aufzählung dar."
+type: docs
+weight: 67
+url: /de/java/com.aspose.font/nameid/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class NameId
+```
+
+Stellt die NameId-Aufzählung dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CompatibleFull](#CompatibleFull) | 18 Kompatibel Voll (nur Macintosh); Auf dem Macintosh wird der Menüname mit der Font-Ressource erstellt. |
+| [CopyrightNotice](#CopyrightNotice) | 0 Urheberrechtshinweis. |
+| [DarkBackground](#DarkBackground) | Diese ID, wenn sie im CPAL table\\u2019s Palette Labels Array verwendet wird, gibt an, dass die entsprechende Farbpalette in der CPAL‑Tabelle für die Verwendung mit der Font geeignet ist, wenn sie auf einem dunklen Hintergrund wie Schwarz angezeigt wird. |
+| [Description](#Description) | 10 Beschreibung; Beschreibung des Schriftsatzes. |
+| [DesignerName](#DesignerName) | 9 Designer; Name des Designers der Schriftart. |
+| [FontFamily](#FontFamily) | 1 Schriftfamilie. |
+| [FontSubfamily](#FontSubfamily) | 2 Schriftunterfamilie. |
+| [FullName](#FullName) | 4 Vollständiger Name der Schrift. |
+| [LicenseDescription](#LicenseDescription) | 13 Lizenzbeschreibung; Beschreibung, wie die Schrift rechtlich verwendet werden darf, oder verschiedene Beispielszenarien für die lizenzierte Nutzung. |
+| [LicenseInfoUrl](#LicenseInfoUrl) | 14 Lizenzinformationen-URL, wo zusätzliche Lizenzinformationen gefunden werden können. |
+| [LightBackground](#LightBackground) | Diese ID gibt, wenn sie im Palette Labels Array der CPAL\\u2019s verwendet wird, an, dass die entsprechende Farbpalette in der CPAL‑Tabelle geeignet ist, mit der Schrift verwendet zu werden, wenn sie auf einem hellen Hintergrund wie Weiß angezeigt wird. |
+| [ManufacturerName](#ManufacturerName) | 8 Herstellername. |
+| [PostScriptCID](#PostScriptCID) | Seine Anwesenheit in einer Schrift bedeutet, dass nameID 6 einen PostScript‑Schriftnamen enthält, der mit dem Aufruf \\u201ccomposefont\\u201d verwendet werden soll, um die Schrift in einem PostScript‑Interpreter zu aktivieren. |
+| [PostScriptName](#PostScriptName) | 6 PostScript‑Name der Schrift. |
+| [PreferredFamily](#PreferredFamily) | 15 Reserviert 16 Bevorzugte Familie (nur Windows); In Windows wird der Familienname im Schriftmenü angezeigt; der Unterfamilienname wird als Stilname dargestellt. |
+| [PreferredSubfamily](#PreferredSubfamily) | 17 Bevorzugte Unterfamilie (nur Windows); In Windows wird der Familienname im Schriftmenü angezeigt; der Unterfamilienname wird als Stilname dargestellt. |
+| [SampleText](#SampleText) | 19 Beispieltext. |
+| [TrademarkNotice](#TrademarkNotice) | 7 Markenhinweis. |
+| [UniqueFontId](#UniqueFontId) | 3 Apple‑Spezifikation: Eindeutige Unterfamilienidentifikation. 3 MS‑Spezifikation: Eindeutiger Schriftidentifikator |
+| [UrlDesigner](#UrlDesigner) | 12 URL des Schrift‑Designers (mit Protokoll, z. B. http://, ftp://) |
+| [UrlVendor](#UrlVendor) | 11 URL des Schrift‑Anbieters (mit Protokoll, z. B. http://, ftp://). |
+| [VariationsPostScriptNamePrefix](#VariationsPostScriptNamePrefix) | Falls in einer variablen Schrift vorhanden, kann es als Familienpräfix im Algorithmus zur PostScript‑Namensgenerierung für Variationsschriften verwendet werden. |
+| [Version](#Version) | 5 Version der Namens‑Tabelle. |
+| [WwsFamilyName](#WwsFamilyName) | Wird verwendet, um einen WWS‑konformen Familiennamen bereitzustellen, falls die Einträge für IDs 16 und 17 nicht dem WWS‑Modell entsprechen. |
+| [WwsSubfamilyName](#WwsSubfamilyName) | In Kombination mit ID 21 liefert diese ID einen WWS‑konformen Unterfamiliennamen (der nur Gewicht-, Breiten- und Neigungsattribute widerspiegelt), falls die Einträge für IDs 16 und 17 nicht dem WWS‑Modell entsprechen. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fromId(int id)](#fromId-int-) | Erstellt eine Namens‑ID aus einem ganzzahligen Wert. |
+| [getClass()](#getClass--) |  |
+| [getId()](#getId--) | Gib den ganzzahligen Wert zurück. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CompatibleFull {#CompatibleFull}
+```
+public static final NameId CompatibleFull
+```
+
+
+18 Kompatibler Vollname (nur Macintosh); Auf dem Macintosh wird der Menüname mithilfe der Schriftressource erstellt. Dieser stimmt in der Regel mit dem Vollständigen Namen überein. Wenn der Name der Schrift anders als der Vollständige Name angezeigt werden soll, kann der Kompatible Vollname in ID 18 eingefügt werden. Dieser Name wird vom Mac‑OS selbst nicht verwendet, kann aber von Anwendungsentwicklern (z. B. Adobe) genutzt werden.
+
+### CopyrightNotice {#CopyrightNotice}
+```
+public static final NameId CopyrightNotice
+```
+
+
+0 Urheberrechtshinweis.
+
+### DarkBackground {#DarkBackground}
+```
+public static final NameId DarkBackground
+```
+
+
+Diese ID, wenn sie im CPAL table\\u2019s Palette Labels Array verwendet wird, gibt an, dass die entsprechende Farbpalette in der CPAL‑Tabelle für die Verwendung mit der Font geeignet ist, wenn sie auf einem dunklen Hintergrund wie Schwarz angezeigt wird.
+
+### Description {#Description}
+```
+public static final NameId Description
+```
+
+
+10 Beschreibung; Beschreibung der Schriftart. Kann Versionsinformationen, Nutzungsempfehlungen, Geschichte, Merkmale usw. enthalten.
+
+### DesignerName {#DesignerName}
+```
+public static final NameId DesignerName
+```
+
+
+9 Designer; Name des Designers der Schriftart.
+
+### FontFamily {#FontFamily}
+```
+public static final NameId FontFamily
+```
+
+
+1 Schriftfamilie. Diese Zeichenkette ist der Schriftfamilienname, den der Benutzer auf Macintosh‑Plattformen sieht.
+
+### FontSubfamily {#FontSubfamily}
+```
+public static final NameId FontSubfamily
+```
+
+
+2 Font Subfamily. Dieser String ist die Schriftfamilie, die der Benutzer auf Macintosh-Plattformen sieht.
+
+### FullName {#FullName}
+```
+public static final NameId FullName
+```
+
+
+4 Vollständiger Name der Schrift.
+
+### LicenseDescription {#LicenseDescription}
+```
+public static final NameId LicenseDescription
+```
+
+
+13 Lizenzbeschreibung; Beschreibung, wie die Schrift legal verwendet werden darf, oder verschiedene Beispielszenarien für lizenzierte Nutzung. Dieses Feld sollte in klarer Sprache verfasst sein, nicht in Rechtssprache.
+
+### LicenseInfoUrl {#LicenseInfoUrl}
+```
+public static final NameId LicenseInfoUrl
+```
+
+
+14 Lizenzinformationen-URL, wo zusätzliche Lizenzinformationen gefunden werden können.
+
+### LightBackground {#LightBackground}
+```
+public static final NameId LightBackground
+```
+
+
+Diese ID gibt, wenn sie im Palette Labels Array der CPAL\\u2019s verwendet wird, an, dass die entsprechende Farbpalette in der CPAL‑Tabelle geeignet ist, mit der Schrift verwendet zu werden, wenn sie auf einem hellen Hintergrund wie Weiß angezeigt wird.
+
+### ManufacturerName {#ManufacturerName}
+```
+public static final NameId ManufacturerName
+```
+
+
+8 Herstellername.
+
+### PostScriptCID {#PostScriptCID}
+```
+public static final NameId PostScriptCID
+```
+
+
+Seine Anwesenheit in einer Schrift bedeutet, dass nameID 6 einen PostScript‑Schriftnamen enthält, der mit dem Aufruf \\u201ccomposefont\\u201d verwendet werden soll, um die Schrift in einem PostScript‑Interpreter zu aktivieren.
+
+### PostScriptName {#PostScriptName}
+```
+public static final NameId PostScriptName
+```
+
+
+6 PostScript-Name der Schrift. Hinweis: Eine Schrift darf nur einen PostScript-Namen haben und dieser Name muss ASCII sein.
+
+### PreferredFamily {#PreferredFamily}
+```
+public static final NameId PreferredFamily
+```
+
+
+15 Reserved 16 Preferred Family (nur Windows); In Windows wird der Familienname im Schriftmenü angezeigt; der Subfamilienname wird als Stilname dargestellt. Aus historischen Gründen enthielten Schriftfamilien maximal vier Stile, aber Schriftgestalter können mehr als vier Schriften zu einer einzigen Familie gruppieren. Die Preferred Family- und Preferred Subfamily-IDs ermöglichen es den Schriftgestaltern, die bevorzugten Familien‑/Subfamilien‑Gruppierungen anzugeben. Diese IDs sind nur vorhanden, wenn sie sich von den IDs 1 und 2 unterscheiden.
+
+### PreferredSubfamily {#PreferredSubfamily}
+```
+public static final NameId PreferredSubfamily
+```
+
+
+17 Preferred Subfamily (nur Windows); In Windows wird der Familienname im Schriftmenü angezeigt; der Subfamilienname wird als Stilname dargestellt. Aus historischen Gründen enthielten Schriftfamilien maximal vier Stile, aber Schriftgestalter können mehr als vier Schriften zu einer einzigen Familie gruppieren. Die Preferred Family- und Preferred Subfamily-IDs ermöglichen es den Schriftgestaltern, die bevorzugten Familien‑/Subfamilien‑Gruppierungen anzugeben. Diese IDs sind nur vorhanden, wenn sie sich von den IDs 1 und 2 unterscheiden.
+
+### SampleText {#SampleText}
+```
+public static final NameId SampleText
+```
+
+
+19 Beispieltext. Dies kann der Schriftname sein oder jeder andere Text, den der Gestalter für den besten Beispieltext hält, um zu zeigen, wie die Schrift aussieht.
+
+### TrademarkNotice {#TrademarkNotice}
+```
+public static final NameId TrademarkNotice
+```
+
+
+7 Markenhinweis.
+
+### UniqueFontId {#UniqueFontId}
+```
+public static final NameId UniqueFontId
+```
+
+
+3 Apple‑Spezifikation: Eindeutige Unterfamilienidentifikation. 3 MS‑Spezifikation: Eindeutiger Schriftidentifikator
+
+### UrlDesigner {#UrlDesigner}
+```
+public static final NameId UrlDesigner
+```
+
+
+12 URL des Schrift‑Designers (mit Protokoll, z. B. http://, ftp://)
+
+### UrlVendor {#UrlVendor}
+```
+public static final NameId UrlVendor
+```
+
+
+11 URL des Schriftanbieters (mit Protokoll, z. B. http://, ftp://). Wenn eine eindeutige Seriennummer in der URL eingebettet ist, kann sie zur Registrierung der Schrift verwendet werden.
+
+### VariationsPostScriptNamePrefix {#VariationsPostScriptNamePrefix}
+```
+public static final NameId VariationsPostScriptNamePrefix
+```
+
+
+Falls in einer variablen Schrift vorhanden, kann es als Familienpräfix im Algorithmus zur PostScript‑Namensgenerierung für Variationsschriften verwendet werden.
+
+### Version {#Version}
+```
+public static final NameId Version
+```
+
+
+5 Version der Namens‑Tabelle.
+
+### WwsFamilyName {#WwsFamilyName}
+```
+public static final NameId WwsFamilyName
+```
+
+
+Wird verwendet, um einen WWS‑konformen Familiennamen bereitzustellen, falls die Einträge für IDs 16 und 17 nicht dem WWS‑Modell entsprechen.
+
+### WwsSubfamilyName {#WwsSubfamilyName}
+```
+public static final NameId WwsSubfamilyName
+```
+
+
+In Kombination mit ID 21 liefert diese ID einen WWS‑konformen Unterfamiliennamen (der nur Gewicht-, Breiten- und Neigungsattribute widerspiegelt), falls die Einträge für IDs 16 und 17 nicht dem WWS‑Modell entsprechen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fromId(int id) {#fromId-int-}
+```
+public static NameId fromId(int id)
+```
+
+
+Erstellt eine Namens‑ID aus einem ganzzahligen Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| id | int | Ein ganzzahliger Wert. |
+
+**Returns:**
+[NameId](../../com.aspose.font/nameid) - The name id.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getId() {#getId--}
+```
+public int getId()
+```
+
+
+Gib den ganzzahligen Wert zurück.
+
+**Returns:**
+int - Der ganzzahlige Wert.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/nameindexdataprovider/_index.md
+++ b/german/java/com.aspose.font/nameindexdataprovider/_index.md
@@ -1,0 +1,250 @@
+---
+title: "NameIndexDataProvider"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt Einstellungen bereit, die für CFF‑Schriftarten gemein sind."
+type: docs
+weight: 68
+url: /de/java/com.aspose.font/nameindexdataprovider/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.ICffIndexDataProvider](../../com.aspose.font/icffindexdataprovider)
+```
+public abstract class NameIndexDataProvider implements ICffIndexDataProvider
+```
+
+Stellt Einstellungen bereit, die für CFF‑Schriftarten gemein sind.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [NameIndexDataProvider()](#NameIndexDataProvider--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addName(String name)](#addName-java.lang.String-) | Fügt einen Schriftartnamen zur Name-INDEX-Struktur hinzu. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Liefert den Schriftartnamen am angegebenen Index. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Liefert die Anzahl der Objekte in der CFF-INDEX-Struktur. |
+| [getName(int index)](#getName-int-) | Liefert den Namen der Schriftart am angegebenen Index. |
+| [getRawBytes()](#getRawBytes--) | Liest alle Bytes der CFF INDEX-Struktur. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeName(int index)](#removeName-int-) | Entfernt den Namen am angegebenen Index. |
+| [set(int index, String name)](#set-int-java.lang.String-) | Gibt den Schriftartnamen am angegebenen Index an. |
+| [setName(String name, int index)](#setName-java.lang.String-int-) | Setzt den Schriftartnamen am angegebenen Index. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NameIndexDataProvider() {#NameIndexDataProvider--}
+```
+public NameIndexDataProvider()
+```
+
+
+### addName(String name) {#addName-java.lang.String-}
+```
+public abstract void addName(String name)
+```
+
+
+Fügt einen Schriftartnamen zur Name INDEX-Struktur hinzu. Verwenden Sie diese Methode mit Vorsicht, da jeder Schriftartname in der CFF Name INDEX-Struktur gemäß der CFF-Spezifikation eine entsprechende DICT-Struktur im Top DICT-Index haben muss.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public abstract String get(int index)
+```
+
+
+Liefert den Schriftartnamen am angegebenen Index.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Schriftart-Index. |
+
+**Returns:**
+java.lang.String - Schriftartname.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public abstract int getCount()
+```
+
+
+Liefert die Anzahl der Objekte in der CFF-INDEX-Struktur.
+
+**Returns:**
+int
+### getName(int index) {#getName-int-}
+```
+public abstract String getName(int index)
+```
+
+
+Liefert den Namen der Schriftart am angegebenen Index.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Schriftart-Index. |
+
+**Returns:**
+java.lang.String - Der Schriftartname.
+### getRawBytes() {#getRawBytes--}
+```
+public abstract byte[] getRawBytes()
+```
+
+
+Liest alle Bytes der CFF INDEX-Struktur.
+
+**Returns:**
+byte[] - Bytes der CFF INDEX-Struktur
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeName(int index) {#removeName-int-}
+```
+public abstract void removeName(int index)
+```
+
+
+Entfernt den Namen am angegebenen Index. Verwenden Sie diese Methode mit Vorsicht, da jeder Schriftartname in der CFF Name INDEX-Struktur gemäß der CFF-Spezifikation eine entsprechende DICT-Struktur im Top DICT-Index haben muss.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Schriftart-Index. |
+
+### set(int index, String name) {#set-int-java.lang.String-}
+```
+public abstract void set(int index, String name)
+```
+
+
+Gibt den Schriftartnamen am angegebenen Index an.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Schriftart-Index. |
+| Name | java.lang.String | Schriftartname. |
+
+### setName(String name, int index) {#setName-java.lang.String-int-}
+```
+public abstract void setName(String name, int index)
+```
+
+
+Setzt den Schriftartnamen am angegebenen Index.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String | Schriftartname. |
+| Index | int | Schriftart-Index. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/namerecord/_index.md
+++ b/german/java/com.aspose.font/namerecord/_index.md
@@ -1,0 +1,190 @@
+---
+title: "NameRecord"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die NameRecord-Struktur der Namens­tabelle dar."
+type: docs
+weight: 69
+url: /de/java/com.aspose.font/namerecord/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class NameRecord
+```
+
+Stellt die NameRecord-Struktur der 'name'-Tabelle dar
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [NameRecord()](#NameRecord--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getLanguageId()](#getLanguageId--) | Liest den Sprachidentifikator. |
+| [getNameId()](#getNameId--) | Liest den Namensidentifikator. |
+| [getPlatformId()](#getPlatformId--) | Liest den Plattform‑Identifikationscode. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Liest den plattformspezifischen Kodierungsidentifikator. |
+| [getString()](#getString--) | Liest die Zeichenkette im Zeichenketten‑Speicher, die zu diesem NameRecord gehört. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NameRecord() {#NameRecord--}
+```
+public NameRecord()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLanguageId() {#getLanguageId--}
+```
+public int getLanguageId()
+```
+
+
+Liest den Sprachidentifikator.
+
+**Returns:**
+int – Sprachidentifikator.
+### getNameId() {#getNameId--}
+```
+public int getNameId()
+```
+
+
+Liest den Namensidentifikator.
+
+**Returns:**
+int – Namensidentifikator.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Liest den Plattform‑Identifikationscode.
+
+**Returns:**
+int – Plattform‑Identifikationscode.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Liest den plattformspezifischen Kodierungsidentifikator.
+
+**Returns:**
+int – plattformspezifischer Kodierungsidentifikator.
+### getString() {#getString--}
+```
+public String getString()
+```
+
+
+Liest die Zeichenkette im Zeichenketten‑Speicher, die zu diesem NameRecord gehört.
+
+**Returns:**
+java.lang.String – Zeichenkette im Zeichenketten‑Speicher, die zu diesem NameRecord gehört.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/nametocodemap/_index.md
+++ b/german/java/com.aspose.font/nametocodemap/_index.md
@@ -1,0 +1,178 @@
+---
+title: "NameToCodeMap"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Namens-zu-Code-Zuordnung dar."
+type: docs
+weight: 70
+url: /de/java/com.aspose.font/nametocodemap/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class NameToCodeMap
+```
+
+Stellt die Namens-zu-Code-Zuordnung dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [containsKey(String name)](#containsKey-java.lang.String-) | Gibt true zurück, falls der Schlüssel bereits in der Map ist. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(String name)](#get-java.lang.String-) | Liefert den Code nach Namen. |
+| [getClass()](#getClass--) |  |
+| [getKeys()](#getKeys--) | Gibt die Sammlung von Zeichenkettennamen zurück. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [size()](#size--) | Liefert die Anzahl der Namens‑Code‑Paare in der Map. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### containsKey(String name) {#containsKey-java.lang.String-}
+```
+public boolean containsKey(String name)
+```
+
+
+Gibt true zurück, falls der Schlüssel bereits in der Map ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String | Glyph-Name. |
+
+**Returns:**
+boolean - Wahr oder falsch.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(String name) {#get-java.lang.String-}
+```
+public int get(String name)
+```
+
+
+Liefert den Code nach Namen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String | Glyph-Name. |
+
+**Returns:**
+int - Glyph-Code.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getKeys() {#getKeys--}
+```
+public Collection<String> getKeys()
+```
+
+
+Gibt die Sammlung von Zeichenkettennamen zurück.
+
+**Returns:**
+java.util.Collection<java.lang.String> - Sammlung von String-Namen.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+Liefert die Anzahl der Namens‑Code‑Paare in der Map.
+
+**Returns:**
+int - Anzahl der Namens‑Code‑Paare in der Map.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/offsetslist/_index.md
+++ b/german/java/com.aspose.font/offsetslist/_index.md
@@ -1,0 +1,151 @@
+---
+title: "TtfLocaTable.OffsetsList"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Liste von Glyphen-Offsets dar."
+type: docs
+weight: 10
+url: /de/java/com.aspose.font/ttflocatable.offsetslist/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static class TtfLocaTable.OffsetsList
+```
+
+Stellt eine Liste von Glyphen-Offsets dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Liefert den Offset nach Index. |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [size()](#size--) | Liefert die Anzahl der Glyphen-Offsets. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public long get(int index)
+```
+
+
+Liefert den Offset nach Index.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Offset-Index. |
+
+**Returns:**
+long - Glyph-Offset.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+Liefert die Anzahl der Glyphen-Offsets.
+
+**Returns:**
+int - Anzahl der Glyphen-Offsets.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/parsingstrictness/_index.md
+++ b/german/java/com.aspose.font/parsingstrictness/_index.md
@@ -1,0 +1,248 @@
+---
+title: "FontEnvironment.ParsingStrictness"
+second_title: "Aspose.Font für Java API-Referenz"
+description: 
+type: docs
+weight: 10
+url: /de/java/com.aspose.font/fontenvironment.parsingstrictness/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum FontEnvironment.ParsingStrictness extends Enum<FontEnvironment.ParsingStrictness>
+```
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [Strict](#Strict) | Gibt den strikten Typ an. |
+| [Tolerant](#Tolerant) | Gibt den toleranten Typ an. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Strict {#Strict}
+```
+public static final FontEnvironment.ParsingStrictness Strict
+```
+
+
+Gibt den strikten Typ an.
+
+### Tolerant {#Tolerant}
+```
+public static final FontEnvironment.ParsingStrictness Tolerant
+```
+
+
+Gibt den toleranten Typ an.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static FontEnvironment.ParsingStrictness valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[ParsingStrictness](../../com.aspose.font/parsingstrictness)
+### values() {#values--}
+```
+public static FontEnvironment.ParsingStrictness[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.FontEnvironment.ParsingStrictness[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/pathsegmentcollection/_index.md
+++ b/german/java/com.aspose.font/pathsegmentcollection/_index.md
@@ -1,0 +1,565 @@
+---
+title: "PathSegmentCollection"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Sammlung von Pfadsegmenten dar."
+type: docs
+weight: 71
+url: /de/java/com.aspose.font/pathsegmentcollection/
+---
+**Inheritance:**
+java.lang.Object, java.util.AbstractCollection, java.util.AbstractList, java.util.ArrayList
+```
+public class PathSegmentCollection extends ArrayList<IPathSegment>
+```
+
+Stellt eine Sammlung von Pfadsegmenten dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>toArray(T[] arg0)](#-T-toArray-T---) |  |
+| [add(E arg0)](#add-E-) |  |
+| [add(int arg0, E arg1)](#add-int-E-) |  |
+| [addAll(int arg0, Collection<? extends E> arg1)](#addAll-int-java.util.Collection---extends-E--) |  |
+| [addAll(Collection<? extends E> arg0)](#addAll-java.util.Collection---extends-E--) |  |
+| [clear()](#clear--) |  |
+| [clone()](#clone--) |  |
+| [contains(Object arg0)](#contains-java.lang.Object-) |  |
+| [containsAll(Collection<?> arg0)](#containsAll-java.util.Collection----) |  |
+| [ensureCapacity(int arg0)](#ensureCapacity-int-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [forEach(Consumer<? super E> arg0)](#forEach-java.util.function.Consumer---super-E--) |  |
+| [get(int arg0)](#get-int-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object arg0)](#indexOf-java.lang.Object-) |  |
+| [isEmpty()](#isEmpty--) |  |
+| [iterator()](#iterator--) |  |
+| [lastIndexOf(Object arg0)](#lastIndexOf-java.lang.Object-) |  |
+| [listIterator()](#listIterator--) |  |
+| [listIterator(int arg0)](#listIterator-int-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(int arg0)](#remove-int-) |  |
+| [remove(Object arg0)](#remove-java.lang.Object-) |  |
+| [removeAll(Collection<?> arg0)](#removeAll-java.util.Collection----) |  |
+| [removeIf(Predicate<? super E> arg0)](#removeIf-java.util.function.Predicate---super-E--) |  |
+| [replaceAll(UnaryOperator<E> arg0)](#replaceAll-java.util.function.UnaryOperator-E--) |  |
+| [retainAll(Collection<?> arg0)](#retainAll-java.util.Collection----) |  |
+| [set(int arg0, E arg1)](#set-int-E-) |  |
+| [size()](#size--) |  |
+| [sort(Comparator<? super E> arg0)](#sort-java.util.Comparator---super-E--) |  |
+| [spliterator()](#spliterator--) |  |
+| [subList(int arg0, int arg1)](#subList-int-int-) |  |
+| [toArray()](#toArray--) |  |
+| [toString()](#toString--) |  |
+| [trimToSize()](#trimToSize--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>toArray(T[] arg0) {#-T-toArray-T---}
+```
+public T[] <T>toArray(T[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | T[] |  |
+
+**Returns:**
+T[]
+### add(E arg0) {#add-E-}
+```
+public boolean add(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+boolean
+### add(int arg0, E arg1) {#add-int-E-}
+```
+public void add(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+### addAll(int arg0, Collection<? extends E> arg1) {#addAll-int-java.util.Collection---extends-E--}
+```
+public boolean addAll(int arg0, Collection<? extends E> arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### addAll(Collection<? extends E> arg0) {#addAll-java.util.Collection---extends-E--}
+```
+public boolean addAll(Collection<? extends E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### contains(Object arg0) {#contains-java.lang.Object-}
+```
+public boolean contains(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### containsAll(Collection<?> arg0) {#containsAll-java.util.Collection----}
+```
+public boolean containsAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### ensureCapacity(int arg0) {#ensureCapacity-int-}
+```
+public void ensureCapacity(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### forEach(Consumer<? super E> arg0) {#forEach-java.util.function.Consumer---super-E--}
+```
+public void forEach(Consumer<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.function.Consumer<? super E> |  |
+
+### get(int arg0) {#get-int-}
+```
+public E get(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object arg0) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public Iterator<E> iterator()
+```
+
+
+
+
+**Returns:**
+java.util.Iterator<E>
+### lastIndexOf(Object arg0) {#lastIndexOf-java.lang.Object-}
+```
+public int lastIndexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### listIterator() {#listIterator--}
+```
+public ListIterator<E> listIterator()
+```
+
+
+
+
+**Returns:**
+java.util.ListIterator<E>
+### listIterator(int arg0) {#listIterator-int-}
+```
+public ListIterator<E> listIterator(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+java.util.ListIterator<E>
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(int arg0) {#remove-int-}
+```
+public E remove(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### remove(Object arg0) {#remove-java.lang.Object-}
+```
+public boolean remove(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### removeAll(Collection<?> arg0) {#removeAll-java.util.Collection----}
+```
+public boolean removeAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### removeIf(Predicate<? super E> arg0) {#removeIf-java.util.function.Predicate---super-E--}
+```
+public boolean removeIf(Predicate<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.function.Predicate<? super E> |  |
+
+**Returns:**
+boolean
+### replaceAll(UnaryOperator<E> arg0) {#replaceAll-java.util.function.UnaryOperator-E--}
+```
+public void replaceAll(UnaryOperator<E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.function.UnaryOperator<E> |  |
+
+### retainAll(Collection<?> arg0) {#retainAll-java.util.Collection----}
+```
+public boolean retainAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### set(int arg0, E arg1) {#set-int-E-}
+```
+public E set(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+**Returns:**
+E
+### size() {#size--}
+```
+public int size()
+```
+
+
+
+
+**Returns:**
+int
+### sort(Comparator<? super E> arg0) {#sort-java.util.Comparator---super-E--}
+```
+public void sort(Comparator<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.util.Comparator<? super E> |  |
+
+### spliterator() {#spliterator--}
+```
+public Spliterator<E> spliterator()
+```
+
+
+
+
+**Returns:**
+java.util.Spliterator<E>
+### subList(int arg0, int arg1) {#subList-int-int-}
+```
+public List<E> subList(int arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | int |  |
+
+**Returns:**
+java.util.List<E>
+### toArray() {#toArray--}
+```
+public Object[] toArray()
+```
+
+
+
+
+**Returns:**
+java.lang.Object[]
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### trimToSize() {#trimToSize--}
+```
+public void trimToSize()
+```
+
+
+
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/platformid/_index.md
+++ b/german/java/com.aspose.font/platformid/_index.md
@@ -1,0 +1,268 @@
+---
+title: "PlatformId"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die PlatformId‑Aufzählung dar."
+type: docs
+weight: 141
+url: /de/java/com.aspose.font/platformid/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum PlatformId extends Enum<PlatformId>
+```
+
+Stellt die PlatformId‑Aufzählung dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ISO](#ISO) | Value2 Apple-Spezifikation: (reserviert; nicht verwenden) MS-Spezifikation: ISO‑Kodierung. |
+| [Macintosh](#Macintosh) | Value 1 Macintosh Script Manager‑Code. |
+| [Microsoft](#Microsoft) | Value 3 Microsoft‑Kodierung. |
+| [Unicode](#Unicode) | Value 0 Unicode |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ISO {#ISO}
+```
+public static final PlatformId ISO
+```
+
+
+Value2 Apple-Spezifikation: (reserviert; nicht verwenden) MS-Spezifikation: ISO‑Kodierung. Hinweis: Die Plattform‑ID 2 (ISO) wurde mit der OpenType‑Spezifikation v1.3 veraltet. Sie sollte ISO/IEC 10646 darstellen, im Gegensatz zu Unicode; beide Standards haben identische Zeichenkodierungszuweisungen.
+
+### Macintosh {#Macintosh}
+```
+public static final PlatformId Macintosh
+```
+
+
+Value 1 Macintosh Script Manager‑Code.
+
+### Microsoft {#Microsoft}
+```
+public static final PlatformId Microsoft
+```
+
+
+Value 3 Microsoft‑Kodierung.
+
+### Unicode {#Unicode}
+```
+public static final PlatformId Unicode
+```
+
+
+Value 0 Unicode
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static PlatformId valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[PlatformId](../../com.aspose.font/platformid)
+### values() {#values--}
+```
+public static PlatformId[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.PlatformId[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/renderingutils/_index.md
+++ b/german/java/com.aspose.font/renderingutils/_index.md
@@ -1,0 +1,202 @@
+---
+title: "RenderingUtils"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt Dienstprogrammmethoden für das Rendering bereit."
+type: docs
+weight: 72
+url: /de/java/com.aspose.font/renderingutils/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class RenderingUtils
+```
+
+Stellt Dienstprogrammmethoden für das Rendering bereit.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [drawText(Font font, GlyphId[] glyphIds, double fontSize)](#drawText-com.aspose.font.Font-com.aspose.font.GlyphId---double-) | Text in BitMap rendern. |
+| [drawText(Font font, GlyphId[] glyphIds, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)](#drawText-com.aspose.font.Font-com.aspose.font.GlyphId---double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-) | Text in BitMap rendern. |
+| [drawText(Font font, String text, double fontSize)](#drawText-com.aspose.font.Font-java.lang.String-double-) | Text in BitMap rendern. |
+| [drawText(Font font, String text, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)](#drawText-com.aspose.font.Font-java.lang.String-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-) | Text in BitMap rendern. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### drawText(Font font, GlyphId[] glyphIds, double fontSize) {#drawText-com.aspose.font.Font-com.aspose.font.GlyphId---double-}
+```
+public static InputStream drawText(Font font, GlyphId[] glyphIds, double fontSize)
+```
+
+
+Text in BitMap rendern. Ergebnis im PNG-Format als Byte-Stream zurückgeben.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.font/font) | Schriftart |
+| glyphIds | [GlyphId\[\]](../../com.aspose.font/glyphid) | Text dargestellt als Array von Glyph-Bezeichnern |
+| fontSize | double | Schriftgröße |
+
+**Returns:**
+java.io.InputStream - Bild im PNG-Format als Byte-Stream
+### drawText(Font font, GlyphId[] glyphIds, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth) {#drawText-com.aspose.font.Font-com.aspose.font.GlyphId---double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-}
+```
+public static InputStream drawText(Font font, GlyphId[] glyphIds, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)
+```
+
+
+Text in BitMap rendern. Ergebnis im PNG-Format als Byte-Stream zurückgeben.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.font/font) | Schriftart |
+| glyphIds | [GlyphId\[\]](../../com.aspose.font/glyphid) | Text dargestellt als Array von Glyph-Bezeichnern |
+| fontSize | double | Schriftgröße |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Art des Zeilenabstands. Anzahl von Pixeln oder Prozentsatz der Schriftgröße |
+| lineSpacingValue | int | Wert des Zeilenabstands |
+| maxWidth | int | Maximale Breite in Pixeln für das Bild |
+
+**Returns:**
+java.io.InputStream - Bild im PNG-Format als Byte-Stream
+### drawText(Font font, String text, double fontSize) {#drawText-com.aspose.font.Font-java.lang.String-double-}
+```
+public static InputStream drawText(Font font, String text, double fontSize)
+```
+
+
+Text in BitMap rendern.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.font/font) | Die Schriftart. |
+| text | java.lang.String | Der Text. |
+| fontSize | double | Die Schriftgröße. |
+
+**Returns:**
+java.io.InputStream - Das PNG-Bild mit dem Text als Bytestrom.
+### drawText(Font font, String text, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth) {#drawText-com.aspose.font.Font-java.lang.String-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-}
+```
+public static InputStream drawText(Font font, String text, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)
+```
+
+
+Text in BitMap rendern.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.font/font) | Die Schriftart. |
+| text | java.lang.String | Der Text. |
+| fontSize | double | Die Schriftgröße. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Der Typ des Zeilenabstands. Anzahl der Pixel oder Prozentsatz der Schrifthöhe. |
+| lineSpacingValue | int | Der Wert des Zeilenabstands. |
+| maxWidth | int | Die maximale Breite in Pixeln für das resultierende Bild. |
+
+**Returns:**
+java.io.InputStream - Das PNG-Bild mit dem Text als Bytestrom.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/segmentpath/_index.md
+++ b/german/java/com.aspose.font/segmentpath/_index.md
@@ -1,0 +1,149 @@
+---
+title: "SegmentPath"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt den Rendering-Pfad dar."
+type: docs
+weight: 73
+url: /de/java/com.aspose.font/segmentpath/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Cloneable
+```
+public class SegmentPath implements Cloneable
+```
+
+Stellt den Rendering-Pfad dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clone()](#clone--) | Kloniert Pfad. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getSegments()](#getSegments--) | Ermittelt Pfadsegmente. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Kloniert Pfad.
+
+**Returns:**
+java.lang.Object - Kopie des Pfads.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSegments() {#getSegments--}
+```
+public PathSegmentCollection getSegments()
+```
+
+
+Ermittelt Pfadsegmente.
+
+**Returns:**
+[PathSegmentCollection](../../com.aspose.font/pathsegmentcollection) - Path segments.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/streamsource/_index.md
+++ b/german/java/com.aspose.font/streamsource/_index.md
@@ -1,0 +1,195 @@
+---
+title: "StreamSource"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Definiert eine Möglichkeit, einen Dateistream zu erhalten, wenn er benötigt wird."
+type: docs
+weight: 74
+url: /de/java/com.aspose.font/streamsource/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class StreamSource
+```
+
+Definiert eine Möglichkeit, einen Dateistream zu erhalten, wenn er benötigt wird.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [StreamSource()](#StreamSource--) | Initialisiert die StreamSource-Instanz. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Klont das StreamSource-Objekt. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontStream()](#getFontStream--) | Gibt den Font-Stream zurück. |
+| [getOffset()](#getOffset--) | Liefert den Offset innerhalb der Quelle. |
+| [hashCode()](#hashCode--) |  |
+| [mustCloseAfterUse()](#mustCloseAfterUse--) | Die Erben können verhindern, dass der Stream geschlossen wird. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOffset(long value)](#setOffset-long-) | Setzt den Offset innerhalb der Quelle. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StreamSource() {#StreamSource--}
+```
+public StreamSource()
+```
+
+
+Initialisiert die StreamSource-Instanz.
+
+### deepClone() {#deepClone--}
+```
+public abstract Object deepClone()
+```
+
+
+Klont das StreamSource-Objekt.
+
+**Returns:**
+java.lang.Object - Kopie des StreamSource-Objekts.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontStream() {#getFontStream--}
+```
+public abstract InputStream getFontStream()
+```
+
+
+Gibt den Font-Stream zurück.
+
+**Returns:**
+java.io.InputStream - Font-Stream.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset innerhalb der Quelle.
+
+**Returns:**
+long - Offset innerhalb der Quelle.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### mustCloseAfterUse() {#mustCloseAfterUse--}
+```
+public boolean mustCloseAfterUse()
+```
+
+
+Die Erben können verhindern, dass der Stream geschlossen wird. Gibt true zurück, wenn die StreamSource den Stream nach der Verwendung schließen möchte. Andernfalls wird false zurückgegeben.
+
+**Returns:**
+boolean - true, wenn die StreamSource den Stream nach der Verwendung schließen möchte, sonst false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOffset(long value) {#setOffset-long-}
+```
+public void setOffset(long value)
+```
+
+
+Setzt den Offset innerhalb der Quelle.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long | Offset innerhalb der Quelle. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/stringindexdataprovider/_index.md
+++ b/german/java/com.aspose.font/stringindexdataprovider/_index.md
@@ -1,0 +1,250 @@
+---
+title: "StringIndexDataProvider"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Deklariert Funktionalität zum Zugriff auf die CFF String INDEX Struktur."
+type: docs
+weight: 75
+url: /de/java/com.aspose.font/stringindexdataprovider/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.ICffIndexDataProvider](../../com.aspose.font/icffindexdataprovider)
+```
+public abstract class StringIndexDataProvider implements ICffIndexDataProvider
+```
+
+Deklariert Funktionalität zum Zugriff auf die CFF String INDEX Struktur.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [StringIndexDataProvider()](#StringIndexDataProvider--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addString(String value)](#addString-java.lang.String-) | Fügt Zeichenfolge in die CFF String INDEX-Struktur ein. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Liest/setzt Zeichenfolge am angegebenen Index. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Die Anzahl der Objekte in der CFF INDEX-Struktur. |
+| [getRawBytes()](#getRawBytes--) | Liest alle Bytes der CFF INDEX-Struktur. |
+| [getString(int index)](#getString-int-) | Liest Zeichenfolge am angegebenen Index aus der CFF String INDEX-Struktur. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeString(int index)](#removeString-int-) | Entfernt Zeichenfolge aus der CFF String Index-Struktur am angegebenen Index. |
+| [set(int index, String value)](#set-int-java.lang.String-) |  |
+| [setString(String value, int index)](#setString-java.lang.String-int-) | Setzt Zeichenfolge in der CFF String Index-Struktur am angegebenen Index. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StringIndexDataProvider() {#StringIndexDataProvider--}
+```
+public StringIndexDataProvider()
+```
+
+
+### addString(String value) {#addString-java.lang.String-}
+```
+public abstract void addString(String value)
+```
+
+
+Fügt Zeichenfolge in die CFF String INDEX-Struktur ein.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | String-Wert |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public abstract String get(int index)
+```
+
+
+Liest/setzt Zeichenfolge am angegebenen Index.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index der Zeichenfolge, Index bedeutet eine Ordnungszahl in der CFF INDEX-Struktur, nicht SID. |
+
+**Returns:**
+java.lang.String - String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public abstract int getCount()
+```
+
+
+Die Anzahl der Objekte in der CFF INDEX-Struktur.
+
+**Returns:**
+int
+### getRawBytes() {#getRawBytes--}
+```
+public abstract byte[] getRawBytes()
+```
+
+
+Liest alle Bytes der CFF INDEX-Struktur.
+
+**Returns:**
+byte[] - Bytes der CFF INDEX-Struktur
+### getString(int index) {#getString-int-}
+```
+public abstract String getString(int index)
+```
+
+
+Liest Zeichenfolge am angegebenen Index aus der CFF String INDEX-Struktur.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index der Zeichenfolge, Index bedeutet Ordnungszahl in der CFF INDEX-Struktur, nicht SID. |
+
+**Returns:**
+java.lang.String - String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeString(int index) {#removeString-int-}
+```
+public abstract void removeString(int index)
+```
+
+
+Entfernt Zeichenfolge aus der CFF String Index-Struktur am angegebenen Index.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index der Zeichenfolge, Index bedeutet eine Ordnungszahl in der CFF INDEX-Struktur, nicht SID. |
+
+### set(int index, String value) {#set-int-java.lang.String-}
+```
+public abstract void set(int index, String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+| Wert | java.lang.String |  |
+
+### setString(String value, int index) {#setString-java.lang.String-int-}
+```
+public abstract void setString(String value, int index)
+```
+
+
+Setzt Zeichenfolge in der CFF String Index-Struktur am angegebenen Index.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | String-Wert |
+| Index | int | Index der Zeichenfolge, Index bedeutet Ordnungszahl in der CFF INDEX-Struktur, nicht SID. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/svgconversionexception/_index.md
+++ b/german/java/com.aspose.font/svgconversionexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "SvgConversionException"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine Font-Konvertierungsausnahme für das SVG-Format dar."
+type: docs
+weight: 76
+url: /de/java/com.aspose.font/svgconversionexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class SvgConversionException extends FontException
+```
+
+Stellt eine Schriftarten‑Konvertierungsausnahme für das SVG-Format dar. Die Ausnahme kann im Falle von Fehlern während des Schriftarten‑Konvertierungsprozesses ausgelöst werden.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [SvgConversionException()](#SvgConversionException--) | Initialisiert ein neues SvgConversionException-Objekt. |
+| [SvgConversionException(String message)](#SvgConversionException-java.lang.String-) | Initialisiert ein neues SvgConversionException-Objekt. |
+| [SvgConversionException(String message, RuntimeException innerException)](#SvgConversionException-java.lang.String-java.lang.RuntimeException-) | Initialisiert ein neues SvgConversionException-Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SvgConversionException() {#SvgConversionException--}
+```
+public SvgConversionException()
+```
+
+
+Initialisiert ein neues SvgConversionException-Objekt.
+
+### SvgConversionException(String message) {#SvgConversionException-java.lang.String-}
+```
+public SvgConversionException(String message)
+```
+
+
+Initialisiert ein neues SvgConversionException-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+
+### SvgConversionException(String message, RuntimeException innerException) {#SvgConversionException-java.lang.String-java.lang.RuntimeException-}
+```
+public SvgConversionException(String message, RuntimeException innerException)
+```
+
+
+Initialisiert ein neues SvgConversionException-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+| innerException | java.lang.RuntimeException | Die Ausnahme, die die aktuelle Ausnahme verursacht. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/topdictdataprovider/_index.md
+++ b/german/java/com.aspose.font/topdictdataprovider/_index.md
@@ -1,0 +1,968 @@
+---
+title: "TopDictDataProvider"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Deklariert Funktionalität zum Lesen/Aktualisieren der CFF Top DICT Struktur."
+type: docs
+weight: 77
+url: /de/java/com.aspose.font/topdictdataprovider/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class TopDictDataProvider
+```
+
+Deklariert Funktionalität zum Lesen/Aktualisieren der CFF Top DICT Struktur.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBaseFontName()](#getBaseFontName--) |  |
+| [getCidCount()](#getCidCount--) |  |
+| [getCidFontRevision()](#getCidFontRevision--) |  |
+| [getCidFontType()](#getCidFontType--) |  |
+| [getCidFontVersion()](#getCidFontVersion--) |  |
+| [getClass()](#getClass--) |  |
+| [getCopyright()](#getCopyright--) |  |
+| [getFamilyName()](#getFamilyName--) |  |
+| [getFontBBox()](#getFontBBox--) |  |
+| [getFontMatrix()](#getFontMatrix--) |  |
+| [getFontName()](#getFontName--) |  |
+| [getFullName()](#getFullName--) |  |
+| [getItalicAngle()](#getItalicAngle--) |  |
+| [getNotice()](#getNotice--) |  |
+| [getPaintType()](#getPaintType--) |  |
+| [getPostScript()](#getPostScript--) |  |
+| [getPrivateDictProvider()](#getPrivateDictProvider--) |  |
+| [getRos(int[] registrySid, int[] orderingSid, int[] supplement)](#getRos-int---int---int---) |  |
+| [getRos(String[] registry, String[] ordering, int[] supplement)](#getRos-java.lang.String---java.lang.String---int---) |  |
+| [getStrokeWidth()](#getStrokeWidth--) |  |
+| [getSyntheticBase()](#getSyntheticBase--) |  |
+| [getUidBase()](#getUidBase--) |  |
+| [getUnderlinePosition()](#getUnderlinePosition--) |  |
+| [getUnderlineThickness()](#getUnderlineThickness--) |  |
+| [getUniqueId()](#getUniqueId--) |  |
+| [getVersion()](#getVersion--) |  |
+| [getWeight()](#getWeight--) |  |
+| [getXuid()](#getXuid--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBaseFontName(String value)](#setBaseFontName-java.lang.String-) |  |
+| [setBaseFontNameSid(int sid)](#setBaseFontNameSid-int-) |  |
+| [setCidCount(int value)](#setCidCount-int-) |  |
+| [setCidFontRevision(int value)](#setCidFontRevision-int-) |  |
+| [setCidFontType(int value)](#setCidFontType-int-) |  |
+| [setCidFontVersion(int value)](#setCidFontVersion-int-) |  |
+| [setCopyright(String value)](#setCopyright-java.lang.String-) |  |
+| [setCopyrightSid(int sid)](#setCopyrightSid-int-) |  |
+| [setFamilyName(String value)](#setFamilyName-java.lang.String-) |  |
+| [setFamilyNameSid(int sid)](#setFamilyNameSid-int-) |  |
+| [setFixedPitch(boolean value)](#setFixedPitch-boolean-) |  |
+| [setFontBBox(FontBBox value)](#setFontBBox-com.aspose.font.FontBBox-) |  |
+| [setFontMatrix(TransformationMatrix value)](#setFontMatrix-com.aspose.font.TransformationMatrix-) |  |
+| [setFontName(String value)](#setFontName-java.lang.String-) |  |
+| [setFontNameSid(int sid)](#setFontNameSid-int-) |  |
+| [setFullName(String value)](#setFullName-java.lang.String-) |  |
+| [setFullNameSid(int sid)](#setFullNameSid-int-) |  |
+| [setItalicAngle(int value)](#setItalicAngle-int-) |  |
+| [setNotice(String value)](#setNotice-java.lang.String-) |  |
+| [setNoticeSid(int sid)](#setNoticeSid-int-) |  |
+| [setPaintType(int value)](#setPaintType-int-) |  |
+| [setPostScript(String value)](#setPostScript-java.lang.String-) |  |
+| [setPostScriptSid(int sid)](#setPostScriptSid-int-) |  |
+| [setRos(int registry, int ordering, int supplement)](#setRos-int-int-int-) |  |
+| [setRos(String registry, String ordering, int supplement)](#setRos-java.lang.String-java.lang.String-int-) |  |
+| [setStrokeWidth(int value)](#setStrokeWidth-int-) |  |
+| [setSyntheticBase(int value)](#setSyntheticBase-int-) |  |
+| [setUidBase(int value)](#setUidBase-int-) |  |
+| [setUnderlinePosition(int value)](#setUnderlinePosition-int-) |  |
+| [setUnderlineThickness(int value)](#setUnderlineThickness-int-) |  |
+| [setUniqueId(int value)](#setUniqueId-int-) |  |
+| [setVersion(String value)](#setVersion-java.lang.String-) |  |
+| [setVersionSid(int sid)](#setVersionSid-int-) |  |
+| [setWeight(String value)](#setWeight-java.lang.String-) |  |
+| [setWeightSid(int sid)](#setWeightSid-int-) |  |
+| [setXuid(double[] value)](#setXuid-double---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBaseFontName() {#getBaseFontName--}
+```
+public String getBaseFontName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getCidCount() {#getCidCount--}
+```
+public int getCidCount()
+```
+
+
+
+
+**Returns:**
+int
+### getCidFontRevision() {#getCidFontRevision--}
+```
+public int getCidFontRevision()
+```
+
+
+
+
+**Returns:**
+int
+### getCidFontType() {#getCidFontType--}
+```
+public int getCidFontType()
+```
+
+
+
+
+**Returns:**
+int
+### getCidFontVersion() {#getCidFontVersion--}
+```
+public int getCidFontVersion()
+```
+
+
+
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCopyright() {#getCopyright--}
+```
+public String getCopyright()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getFamilyName() {#getFamilyName--}
+```
+public String getFamilyName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox)
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix)
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getFullName() {#getFullName--}
+```
+public String getFullName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getItalicAngle() {#getItalicAngle--}
+```
+public int getItalicAngle()
+```
+
+
+
+
+**Returns:**
+int
+### getNotice() {#getNotice--}
+```
+public String getNotice()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getPaintType() {#getPaintType--}
+```
+public int getPaintType()
+```
+
+
+
+
+**Returns:**
+int
+### getPostScript() {#getPostScript--}
+```
+public String getPostScript()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getPrivateDictProvider() {#getPrivateDictProvider--}
+```
+public PrivateDictDataProvider getPrivateDictProvider()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.PrivateDictDataProvider
+### getRos(int[] registrySid, int[] orderingSid, int[] supplement) {#getRos-int---int---int---}
+```
+public void getRos(int[] registrySid, int[] orderingSid, int[] supplement)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| registrySid | int[] |  |
+| orderingSid | int[] |  |
+| supplement | int[] |  |
+
+### getRos(String[] registry, String[] ordering, int[] supplement) {#getRos-java.lang.String---java.lang.String---int---}
+```
+public void getRos(String[] registry, String[] ordering, int[] supplement)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| registry | java.lang.String[] |  |
+| ordering | java.lang.String[] |  |
+| supplement | int[] |  |
+
+### getStrokeWidth() {#getStrokeWidth--}
+```
+public int getStrokeWidth()
+```
+
+
+
+
+**Returns:**
+int
+### getSyntheticBase() {#getSyntheticBase--}
+```
+public int getSyntheticBase()
+```
+
+
+
+
+**Returns:**
+int
+### getUidBase() {#getUidBase--}
+```
+public int getUidBase()
+```
+
+
+
+
+**Returns:**
+int
+### getUnderlinePosition() {#getUnderlinePosition--}
+```
+public int getUnderlinePosition()
+```
+
+
+
+
+**Returns:**
+int
+### getUnderlineThickness() {#getUnderlineThickness--}
+```
+public int getUnderlineThickness()
+```
+
+
+
+
+**Returns:**
+int
+### getUniqueId() {#getUniqueId--}
+```
+public int getUniqueId()
+```
+
+
+
+
+**Returns:**
+int
+### getVersion() {#getVersion--}
+```
+public String getVersion()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getWeight() {#getWeight--}
+```
+public String getWeight()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getXuid() {#getXuid--}
+```
+public double[] getXuid()
+```
+
+
+
+
+**Returns:**
+double[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBaseFontName(String value) {#setBaseFontName-java.lang.String-}
+```
+public int setBaseFontName(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+**Returns:**
+int
+### setBaseFontNameSid(int sid) {#setBaseFontNameSid-int-}
+```
+public void setBaseFontNameSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| sid | int |  |
+
+### setCidCount(int value) {#setCidCount-int-}
+```
+public void setCidCount(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setCidFontRevision(int value) {#setCidFontRevision-int-}
+```
+public void setCidFontRevision(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setCidFontType(int value) {#setCidFontType-int-}
+```
+public void setCidFontType(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setCidFontVersion(int value) {#setCidFontVersion-int-}
+```
+public void setCidFontVersion(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setCopyright(String value) {#setCopyright-java.lang.String-}
+```
+public int setCopyright(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+**Returns:**
+int
+### setCopyrightSid(int sid) {#setCopyrightSid-int-}
+```
+public void setCopyrightSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| sid | int |  |
+
+### setFamilyName(String value) {#setFamilyName-java.lang.String-}
+```
+public int setFamilyName(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+**Returns:**
+int
+### setFamilyNameSid(int sid) {#setFamilyNameSid-int-}
+```
+public void setFamilyNameSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| sid | int |  |
+
+### setFixedPitch(boolean value) {#setFixedPitch-boolean-}
+```
+public void setFixedPitch(boolean value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setFontBBox(FontBBox value) {#setFontBBox-com.aspose.font.FontBBox-}
+```
+public void setFontBBox(FontBBox value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [FontBBox](../../com.aspose.font/fontbbox) |  |
+
+### setFontMatrix(TransformationMatrix value) {#setFontMatrix-com.aspose.font.TransformationMatrix-}
+```
+public void setFontMatrix(TransformationMatrix value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [TransformationMatrix](../../com.aspose.font/transformationmatrix) |  |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public int setFontName(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+**Returns:**
+int
+### setFontNameSid(int sid) {#setFontNameSid-int-}
+```
+public void setFontNameSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| sid | int |  |
+
+### setFullName(String value) {#setFullName-java.lang.String-}
+```
+public int setFullName(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+**Returns:**
+int
+### setFullNameSid(int sid) {#setFullNameSid-int-}
+```
+public void setFullNameSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| sid | int |  |
+
+### setItalicAngle(int value) {#setItalicAngle-int-}
+```
+public void setItalicAngle(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setNotice(String value) {#setNotice-java.lang.String-}
+```
+public int setNotice(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+**Returns:**
+int
+### setNoticeSid(int sid) {#setNoticeSid-int-}
+```
+public void setNoticeSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| sid | int |  |
+
+### setPaintType(int value) {#setPaintType-int-}
+```
+public void setPaintType(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPostScript(String value) {#setPostScript-java.lang.String-}
+```
+public int setPostScript(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+**Returns:**
+int
+### setPostScriptSid(int sid) {#setPostScriptSid-int-}
+```
+public void setPostScriptSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| sid | int |  |
+
+### setRos(int registry, int ordering, int supplement) {#setRos-int-int-int-}
+```
+public void setRos(int registry, int ordering, int supplement)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| registry | int |  |
+| ordering | int |  |
+| supplement | int |  |
+
+### setRos(String registry, String ordering, int supplement) {#setRos-java.lang.String-java.lang.String-int-}
+```
+public void setRos(String registry, String ordering, int supplement)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| registry | java.lang.String |  |
+| ordering | java.lang.String |  |
+| supplement | int |  |
+
+### setStrokeWidth(int value) {#setStrokeWidth-int-}
+```
+public void setStrokeWidth(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSyntheticBase(int value) {#setSyntheticBase-int-}
+```
+public void setSyntheticBase(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setUidBase(int value) {#setUidBase-int-}
+```
+public void setUidBase(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setUnderlinePosition(int value) {#setUnderlinePosition-int-}
+```
+public void setUnderlinePosition(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setUnderlineThickness(int value) {#setUnderlineThickness-int-}
+```
+public void setUnderlineThickness(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setUniqueId(int value) {#setUniqueId-int-}
+```
+public void setUniqueId(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setVersion(String value) {#setVersion-java.lang.String-}
+```
+public int setVersion(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+**Returns:**
+int
+### setVersionSid(int sid) {#setVersionSid-int-}
+```
+public void setVersionSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| sid | int |  |
+
+### setWeight(String value) {#setWeight-java.lang.String-}
+```
+public int setWeight(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+**Returns:**
+int
+### setWeightSid(int sid) {#setWeightSid-int-}
+```
+public void setWeightSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| sid | int |  |
+
+### setXuid(double[] value) {#setXuid-double---}
+```
+public void setXuid(double[] value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/transformationmatrix/_index.md
+++ b/german/java/com.aspose.font/transformationmatrix/_index.md
@@ -1,0 +1,412 @@
+---
+title: "Transformationsmatrix"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine 3x3-Matrix  A   B   0   C   D   0   TX  TY  1 ."
+type: docs
+weight: 78
+url: /de/java/com.aspose.font/transformationmatrix/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TransformationMatrix
+```
+
+Stellt eine 3x3-Matrix | A B 0 | | C D 0 | | TX TY 1 | dar. Transformiert Koordinaten auf folgende Weise: x1 = A\*x + C\*y + TX y1 = B\*x + D\*y + TY.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [TransformationMatrix()](#TransformationMatrix--) | Erstellt eine Standard‑1‑zu‑1‑Matrix: [ A B C D TX TY ] = [ 1, 0, 0, 1, 0, 0] |
+| [TransformationMatrix(double[] matrixArray)](#TransformationMatrix-double---) | Akzeptiert eine Transformationsmatrix mit folgender Array‑Darstellung: [ A B C D TX TY ] |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Bietet Zugriff auf das zugrunde liegende Array. |
+| [getA()](#getA--) | Liest den Wert A der Transformationsmatrix. |
+| [getB()](#getB--) | Liest den Wert B der Transformationsmatrix. |
+| [getC()](#getC--) | Liest den Wert C der Transformationsmatrix. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Liest den Wert D der Transformationsmatrix. |
+| [getTX()](#getTX--) | Liest den Wert TX der Transformationsmatrix. |
+| [getTY()](#getTY--) | Liest den Wert TY der Transformationsmatrix. |
+| [hashCode()](#hashCode--) |  |
+| [multiply(TransformationMatrix matrix)](#multiply-com.aspose.font.TransformationMatrix-) | Multipliziert mit einer anderen Transformationsmatrix. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [scale(double x, double y, double[] x1, double[] y1)](#scale-double-double-double---double---) | Skaliert x und y mit der Transformationsmatrix: x1 = A\*x + C\*y; y1 = B\*x + D\*y; |
+| [setA(double value)](#setA-double-) | Setzt den Wert A der Transformationsmatrix. |
+| [setB(double value)](#setB-double-) | Setzt den Wert B der Transformationsmatrix. |
+| [setC(double value)](#setC-double-) | Setzt den Wert C der Transformationsmatrix. |
+| [setD(double value)](#setD-double-) | Setzt den Wert D der Transformationsmatrix. |
+| [setTX(double value)](#setTX-double-) | Setzt den Wert TX der Transformationsmatrix. |
+| [setTY(double value)](#setTY-double-) | Setzt den Wert TY der Transformationsmatrix. |
+| [toArray()](#toArray--) | Allokiert ein neues Array, kopiert die Transformationsmatrix und gibt es zurück. |
+| [toString()](#toString--) |  |
+| [transform(double x, double y, double[] x1, double[] y1)](#transform-double-double-double---double---) | Transformiert x und y mit der Transformationsmatrix: x1 = A\*x + C\*y + TX; y1 = B\*x + D\*y + TY; |
+| [unScale(double x1, double y1, double[] x, double[] y)](#unScale-double-double-double---double---) | Skaliert x1 und y1 zurück und gibt x und y vor der Transformationsmatrix zurück. |
+| [unTransform(double x1, double y1, double[] x, double[] y)](#unTransform-double-double-double---double---) | Transformiert x1 und y1 zurück und gibt x und y vor der Transformationsmatrix zurück. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TransformationMatrix() {#TransformationMatrix--}
+```
+public TransformationMatrix()
+```
+
+
+Erstellt eine Standard‑1‑zu‑1‑Matrix: [ A B C D TX TY ] = [ 1, 0, 0, 1, 0, 0]
+
+### TransformationMatrix(double[] matrixArray) {#TransformationMatrix-double---}
+```
+public TransformationMatrix(double[] matrixArray)
+```
+
+
+Akzeptiert eine Transformationsmatrix mit folgender Array‑Darstellung: [ A B C D TX TY ]
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| matrixArray | double[] | Array mit Transformationsmatrixwerten, muss 6 Elemente enthalten. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public double get(int index)
+```
+
+
+Bietet Zugriff auf das zugrunde liegende Array.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index im Transformationsmatrix-Array. |
+
+**Returns:**
+double - Das Element des zugrunde liegenden Arrays nach Index.
+### getA() {#getA--}
+```
+public double getA()
+```
+
+
+Liest den Wert A der Transformationsmatrix.
+
+**Returns:**
+double - Ein Transformationsmatrixwert.
+### getB() {#getB--}
+```
+public double getB()
+```
+
+
+Liest den Wert B der Transformationsmatrix.
+
+**Returns:**
+double - B Transformationsmatrixwert.
+### getC() {#getC--}
+```
+public double getC()
+```
+
+
+Liest den Wert C der Transformationsmatrix.
+
+**Returns:**
+double - C Transformationsmatrixwert.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public double getD()
+```
+
+
+Liest den Wert D der Transformationsmatrix.
+
+**Returns:**
+double - D Transformationsmatrixwert.
+### getTX() {#getTX--}
+```
+public double getTX()
+```
+
+
+Liest den Wert TX der Transformationsmatrix.
+
+**Returns:**
+double - TX Transformationsmatrixwert.
+### getTY() {#getTY--}
+```
+public double getTY()
+```
+
+
+Liest den Wert TY der Transformationsmatrix.
+
+**Returns:**
+double - TY Transformationsmatrixwert.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### multiply(TransformationMatrix matrix) {#multiply-com.aspose.font.TransformationMatrix-}
+```
+public TransformationMatrix multiply(TransformationMatrix matrix)
+```
+
+
+Multipliziert mit einer anderen Transformationsmatrix. Ändert die ursprüngliche Transformationsmatrix nicht und gibt ein neues TransformationMatrix-Objekt zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Transformationsmatrix, mit der multipliziert werden soll. |
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - New TransformationMatrix object.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### scale(double x, double y, double[] x1, double[] y1) {#scale-double-double-double---double---}
+```
+public void scale(double x, double y, double[] x1, double[] y1)
+```
+
+
+Skaliert x und y mit der Transformationsmatrix: x1 = A\*x + C\*y; y1 = B\*x + D\*y;
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| x | double | Ursprüngliche x-Koordinate |
+| y | double | Ursprüngliche y-Koordinate. |
+| x1 | double[] | Koordinate x skaliert. |
+| y1 | double[] | Koordinate y skaliert. |
+
+### setA(double value) {#setA-double-}
+```
+public void setA(double value)
+```
+
+
+Setzt den Wert A der Transformationsmatrix.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | Ein Transformationsmatrixwert. |
+
+### setB(double value) {#setB-double-}
+```
+public void setB(double value)
+```
+
+
+Setzt den Wert B der Transformationsmatrix.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | B Transformationsmatrixwert. |
+
+### setC(double value) {#setC-double-}
+```
+public void setC(double value)
+```
+
+
+Setzt den Wert C der Transformationsmatrix.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | C Transformationsmatrixwert. |
+
+### setD(double value) {#setD-double-}
+```
+public void setD(double value)
+```
+
+
+Setzt den Wert D der Transformationsmatrix.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | D Transformationsmatrixwert. |
+
+### setTX(double value) {#setTX-double-}
+```
+public void setTX(double value)
+```
+
+
+Setzt den Wert TX der Transformationsmatrix.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | TX-Transformationsmatrixwert. |
+
+### setTY(double value) {#setTY-double-}
+```
+public void setTY(double value)
+```
+
+
+Setzt den Wert TY der Transformationsmatrix.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | TY-Transformationsmatrixwert. |
+
+### toArray() {#toArray--}
+```
+public double[] toArray()
+```
+
+
+Allokiert ein neues Array, kopiert die Transformationsmatrix und gibt es zurück.
+
+**Returns:**
+double[] - Transformationsmatrix in Arrayform.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(double x, double y, double[] x1, double[] y1) {#transform-double-double-double---double---}
+```
+public void transform(double x, double y, double[] x1, double[] y1)
+```
+
+
+Transformiert x und y mit der Transformationsmatrix: x1 = A\*x + C\*y + TX; y1 = B\*x + D\*y + TY;
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| x | double | Ursprüngliche x-Koordinate. |
+| y | double | Ursprüngliche y-Koordinate. |
+| x1 | double[] | Transformierte x-Koordinate. |
+| y1 | double[] | Transformierte y-Koordinate. |
+
+### unScale(double x1, double y1, double[] x, double[] y) {#unScale-double-double-double---double---}
+```
+public void unScale(double x1, double y1, double[] x, double[] y)
+```
+
+
+Skaliert x1 und y1 zurück und gibt x und y vor der Transformationsmatrix zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| x1 | double | Koordinate x1 |
+| y1 | double | Koordinate y1 |
+| x | double[] | Koordinate x zurückskaliert. |
+| y | double[] | Koordinate y zurückskaliert. |
+
+### unTransform(double x1, double y1, double[] x, double[] y) {#unTransform-double-double-double---double---}
+```
+public void unTransform(double x1, double y1, double[] x, double[] y)
+```
+
+
+Transformiert x1 und y1 zurück und gibt x und y vor der Transformationsmatrix zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| x1 | double | Koordinate x1. |
+| y1 | double | Koordinate y1. |
+| x | double[] | Koordinate x zurücktransformiert. |
+| y | double[] | Koordinate y zurücktransformiert. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttcfontfiledefinition/_index.md
+++ b/german/java/com.aspose.font/ttcfontfiledefinition/_index.md
@@ -1,0 +1,200 @@
+---
+title: "TtcFontFileDefinition"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Dateidefinition für die TTC Schriftart dar."
+type: docs
+weight: 79
+url: /de/java/com.aspose.font/ttcfontfiledefinition/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.FontFileDefinition](../../com.aspose.font/fontfiledefinition)
+```
+public class TtcFontFileDefinition extends FontFileDefinition
+```
+
+Stellt die Dateidefinition für die TTC Schriftart dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [TtcFontFileDefinition(int fontIndex, String fileExtension, StreamSource streamSource, long offset)](#TtcFontFileDefinition-int-java.lang.String-com.aspose.font.StreamSource-long-) | Erstellt eine Dateidefinition, die ausschließlich den Dateiinhalt verwendet. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileExtension()](#getFileExtension--) | Liefert Dateierweiterung. |
+| [getFileName()](#getFileName--) | Liefert Dateinamen. |
+| [getFontIndex()](#getFontIndex--) | Liefert Schriftindex innerhalb der TTC-Schrift. |
+| [getOffset()](#getOffset--) | Liefert Offset innerhalb des Streams. |
+| [getStreamSource()](#getStreamSource--) | Liefert die Stream-Quelle. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TtcFontFileDefinition(int fontIndex, String fileExtension, StreamSource streamSource, long offset) {#TtcFontFileDefinition-int-java.lang.String-com.aspose.font.StreamSource-long-}
+```
+public TtcFontFileDefinition(int fontIndex, String fileExtension, StreamSource streamSource, long offset)
+```
+
+
+Erstellt eine Dateidefinition, die ausschließlich den Dateiinhalt verwendet.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontIndex | int | Index der Schrift innerhalb der TTC-Schriftensammlung. |
+| fileExtension | java.lang.String | Erweiterung der Schriftdateisammlung. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Quelle der Schriftdateisammlung. |
+| Versatz | long | Versatz zu den Schriftartdaten in der Schriftdateisammlung, siehe TTC-Header, Offset-Tabelle in der OpenType-Schriftdateispezifikation. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileExtension() {#getFileExtension--}
+```
+public String getFileExtension()
+```
+
+
+Liefert Dateierweiterung.
+
+**Returns:**
+java.lang.String - Dateierweiterung.
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Liefert Dateinamen.
+
+**Returns:**
+java.lang.String - Dateiname.
+### getFontIndex() {#getFontIndex--}
+```
+public long getFontIndex()
+```
+
+
+Liefert Schriftindex innerhalb der TTC-Schrift.
+
+**Returns:**
+long - Schriftartindex innerhalb der TTC-Schrift.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert Offset innerhalb des Streams.
+
+**Returns:**
+long - Versatz innerhalb des Streams.
+### getStreamSource() {#getStreamSource--}
+```
+public StreamSource getStreamSource()
+```
+
+
+Liefert die Stream-Quelle.
+
+**Returns:**
+[StreamSource](../../com.aspose.font/streamsource) - The stream source.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttcfontsource/_index.md
+++ b/german/java/com.aspose.font/ttcfontsource/_index.md
@@ -1,0 +1,170 @@
+---
+title: "TtcFontSource"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die TTC Schriftart-Quelle dar."
+type: docs
+weight: 80
+url: /de/java/com.aspose.font/ttcfontsource/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+com.aspose.font.IFontSource
+```
+public class TtcFontSource implements IFontSource
+```
+
+Stellt die TTC Schriftart-Quelle dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [TtcFontSource(StreamSource source)](#TtcFontSource-com.aspose.font.StreamSource-) | Erstellt eine TTC-Schriftquelle basierend auf einem IStreamSource‑Stream‑bereitstellenden Objekt. |
+| [TtcFontSource(String filePath)](#TtcFontSource-java.lang.String-) | Erstellt eine TTC-Schriftquelle basierend auf dem Dateipfad einer TTC-Schriftartsammlung. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontDefinitions()](#getFontDefinitions--) | Gibt ein Array von Schriftdefinitionen der TTC-Schriftquelle zurück. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TtcFontSource(StreamSource source) {#TtcFontSource-com.aspose.font.StreamSource-}
+```
+public TtcFontSource(StreamSource source)
+```
+
+
+Erstellt eine TTC-Schriftquelle basierend auf einem IStreamSource‑Stream‑bereitstellenden Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| source | [StreamSource](../../com.aspose.font/streamsource) | Quell‑Stream, aus dem TTC‑Schriftartsammlungsdaten extrahiert werden. |
+
+### TtcFontSource(String filePath) {#TtcFontSource-java.lang.String-}
+```
+public TtcFontSource(String filePath)
+```
+
+
+Erstellt eine TTC-Schriftquelle basierend auf dem Dateipfad einer TTC-Schriftartsammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| filePath | java.lang.String | Schriftartsammlungsdatei. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontDefinitions() {#getFontDefinitions--}
+```
+public FontDefinition[] getFontDefinitions()
+```
+
+
+Gibt ein Array von Schriftdefinitionen der TTC-Schriftquelle zurück.
+
+**Returns:**
+com.aspose.font.FontDefinition[] - Alle Schriftartdefinitionen aus der TTC-Schriftartquelle.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfcfftable/_index.md
+++ b/german/java/com.aspose.font/ttfcfftable/_index.md
@@ -1,0 +1,182 @@
+---
+title: "TtfCffTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die cff-Tabelle der TTF-Schriftdatei dar."
+type: docs
+weight: 90
+url: /de/java/com.aspose.font/ttfcfftable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfCffTable extends TtfTableBase
+```
+
+Stellt die "cff" Tabelle der TTF Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCffSource()](#getCffSource--) | Rohbytes für Konturen im Compact Font Format. |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCffSource(StreamSource streamSource)](#setCffSource-com.aspose.font.StreamSource-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCffSource() {#getCffSource--}
+```
+public StreamSource getCffSource()
+```
+
+
+Rohbytes für Konturen im Compact Font Format.
+
+**Returns:**
+[StreamSource](../../com.aspose.font/streamsource) - Raw bytes for outlines in Compact Font Format representation.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Tabellen‑Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCffSource(StreamSource streamSource) {#setCffSource-com.aspose.font.StreamSource-}
+```
+public void setCffSource(StreamSource streamSource)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfcmapformat0table/_index.md
+++ b/german/java/com.aspose.font/ttfcmapformat0table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat0Table"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Format0 CMap Untertabelle der TTF Schriftdatei dar."
+type: docs
+weight: 81
+url: /de/java/com.aspose.font/ttfcmapformat0table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat0Table extends TtfCMapFormatBaseTable
+```
+
+Stellt die Format0 CMap Untertabelle der TTF Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Ruft alle Codes aus der aktuellen CMap-Untertabelle ab. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Ruft einen Glyphenindex für einen angegebenen Zeichencode ab. |
+| [getPlatformId()](#getPlatformId--) | Ruft PlatformId ab. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ruft PlatformSpecificId ab. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Ruft alle Codes aus der aktuellen CMap-Untertabelle ab.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Alle Codes aus der aktuellen CMap‑Untertabelle.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Ruft einen Glyphenindex für einen angegebenen Zeichencode ab.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| charCode | long | Zeichencode. |
+
+**Returns:**
+long - Glyph-Index.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ruft PlatformId ab.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ruft PlatformSpecificId ab.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfcmapformat10table/_index.md
+++ b/german/java/com.aspose.font/ttfcmapformat10table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat10Table"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Format10 CMap Untertabelle der TTF Schriftdatei dar."
+type: docs
+weight: 82
+url: /de/java/com.aspose.font/ttfcmapformat10table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat10Table extends TtfCMapFormatBaseTable
+```
+
+Stellt die Format10 CMap Untertabelle der TTF Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Ruft alle Codes aus der aktuellen CMap-Untertabelle ab. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Ruft einen Glyphenindex für einen angegebenen Zeichencode ab. |
+| [getPlatformId()](#getPlatformId--) | Ruft PlatformId ab. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ruft PlatformSpecificId ab. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Ruft alle Codes aus der aktuellen CMap-Untertabelle ab.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Alle Codes aus der aktuellen CMap‑Untertabelle.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Ruft einen Glyphenindex für einen angegebenen Zeichencode ab.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| charCode | long | Zeichencode. |
+
+**Returns:**
+long - Glyph-Index.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ruft PlatformId ab.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ruft PlatformSpecificId ab.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfcmapformat12table/_index.md
+++ b/german/java/com.aspose.font/ttfcmapformat12table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat12Table"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Format8 CMap Untertabelle der TTF Schriftdatei dar."
+type: docs
+weight: 83
+url: /de/java/com.aspose.font/ttfcmapformat12table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat12Table extends TtfCMapFormatBaseTable
+```
+
+Stellt die Format8 CMap Untertabelle der TTF Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Ruft alle Codes aus der aktuellen CMap-Untertabelle ab. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Ruft einen Glyphenindex für einen angegebenen Zeichencode ab. |
+| [getPlatformId()](#getPlatformId--) | Ruft PlatformId ab. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ruft PlatformSpecificId ab. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Ruft alle Codes aus der aktuellen CMap-Untertabelle ab.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Alle Codes aus der aktuellen CMap-Untertabelle.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Ruft einen Glyphenindex für einen angegebenen Zeichencode ab.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| charCode | long | Zeichencode |
+
+**Returns:**
+long - Glyph-Index.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ruft PlatformId ab.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ruft PlatformSpecificId ab.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfcmapformat2table/_index.md
+++ b/german/java/com.aspose.font/ttfcmapformat2table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat2Table"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Format2 CMap Untertabelle der TTF Schriftdatei dar."
+type: docs
+weight: 84
+url: /de/java/com.aspose.font/ttfcmapformat2table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat2Table extends TtfCMapFormatBaseTable
+```
+
+Stellt die Format2 CMap Untertabelle der TTF Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Ruft alle Codes aus der aktuellen CMap-Untertabelle ab. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Ruft einen Glyphenindex für einen angegebenen Zeichencode ab. |
+| [getPlatformId()](#getPlatformId--) | Ruft PlatformId ab. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ruft PlatformSpecificId ab. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Ruft alle Codes aus der aktuellen CMap-Untertabelle ab.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Alle Codes aus der aktuellen CMap-Untertabelle.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Ruft einen Glyphenindex für einen angegebenen Zeichencode ab.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| charCode | long | Zeichencode. |
+
+**Returns:**
+long - Glyph-Index.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ruft PlatformId ab.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ruft PlatformSpecificId ab.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfcmapformat4table/_index.md
+++ b/german/java/com.aspose.font/ttfcmapformat4table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat4Table"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Format4 CMap Untertabelle der TTF Schriftdatei dar."
+type: docs
+weight: 85
+url: /de/java/com.aspose.font/ttfcmapformat4table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat4Table extends TtfCMapFormatBaseTable
+```
+
+Stellt die Format4 CMap Untertabelle der TTF Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Ruft alle Codes aus der aktuellen CMap-Untertabelle ab. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Ruft einen Glyphenindex für einen angegebenen Zeichencode ab. |
+| [getPlatformId()](#getPlatformId--) | Ruft PlatformId ab. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ruft PlatformSpecificId ab. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Ruft alle Codes aus der aktuellen CMap-Untertabelle ab.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Alle Codes aus der aktuellen CMap‑Untertabelle.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Ruft einen Glyphenindex für einen angegebenen Zeichencode ab.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| charCode | long | Zeichencode. |
+
+**Returns:**
+long - Glyph-Index.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ruft PlatformId ab.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ruft PlatformSpecificId ab.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfcmapformat6table/_index.md
+++ b/german/java/com.aspose.font/ttfcmapformat6table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat6Table"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Format6 CMap Untertabelle der TTF Schriftdatei dar."
+type: docs
+weight: 86
+url: /de/java/com.aspose.font/ttfcmapformat6table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat6Table extends TtfCMapFormatBaseTable
+```
+
+Stellt die Format6 CMap Untertabelle der TTF Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Ruft alle Codes aus der aktuellen CMap-Untertabelle ab. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Ruft einen Glyphenindex für einen angegebenen Zeichencode ab. |
+| [getPlatformId()](#getPlatformId--) | Ruft PlatformId ab. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ruft PlatformSpecificId ab. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Ruft alle Codes aus der aktuellen CMap-Untertabelle ab.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Alle Codes aus der aktuellen CMap-Untertabelle.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Ruft einen Glyphenindex für einen angegebenen Zeichencode ab.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| charCode | long | Zeichencode. |
+
+**Returns:**
+long - Glyph-Index.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ruft PlatformId ab.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ruft PlatformSpecificId ab.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfcmapformat8table/_index.md
+++ b/german/java/com.aspose.font/ttfcmapformat8table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat8Table"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Format8 CMap Untertabelle der TTF Schriftdatei dar."
+type: docs
+weight: 87
+url: /de/java/com.aspose.font/ttfcmapformat8table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat8Table extends TtfCMapFormatBaseTable
+```
+
+Stellt die Format8 CMap Untertabelle der TTF Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Ruft alle Codes aus der aktuellen CMap-Untertabelle ab. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Ruft einen Glyphenindex für einen angegebenen Zeichencode ab. |
+| [getPlatformId()](#getPlatformId--) | Ruft PlatformId ab. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ruft PlatformSpecificId ab. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Ruft alle Codes aus der aktuellen CMap-Untertabelle ab.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Alle Codes aus der aktuellen CMap‑Untertabelle.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Ruft einen Glyphenindex für einen angegebenen Zeichencode ab.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| charCode | long | Zeichencode. |
+
+**Returns:**
+long - Glyph-Index.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ruft PlatformId ab.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ruft PlatformSpecificId ab.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfcmapformatbasetable/_index.md
+++ b/german/java/com.aspose.font/ttfcmapformatbasetable/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormatBaseTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Basisklasse der CMap Untertabelle dar."
+type: docs
+weight: 88
+url: /de/java/com.aspose.font/ttfcmapformatbasetable/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TtfCMapFormatBaseTable
+```
+
+Stellt die Basisklasse der CMap Untertabelle dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Ruft alle Codes aus der aktuellen CMap-Untertabelle ab. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Ermittelt einen Glyphenindex für einen angegebenen Zeichencode |
+| [getPlatformId()](#getPlatformId--) | Ruft PlatformId ab. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ruft PlatformSpecificId ab. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Ruft alle Codes aus der aktuellen CMap-Untertabelle ab.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Alle Codes aus der aktuellen CMap‑Untertabelle.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Ermittelt einen Glyphenindex für einen angegebenen Zeichencode
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| charCode | long | Zeichencode |
+
+**Returns:**
+long - Glyph-Index.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ruft PlatformId ab.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ruft PlatformSpecificId ab.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfcmapsubtabledescription/_index.md
+++ b/german/java/com.aspose.font/ttfcmapsubtabledescription/_index.md
@@ -1,0 +1,157 @@
+---
+title: "TtfCMapTable.TtfCMapSubtableDescription"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Bietet kurze Informationen über die CMap Untertabelle."
+type: docs
+weight: 10
+url: /de/java/com.aspose.font/ttfcmaptable.ttfcmapsubtabledescription/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract static class TtfCMapTable.TtfCMapSubtableDescription
+```
+
+Bietet kurze Informationen über die CMap Untertabelle.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFormat()](#getFormat--) | Ruft das Untertabellenformat ab. |
+| [getPlatformId()](#getPlatformId--) | Ruft die Plattform-ID ab. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ruft die plattformspezifische Kodierungs-ID ab. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Ruft das Untertabellenformat ab.
+
+**Returns:**
+int - Untertabellenformat.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ruft die Plattform-ID ab.
+
+**Returns:**
+int - Plattform-ID.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ruft die plattformspezifische Kodierungs-ID ab.
+
+**Returns:**
+int - Plattformspezifische Kodierungs-ID.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfcmaptable/_index.md
+++ b/german/java/com.aspose.font/ttfcmaptable/_index.md
@@ -1,0 +1,196 @@
+---
+title: "TtfCMapTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Cmap-Tabelle der TTF-Schriftdatei dar."
+type: docs
+weight: 89
+url: /de/java/com.aspose.font/ttfcmaptable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfCMapTable extends TtfTableBase
+```
+
+Stellt die "cmap" Tabelle der TTF Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [findUnicodeTable()](#findUnicodeTable--) | Durchsucht und gibt die Unicode-CMap zurück. |
+| [getAllSubtables()](#getAllSubtables--) | Gibt alle Untertabellen der CMap-Tabelle zurück. |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getPlatformTables(int platformId, int platformSpecificId)](#getPlatformTables-int-int-) | Gibt CMap-Untertabellen für planformId und platformSpecificId zurück. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### findUnicodeTable() {#findUnicodeTable--}
+```
+public TtfCMapFormatBaseTable findUnicodeTable()
+```
+
+
+Durchsucht und gibt die Unicode-CMap zurück. Wenn es eine UCS-4-CMap gibt, wird diese zuerst zurückgegeben; andernfalls wird irgendeine gefundene Unicode-CMap zurückgegeben.
+
+**Returns:**
+[TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable) - Unicode subtable.
+### getAllSubtables() {#getAllSubtables--}
+```
+public TtfCMapTable.TtfCMapSubtableDescription[] getAllSubtables()
+```
+
+
+Gibt alle Untertabellen der CMap-Tabelle zurück.
+
+**Returns:**
+com.aspose.font.TtfCMapTable.TtfCMapSubtableDescription[] - Array von TtfCmapSubtableDescription-Objekten
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getPlatformTables(int platformId, int platformSpecificId) {#getPlatformTables-int-int-}
+```
+public TtfCMapFormatBaseTable[] getPlatformTables(int platformId, int platformSpecificId)
+```
+
+
+Gibt CMap-Untertabellen für planformId und platformSpecificId zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| platformId | int | Plattform‑Id. |
+| platformSpecificId | int | Plattform‑spezifische Kodierungs‑Id. |
+
+**Returns:**
+com.aspose.font.TtfCMapFormatBaseTable[] - CMap‑Untertabellen.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Tabellen‑Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfcvttable/_index.md
+++ b/german/java/com.aspose.font/ttfcvttable/_index.md
@@ -1,0 +1,168 @@
+---
+title: "TtfCvtTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Control Value Table (CVT) der TTF-Font-Datei dar."
+type: docs
+weight: 91
+url: /de/java/com.aspose.font/ttfcvttable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfCvtTable extends TtfTableBase
+```
+
+Stellt die Control Value Table (CVT) der TTF Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getControlValues()](#getControlValues--) | Ermittelt die Liste von Werten, die von Anweisungen referenzierbar sind. |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getControlValues() {#getControlValues--}
+```
+public short[] getControlValues()
+```
+
+
+Ermittelt die Liste von Werten, die von Anweisungen referenzierbar sind.
+
+**Returns:**
+short[] - Liste von Werten, die von Anweisungen referenzierbar sind.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Tabellen‑Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfencoding/_index.md
+++ b/german/java/com.aspose.font/ttfencoding/_index.md
@@ -1,0 +1,207 @@
+---
+title: "TtfEncoding"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die TTF Schriftkodierung dar."
+type: docs
+weight: 92
+url: /de/java/com.aspose.font/ttfencoding/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFontEncoding](../../com.aspose.font/ifontencoding)
+```
+public class TtfEncoding implements IFontEncoding
+```
+
+Stellt die TTF Schriftkodierung dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [decodeToGid(long unicode)](#decodeToGid-long-) | Die DecodeToGlyphId-Implementierung der TTF-Schrift findet die Unicode-Tabelle und gibt die Glyph-ID für das Unicode-Zeichen zurück. |
+| [decodeToGidParameterized(IEncodingParameters parameters, long charCode)](#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-) | Die parametrische Version ermöglicht die Verwendung einer spezifischen CMap-Tabelle (nicht Unicode). |
+| [encode(long gid, long charCode)](#encode-long-long-) | Kodiert den Glyph. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [gidToUnicode(GlyphId glyphId)](#gidToUnicode-com.aspose.font.GlyphId-) | Dekodiert Glyph-ID zu Unicode. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [unicodeToGid(long unicode)](#unicodeToGid-long-) | Dekodiert ein Unicode-Zeichen und gibt die Glyph-ID zurück. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### decodeToGid(long unicode) {#decodeToGid-long-}
+```
+public GlyphId decodeToGid(long unicode)
+```
+
+
+Die DecodeToGlyphId-Implementierung der TTF-Schrift findet die Unicode-Tabelle und gibt die Glyph-ID für das Unicode-Zeichen zurück. Die Glyph-ID ist eine eindeutige Nummer für ein Glyph, die vom Schrifttyp abhängt. Zum Beispiel: Die ID von Type1 ist ein Glyph-Name, eine Instanz der Klasse ( GlyphStringId ). Die ID von TTF ist ein int-Index, eine Instanz der Klasse ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| unicode | long | Zeichencode, für den der Glyph‑Bezeichner ermittelt werden soll. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to character code passed.
+### decodeToGidParameterized(IEncodingParameters parameters, long charCode) {#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-}
+```
+public GlyphId decodeToGidParameterized(IEncodingParameters parameters, long charCode)
+```
+
+
+Die parametrische Version ermöglicht die Verwendung einer spezifischen CMap-Tabelle (nicht Unicode).
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| parameters | [IEncodingParameters](../../com.aspose.font/iencodingparameters) | Implementierung des Interfaces IEncodingParameters. |
+| charCode | long | Zeichencode, um den Glyph-Bezeichner zu erhalten. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to character code passed.
+### encode(long gid, long charCode) {#encode-long-long-}
+```
+public void encode(long gid, long charCode)
+```
+
+
+Kodiert das Glyph. Bei TTF-Schriften ist der Zeichencode Unicode.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| gid | long | Glyph‑Bezeichner. |
+| charCode | long | Zeichencode. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### gidToUnicode(GlyphId glyphId) {#gidToUnicode-com.aspose.font.GlyphId-}
+```
+public long gidToUnicode(GlyphId glyphId)
+```
+
+
+Dekodiert Glyph-ID zu Unicode. Die Glyph-ID ist eine eindeutige Nummer für ein Glyph, die vom Schrifttyp abhängt. Zum Beispiel: Die ID von Type1 ist ein Glyph-Name, eine Instanz der Klasse ( GlyphStringId ). Die ID von TTF ist ein int-Index, eine Instanz der Klasse ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑Bezeichner des zu dekodierenden Symbols. |
+
+**Returns:**
+long – Unicode‑Wert, der zur übergebenen Glyph‑Id gehört.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unicodeToGid(long unicode) {#unicodeToGid-long-}
+```
+public GlyphId unicodeToGid(long unicode)
+```
+
+
+Dekodiert ein Unicode-Zeichen und gibt die Glyph-ID zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| unicode | long | Unicode, für den der Glyph‑Bezeichner ermittelt werden soll. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to unicode passed.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfencodingparameters/_index.md
+++ b/german/java/com.aspose.font/ttfencodingparameters/_index.md
@@ -1,0 +1,196 @@
+---
+title: "TtfEncodingParameters"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die TTF Kodierungsparameter dar."
+type: docs
+weight: 93
+url: /de/java/com.aspose.font/ttfencodingparameters/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IEncodingParameters](../../com.aspose.font/iencodingparameters)
+```
+public class TtfEncodingParameters implements IEncodingParameters
+```
+
+Stellt TTF-Codierungsparameter dar. Sollte verwendet werden, um eine bestimmte Codierung von einer TTF-Schrift anzufordern.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [TtfEncodingParameters(int platformId, int platformSpecificId)](#TtfEncodingParameters-int-int-) | Initialisiert eine neue Instanz der Klasse TtfEncodingParameters. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPlatformId()](#getPlatformId--) | Ruft den PlatformId-Wert ab. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ruft den PlatformSpecificId-Wert ab. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setPlatformId(int value)](#setPlatformId-int-) | Setzt den PlatformId-Wert. |
+| [setPlatformSpecificId(int value)](#setPlatformSpecificId-int-) | Setzt den PlatformSpecificId-Wert. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TtfEncodingParameters(int platformId, int platformSpecificId) {#TtfEncodingParameters-int-int-}
+```
+public TtfEncodingParameters(int platformId, int platformSpecificId)
+```
+
+
+Initialisiert eine neue Instanz der Klasse TtfEncodingParameters. Nimmt Platform Id und Platform-spezifische Codierungs-ID als Parameter. Diese Parameter werden verwendet, um eine spezielle CMap-Untertabelle aus der Haupt‑CMap‑Tabelle der Schrift anzufordern, siehe Tabelle 'CMap', 'name' in der OpenType-Schriftdateispezifikation.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| platformId | int | Platform‑Id. |
+| platformSpecificId | int | Platform‑spezifische Codierungs‑ID. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ruft den PlatformId-Wert ab.
+
+**Returns:**
+int – PlatformId-Wert.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ruft den PlatformSpecificId-Wert ab.
+
+**Returns:**
+int – PlatformSpecificId-Wert.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setPlatformId(int value) {#setPlatformId-int-}
+```
+public void setPlatformId(int value)
+```
+
+
+Setzt den PlatformId-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int | PlatformId-Wert. |
+
+### setPlatformSpecificId(int value) {#setPlatformSpecificId-int-}
+```
+public void setPlatformSpecificId(int value)
+```
+
+
+Setzt den PlatformSpecificId-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int | PlatformSpecificId-Wert. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttffont/_index.md
+++ b/german/java/com.aspose.font/ttffont/_index.md
@@ -1,0 +1,648 @@
+---
+title: "TtfFont"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt TrueType Font TTF dar."
+type: docs
+weight: 94
+url: /de/java/com.aspose.font/ttffont/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Font](../../com.aspose.font/font)
+```
+public class TtfFont extends Font
+```
+
+Stellt die TrueType Schrift (TTF) dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Konvertiert die Font in ein anderes Format. |
+| [convert(FontType fontType, Collection<Integer> limitingCharacterSet)](#convert-com.aspose.font.FontType-java.util.Collection-java.lang.Integer--) | Konvertiert die Font in ein anderes Format mit begrenztem Zeichensatz  *Hinweis: TTF Font-Typ wird jetzt nur noch unterstützt.* |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Gibt ein Array aller Glyph-IDs zurück, die in der Font verfügbar sind. |
+| [getCffFont()](#getCffFont--) | Liefert CFF Font, falls vorhanden. |
+| [getClass()](#getClass--) |  |
+| [getEncoding()](#getEncoding--) | Liefert Font‑Kodierung. |
+| [getFontDefinition()](#getFontDefinition--) | Liefert Font‑Definition. |
+| [getFontFamily()](#getFontFamily--) | Liefert Font‑Familie. |
+| [getFontName()](#getFontName--) | Liefert Font‑Face‑Name. |
+| [getFontNames()](#getFontNames--) | Liefert Font‑Namen. |
+| [getFontSaver()](#getFontSaver--) | Liefert Font‑Speicherfunktionalität. |
+| [getFontStyle()](#getFontStyle--) | Liefert Font‑Stil. |
+| [getFontType()](#getFontType--) | Liefert Font‑Typ. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Font‑Glyph‑Zugriff. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Gibt Glyph nach Glyph-ID zurück. |
+| [getGlyphById(String glyphName)](#getGlyphById-java.lang.String-) | Gibt Glyph nach Glyph-Namen zurück. |
+| [getGlyphById(long id)](#getGlyphById-long-) | Gibt Glyph nach Glyph-ID zurück. |
+| [getGlyphComponentsById(GlyphId id, GlyphIdList componentsToPopulate)](#getGlyphComponentsById-com.aspose.font.GlyphId-com.aspose.font.GlyphIdList-) | Liefert ein Glyph anhand der übergebenen Glyph‑Kennung und füllt die übergebene Liste von Glyph‑Kennungen mit den Komponenten dieses Glyphs. |
+| [getGlyphComponentsById(String glyphName, GlyphIdList componentsToPopulate)](#getGlyphComponentsById-java.lang.String-com.aspose.font.GlyphIdList-) | Liefert ein Glyph anhand des übergebenen Glyph‑Namens und füllt die übergebene Liste von Glyph‑Kennungen mit den Komponenten dieses Glyphs. |
+| [getGlyphComponentsById(long id, GlyphIdList componentsToPopulate)](#getGlyphComponentsById-long-com.aspose.font.GlyphIdList-) | Liefert ein Glyph anhand des übergebenen Glyph‑Index und füllt die übergebene Liste von Glyph‑Kennungen mit den Komponenten dieses Glyphs. |
+| [getGlyphIdType()](#getGlyphIdType--) | Liefert Glyph-ID‑Typ‑Spezifikation. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Erhalte Glyph‑Darstellung für Text. |
+| [getMetrics()](#getMetrics--) | Liefert Font‑Metriken. |
+| [getNumGlyphs()](#getNumGlyphs--) | Ermittelt die Anzahl der Glyphen im Font. |
+| [getPostscriptNames()](#getPostscriptNames--) | Ermittelt die Postscript-Fontnamen. |
+| [getStyle()](#getStyle--) | Liefert Font‑Stil. |
+| [getTtfTables()](#getTtfTables--) | Ermittelt TTF-Tabellen. |
+| [hashCode()](#hashCode--) |  |
+| [isSymbolic()](#isSymbolic--) | Gibt true zurück, falls der Font symbolisch ist. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Öffnet einen Font mithilfe eines FontDefinition-Objekts. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Öffnet einen Font mithilfe des Font-Typs und eines Byte-Arrays mit Font-Daten. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Öffnet einen Font mithilfe des Font-Typs und einer Stream-Quelle. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Öffnet einen Font mithilfe des Font-Typs und des Font-Dateinamens. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Speichert den Font im Originalformat. |
+| [save(String fileName)](#save-java.lang.String-) | Speichert den Font im Originalformat. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Speichert den Font im angegebenen Format. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Setzt die Font-Familie. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Setzt den Font-Face-Namen. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Setzt den Font-Stil. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public Font convert(FontType fontType)
+```
+
+
+Konvertiert den Font in ein anderes Format. Hinweis: Der TTF-Fonttyp wird derzeit nur unterstützt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Font-Formattyp, in den konvertiert werden soll. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### convert(FontType fontType, Collection<Integer> limitingCharacterSet) {#convert-com.aspose.font.FontType-java.util.Collection-java.lang.Integer--}
+```
+public Font convert(FontType fontType, Collection<Integer> limitingCharacterSet)
+```
+
+
+Konvertiert die Font in ein anderes Format mit begrenztem Zeichensatz  *Hinweis: TTF Font-Typ wird jetzt nur noch unterstützt.*
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Font-Formattyp, in den konvertiert werden soll. |
+| limitingCharacterSet | java.util.Collection<java.lang.Integer> | Begrenzender Zeichensatz. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public GlyphId[] getAllGlyphIds()
+```
+
+
+Gibt ein Array aller Glyph‑IDs zurück, die im Font verfügbar sind. Eine Glyph‑ID ist eine eindeutige Nummer für eine Glyphe, die vom Font‑Typ abhängt. Eine TTF‑Font‑Glyph‑ID kann eine Instanz der Klasse ( GlyphStringId ) oder der Klasse ( GlyphUInt32Id ) sein. Die Glyph‑Adressierung nach Name (string) wird für TTF‑Fonts über das Post‑Tabellen‑Mapping unterstützt. Im Falle eines CFF‑Fonts werden die CFF‑Strukturen verwendet, um Glyphen per Name zu adressieren.
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyph‑Bezeichner.
+### getCffFont() {#getCffFont--}
+```
+public Font getCffFont()
+```
+
+
+Liefert CFF Font, falls vorhanden.
+
+**Returns:**
+[Font](../../com.aspose.font/font) - CFF Font.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncoding() {#getEncoding--}
+```
+public IFontEncoding getEncoding()
+```
+
+
+Liefert Font‑Kodierung.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public FontDefinition getFontDefinition()
+```
+
+
+Liefert Font‑Definition.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public String getFontFamily()
+```
+
+
+Liefert Font‑Familie.
+
+**Returns:**
+java.lang.String - Font‑Familie.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Liefert Font‑Face‑Name.
+
+**Returns:**
+java.lang.String - Font‑Face‑Name.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Liefert Font‑Namen.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Liefert Font‑Speicherfunktionalität.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public int getFontStyle()
+```
+
+
+Ermittelt den Font-Stil. Dies ist ein Wert, der berechnet und in einem generalisierten Typ dargestellt wird.
+
+**Returns:**
+int - Font-Stil. In der Regel eine Kombination von Konstanten‑Flag‑Werten der FontStyle‑Klasse oder 0.
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Ermittelt den Font-Typ. Gibt den Wert FontType.TTF zurück.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Schriftzeichen-Glyph-Zugriff. Ruft Glyphs und Glyph-Identifikatoren ab.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public Glyph getGlyphById(GlyphId id)
+```
+
+
+Gibt ein Glyph anhand der Glyph-ID zurück. Die Glyph-ID ist eine eindeutige Nummer für ein Glyph, die vom Schriftarttyp abhängt. Die Glyph-ID einer TTF-Schrift kann eine Instanz der Klasse ( GlyphStringId ) oder der Klasse ( GlyphUInt32Id ) sein. Die Namens-(String-)Glyph-Adressierung wird für TTF-Schriften über die Post-Tabellen-Zuordnung unterstützt. Im Falle einer CFF-Schrift werden die CFF-Strukturen verwendet, um Glyphs über ihren Namen anzusprechen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) |  |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph)
+### getGlyphById(String glyphName) {#getGlyphById-java.lang.String-}
+```
+public Glyph getGlyphById(String glyphName)
+```
+
+
+Gibt ein Glyph anhand des Glyph-Namens zurück. Die Namens-(String-)Glyph-Adressierung wird für TTF-Schriften über die Post-Tabellen-Zuordnung unterstützt. Im Falle einer CFF-Schrift werden die CFF-Strukturen verwendet, um Glyphs über ihren Namen anzusprechen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphName | java.lang.String | Glyph-String-Identifikator. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(long id) {#getGlyphById-long-}
+```
+public Glyph getGlyphById(long id)
+```
+
+
+Gibt Glyph nach Glyph-ID zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| id | long | Glyph-Index. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphComponentsById(GlyphId id, GlyphIdList componentsToPopulate) {#getGlyphComponentsById-com.aspose.font.GlyphId-com.aspose.font.GlyphIdList-}
+```
+public void getGlyphComponentsById(GlyphId id, GlyphIdList componentsToPopulate)
+```
+
+
+Ermittelt ein Glyph anhand der übergebenen Glyph-Identifikator und füllt die übergebene Liste von Glyph-Identifikatoren mit den Komponenten dieses Glyphs. Die Glyph-ID ist eine eindeutige Nummer für ein Glyph, die vom Schriftarttyp abhängt. Die Glyph-ID einer TTF-Schrift kann eine Instanz der Klasse ( GlyphStringId ) oder der Klasse ( GlyphUInt32Id ) sein. Die Namens-(String-)Glyph-Adressierung wird für TTF-Schriften über die Post-Tabellen-Zuordnung unterstützt. Im Falle einer CFF-Schrift werden die CFF-Strukturen verwendet, um Glyphs über ihren Namen anzusprechen.
+
+--------------------
+
+Eine leere Sammlung componentsToPopulate sollte übergeben werden, die die Glyph-Komponenten-ID-Liste enthält.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | Glyph-ID. |
+| componentsToPopulate | [GlyphIdList](../../com.aspose.font/glyphidlist) | Liste der zu füllenden Glyph-Identifikatoren. |
+
+### getGlyphComponentsById(String glyphName, GlyphIdList componentsToPopulate) {#getGlyphComponentsById-java.lang.String-com.aspose.font.GlyphIdList-}
+```
+public void getGlyphComponentsById(String glyphName, GlyphIdList componentsToPopulate)
+```
+
+
+Liefert ein Glyph anhand des übergebenen Glyph‑Namens und füllt die übergebene Liste von Glyph‑Kennungen mit den Komponenten dieses Glyphs.
+
+--------------------
+
+Eine leere Sammlung componentsToPopulate sollte übergeben werden, die die Glyph-Komponenten-ID-Liste enthält.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphName | java.lang.String | Glyph-Name. |
+| componentsToPopulate | [GlyphIdList](../../com.aspose.font/glyphidlist) | Liste der zu füllenden Glyph-Identifikatoren. |
+
+### getGlyphComponentsById(long id, GlyphIdList componentsToPopulate) {#getGlyphComponentsById-long-com.aspose.font.GlyphIdList-}
+```
+public void getGlyphComponentsById(long id, GlyphIdList componentsToPopulate)
+```
+
+
+Liefert ein Glyph anhand des übergebenen Glyph‑Index und füllt die übergebene Liste von Glyph‑Kennungen mit den Komponenten dieses Glyphs.
+
+--------------------
+
+Eine leere Sammlung componentsToPopulate sollte übergeben werden, die die Glyph-Komponenten-ID-Liste enthält.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| id | long | Glyph-Index. |
+| componentsToPopulate | [GlyphIdList](../../com.aspose.font/glyphidlist) | Liste der zu füllenden Glyph-Identifikatoren. |
+
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public GlyphIdType getGlyphIdType()
+```
+
+
+Liefert Glyph-ID‑Typ‑Spezifikation.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype) - Glyph id type specification.
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Erhalte Glyph‑Darstellung für Text.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| text | java.lang.String | Eingabetext. |
+
+**Returns:**
+com.aspose.font.GlyphId[] – GlyphId-Array.
+### getMetrics() {#getMetrics--}
+```
+public IFontMetrics getMetrics()
+```
+
+
+Liefert Font‑Metriken.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Ermittelt die Anzahl der Glyphen im Font.
+
+**Returns:**
+int – Anzahl der Glyphs in der Schrift.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Ermittelt die Postscript-Fontnamen.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript font names.
+### getStyle() {#getStyle--}
+```
+public String getStyle()
+```
+
+
+Ermittelt den Schriftstil. Dies ist ein Roh-String-Wert, der von der Schriftdatei bereitgestellt wird.
+
+**Returns:**
+java.lang.String – Schriftstil.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Ermittelt TTF-Tabellen.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - TTF tables.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isSymbolic() {#isSymbolic--}
+```
+public boolean isSymbolic()
+```
+
+
+Gibt true zurück, falls der Font symbolisch ist.
+
+**Returns:**
+boolean – Wahr, falls die Schrift symbolisch ist.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Öffnet einen Font mithilfe eines FontDefinition-Objekts.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Schriftdefinitions-Objekt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und eines Byte-Arrays mit Font-Daten.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fontData | byte[] | Byte-Array, aus dem die Schrift geladen wird. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und einer Stream-Quelle.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Stream-Quelle für die Schrift. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und des Font-Dateinamens.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fileName | java.lang.String | Schriftdateiname. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Speichert den Font im Originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Stream zum Speichern der Schrift. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Speichert den Font im Originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fileName | java.lang.String | Datei zum Speichern der Schrift. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Speichert den Font im angegebenen Format.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Stream zum Speichern der Schrift |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | gewünschtes Format |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public void setFontFamily(String value)
+```
+
+
+Setzt die Font-Familie.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Neue Schriftfamilie. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public void setFontName(String value)
+```
+
+
+Setzt den Font-Face-Namen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Neuer Schriftartname. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public void setStyle(String value)
+```
+
+
+Setzt Schriftstil. Dies ist ein Rohzeichenfolgenwert, der von der Schriftdatei bereitgestellt wird.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Neuer Schriftstil. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttffontmetrics/_index.md
+++ b/german/java/com.aspose.font/ttffontmetrics/_index.md
@@ -1,0 +1,484 @@
+---
+title: "TtfFontMetrics"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die TTF Schriftmetriken dar."
+type: docs
+weight: 95
+url: /de/java/com.aspose.font/ttffontmetrics/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.FontMetrics](../../com.aspose.font/fontmetrics)
+```
+public class TtfFontMetrics extends FontMetrics
+```
+
+Stellt die TTF Schriftmetriken dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAscender()](#getAscender--) | Liefert Aufstiegswert. |
+| [getAscender(double fontSize)](#getAscender-double-) | Gibt den Ascender für eine bestimmte Schriftgröße zurück. |
+| [getClass()](#getClass--) |  |
+| [getDescender()](#getDescender--) | Liefert Descender-Wert. |
+| [getDescender(double fontSize)](#getDescender-double-) | Gibt den Descender für eine bestimmte Schriftgröße zurück. |
+| [getFontBBox()](#getFontBBox--) | Liefert den FontBBox-Wert. |
+| [getFontMatrix()](#getFontMatrix--) | Liefert den FontBBox-Wert. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Gibt das Glyph-Bbox zurück. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Gibt die Breite von Glyphen anhand der Glyphen‑ID zurück. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Gibt den Kerning-Wert für das Glyph-Paar zurück. |
+| [getLineGap()](#getLineGap--) | Liest den LineGap-Wert. |
+| [getTypoAscender()](#getTypoAscender--) | Liest den TypoAscender-Wert. |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Gibt den typografischen Ascender für eine bestimmte Schriftgröße zurück. |
+| [getTypoDescender()](#getTypoDescender--) | Liest den TypoDescender-Wert. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Gibt den typografischen Descender für eine bestimmte Schriftgröße zurück. |
+| [getTypoLineGap()](#getTypoLineGap--) | Liest den TypoLineGap-Wert. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Gibt den Zeilenabstand für eine bestimmte Schriftgröße zurück. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Liest den UnitsPerEM-Wert. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Liest den IsFixedPitch-Wert. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Misst die Zeichenkette und gibt die Zeichenkettenbreite zurück. |
+| [measureString(long[] charCodes, double fontSize)](#measureString-long---double-) | Misst Text, dargestellt als Array von Zeichen­codes, und gibt die String‑Breite zurück. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAscender(double value)](#setAscender-double-) | Setzt Aufstiegswert. |
+| [setDescender(double value)](#setDescender-double-) | Setzt den Descender-Wert. |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) | Setzt die Glyph-Breite. |
+| [setTypoAscender(double value)](#setTypoAscender-double-) | Setzt den TypoAscender-Wert. |
+| [setTypoDescender(double value)](#setTypoDescender-double-) | Setzt den TypoDescender-Wert. |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAscender() {#getAscender--}
+```
+public double getAscender()
+```
+
+
+Liefert Aufstiegswert.
+
+**Returns:**
+double - Ascender-Wert.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public double getAscender(double fontSize)
+```
+
+
+Gibt den Ascender für eine bestimmte Schriftgröße zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Ascender-Wert.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescender() {#getDescender--}
+```
+public double getDescender()
+```
+
+
+Liefert Descender-Wert.
+
+**Returns:**
+double - Descender-Wert.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public double getDescender(double fontSize)
+```
+
+
+Gibt den Descender für eine bestimmte Schriftgröße zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Descender-Wert.
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+Liefert den FontBBox-Wert.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox)
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+Liefert den FontBBox-Wert.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix)
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Gibt das Glyph-Bbox zurück. Gibt FontBBox zurück, wenn das BBox für das Glyph nicht definiert war. Kann von spezifischen Font-Encoding-Erben überschrieben werden.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑Bezeichner. |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox.
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Gibt die Breite von Glyphen anhand der Glyphen‑ID zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑Bezeichner. |
+
+**Returns:**
+double - Glyphenbreite.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Gibt den Kerning-Wert für das Glyph-Paar zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Erste Glyphe im Paar. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Schriftgröße. |
+
+**Returns:**
+double - Kerning-Wert
+### getLineGap() {#getLineGap--}
+```
+public double getLineGap()
+```
+
+
+Liest den LineGap-Wert.
+
+**Returns:**
+double - LineGap-Wert.
+### getTypoAscender() {#getTypoAscender--}
+```
+public double getTypoAscender()
+```
+
+
+Liest den TypoAscender-Wert.
+
+**Returns:**
+double - TypoAscender-Wert.
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public double getTypoAscender(double fontSize)
+```
+
+
+Gibt den typografischen Ascender für eine bestimmte Schriftgröße zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Typografischer Aufsteigerwert.
+### getTypoDescender() {#getTypoDescender--}
+```
+public double getTypoDescender()
+```
+
+
+Liest den TypoDescender-Wert.
+
+**Returns:**
+double - TypoDescender-Wert.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public double getTypoDescender(double fontSize)
+```
+
+
+Gibt den typografischen Descender für eine bestimmte Schriftgröße zurück.
+
+param fontSize Schriftgröße.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double |  |
+
+**Returns:**
+double - Typografischer Abstiegwert.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public double getTypoLineGap()
+```
+
+
+Liest den TypoLineGap-Wert.
+
+**Returns:**
+double - TypoLineGap-Wert.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public double getTypoLineGap(double fontSize)
+```
+
+
+Gibt den Zeilenabstand für eine bestimmte Schriftgröße zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Zeilenabstandswert.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Liest den UnitsPerEM-Wert.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+Liest den IsFixedPitch-Wert.
+
+**Returns:**
+boolean - IsFixedPitch-Wert.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public double measureString(String unicode, double fontSize)
+```
+
+
+Misst die Zeichenkette und gibt die Zeichenkettenbreite zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| unicode | java.lang.String | Unicode-Zeichenkette. |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Zeichenkettenbreite.
+### measureString(long[] charCodes, double fontSize) {#measureString-long---double-}
+```
+public double measureString(long[] charCodes, double fontSize)
+```
+
+
+Misst Text, dargestellt als Array von Zeichen­codes, und gibt die String‑Breite zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| charCodes | long[] | Textzeichenfolge, dargestellt als Array von Zeichen-Codes. |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Zeichenkettenbreite.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAscender(double value) {#setAscender-double-}
+```
+public void setAscender(double value)
+```
+
+
+Setzt Aufstiegswert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | Aufsteigerwert. |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public void setDescender(double value)
+```
+
+
+Setzt den Descender-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | Abstiegwert. |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Setzt die Glyph-Breite.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑Bezeichner. |
+| Wert | double | Neue Breite. |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public void setTypoAscender(double value)
+```
+
+
+Setzt den TypoAscender-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | TypoAscender-Wert. |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public void setTypoDescender(double value)
+```
+
+
+Setzt den TypoDescender-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | TypoDescender-Wert. |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public void setUnitsPerEM(long value)
+```
+
+
+Setzt den UnitsPerEM-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttffpgmtable/_index.md
+++ b/german/java/com.aspose.font/ttffpgmtable/_index.md
@@ -1,0 +1,168 @@
+---
+title: "TtfFpgmTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die fpgm-Tabelle der TTF-Schriftdatei dar."
+type: docs
+weight: 96
+url: /de/java/com.aspose.font/ttffpgmtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfFpgmTable extends TtfTableBase
+```
+
+Stellt die "fpgm" Tabelle der TTF Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getProgram()](#getProgram--) | Liefert das fpgm-Programm. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getProgram() {#getProgram--}
+```
+public byte[] getProgram()
+```
+
+
+Liefert das fpgm-Programm.
+
+**Returns:**
+byte[] - Fpgm-Programm.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Tabellen‑Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfgasptable/_index.md
+++ b/german/java/com.aspose.font/ttfgasptable/_index.md
@@ -1,0 +1,190 @@
+---
+title: "TtfGaspTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Gasp‑Tabelle der TTF‑Font‑Datei dar."
+type: docs
+weight: 97
+url: /de/java/com.aspose.font/ttfgasptable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfGaspTable extends TtfTableBase
+```
+
+Stellt die "gasp" Tabelle der TTF Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGaspRanges()](#getGaspRanges--) | Ruft die Liste der GaspRange‑Datensätze ab und liefert empfohlene Verhaltensweisen für verschiedene ppem‑Größen. |
+| [getNumRanges()](#getNumRanges--) | Ruft GaspRange‑Datensätze ab. |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getTag()](#getTag--) | Ruft das Tabellen-Tag ab. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [getVersion()](#getVersion--) | Ruft die Tabellen-Version ab. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGaspRanges() {#getGaspRanges--}
+```
+public List<GaspRange> getGaspRanges()
+```
+
+
+Ruft die Liste der GaspRange‑Datensätze ab und liefert empfohlene Verhaltensweisen für verschiedene ppem‑Größen.
+
+**Returns:**
+java.util.List<com.aspose.font.GaspRange> - Die Liste der GaspRange.
+### getNumRanges() {#getNumRanges--}
+```
+public int getNumRanges()
+```
+
+
+Ruft GaspRange‑Datensätze ab.
+
+**Returns:**
+int - GaspRange‑Datensätze.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ruft das Tabellen-Tag ab.
+
+**Returns:**
+java.lang.String - Das Tabellen-Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public int getVersion()
+```
+
+
+Ruft die Tabellen-Version ab.
+
+**Returns:**
+int - Die Tabellenversion.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfglyftable/_index.md
+++ b/german/java/com.aspose.font/ttfglyftable/_index.md
@@ -1,0 +1,189 @@
+---
+title: "TtfGlyfTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Glyf-Tabelle der TTF-Schriftdatei dar."
+type: docs
+weight: 98
+url: /de/java/com.aspose.font/ttfglyftable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfGlyfTable extends TtfTableBase
+```
+
+Stellt die "glyf" Tabelle der TTF Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [containsGlyph(int glyphIndex)](#containsGlyph-int-) | Gibt true zurück, falls die Tabelle ein Glyph mit glyphIndex enthält. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGlyph(long glyphIndex)](#getGlyph-long-) | Gibt ein Glyph anhand des Glyph-Index zurück. |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### containsGlyph(int glyphIndex) {#containsGlyph-int-}
+```
+public boolean containsGlyph(int glyphIndex)
+```
+
+
+Gibt true zurück, falls die Tabelle ein Glyph mit glyphIndex enthält.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphIndex | int | Glyph-Index. |
+
+**Returns:**
+boolean - True, wenn die Tabelle ein Glyph für den angegebenen Index enthält, sonst false.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyph(long glyphIndex) {#getGlyph-long-}
+```
+public Glyph getGlyph(long glyphIndex)
+```
+
+
+Gibt ein Glyph anhand des Glyph-Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphIndex | long | Glyph-Index. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph Glyph related to index specified.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Tabellen‑Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfheadtable/_index.md
+++ b/german/java/com.aspose.font/ttfheadtable/_index.md
@@ -1,0 +1,344 @@
+---
+title: "TtfHeadTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Kopf‑Tabelle der TTF‑Schriftdatei dar."
+type: docs
+weight: 99
+url: /de/java/com.aspose.font/ttfheadtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfHeadTable extends TtfTableBase
+```
+
+Stellt die "head" Tabelle der TTF Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCheckSumAdjustment()](#getCheckSumAdjustment--) | Liefert uint32 checkSumAdjustment. |
+| [getClass()](#getClass--) |  |
+| [getCreated()](#getCreated--) | Liefert longDateTime erstelltes internationales Datum. |
+| [getFlags()](#getFlags--) | Liefert uint16 flags. |
+| [getFontDirectionHint()](#getFontDirectionHint--) | Liefert int16 fontDirectionHint. 0 Gemischte Richtungs‑Glyphen; 1 Nur stark von links nach rechts gerichtete Glyphen; 2 Wie 1, enthält aber auch neutrale Glyphen; -1 Nur stark von rechts nach links gerichtete Glyphen; -2 Wie -1, enthält aber auch neutrale Glyphen. |
+| [getFontRevision()](#getFontRevision--) | Liefert Fixed fontRevision, festgelegt vom Schriftartenhersteller. |
+| [getGlyphDataFormat()](#getGlyphDataFormat--) | Liefert int16 glyphDataFormat 0 für das aktuelle Format. |
+| [getIndexToLocFormat()](#getIndexToLocFormat--) | Liefert int16 indexToLocFormat 0 für kurze Offsets, 1 für lange. |
+| [getLowestRecPPEM()](#getLowestRecPPEM--) | Liefert uint16 lowestRecPPEM kleinste lesbare Größe in Pixeln. |
+| [getMacStyle()](#getMacStyle--) | Liefert uint16 macStyle. |
+| [getMagicNumber()](#getMagicNumber--) | Liefert uint32 magicNumber, gesetzt auf 0x5F0F3CF5. |
+| [getModified()](#getModified--) | Liefert longDateTime modifiziertes internationales Datum. |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Liefert uint16 unitsPerEM, Bereich von 64 bis 16384. |
+| [getVersion()](#getVersion--) | Fixed version 0x00010000, falls (Version 1.0). |
+| [getXMax()](#getXMax--) | Liefert FWord xMax für alle Glyphenbegrenzungsrahmen. |
+| [getXMin()](#getXMin--) | Liefert FWord xMin für alle Glyphenbegrenzungsrahmen. |
+| [getYMax()](#getYMax--) | Liefert FWord yMax für alle Glyphenbegrenzungsrahmen. |
+| [getYMin()](#getYMin--) | Liefert FWord yMin für alle Glyphenbegrenzungsrahmen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCheckSumAdjustment() {#getCheckSumAdjustment--}
+```
+public long getCheckSumAdjustment()
+```
+
+
+Liefert uint32 checkSumAdjustment. Zur Berechnung: Setzen Sie ihn auf 0, berechnen Sie die Prüfsumme für die 'head'-Tabelle und tragen Sie sie in das Tabellendirectory ein, summieren Sie die gesamte Schriftart als uint32 und speichern Sie dann B1B0AFBA - Summe. Die Prüfsumme für die 'head'-Tabelle wird nicht falsch sein. Das ist in Ordnung.
+
+**Returns:**
+long - Uint32 checkSumAdjustment.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCreated() {#getCreated--}
+```
+public Date getCreated()
+```
+
+
+Liefert longDateTime erstelltes internationales Datum.
+
+**Returns:**
+java.util.Date - LongDateTime erstelltes internationales Datum.
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Liefert uint16 flags.
+
+**Returns:**
+int - UInt16 flags.
+### getFontDirectionHint() {#getFontDirectionHint--}
+```
+public short getFontDirectionHint()
+```
+
+
+Liefert int16 fontDirectionHint. 0 Gemischte Richtungs‑Glyphen; 1 Nur stark von links nach rechts gerichtete Glyphen; 2 Wie 1, enthält aber auch neutrale Glyphen; -1 Nur stark von rechts nach links gerichtete Glyphen; -2 Wie -1, enthält aber auch neutrale Glyphen.
+
+**Returns:**
+short - Int16 fontDirectionHint.
+### getFontRevision() {#getFontRevision--}
+```
+public float getFontRevision()
+```
+
+
+Liefert Fixed fontRevision, festgelegt vom Schriftartenhersteller.
+
+**Returns:**
+float - Fixed fontRevision, festgelegt vom Schriftartenhersteller.
+### getGlyphDataFormat() {#getGlyphDataFormat--}
+```
+public short getGlyphDataFormat()
+```
+
+
+Liefert int16 glyphDataFormat 0 für das aktuelle Format.
+
+**Returns:**
+short - Int16 glyphDataFormat 0 für das aktuelle Format.
+### getIndexToLocFormat() {#getIndexToLocFormat--}
+```
+public short getIndexToLocFormat()
+```
+
+
+Liefert int16 indexToLocFormat 0 für kurze Offsets, 1 für lange.
+
+**Returns:**
+short - Int16 indexToLocFormat 0 für kurze Offsets, 1 für lange.
+### getLowestRecPPEM() {#getLowestRecPPEM--}
+```
+public int getLowestRecPPEM()
+```
+
+
+Liefert uint16 lowestRecPPEM kleinste lesbare Größe in Pixeln.
+
+**Returns:**
+int - UInt16 lowestRecPPEM kleinste lesbare Größe in Pixeln.
+### getMacStyle() {#getMacStyle--}
+```
+public int getMacStyle()
+```
+
+
+Liefert uint16 macStyle.
+
+**Returns:**
+int - UInt16 macStyle.
+### getMagicNumber() {#getMagicNumber--}
+```
+public long getMagicNumber()
+```
+
+
+Liefert uint32 magicNumber, gesetzt auf 0x5F0F3CF5.
+
+**Returns:**
+long - UInt32 magicNumber auf 0x5F0F3CF5 gesetzt.
+### getModified() {#getModified--}
+```
+public Date getModified()
+```
+
+
+Liefert longDateTime modifiziertes internationales Datum.
+
+**Returns:**
+java.util.Date - LongDateTime modifiziertes internationales Datum.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Tabellen‑Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Liefert uint16 unitsPerEM, Bereich von 64 bis 16384.
+
+**Returns:**
+long - UInt16 unitsPerEM Bereich von 64 bis 16384.
+### getVersion() {#getVersion--}
+```
+public float getVersion()
+```
+
+
+Fixed version 0x00010000, falls (Version 1.0).
+
+**Returns:**
+float - Feste Version 0x00010000, wenn (Version 1.0).
+### getXMax() {#getXMax--}
+```
+public short getXMax()
+```
+
+
+Liefert FWord xMax für alle Glyphenbegrenzungsrahmen.
+
+**Returns:**
+short - FWord xMax für alle Glyphenbegrenzungsrahmen.
+### getXMin() {#getXMin--}
+```
+public short getXMin()
+```
+
+
+Liefert FWord xMin für alle Glyphenbegrenzungsrahmen.
+
+**Returns:**
+short - FWord xMin für alle Glyphenbegrenzungsrahmen.
+### getYMax() {#getYMax--}
+```
+public short getYMax()
+```
+
+
+Liefert FWord yMax für alle Glyphenbegrenzungsrahmen.
+
+**Returns:**
+short - FWord yMax für alle Glyphenbegrenzungsrahmen.
+### getYMin() {#getYMin--}
+```
+public short getYMin()
+```
+
+
+Liefert FWord yMin für alle Glyphenbegrenzungsrahmen.
+
+**Returns:**
+short - FWord yMin für alle Glyphenbegrenzungsrahmen.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfhheatable/_index.md
+++ b/german/java/com.aspose.font/ttfhheatable/_index.md
@@ -1,0 +1,300 @@
+---
+title: "TtfHheaTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die hhea-Tabelle der TTF-Schriftdatei dar."
+type: docs
+weight: 100
+url: /de/java/com.aspose.font/ttfhheatable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfHheaTable extends TtfTableBase
+```
+
+Stellt die "hhea"-Tabelle der TTF-Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdvanceWidthMax()](#getAdvanceWidthMax--) | Ermittelt uFWord advanceWidthMax muss mit den horizontalen Metriken konsistent sein. |
+| [getAscent()](#getAscent--) | Ermittelt die Ascent. |
+| [getCaretOffset()](#getCaretOffset--) | Ermittelt den Offset des Caret. |
+| [getCaretSlopeRise()](#getCaretSlopeRise--) | Ermittelt caret slop rise. |
+| [getCaretSlopeRun()](#getCaretSlopeRun--) | Ermittelt caret slop run. |
+| [getClass()](#getClass--) |  |
+| [getDescent()](#getDescent--) | Ermittelt die Descent. |
+| [getLineGap()](#getLineGap--) | Ermittelt die lineGap. |
+| [getMetricDataFormat()](#getMetricDataFormat--) | Ermittelt das Format der metrics data. |
+| [getMinLeftSideBearing()](#getMinLeftSideBearing--) | Ermittelt den MinLeftSideBearing-Wert. |
+| [getMinRightSideBearing()](#getMinRightSideBearing--) | Ermittelt den MinRightSideBearing-Wert. |
+| [getNumOfLongHorMetrics()](#getNumOfLongHorMetrics--) | Ermittelt uint16 numOfLongHorMetrics Anzahl der advance widths in der Metriktabelle. |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [getVersion()](#getVersion--) | Ermittelt die Version. |
+| [getXMaxExtent()](#getXMaxExtent--) | Ermittelt den XMaxExtent-Wert. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdvanceWidthMax() {#getAdvanceWidthMax--}
+```
+public int getAdvanceWidthMax()
+```
+
+
+Ermittelt uFWord advanceWidthMax muss mit den horizontalen Metriken konsistent sein.
+
+**Returns:**
+int - uFWord advanceWidthMax muss mit den horizontalen Metriken konsistent sein.
+### getAscent() {#getAscent--}
+```
+public short getAscent()
+```
+
+
+Ermittelt die Ascent.
+
+**Returns:**
+short - Die Ascent.
+### getCaretOffset() {#getCaretOffset--}
+```
+public short getCaretOffset()
+```
+
+
+Ermittelt den Offset des Caret.
+
+**Returns:**
+short - Der Offset des Caret.
+### getCaretSlopeRise() {#getCaretSlopeRise--}
+```
+public short getCaretSlopeRise()
+```
+
+
+Ermittelt caret slop rise.
+
+**Returns:**
+short - Der caret slop rise.
+### getCaretSlopeRun() {#getCaretSlopeRun--}
+```
+public short getCaretSlopeRun()
+```
+
+
+Ermittelt caret slop run.
+
+**Returns:**
+short - Der caret slop run.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescent() {#getDescent--}
+```
+public short getDescent()
+```
+
+
+Ermittelt die Descent.
+
+**Returns:**
+short - Der Abstieg.
+### getLineGap() {#getLineGap--}
+```
+public short getLineGap()
+```
+
+
+Ermittelt die lineGap.
+
+**Returns:**
+short - Der Zeilenabstand.
+### getMetricDataFormat() {#getMetricDataFormat--}
+```
+public short getMetricDataFormat()
+```
+
+
+Ermittelt das Format der metrics data.
+
+**Returns:**
+short - Das Format der Metrikdaten.
+### getMinLeftSideBearing() {#getMinLeftSideBearing--}
+```
+public short getMinLeftSideBearing()
+```
+
+
+Ermittelt den MinLeftSideBearing-Wert.
+
+**Returns:**
+short - Der MinLeftSideBearing-Wert.
+### getMinRightSideBearing() {#getMinRightSideBearing--}
+```
+public short getMinRightSideBearing()
+```
+
+
+Ermittelt den MinRightSideBearing-Wert.
+
+**Returns:**
+short - Der MinRightSideBearing-Wert.
+### getNumOfLongHorMetrics() {#getNumOfLongHorMetrics--}
+```
+public int getNumOfLongHorMetrics()
+```
+
+
+Ermittelt uint16 numOfLongHorMetrics Anzahl der advance widths in der Metriktabelle.
+
+**Returns:**
+int - UInt16 numOfLongHorMetrics Anzahl der Vorwärtsbreiten in der Metriktabelle.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Tabellen‑Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public float getVersion()
+```
+
+
+Ermittelt die Version.
+
+**Returns:**
+float - Tabellenformatversion.
+### getXMaxExtent() {#getXMaxExtent--}
+```
+public short getXMaxExtent()
+```
+
+
+Ermittelt den XMaxExtent-Wert.
+
+**Returns:**
+short - Der XMaxExtent-Wert.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfhmtxtable/_index.md
+++ b/german/java/com.aspose.font/ttfhmtxtable/_index.md
@@ -1,0 +1,190 @@
+---
+title: "TtfHmtxTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die hmtx-Tabelle der TTF-Schriftdatei dar."
+type: docs
+weight: 101
+url: /de/java/com.aspose.font/ttfhmtxtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfHmtxTable extends TtfTableBase
+```
+
+Stellt die "hmtx"-Tabelle der TTF-Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalAdvanceWidth()](#getAdditionalAdvanceWidth--) | In der hmtx-Tabelle kann es Fälle geben, in denen die Gesamtzahl der Glyphen nicht gleich hhea.numberOfHMetrics ist. |
+| [getClass()](#getClass--) |  |
+| [getHMetrics()](#getHMetrics--) | Liefert horizontale Metriken. |
+| [getLeftSidebearings()](#getLeftSidebearings--) | Liefert linke Seitenabstände. |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalAdvanceWidth() {#getAdditionalAdvanceWidth--}
+```
+public int getAdditionalAdvanceWidth()
+```
+
+
+In der hmtx-Tabelle kann es Fälle geben, in denen die Gesamtzahl der Glyphen nicht gleich hhea.numberOfHMetrics ist. Für diese Fälle enthält die hmtx-Tabelle ein zusätzliches Array 'leftSideBearing', das der Eigenschaft LeftSidebearings entspricht. Aber Glyphen mit Indizes von hhea.numOfLongHorMetrics bis maxp.numGlyphs haben ebenfalls Breiten. Und diese Breiten haben gemäß der Spezifikation für die hmtx-Tabelle folgende Werte: "Here the advanceWidth is assumed to be the same as the advanceWidth for the last entry above".
+
+**Returns:**
+int - Zusätzliche Vorwärtsbreite.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHMetrics() {#getHMetrics--}
+```
+public TtfHmtxTable.MetricList getHMetrics()
+```
+
+
+Liefert horizontale Metriken.
+
+**Returns:**
+[MetricList](../../com.aspose.font/metriclist) - Horizontal metrics.
+### getLeftSidebearings() {#getLeftSidebearings--}
+```
+public short[] getLeftSidebearings()
+```
+
+
+Liefert linke Seitenabstände.
+
+**Returns:**
+short[] - Linke Seitenabstände.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Tabellen‑Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttflocatable/_index.md
+++ b/german/java/com.aspose.font/ttflocatable/_index.md
@@ -1,0 +1,157 @@
+---
+title: "TtfLocaTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Loca-Tabelle der TTF-Schriftdatei dar."
+type: docs
+weight: 102
+url: /de/java/com.aspose.font/ttflocatable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfLocaTable extends TtfTableBase
+```
+
+Stellt die "loca"-Tabelle der TTF-Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Tabellen‑Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfltshtable/_index.md
+++ b/german/java/com.aspose.font/ttfltshtable/_index.md
@@ -1,0 +1,195 @@
+---
+title: "TtfLtshTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Linear-Threshold-Tabelle der TTF-Schriftdatei dar."
+type: docs
+weight: 103
+url: /de/java/com.aspose.font/ttfltshtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfLtshTable extends TtfTableBase
+```
+
+Stellt die Linear-Threshold-Tabelle der TTF-Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getNumGlyphs()](#getNumGlyphs--) | Ruft die Anzahl der Glyphen ab (aus "numGlyphs" in der 'maxp'-Tabelle). |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getTag()](#getTag--) | Ruft das Tabellen-Tag ab. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [getVersion()](#getVersion--) | Ruft die Tabellen-Version ab. |
+| [getYPel(int glyphNum)](#getYPel-int-) | Gibt die vertikale Pel-Höhe für Glyph/Zero zurück, wenn die Glyph-Nummer inkorrekt ist. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Ruft die Anzahl der Glyphen ab (aus "numGlyphs" in der 'maxp'-Tabelle).
+
+**Returns:**
+int - Die Anzahl der Glyphen (aus "numGlyphs" in der 'maxp'-Tabelle).
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ruft das Tabellen-Tag ab.
+
+**Returns:**
+java.lang.String - Das Tabellen-Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public int getVersion()
+```
+
+
+Ruft die Tabellen-Version ab.
+
+**Returns:**
+int - Die Tabellenversion.
+### getYPel(int glyphNum) {#getYPel-int-}
+```
+public byte getYPel(int glyphNum)
+```
+
+
+Gibt die vertikale Pel-Höhe für Glyph/Zero zurück, wenn die Glyph-Nummer inkorrekt ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphNum | int | Eine Glyph-Nummer (Index). |
+
+**Returns:**
+byte - Die vertikale Pel-Höhe für Glyph/Zero, wenn die Glyph-Nummer inkorrekt ist.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfmaxptable/_index.md
+++ b/german/java/com.aspose.font/ttfmaxptable/_index.md
@@ -1,0 +1,333 @@
+---
+title: "TtfMaxpTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die maxp‑Tabelle der TTF‑Schriftdatei dar"
+type: docs
+weight: 104
+url: /de/java/com.aspose.font/ttfmaxptable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfMaxpTable extends TtfTableBase
+```
+
+Stellt die "maxp"-Tabelle der TTF-Schriftdatei dar
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxComponentContours()](#getMaxComponentContours--) | Liefert uint16 maxComponentContours Konturen in zusammengesetztem Glyph. |
+| [getMaxComponentDepth()](#getMaxComponentDepth--) | Liefert uint16 maxComponentDepth Rekursionsebenen, auf 0 gesetzt, wenn die Schrift nur einfache Glyphen enthält. |
+| [getMaxComponentElements()](#getMaxComponentElements--) | Liefert uint16 maxComponentElements Anzahl der Glyphen, die auf oberster Ebene referenziert werden. |
+| [getMaxComponentPoints()](#getMaxComponentPoints--) | Liefert uint16 maxComponentPoints Punkte in zusammengesetztem Glyph. |
+| [getMaxContours()](#getMaxContours--) | Liefert uint16 maxContours Konturen in nicht‑zusammengesetztem Glyph. |
+| [getMaxFunctionDefs()](#getMaxFunctionDefs--) | Liefert uint16 maxFunctionDefs Anzahl der FDEFs. |
+| [getMaxInstructionDefs()](#getMaxInstructionDefs--) | Liefert uint16 maxInstructionDefs Anzahl der IDEFs. |
+| [getMaxPoints()](#getMaxPoints--) | Liefert uint16 maxPoints Punkte in nicht‑zusammengesetztem Glyph. |
+| [getMaxSizeOfInstructions()](#getMaxSizeOfInstructions--) | Liefert uint16 maxSizeOfInstructions Byteanzahl für Glyph‑Anweisungen. |
+| [getMaxStackElements()](#getMaxStackElements--) | Liefert uint16 maxStackElements maximale Stapeltiefe. |
+| [getMaxStorage()](#getMaxStorage--) | Liefert uint16 maxStorage Anzahl der Speicherbereichs‑Positionen. |
+| [getMaxTwilightPoints()](#getMaxTwilightPoints--) | Liefert uint16 maxTwilightPoints Punkte, die in der Twilight Zone (Z0) verwendet werden. |
+| [getMaxZones()](#getMaxZones--) | Liefert uint16 maxZones, festgelegt auf 2. |
+| [getNumGlyphs()](#getNumGlyphs--) | Liefert uint16 numGlyphs die Anzahl der Glyphen in der Schrift. |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getTableVersion()](#getTableVersion--) | Liefert Formatversion. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [getVersion()](#getVersion--) | Gibt feste Version 0x00010000, wenn (Version 1.0). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxComponentContours() {#getMaxComponentContours--}
+```
+public int getMaxComponentContours()
+```
+
+
+Liefert uint16 maxComponentContours Konturen in zusammengesetztem Glyph.
+
+**Returns:**
+int - UInt16 maxComponentContours Konturen in zusammengesetztem Glyph.
+### getMaxComponentDepth() {#getMaxComponentDepth--}
+```
+public int getMaxComponentDepth()
+```
+
+
+Liefert uint16 maxComponentDepth Rekursionsebenen, auf 0 gesetzt, wenn die Schrift nur einfache Glyphen enthält.
+
+**Returns:**
+int - Uint16 maxComponentDepth Rekursionsebenen, auf 0 setzen, wenn die Schrift nur einfache Glyphen hat.
+### getMaxComponentElements() {#getMaxComponentElements--}
+```
+public int getMaxComponentElements()
+```
+
+
+Liefert uint16 maxComponentElements Anzahl der Glyphen, die auf oberster Ebene referenziert werden.
+
+**Returns:**
+int - UInt16 maxComponentElements Anzahl der Glyphen, die auf oberster Ebene referenziert werden.
+### getMaxComponentPoints() {#getMaxComponentPoints--}
+```
+public int getMaxComponentPoints()
+```
+
+
+Liefert uint16 maxComponentPoints Punkte in zusammengesetztem Glyph.
+
+**Returns:**
+int - UInt16 maxComponentPoints Punkte in zusammengesetztem Glyph.
+### getMaxContours() {#getMaxContours--}
+```
+public int getMaxContours()
+```
+
+
+Liefert uint16 maxContours Konturen in nicht‑zusammengesetztem Glyph.
+
+**Returns:**
+int - UInt16 maxContours Konturen in nicht zusammengesetztem Glyph.
+### getMaxFunctionDefs() {#getMaxFunctionDefs--}
+```
+public int getMaxFunctionDefs()
+```
+
+
+Liefert uint16 maxFunctionDefs Anzahl der FDEFs.
+
+**Returns:**
+int - UInt16 maxFunctionDefs Anzahl der FDEFs.
+### getMaxInstructionDefs() {#getMaxInstructionDefs--}
+```
+public int getMaxInstructionDefs()
+```
+
+
+Liefert uint16 maxInstructionDefs Anzahl der IDEFs.
+
+**Returns:**
+int - UInt16 maxInstructionDefs Anzahl der IDEFs.
+### getMaxPoints() {#getMaxPoints--}
+```
+public int getMaxPoints()
+```
+
+
+Liefert uint16 maxPoints Punkte in nicht‑zusammengesetztem Glyph.
+
+**Returns:**
+int - UInt16 maxPoints Punkte in nicht zusammengesetztem Glyph.
+### getMaxSizeOfInstructions() {#getMaxSizeOfInstructions--}
+```
+public int getMaxSizeOfInstructions()
+```
+
+
+Liefert uint16 maxSizeOfInstructions Byteanzahl für Glyph‑Anweisungen.
+
+**Returns:**
+int - UInt16 maxSizeOfInstructions Byteanzahl für Glyphen‑Anweisungen.
+### getMaxStackElements() {#getMaxStackElements--}
+```
+public int getMaxStackElements()
+```
+
+
+Liefert uint16 maxStackElements maximale Stapeltiefe.
+
+**Returns:**
+int - UInt16 maxStackElements maximale Stapeltiefe.
+### getMaxStorage() {#getMaxStorage--}
+```
+public int getMaxStorage()
+```
+
+
+Liefert uint16 maxStorage Anzahl der Speicherbereichs‑Positionen.
+
+**Returns:**
+int - UInt16 maxStorage Anzahl der Speicherbereichs‑Positionen.
+### getMaxTwilightPoints() {#getMaxTwilightPoints--}
+```
+public int getMaxTwilightPoints()
+```
+
+
+Liefert uint16 maxTwilightPoints Punkte, die in der Twilight Zone (Z0) verwendet werden.
+
+**Returns:**
+int - UInt16 maxTwilightPoints Punkte, die in der Twilight Zone (Z0) verwendet werden.
+### getMaxZones() {#getMaxZones--}
+```
+public int getMaxZones()
+```
+
+
+Liefert uint16 maxZones, festgelegt auf 2.
+
+**Returns:**
+int - Uint16 maxZones auf 2 gesetzt.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Liefert uint16 numGlyphs die Anzahl der Glyphen in der Schrift.
+
+**Returns:**
+int - UInt16 numGlyphs die Anzahl der Glyphen in der Schrift.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getTableVersion() {#getTableVersion--}
+```
+public Version16Dot16 getTableVersion()
+```
+
+
+Liefert Formatversion. Verwende die Eigenschaften MajorNumber und MinorNUmber des Objekts Version16Dot16 in hexadezimaler Schreibweise, um die verwendete Version zu erkennen.
+
+**Returns:**
+[Version16Dot16](../../com.aspose.font/version16dot16) - Format version.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Tabellen‑Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public float getVersion()
+```
+
+
+Liefert feste Version 0x00010000, wenn (Version 1.0). Veraltet, stattdessen die Eigenschaft TableVersion verwenden.
+
+**Returns:**
+float - Feste Version 0x00010000, wenn (Version 1.0).
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfnametable/_index.md
+++ b/german/java/com.aspose.font/ttfnametable/_index.md
@@ -1,0 +1,381 @@
+---
+title: "TtfNameTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Namens­tabelle der TTF‑Schriftdatei dar."
+type: docs
+weight: 105
+url: /de/java/com.aspose.font/ttfnametable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfNameTable extends TtfTableBase
+```
+
+Stellt die "name"-Tabelle der TTF-Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addMultiLanguageNames(MultiLanguageString mlNames, PlatformId platformId, int platformSpecificId, NameId nameId)](#addMultiLanguageNames-com.aspose.font.MultiLanguageString-com.aspose.font.PlatformId-int-com.aspose.font.NameId-) | Extrahiert alle mehrsprachigen Zeichenketten aus dem übergebenen  mlNames‑Objekt und erstellt für jede extrahierte Zeichenkette eine entsprechende NameRecord‑Struktur unter Verwendung der übergebenen Parameter  platformId ,  platformSpecificId  und  nameId . |
+| [addName(NameId nameId, PlatformId platformId, int platformSpecificId, int languageId, String name)](#addName-com.aspose.font.NameId-com.aspose.font.PlatformId-int-int-java.lang.String-) | Fügt einen Eintrag in die Tabelle ein. |
+| [deleteRecords(PlatformId platformId, int platformSpecificId)](#deleteRecords-com.aspose.font.PlatformId-int-) | Löscht alle Datensätze, die zur angegebenen Plattform gehören. |
+| [deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId)](#deleteRecords-com.aspose.font.PlatformId-int-com.aspose.font.NameId-) | Löscht alle Datensätze, die zu den übergebenen Parametern gehören. |
+| [deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId)](#deleteRecords-com.aspose.font.PlatformId-int-com.aspose.font.NameId-int-) | Löscht Datensatz(e), die zu den angegebenen Parametern gehören. |
+| [deleteRecordsByNameId(NameId nameId)](#deleteRecordsByNameId-com.aspose.font.NameId-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllNameRecords()](#getAllNameRecords--) | Gibt alle  NameRecord‑Strukturen aus der Tabelle zurück. |
+| [getClass()](#getClass--) |  |
+| [getMultiLanguageNameById(NameId nameId)](#getMultiLanguageNameById-com.aspose.font.NameId-) | Gibt einen Namen anhand von nameId zurück. |
+| [getMultiLanguageNameById(NameId nameId, PlatformId platformId)](#getMultiLanguageNameById-com.aspose.font.NameId-com.aspose.font.PlatformId-) | Gibt einen Namen anhand von nameId zurück, wobei der übergebene Plattform‑Bezeichner verwendet wird. |
+| [getMultiLanguageNameById(NameId nameId, PlatformId platformId, int platformSpecificId)](#getMultiLanguageNameById-com.aspose.font.NameId-com.aspose.font.PlatformId-int-) | Gibt einen Namen als Objekt des Typs  MultiLanguageString  zurück. |
+| [getNameById(NameId nameId)](#getNameById-com.aspose.font.NameId-) | Gibt einen Namen anhand von nameId zurück, falls gefunden, sonst null. |
+| [getNameRecordsByNameId(NameId nameId)](#getNameRecordsByNameId-com.aspose.font.NameId-) | Gibt alle  NameRecord‑Strukturen zurück, deren NameId‑Feld dem übergebenen  nameId‑Wert entspricht. |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [updateName(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId, String newName)](#updateName-com.aspose.font.PlatformId-int-com.aspose.font.NameId-int-java.lang.String-) | Aktualisiert den Namen in Datensatz(en), die zur angegebenen Plattform (Kombination aus platformId und platformSpecificId), Kategorie (nameId) und Sprache (languageId) gehören. |
+| [updateNamesByNameId(NameId nameId, String newName)](#updateNamesByNameId-com.aspose.font.NameId-java.lang.String-) | Wählt alle Datensätze aus, die zur logischen Zeichenkettenkategorie, angegeben durch den Parameter nameId, gehören, und aktualisiert das Namensfeld (Zeichenkettendaten) in diesen Datensätzen. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### addMultiLanguageNames(MultiLanguageString mlNames, PlatformId platformId, int platformSpecificId, NameId nameId) {#addMultiLanguageNames-com.aspose.font.MultiLanguageString-com.aspose.font.PlatformId-int-com.aspose.font.NameId-}
+```
+public void addMultiLanguageNames(MultiLanguageString mlNames, PlatformId platformId, int platformSpecificId, NameId nameId)
+```
+
+
+Extrahiert alle mehrsprachigen Zeichenketten aus dem übergebenen  mlNames‑Objekt und erstellt für jede extrahierte Zeichenkette eine entsprechende NameRecord‑Struktur unter Verwendung der übergebenen Parameter  platformId ,  platformSpecificId  und  nameId . Der Wert für das Feld languageID wird aus dem  mlNames‑Objekt extrahiert. Der neu erstellte Datensatz wird der Tabelle hinzugefügt. Wird ein Datensatz gefunden, der mit den gerade erstellten Feldern platformID, platformSpecificID, nameID und languageId übereinstimmt, wird der neue Datensatz nicht hinzugefügt und nur die Zeichenkettendaten des bestehenden Datensatzes werden aktualisiert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| mlNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Mehrsprachige Zeichenkette |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Plattform‑Bezeichner |
+| platformSpecificId | int | Plattform‑spezifischer Kodierungsbezeichner |
+| nameId | [NameId](../../com.aspose.font/nameid) | Namensbezeichner, logische Zeichenkettenkategorie, angegeben durch die  NameId‑Aufzählung |
+
+### addName(NameId nameId, PlatformId platformId, int platformSpecificId, int languageId, String name) {#addName-com.aspose.font.NameId-com.aspose.font.PlatformId-int-int-java.lang.String-}
+```
+public void addName(NameId nameId, PlatformId platformId, int platformSpecificId, int languageId, String name)
+```
+
+
+Fügt einen Eintrag in die Tabelle ein. Die String-Datenkategorie, die hinzuzufügen ist, wird durch den Parameter name angegeben.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Namenskennzeichen, logische String-Kategorie, angegeben durch die Aufzählung [NameId](../../com.aspose.font/nameid). |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Plattformkennzeichen. |
+| platformSpecificId | int | Plattform-spezifischer Kodierungsbezeichner. Bitte verwenden Sie einen Wert aus einer der folgenden Aufzählungen – UnicodePlatformSpecificId, MacPlatformSpecificId, MSPlatformSpecificId. Welche Aufzählung zu verwenden ist, wird durch den Kontext (Parameter platformId) definiert. |
+| languageId | int | Sprachkennzeichen. Bitte verwenden Sie einen Wert aus den Aufzählungen MSLanguageId oder MacLanguageId, abhängig vom Kontext, definiert durch den Parameter platformId. |
+| Name | java.lang.String | Tatsächliche String-Daten. |
+
+### deleteRecords(PlatformId platformId, int platformSpecificId) {#deleteRecords-com.aspose.font.PlatformId-int-}
+```
+public void deleteRecords(PlatformId platformId, int platformSpecificId)
+```
+
+
+Löscht alle Datensätze, die zur angegebenen Plattform gehören.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Plattform‑Bezeichner |
+| platformSpecificId | int | Plattform‑spezifischer Kodierungsbezeichner |
+
+### deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId) {#deleteRecords-com.aspose.font.PlatformId-int-com.aspose.font.NameId-}
+```
+public void deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId)
+```
+
+
+Löscht alle Datensätze, die zu den übergebenen Parametern gehören.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Plattform‑Bezeichner |
+| platformSpecificId | int | Plattform‑spezifischer Kodierungsbezeichner |
+| nameId | [NameId](../../com.aspose.font/nameid) | Namensbezeichner, logische Zeichenkettenkategorie, angegeben durch die  NameId‑Aufzählung |
+
+### deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId) {#deleteRecords-com.aspose.font.PlatformId-int-com.aspose.font.NameId-int-}
+```
+public void deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId)
+```
+
+
+Löscht Datensatz(e), die zu den angegebenen Parametern gehören.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Plattform‑Bezeichner |
+| platformSpecificId | int | Plattform‑spezifischer Kodierungsbezeichner |
+| nameId | [NameId](../../com.aspose.font/nameid) | Namensbezeichner, logische Zeichenkettenkategorie, angegeben durch die  NameId‑Aufzählung |
+| languageId | int | Sprachkennung |
+
+### deleteRecordsByNameId(NameId nameId) {#deleteRecordsByNameId-com.aspose.font.NameId-}
+```
+public void deleteRecordsByNameId(NameId nameId)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllNameRecords() {#getAllNameRecords--}
+```
+public NameRecord[] getAllNameRecords()
+```
+
+
+Gibt alle  NameRecord‑Strukturen aus der Tabelle zurück.
+
+**Returns:**
+com.aspose.font.NameRecord[] – Alle NameRecord-Strukturen aus der Tabelle.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMultiLanguageNameById(NameId nameId) {#getMultiLanguageNameById-com.aspose.font.NameId-}
+```
+public MultiLanguageString getMultiLanguageNameById(NameId nameId)
+```
+
+
+Gibt einen Namen anhand von nameId zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Name-ID. |
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - name
+### getMultiLanguageNameById(NameId nameId, PlatformId platformId) {#getMultiLanguageNameById-com.aspose.font.NameId-com.aspose.font.PlatformId-}
+```
+public MultiLanguageString getMultiLanguageNameById(NameId nameId, PlatformId platformId)
+```
+
+
+Gibt einen Namen anhand von nameId zurück, wobei der übergebene Plattform‑Bezeichner verwendet wird.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Name-ID. |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Plattform‑Id. |
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Name.
+### getMultiLanguageNameById(NameId nameId, PlatformId platformId, int platformSpecificId) {#getMultiLanguageNameById-com.aspose.font.NameId-com.aspose.font.PlatformId-int-}
+```
+public MultiLanguageString getMultiLanguageNameById(NameId nameId, PlatformId platformId, int platformSpecificId)
+```
+
+
+Gibt einen Namen als Objekt des Typs MultiLanguageString zurück. Die Methode sammelt alle NameRecord-Strukturen, die mit den übergebenen Parametern nameId, platformId und platformSpecificId übereinstimmen, und erstellt dann ein Ergebnisobjekt basierend auf dieser Strukturliste.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Name-ID. |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Plattform‑Id. |
+| platformSpecificId | int | Plattform-spezifische ID. |
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Name.
+### getNameById(NameId nameId) {#getNameById-com.aspose.font.NameId-}
+```
+public String getNameById(NameId nameId)
+```
+
+
+Gibt einen Namen anhand von nameId zurück, falls gefunden, sonst null.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Namenskennzeichen |
+
+**Returns:**
+java.lang.String – name
+### getNameRecordsByNameId(NameId nameId) {#getNameRecordsByNameId-com.aspose.font.NameId-}
+```
+public NameRecord[] getNameRecordsByNameId(NameId nameId)
+```
+
+
+Gibt alle NameRecord-Strukturen zurück, deren NameId-Feld dem übergebenen nameId-Wert entspricht. Wenn keine Datensätze gefunden werden, wird ein leeres Array zurückgegeben.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Namenskennzeichen |
+
+**Returns:**
+com.aspose.font.NameRecord[] – Array von NameRecord-Strukturen
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Tabellen‑Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### updateName(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId, String newName) {#updateName-com.aspose.font.PlatformId-int-com.aspose.font.NameId-int-java.lang.String-}
+```
+public void updateName(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId, String newName)
+```
+
+
+Aktualisiert den Namen in Datensatz(en), die zur angegebenen Plattform (Kombination aus platformId und platformSpecificId), Kategorie (nameId) und Sprache (languageId) gehören.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Plattform‑Bezeichner |
+| platformSpecificId | int | Plattform‑spezifischer Kodierungsbezeichner |
+| nameId | [NameId](../../com.aspose.font/nameid) | Namensbezeichner, logische Zeichenkettenkategorie, angegeben durch die  NameId‑Aufzählung |
+| languageId | int | Sprachkennung |
+| newName | java.lang.String | Neuer Name oder neue String-Daten |
+
+### updateNamesByNameId(NameId nameId, String newName) {#updateNamesByNameId-com.aspose.font.NameId-java.lang.String-}
+```
+public void updateNamesByNameId(NameId nameId, String newName)
+```
+
+
+Wählt alle Datensätze aus, die mit der logischen String‑Kategorie, angegeben durch den Parameter nameId, zusammenhängen, und aktualisiert das Namensfeld (String‑Daten) in diesen Datensätzen. Felder, die die Plattform (platformID, Plattform‑spezifische Kodierungs‑ID) und die Sprache (Language ID) betreffen, werden von dieser Methode nicht beeinflusst. Nur die String‑Daten des Namens werden durch einen neuen Namen ersetzt. Verwenden Sie diese Methode mit Vorsicht, da sie die ursprünglichen Namen für alle Plattformen und Sprachen, die zu nameId gehören, ersetzt. Es kann zu Konflikten führen, wenn die ursprünglichen Namen unterschiedliche Werte hatten, da der Ersetzungsvorgang all diese Werte durch einen einzigen neuen Wert ändert. Und dieser neue Wert kann eine logische Inkonsistenz mit einigen Plattformen und Sprachen aufweisen. Diese Methode ist nützlich für Fälle, in denen der ursprüngliche Name eine einheitliche Darstellung für alle Plattformen und Sprachen hat, zum Beispiel wenn die String‑Daten des Namens in englischer Sprache vorliegen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Namensbezeichner, logische Zeichenkettenkategorie, angegeben durch die  NameId‑Aufzählung |
+| newName | java.lang.String | Neuer Name oder neue String-Daten |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfos2table/_index.md
+++ b/german/java/com.aspose.font/ttfos2table/_index.md
@@ -1,0 +1,578 @@
+---
+title: "TtfOs2Table"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die OS/2-Tabelle der TTF-Schriftdatei dar."
+type: docs
+weight: 106
+url: /de/java/com.aspose.font/ttfos2table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfOs2Table extends TtfTableBase
+```
+
+Stellt die "OS/2"-Tabelle der TTF-Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAchVendId()](#getAchVendId--) | Ruft den AchVendId-Wert ab. |
+| [getClass()](#getClass--) |  |
+| [getFSSelection()](#getFSSelection--) | Enthält Informationen über die Beschaffenheit der Schriftmuster. |
+| [getFSType()](#getFSType--) | Ruft den FSType-Wert ab. |
+| [getLicenseFlags()](#getLicenseFlags--) | Ruft eingebettete Flags (fsType) in der Objektrepräsentation ab. |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getPanose()](#getPanose--) | Diese 10-Byte‑Zahlenreihe wird verwendet, um die visuellen Merkmale einer bestimmten Schriftart zu beschreiben. |
+| [getSCapHeight()](#getSCapHeight--) | Ruft den SCapHeight-Wert ab. |
+| [getSFamilyClass()](#getSFamilyClass--) | Dieser Parameter ist eine Klassifizierung des Schriftfamilien-Designs. |
+| [getSTypoAscender()](#getSTypoAscender--) | Ruft den STypoAscender-Wert ab. |
+| [getSTypoDescender()](#getSTypoDescender--) | Ruft den STypoDescender-Wert ab. |
+| [getSTypoLineGap()](#getSTypoLineGap--) | Ruft den STypoLineGap-Wert ab. |
+| [getSXHeight()](#getSXHeight--) | Ruft den SXHeight-Wert ab. |
+| [getSupportedTableVersions()](#getSupportedTableVersions--) | Ruft die unterstützten Versionen der OS/2-Tabelle ab. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [getULCodePageRange()](#getULCodePageRange--) | Ruft den ULCodePageRange-Wert ab. |
+| [getULUnicodeRange()](#getULUnicodeRange--) | Ruft den ULUnicodeRange-Wert ab. |
+| [getUSBreakChar()](#getUSBreakChar--) | Ruft den USBreakChar-Wert ab. |
+| [getUSDefaultChar()](#getUSDefaultChar--) | Ruft den USDefaultChar-Wert ab. |
+| [getUSFirstCharIndex()](#getUSFirstCharIndex--) | Ruft den USFirstCharIndex-Wert ab. |
+| [getUSLastCharIndex()](#getUSLastCharIndex--) | Ruft den USLastCharIndex-Wert ab. |
+| [getUSLowerOpticalPointSize()](#getUSLowerOpticalPointSize--) | Ruft den USLowerOpticalPointSize-Wert ab. |
+| [getUSMaxContext()](#getUSMaxContext--) | Ruft den USMaxContext-Wert ab. |
+| [getUSUpperOpticalPointSize()](#getUSUpperOpticalPointSize--) | Ruft den USUpperOpticalPointSize-Wert ab. |
+| [getUSWeightClass()](#getUSWeightClass--) | Gibt das visuelle Gewicht (Grad der Schwärzung oder Strichstärke) der Zeichen in der Schrift an. |
+| [getUSWidthClass()](#getUSWidthClass--) | Gibt eine relative Änderung des normalen Seitenverhältnisses (Breite‑zu‑Höhe‑Verhältnis) an, wie sie von einem Schriftgestalter für die Glyphen einer Schrift festgelegt wurde. |
+| [getUSWinAscent()](#getUSWinAscent--) | Ruft den USWinAscent-Wert ab. |
+| [getUSWinDescent()](#getUSWinDescent--) | Ruft den USWinDescent-Wert ab. |
+| [getVersion()](#getVersion--) | Ruft den Versionswert ab. |
+| [getXAvgCharWidth()](#getXAvgCharWidth--) | Ruft den Parameter für die durchschnittliche Zeichenbreite ab. |
+| [getYStrikeoutPosition()](#getYStrikeoutPosition--) | Ruft den Wert YStrikeoutPosition ab. |
+| [getYStrikeoutSize()](#getYStrikeoutSize--) | Ruft den Wert YStrikeoutSize ab. |
+| [getYSubscriptXOffset()](#getYSubscriptXOffset--) | Ruft den Wert YSubscriptXOffset ab. |
+| [getYSubscriptXSize()](#getYSubscriptXSize--) | Ruft den Wert YSubscriptXSize ab. |
+| [getYSubscriptYOffset()](#getYSubscriptYOffset--) | Ruft den Wert YSubscriptYOffset ab. |
+| [getYSubscriptYSize()](#getYSubscriptYSize--) | Ruft den Wert YSubscriptYSize ab. |
+| [getYSuperscriptXOffset()](#getYSuperscriptXOffset--) | Ruft den Wert YSuperscriptXOffset ab. |
+| [getYSuperscriptXSize()](#getYSuperscriptXSize--) | Ruft den Wert YSuperscriptXSize ab. |
+| [getYSuperscriptYOffset()](#getYSuperscriptYOffset--) | Ruft den Wert YSuperscriptYOffset ab. |
+| [getYSuperscriptYSize()](#getYSuperscriptYSize--) | Ruft den Wert YSuperscriptYSize ab. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAchVendId() {#getAchVendId--}
+```
+public byte[] getAchVendId()
+```
+
+
+Ruft den AchVendId-Wert ab.
+
+**Returns:**
+byte[] - AchVendId-Wert.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFSSelection() {#getFSSelection--}
+```
+public int getFSSelection()
+```
+
+
+Enthält Informationen über die Beschaffenheit der Schriftmuster.
+
+> ```
+> 0	bit 1	ITALIC	Font contains Italic characters, otherwise they are upright.
+>  1	 	    UNDERSCORE	Characters are underscored.
+>  2	 	    NEGATIVE	Characters have their foreground and background reversed.
+>  3	 	    OUTLINED	Outline (hollow) characters, otherwise they are solid.
+>  4	 	    STRIKEOUT	Characters are overstruck.
+>  5	bit 0	BOLD	Characters are emboldened.
+>  6	 	    REGULAR	Characters are in the standard weight/style for the font.
+> ```
+
+**Returns:**
+int - Die Information.
+### getFSType() {#getFSType--}
+```
+public int getFSType()
+```
+
+
+Ruft den FSType-Wert ab.
+
+--------------------
+
+Gibt die Lizenzrechte für das Einbetten der Schriftart an.
+
+**Returns:**
+int - FSType-Wert.
+### getLicenseFlags() {#getLicenseFlags--}
+```
+public LicenseFlags getLicenseFlags()
+```
+
+
+Ruft eingebettete Flags (fsType) in der Objektrepräsentation ab.
+
+**Returns:**
+[LicenseFlags](../../com.aspose.font/licenseflags) - Embedded flags.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getPanose() {#getPanose--}
+```
+public byte[] getPanose()
+```
+
+
+Diese 10‑Byte‑Reihe von Zahlen wird verwendet, um die visuellen Merkmale eines bestimmten Schriftsatzes zu beschreiben. Diese Merkmale werden anschließend genutzt, um die Schriftart mit anderen Schriftarten ähnlichen Aussehens, aber unterschiedlicher Namen, zu verknüpfen.
+
+**Returns:**
+byte[] - Die visuellen Merkmale eines bestimmten Schriftsatzes.
+### getSCapHeight() {#getSCapHeight--}
+```
+public short getSCapHeight()
+```
+
+
+Ruft den SCapHeight-Wert ab.
+
+**Returns:**
+short - SCapHeight-Wert.
+### getSFamilyClass() {#getSFamilyClass--}
+```
+public short getSFamilyClass()
+```
+
+
+Dieser Parameter ist eine Klassifizierung des Schriftfamilien‑Designs. Die Schriftklasse und die Schriftunterklasse sind von IBM für jede Schriftfamilie registrierte Werte. Dieser Parameter ist dafür vorgesehen, bei Nichtverfügbarkeit der angeforderten Schriftart eine alternative Schriftart auszuwählen.
+
+**Returns:**
+short - Klassifizierung des Schriftfamilien‑Designs.
+### getSTypoAscender() {#getSTypoAscender--}
+```
+public short getSTypoAscender()
+```
+
+
+Ruft den STypoAscender-Wert ab.
+
+**Returns:**
+short - STypoAscender-Wert.
+### getSTypoDescender() {#getSTypoDescender--}
+```
+public short getSTypoDescender()
+```
+
+
+Ruft den STypoDescender-Wert ab.
+
+**Returns:**
+short - STypoDescender-Wert.
+### getSTypoLineGap() {#getSTypoLineGap--}
+```
+public short getSTypoLineGap()
+```
+
+
+Ruft den STypoLineGap-Wert ab.
+
+**Returns:**
+short - STypoLineGap-Wert.
+### getSXHeight() {#getSXHeight--}
+```
+public short getSXHeight()
+```
+
+
+Ruft den SXHeight-Wert ab.
+
+**Returns:**
+short - SXHeight-Wert.
+### getSupportedTableVersions() {#getSupportedTableVersions--}
+```
+public int[] getSupportedTableVersions()
+```
+
+
+Ruft die unterstützten Versionen der OS/2-Tabelle ab.
+
+**Returns:**
+int[] - Unterstützte Versionen der OS/2‑Tabelle.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Tabellen‑Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getULCodePageRange() {#getULCodePageRange--}
+```
+public long[] getULCodePageRange()
+```
+
+
+Ruft den ULCodePageRange-Wert ab.
+
+**Returns:**
+long[] - ULCodePageRange‑Wert.
+### getULUnicodeRange() {#getULUnicodeRange--}
+```
+public long[] getULUnicodeRange()
+```
+
+
+Ruft den ULUnicodeRange-Wert ab.
+
+**Returns:**
+long[] - ULUnicodeRange‑Wert.
+### getUSBreakChar() {#getUSBreakChar--}
+```
+public int getUSBreakChar()
+```
+
+
+Ruft den USBreakChar-Wert ab.
+
+**Returns:**
+int - USBreakChar‑Wert.
+### getUSDefaultChar() {#getUSDefaultChar--}
+```
+public int getUSDefaultChar()
+```
+
+
+Ruft den USDefaultChar-Wert ab.
+
+**Returns:**
+int - USDefaultChar‑Wert.
+### getUSFirstCharIndex() {#getUSFirstCharIndex--}
+```
+public int getUSFirstCharIndex()
+```
+
+
+Ruft den USFirstCharIndex-Wert ab.
+
+**Returns:**
+int - USFirstCharIndex‑Wert.
+### getUSLastCharIndex() {#getUSLastCharIndex--}
+```
+public int getUSLastCharIndex()
+```
+
+
+Ruft den USLastCharIndex-Wert ab.
+
+**Returns:**
+int - USLastCharIndex‑Wert.
+### getUSLowerOpticalPointSize() {#getUSLowerOpticalPointSize--}
+```
+public int getUSLowerOpticalPointSize()
+```
+
+
+Ruft den USLowerOpticalPointSize-Wert ab.
+
+**Returns:**
+int - Der USLowerOpticalPointSize‑Wert.
+### getUSMaxContext() {#getUSMaxContext--}
+```
+public int getUSMaxContext()
+```
+
+
+Ruft den USMaxContext-Wert ab.
+
+**Returns:**
+int - UsMaxContext‑Wert.
+### getUSUpperOpticalPointSize() {#getUSUpperOpticalPointSize--}
+```
+public int getUSUpperOpticalPointSize()
+```
+
+
+Ruft den USUpperOpticalPointSize-Wert ab.
+
+**Returns:**
+int - Der USUpperOpticalPointSize‑Wert.
+### getUSWeightClass() {#getUSWeightClass--}
+```
+public int getUSWeightClass()
+```
+
+
+Gibt das visuelle Gewicht (Grad der Schwärzung oder Strichstärke) der Zeichen in der Schrift an.
+
+**Returns:**
+int - Das visuelle Gewicht (Grad der Schwärze oder Strichstärke) der Zeichen in der Font.
+### getUSWidthClass() {#getUSWidthClass--}
+```
+public int getUSWidthClass()
+```
+
+
+Gibt eine relative Änderung des normalen Seitenverhältnisses (Breite‑zu‑Höhe‑Verhältnis) an, wie sie von einem Schriftgestalter für die Glyphen einer Schrift festgelegt wurde.
+
+**Returns:**
+int - Eine relative Änderung des normalen Seitenverhältnisses (Breite‑zu‑Höhe‑Verhältnis), wie von einem Schriftgestalter für die Glyphen in einer Font angegeben.
+### getUSWinAscent() {#getUSWinAscent--}
+```
+public int getUSWinAscent()
+```
+
+
+Ruft den USWinAscent-Wert ab.
+
+**Returns:**
+int - USWinAscent‑Wert.
+### getUSWinDescent() {#getUSWinDescent--}
+```
+public int getUSWinDescent()
+```
+
+
+Ruft den USWinDescent-Wert ab.
+
+**Returns:**
+int - USWinDescent‑Wert.
+### getVersion() {#getVersion--}
+```
+public int getVersion()
+```
+
+
+Ruft den Versionswert ab.
+
+**Returns:**
+int - Versionswert.
+### getXAvgCharWidth() {#getXAvgCharWidth--}
+```
+public short getXAvgCharWidth()
+```
+
+
+Ruft den Parameter für die durchschnittliche Zeichenbreite ab.
+
+**Returns:**
+short - Der Parameter für die durchschnittliche Zeichenbreite.
+### getYStrikeoutPosition() {#getYStrikeoutPosition--}
+```
+public short getYStrikeoutPosition()
+```
+
+
+Ruft den Wert YStrikeoutPosition ab.
+
+**Returns:**
+short - YStrikeoutPosition‑Wert.
+### getYStrikeoutSize() {#getYStrikeoutSize--}
+```
+public short getYStrikeoutSize()
+```
+
+
+Ruft den Wert YStrikeoutSize ab.
+
+**Returns:**
+short - YStrikeoutSize‑Wert.
+### getYSubscriptXOffset() {#getYSubscriptXOffset--}
+```
+public short getYSubscriptXOffset()
+```
+
+
+Ruft den Wert YSubscriptXOffset ab.
+
+**Returns:**
+short - YSubscriptXOffset‑Wert.
+### getYSubscriptXSize() {#getYSubscriptXSize--}
+```
+public short getYSubscriptXSize()
+```
+
+
+Ruft den Wert YSubscriptXSize ab.
+
+**Returns:**
+short - YSubscriptXSize‑Wert.
+### getYSubscriptYOffset() {#getYSubscriptYOffset--}
+```
+public short getYSubscriptYOffset()
+```
+
+
+Ruft den Wert YSubscriptYOffset ab.
+
+**Returns:**
+short - YSubscriptYOffset‑Wert.
+### getYSubscriptYSize() {#getYSubscriptYSize--}
+```
+public short getYSubscriptYSize()
+```
+
+
+Ruft den Wert YSubscriptYSize ab.
+
+**Returns:**
+short - YSubscriptYSize‑Wert.
+### getYSuperscriptXOffset() {#getYSuperscriptXOffset--}
+```
+public short getYSuperscriptXOffset()
+```
+
+
+Ruft den Wert YSuperscriptXOffset ab.
+
+**Returns:**
+short - YSuperscriptXOffset‑Wert.
+### getYSuperscriptXSize() {#getYSuperscriptXSize--}
+```
+public short getYSuperscriptXSize()
+```
+
+
+Ruft den Wert YSuperscriptXSize ab.
+
+**Returns:**
+short - YSuperscriptXSize‑Wert.
+### getYSuperscriptYOffset() {#getYSuperscriptYOffset--}
+```
+public short getYSuperscriptYOffset()
+```
+
+
+Ruft den Wert YSuperscriptYOffset ab.
+
+**Returns:**
+short - YSuperscriptYOffset‑Wert.
+### getYSuperscriptYSize() {#getYSuperscriptYSize--}
+```
+public short getYSuperscriptYSize()
+```
+
+
+Ruft den Wert YSuperscriptYSize ab.
+
+**Returns:**
+Kurz - YSuperscriptYSize Wert.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfposttable/_index.md
+++ b/german/java/com.aspose.font/ttfposttable/_index.md
@@ -1,0 +1,326 @@
+---
+title: "TtfPostTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die post-Tabelle der TTF-Schriftdatei dar"
+type: docs
+weight: 107
+url: /de/java/com.aspose.font/ttfposttable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfPostTable extends TtfTableBase
+```
+
+Stellt die "post"-Tabelle der TTF-Schriftdatei dar
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIndexesForGlyphName(String glyphName)](#getAllGlyphIndexesForGlyphName-java.lang.String-) | Liefert ein Array von Glyphenindizes nach Glyphennamen |
+| [getClass()](#getClass--) |  |
+| [getFormat()](#getFormat--) | Liefert das feste Format (Version) dieser Tabelle. |
+| [getGlyphIndex(String glyphName)](#getGlyphIndex-java.lang.String-) | Liefert den Glyphenindex nach Glyphennamen. |
+| [getGlyphName(long glyphIndex)](#getGlyphName-long-) | Liefert den Glyphennamen nach Glyphenindex. |
+| [getItalicAngle()](#getItalicAngle--) | Liest den festen italicAngle Italic-Winkel in Grad. |
+| [getMaxMemType1()](#getMaxMemType1--) | Liest uint32 maxMemType1 Maximale Speichernutzung, wenn eine TrueType-Schrift als Type-1-Schrift heruntergeladen wird. |
+| [getMaxMemType42()](#getMaxMemType42--) | Liest uint32 maxMemType42 Maximale Speichernutzung, wenn eine TrueType-Schrift als Type-42-Schrift heruntergeladen wird. |
+| [getMinMemType1()](#getMinMemType1--) | Liest uint32 minMemType1 Minimale Speichernutzung, wenn eine TrueType-Schrift als Type-1-Schrift heruntergeladen wird. |
+| [getMinMemType42()](#getMinMemType42--) | Liest uint32 minMemType42 Minimale Speichernutzung, wenn eine TrueType-Schrift als Type-42-Schrift heruntergeladen wird. |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getTableFormat()](#getTableFormat--) | Liest das feste Format (Version) dieser Tabelle. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [getUnderlinePosition()](#getUnderlinePosition--) | Liest FWord underlinePosition Unterstreichungsposition. |
+| [getUnderlineThickness()](#getUnderlineThickness--) | Liest FWord underlineThickness Unterstreichungsstärke. |
+| [hasNoPostScriptNames()](#hasNoPostScriptNames--) | Gibt an, dass keine PostScript‑Namensinformationen für die Glyphen in dieser Schriftdatei bereitgestellt werden. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Liest uint32 isFixedPitch. 0, wenn die Schrift proportional proportioniert ist, ungleich Null, wenn die Schrift nicht proportional proportioniert ist (d. h. monospaced). |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIndexesForGlyphName(String glyphName) {#getAllGlyphIndexesForGlyphName-java.lang.String-}
+```
+public long[] getAllGlyphIndexesForGlyphName(String glyphName)
+```
+
+
+Liefert ein Array von Glyphenindizes nach Glyphennamen
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphName | java.lang.String | Glyph-Name |
+
+**Returns:**
+long[] – Array von Glyphen‑Indizes
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFormat() {#getFormat--}
+```
+public float getFormat()
+```
+
+
+Liefert das feste Format (Version) dieser Tabelle.
+
+**Returns:**
+float – Festes Format (Version) dieser Tabelle.
+### getGlyphIndex(String glyphName) {#getGlyphIndex-java.lang.String-}
+```
+public long getGlyphIndex(String glyphName)
+```
+
+
+Liefert den Glyphenindex nach Glyphennamen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphName | java.lang.String | Glyph-Name. |
+
+**Returns:**
+long – Glyphen‑Index. Wenn keine PostScript‑Namensinformationen für die Glyphen in dieser Schriftdatei bereitgestellt werden, wird der Index 0 zurückgegeben, der das undefinierte Glyph oder das ".notdef"‑Glyph ist.
+### getGlyphName(long glyphIndex) {#getGlyphName-long-}
+```
+public String getGlyphName(long glyphIndex)
+```
+
+
+Liefert den Glyphennamen nach Glyphenindex.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphIndex | long | Glyph-Index. |
+
+**Returns:**
+java.lang.String – Glyph‑Name. Wenn keine PostScript‑Namensinformationen für die Glyphen in dieser Schriftdatei bereitgestellt werden, wird null zurückgegeben.
+### getItalicAngle() {#getItalicAngle--}
+```
+public float getItalicAngle()
+```
+
+
+Liest den festen italicAngle Italic-Winkel in Grad.
+
+**Returns:**
+float – Festes italicAngle Italic‑Winkel in Grad.
+### getMaxMemType1() {#getMaxMemType1--}
+```
+public long getMaxMemType1()
+```
+
+
+Liest uint32 maxMemType1 Maximale Speichernutzung, wenn eine TrueType-Schrift als Type-1-Schrift heruntergeladen wird.
+
+**Returns:**
+long – UInt32 maxMemType1 Maximale Speichernutzung, wenn eine TrueType‑Schrift als Type‑1‑Schrift heruntergeladen wird.
+### getMaxMemType42() {#getMaxMemType42--}
+```
+public long getMaxMemType42()
+```
+
+
+Liest uint32 maxMemType42 Maximale Speichernutzung, wenn eine TrueType-Schrift als Type-42-Schrift heruntergeladen wird.
+
+**Returns:**
+long – UInt32 maxMemType42 Maximale Speichernutzung, wenn eine TrueType‑Schrift als Type‑42‑Schrift heruntergeladen wird.
+### getMinMemType1() {#getMinMemType1--}
+```
+public long getMinMemType1()
+```
+
+
+Liest uint32 minMemType1 Minimale Speichernutzung, wenn eine TrueType-Schrift als Type-1-Schrift heruntergeladen wird.
+
+**Returns:**
+long – UInt32 minMemType1 Minimale Speichernutzung, wenn eine TrueType‑Schrift als Type‑1‑Schrift heruntergeladen wird.
+### getMinMemType42() {#getMinMemType42--}
+```
+public long getMinMemType42()
+```
+
+
+Liest uint32 minMemType42 Minimale Speichernutzung, wenn eine TrueType-Schrift als Type-42-Schrift heruntergeladen wird.
+
+**Returns:**
+long – UInt32 minMemType42 Minimale Speichernutzung, wenn eine TrueType‑Schrift als Type‑42‑Schrift heruntergeladen wird.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getTableFormat() {#getTableFormat--}
+```
+public Version16Dot16 getTableFormat()
+```
+
+
+Liest das feste Format (Version) dieser Tabelle. Verwenden Sie die Eigenschaften MajorNumber und MinorNumber des Objekts Version16Dot16 in hexadezimaler Schreibweise, um die verwendete Version zu ermitteln.
+
+**Returns:**
+[Version16Dot16](../../com.aspose.font/version16dot16) - Fixed format (version) of this table.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Tabellen‑Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getUnderlinePosition() {#getUnderlinePosition--}
+```
+public short getUnderlinePosition()
+```
+
+
+Liest FWord underlinePosition Unterstreichungsposition.
+
+**Returns:**
+short – FWord underlinePosition Unterstreichungsposition.
+### getUnderlineThickness() {#getUnderlineThickness--}
+```
+public short getUnderlineThickness()
+```
+
+
+Liest FWord underlineThickness Unterstreichungsstärke.
+
+**Returns:**
+short – FWord underlineThickness Unterstreichungsstärke.
+### hasNoPostScriptNames() {#hasNoPostScriptNames--}
+```
+public boolean hasNoPostScriptNames()
+```
+
+
+Gibt an, dass keine PostScript‑Namensinformationen für die Glyphen in dieser Schriftdatei bereitgestellt werden.
+
+**Returns:**
+boolean – Wahr, wenn keine PostScript‑Namensinformationen für die Glyphen in dieser Schriftdatei bereitgestellt werden; sonst falsch.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public long isFixedPitch()
+```
+
+
+Liest uint32 isFixedPitch. 0, wenn die Schrift proportional proportioniert ist, ungleich Null, wenn die Schrift nicht proportional proportioniert ist (d. h. monospaced).
+
+**Returns:**
+long – UInt32 isFixedPitch. 0, wenn die Schrift proportional proportioniert ist, ungleich Null, wenn die Schrift nicht proportional proportioniert ist (d. h. monospaced).
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfpreptable/_index.md
+++ b/german/java/com.aspose.font/ttfpreptable/_index.md
@@ -1,0 +1,168 @@
+---
+title: "TtfPrepTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Prep-Tabelle der TTF-Schriftdatei dar."
+type: docs
+weight: 108
+url: /de/java/com.aspose.font/ttfpreptable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfPrepTable extends TtfTableBase
+```
+
+Stellt die "prep"-Tabelle der TTF-Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getProgram()](#getProgram--) | Satz von Anweisungen. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getProgram() {#getProgram--}
+```
+public byte[] getProgram()
+```
+
+
+Satz von Anweisungen.
+
+**Returns:**
+byte[] - Satz von Anweisungen.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Tabellen‑Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfstattable/_index.md
+++ b/german/java/com.aspose.font/ttfstattable/_index.md
@@ -1,0 +1,267 @@
+---
+title: "TtfStatTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: 
+type: docs
+weight: 109
+url: /de/java/com.aspose.font/ttfstattable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfStatTable extends TtfTableBase
+```
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addAxisRecord(AxisRecord axisRecord)](#addAxisRecord-com.aspose.font.AxisRecord-) | Fügt der Tabelle eine Achsenaufzeichnungsstruktur hinzu. |
+| [addAxisValueTable(AxisValueTableBase axisValueTable)](#addAxisValueTable-com.aspose.font.AxisValueTableBase-) | Fügt der Tabelle eine Achsenwerttabellenstruktur hinzu. |
+| [clearAxisRecords()](#clearAxisRecords--) | Entfernt alle Achsenaufzeichnungen aus der Tabelle. |
+| [clearAxisValueTables()](#clearAxisValueTables--) | Entfernt alle Achsenwerttabellen aus der Tabelle. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisRecords()](#getAxisRecords--) | Gibt das Array der Designachsen zurück. |
+| [getAxisValueCount()](#getAxisValueCount--) | Gibt die Anzahl der Achsenwerttabellen zurück. |
+| [getAxisValueTables()](#getAxisValueTables--) | Gibt ein Array von Achsenwerttabellen zurück. |
+| [getClass()](#getClass--) |  |
+| [getDesignAxisCount()](#getDesignAxisCount--) | Gibt die Anzahl der Achsenaufzeichnungen zurück. |
+| [getElidedFallbackName()](#getElidedFallbackName--) | Spez.: Name, der als Rückfall verwendet wird, wenn die Projektion von Namen in ein bestimmtes Schriftmodell einen Unterschriftennamen erzeugt, der nur aus entfernbaren Elementen besteht. |
+| [getElidedFallbackNameId()](#getElidedFallbackNameId--) | Spez.: Namens-ID, die als Rückfall verwendet wird, wenn die Projektion von Namen in ein bestimmtes Schriftmodell einen Unterschriftennamen erzeugt, der nur aus entfernbaren Elementen besteht. |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### addAxisRecord(AxisRecord axisRecord) {#addAxisRecord-com.aspose.font.AxisRecord-}
+```
+public void addAxisRecord(AxisRecord axisRecord)
+```
+
+
+Fügt der Tabelle eine Achsenaufzeichnungsstruktur hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| axisRecord | [AxisRecord](../../com.aspose.font/axisrecord) | AxisRecord-Struktur |
+
+### addAxisValueTable(AxisValueTableBase axisValueTable) {#addAxisValueTable-com.aspose.font.AxisValueTableBase-}
+```
+public void addAxisValueTable(AxisValueTableBase axisValueTable)
+```
+
+
+Fügt der Tabelle eine Achsenwerttabellenstruktur hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| axisValueTable | [AxisValueTableBase](../../com.aspose.font/axisvaluetablebase) | Achsenwerttabellenstruktur |
+
+### clearAxisRecords() {#clearAxisRecords--}
+```
+public void clearAxisRecords()
+```
+
+
+Entfernt alle Achsenaufzeichnungen aus der Tabelle.
+
+### clearAxisValueTables() {#clearAxisValueTables--}
+```
+public void clearAxisValueTables()
+```
+
+
+Entfernt alle Achsenwerttabellen aus der Tabelle.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisRecords() {#getAxisRecords--}
+```
+public AxisRecord[] getAxisRecords()
+```
+
+
+Gibt das Array der Designachsen zurück. Das Achsenarray ist ein Array von Strukturen des Typs Axis Record. Spez.: Die Achsenaufzeichnung liefert Informationen über eine einzelne Designachse.
+
+**Returns:**
+com.aspose.font.AxisRecord[] - Das Designachsen-Array.
+### getAxisValueCount() {#getAxisValueCount--}
+```
+public int getAxisValueCount()
+```
+
+
+Gibt die Anzahl der Achsenwerttabellen zurück.
+
+**Returns:**
+int - Die Anzahl der Achsenwerttabellen.
+### getAxisValueTables() {#getAxisValueTables--}
+```
+public AxisValueTableBase[] getAxisValueTables()
+```
+
+
+Gibt ein Array von Achsenwerttabellen zurück. Spez.: Achsenwerttabellen liefern Details zu einem bestimmten Stil-Attributwert auf einer bestimmten Achse der Designvariation oder einer Kombination von Designvariations-Achsenwerten sowie die Beziehung dieser Werte zu Bezeichnungen, die als Elemente in Unterschriftennamen verwendet werden.
+
+**Returns:**
+com.aspose.font.AxisValueTableBase[] - Das Array der Achsenwerttabellen.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDesignAxisCount() {#getDesignAxisCount--}
+```
+public int getDesignAxisCount()
+```
+
+
+Gibt die Anzahl der Achsen‑Datensätze zurück. Spezifikation: In einer Schrift mit einer 'fvar'-Tabelle muss dieser Wert größer oder gleich dem axisCount‑Wert in der 'fvar'-Tabelle sein. In allen Schriften muss er größer als null sein, wenn axisValueCount größer als null ist.
+
+**Returns:**
+int - Die Anzahl der Achsen‑Datensätze.
+### getElidedFallbackName() {#getElidedFallbackName--}
+```
+public String getElidedFallbackName()
+```
+
+
+Spez.: Name, der als Rückfall verwendet wird, wenn die Projektion von Namen in ein bestimmtes Schriftmodell einen Unterschriftennamen erzeugt, der nur aus entfernbaren Elementen besteht.
+
+**Returns:**
+java.lang.String - Der Name, der als Rückfall verwendet wird, wenn die Projektion von Namen in ein bestimmtes Schriftmodell einen Unterfamiliennamen erzeugt, der nur entfernbare Elemente enthält.
+### getElidedFallbackNameId() {#getElidedFallbackNameId--}
+```
+public int getElidedFallbackNameId()
+```
+
+
+Spez.: Namens-ID, die als Rückfall verwendet wird, wenn die Projektion von Namen in ein bestimmtes Schriftmodell einen Unterschriftennamen erzeugt, der nur aus entfernbaren Elementen besteht.
+
+**Returns:**
+int - Die Namens‑ID.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Tabellen‑Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttftablebase/_index.md
+++ b/german/java/com.aspose.font/ttftablebase/_index.md
@@ -1,0 +1,146 @@
+---
+title: "TtfTableBase"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die TTF-Tabellendefinition dar."
+type: docs
+weight: 110
+url: /de/java/com.aspose.font/ttftablebase/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TtfTableBase
+```
+
+Stellt die TTF-Tabellendefinition dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttftablerepository/_index.md
+++ b/german/java/com.aspose.font/ttftablerepository/_index.md
@@ -1,0 +1,333 @@
+---
+title: "TtfTableRepository"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Repository der TTF-Tabellen"
+type: docs
+weight: 111
+url: /de/java/com.aspose.font/ttftablerepository/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TtfTableRepository
+```
+
+Repository der TTF-Tabellen
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCMapTable()](#getCMapTable--) | Liest die cmap-Tabelle. |
+| [getCffTable()](#getCffTable--) | Liest die cff-Tabelle. |
+| [getClass()](#getClass--) |  |
+| [getCvtTable()](#getCvtTable--) | Liest die cvt-Tabelle. |
+| [getFpgmTable()](#getFpgmTable--) | Liest die fpgm-Tabelle. |
+| [getGaspTable()](#getGaspTable--) | Liest die GASP-Tabelle. |
+| [getGlyfTable()](#getGlyfTable--) | Liest die glyf-Tabelle. |
+| [getHeadTable()](#getHeadTable--) | Liest die head-Tabelle. |
+| [getHheaTable()](#getHheaTable--) | Liest die hhea-Tabelle. |
+| [getHmtxTable()](#getHmtxTable--) | Liest die hmtx-Tabelle. |
+| [getLocaTable()](#getLocaTable--) | Liest die loca-Tabelle. |
+| [getLtshTable()](#getLtshTable--) | Liest die LTSH-Tabelle. |
+| [getMaxpTable()](#getMaxpTable--) | Liest die maxp-Tabelle. |
+| [getNameTable()](#getNameTable--) | Liest die name-Tabelle. |
+| [getOs2Table()](#getOs2Table--) | Liest die OS/2-Tabelle. |
+| [getPostTable()](#getPostTable--) | Liest die post-Tabelle. |
+| [getPrepTable()](#getPrepTable--) | Liest die prep-Tabelle. |
+| [getStatTable()](#getStatTable--) | Ruft die STAT-Tabelle ab. |
+| [getVheaTable()](#getVheaTable--) | Ruft die vhea-Tabelle ab. |
+| [getVmtxTable()](#getVmtxTable--) | Ruft die vmtx-Tabelle ab. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCMapTable() {#getCMapTable--}
+```
+public TtfCMapTable getCMapTable()
+```
+
+
+Liest die cmap-Tabelle.
+
+**Returns:**
+[TtfCMapTable](../../com.aspose.font/ttfcmaptable) - Cmap table.
+### getCffTable() {#getCffTable--}
+```
+public TtfCffTable getCffTable()
+```
+
+
+Liest die cff-Tabelle.
+
+**Returns:**
+[TtfCffTable](../../com.aspose.font/ttfcfftable) - Cff table.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCvtTable() {#getCvtTable--}
+```
+public TtfCvtTable getCvtTable()
+```
+
+
+Liest die cvt-Tabelle.
+
+**Returns:**
+[TtfCvtTable](../../com.aspose.font/ttfcvttable) - Cvt table.
+### getFpgmTable() {#getFpgmTable--}
+```
+public TtfFpgmTable getFpgmTable()
+```
+
+
+Liest die fpgm-Tabelle.
+
+**Returns:**
+[TtfFpgmTable](../../com.aspose.font/ttffpgmtable) - Fpgm table.
+### getGaspTable() {#getGaspTable--}
+```
+public TtfGaspTable getGaspTable()
+```
+
+
+Liest die GASP-Tabelle.
+
+**Returns:**
+[TtfGaspTable](../../com.aspose.font/ttfgasptable) - The GASP table.
+### getGlyfTable() {#getGlyfTable--}
+```
+public TtfGlyfTable getGlyfTable()
+```
+
+
+Liest die glyf-Tabelle.
+
+**Returns:**
+[TtfGlyfTable](../../com.aspose.font/ttfglyftable) - Glyf table.
+### getHeadTable() {#getHeadTable--}
+```
+public TtfHeadTable getHeadTable()
+```
+
+
+Liest die head-Tabelle.
+
+**Returns:**
+[TtfHeadTable](../../com.aspose.font/ttfheadtable) - Head table.
+### getHheaTable() {#getHheaTable--}
+```
+public TtfHheaTable getHheaTable()
+```
+
+
+Liest die hhea-Tabelle.
+
+**Returns:**
+[TtfHheaTable](../../com.aspose.font/ttfhheatable) - Hhea table.
+### getHmtxTable() {#getHmtxTable--}
+```
+public TtfHmtxTable getHmtxTable()
+```
+
+
+Liest die hmtx-Tabelle.
+
+**Returns:**
+[TtfHmtxTable](../../com.aspose.font/ttfhmtxtable) - Hmtx table.
+### getLocaTable() {#getLocaTable--}
+```
+public TtfLocaTable getLocaTable()
+```
+
+
+Liest die loca-Tabelle.
+
+**Returns:**
+[TtfLocaTable](../../com.aspose.font/ttflocatable) - Loca table.
+### getLtshTable() {#getLtshTable--}
+```
+public TtfLtshTable getLtshTable()
+```
+
+
+Liest die LTSH-Tabelle.
+
+**Returns:**
+[TtfLtshTable](../../com.aspose.font/ttfltshtable) - The LTSH table.
+### getMaxpTable() {#getMaxpTable--}
+```
+public TtfMaxpTable getMaxpTable()
+```
+
+
+Liest die maxp-Tabelle.
+
+**Returns:**
+[TtfMaxpTable](../../com.aspose.font/ttfmaxptable) - Maxp table.
+### getNameTable() {#getNameTable--}
+```
+public TtfNameTable getNameTable()
+```
+
+
+Liest die name-Tabelle.
+
+**Returns:**
+[TtfNameTable](../../com.aspose.font/ttfnametable) - Name table.
+### getOs2Table() {#getOs2Table--}
+```
+public TtfOs2Table getOs2Table()
+```
+
+
+Liest die OS/2-Tabelle.
+
+**Returns:**
+[TtfOs2Table](../../com.aspose.font/ttfos2table) - OS/2 table.
+### getPostTable() {#getPostTable--}
+```
+public TtfPostTable getPostTable()
+```
+
+
+Liest die post-Tabelle.
+
+**Returns:**
+[TtfPostTable](../../com.aspose.font/ttfposttable) - Post table.
+### getPrepTable() {#getPrepTable--}
+```
+public TtfPrepTable getPrepTable()
+```
+
+
+Liest die prep-Tabelle.
+
+**Returns:**
+[TtfPrepTable](../../com.aspose.font/ttfpreptable) - Prep table.
+### getStatTable() {#getStatTable--}
+```
+public TtfStatTable getStatTable()
+```
+
+
+Ruft die STAT-Tabelle ab.
+
+**Returns:**
+[TtfStatTable](../../com.aspose.font/ttfstattable) - The STAT table.
+### getVheaTable() {#getVheaTable--}
+```
+public TtfVheaTable getVheaTable()
+```
+
+
+Ruft die vhea-Tabelle ab.
+
+**Returns:**
+[TtfVheaTable](../../com.aspose.font/ttfvheatable) - Vhea table.
+### getVmtxTable() {#getVmtxTable--}
+```
+public TtfVmtxTable getVmtxTable()
+```
+
+
+Ruft die vmtx-Tabelle ab.
+
+**Returns:**
+[TtfVmtxTable](../../com.aspose.font/ttfvmtxtable) - Vmtx table.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfvheatable/_index.md
+++ b/german/java/com.aspose.font/ttfvheatable/_index.md
@@ -1,0 +1,300 @@
+---
+title: "TtfVheaTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die hhea-Tabelle der TTF-Schriftdatei dar."
+type: docs
+weight: 112
+url: /de/java/com.aspose.font/ttfvheatable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfVheaTable extends TtfTableBase
+```
+
+Stellt die "hhea"-Tabelle der TTF-Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdvanceHeightMax()](#getAdvanceHeightMax--) | Ruft AdvanceHeightMax ab. |
+| [getAscent()](#getAscent--) | Liest Ascent. |
+| [getCaretOffset()](#getCaretOffset--) | Liest CaretOffset. |
+| [getCaretSlopeRise()](#getCaretSlopeRise--) | Liest CaretSlopeRise. |
+| [getCaretSlopeRun()](#getCaretSlopeRun--) | Liest CaretSlopeRun. |
+| [getClass()](#getClass--) |  |
+| [getDescent()](#getDescent--) | Liest Descent. |
+| [getLineGap()](#getLineGap--) | Liest LineGap. |
+| [getMetricDataFormat()](#getMetricDataFormat--) | Liest MetricDataFormat. |
+| [getMinBottomSideBearing()](#getMinBottomSideBearing--) | Liest MinBottomSideBearing. |
+| [getMinTopSideBearing()](#getMinTopSideBearing--) | Liest MinTopSideBearing. |
+| [getNumOfLongVerMetrics()](#getNumOfLongVerMetrics--) | Liest MetricDataFormat. |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [getVersion()](#getVersion--) | Liest Versionsnummer der vertikalen Header-Tabelle. |
+| [getYMaxExtent()](#getYMaxExtent--) | Liest \_yMaxExtent. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdvanceHeightMax() {#getAdvanceHeightMax--}
+```
+public short getAdvanceHeightMax()
+```
+
+
+Liest AdvanceHeightMax. Die maximale Vorwärts-Höhenmessung in FUnits, die in der Schriftart gefunden wurde.
+
+**Returns:**
+short - Der AdvanceHeightMax.
+### getAscent() {#getAscent--}
+```
+public short getAscent()
+```
+
+
+Liest Ascent. Abstand in FUnits von der Mittellinie zur vorherigen Zeile\\u2019s \_descent.
+
+**Returns:**
+short - Der Ascent.
+### getCaretOffset() {#getCaretOffset--}
+```
+public short getCaretOffset()
+```
+
+
+Liest CaretOffset.
+
+**Returns:**
+short - Der CaretOffset.
+### getCaretSlopeRise() {#getCaretSlopeRise--}
+```
+public short getCaretSlopeRise()
+```
+
+
+Liest CaretSlopeRise.
+
+**Returns:**
+short - Der CaretSlopeRise.
+### getCaretSlopeRun() {#getCaretSlopeRun--}
+```
+public short getCaretSlopeRun()
+```
+
+
+Liest CaretSlopeRun.
+
+**Returns:**
+short - Der CaretSlopeRun.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescent() {#getDescent--}
+```
+public short getDescent()
+```
+
+
+Liest Descent. Abstand in FUnits von der Mittellinie zur nächsten Zeile\\u2019s \_ascent.
+
+**Returns:**
+short - Der Descent.
+### getLineGap() {#getLineGap--}
+```
+public short getLineGap()
+```
+
+
+Liest LineGap. Der vertikale typografische Abstand für diese Schriftart.
+
+**Returns:**
+short - Der LineGap.
+### getMetricDataFormat() {#getMetricDataFormat--}
+```
+public short getMetricDataFormat()
+```
+
+
+Liest MetricDataFormat.
+
+**Returns:**
+short - Der MetricDataFormat.
+### getMinBottomSideBearing() {#getMinBottomSideBearing--}
+```
+public short getMinBottomSideBearing()
+```
+
+
+Liest MinBottomSideBearing. Die minimale untere Seitenrandmessung, die in der Schriftart gefunden wurde, in FUnits.
+
+**Returns:**
+short - Der MinBottomSideBearing.
+### getMinTopSideBearing() {#getMinTopSideBearing--}
+```
+public short getMinTopSideBearing()
+```
+
+
+Ermittelt MinTopSideBearing. Die minimale obere Seitenrandmessung, die in der Schrift gefunden wurde, in FUnits.
+
+**Returns:**
+short - Das MinTopSideBearing.
+### getNumOfLongVerMetrics() {#getNumOfLongVerMetrics--}
+```
+public int getNumOfLongVerMetrics()
+```
+
+
+Ermittelt MetricDataFormat. Anzahl der advance heights in der vertikalen Metriktabelle.
+
+**Returns:**
+int - Das MetricDataFormat.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Das Tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public Version16Dot16 getVersion()
+```
+
+
+Liest Versionsnummer der vertikalen Header-Tabelle.
+
+**Returns:**
+[Version16Dot16](../../com.aspose.font/version16dot16) - The Version number of the vertical header table.
+### getYMaxExtent() {#getYMaxExtent--}
+```
+public short getYMaxExtent()
+```
+
+
+Liest \_yMaxExtent.
+
+**Returns:**
+short - Das \_yMaxExtent.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/ttfvmtxtable/_index.md
+++ b/german/java/com.aspose.font/ttfvmtxtable/_index.md
@@ -1,0 +1,179 @@
+---
+title: "TtfVmtxTable"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die vmtx-Tabelle der TTF-Schriftdatei dar."
+type: docs
+weight: 113
+url: /de/java/com.aspose.font/ttfvmtxtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfVmtxTable extends TtfTableBase
+```
+
+Stellt die "vmtx"-Tabelle der TTF-Schriftdatei dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Liefert den Offset vom Anfang des sfnt. |
+| [getTag()](#getTag--) | Liest das Tabellen-Tag. |
+| [getTopSideBearings()](#getTopSideBearings--) | Liefert die oberen Seitenabstände. |
+| [getTtfTables()](#getTtfTables--) | Verweis auf das TTF-Tabellen-Repository. |
+| [getVMetrics()](#getVMetrics--) | Liefert vertikale Metriken. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Liefert den Offset vom Anfang des sfnt.
+
+**Returns:**
+long - Offset vom Anfang des sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Liest das Tabellen-Tag.
+
+**Returns:**
+java.lang.String - Das Tabellen-Tag.
+### getTopSideBearings() {#getTopSideBearings--}
+```
+public short[] getTopSideBearings()
+```
+
+
+Liefert die oberen Seitenabstände. Array der oberen Seitenabstände des Glyphen.
+
+**Returns:**
+short[] - Die oberen Seitenlager.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Verweis auf das TTF-Tabellen-Repository.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVMetrics() {#getVMetrics--}
+```
+public TtfVmtxTable.LongVerMetric[] getVMetrics()
+```
+
+
+Liefert vertikale Metriken.
+
+**Returns:**
+com.aspose.font.TtfVmtxTable.LongVerMetric[] - Die vertikalen Metriken.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/type1encoding/_index.md
+++ b/german/java/com.aspose.font/type1encoding/_index.md
@@ -1,0 +1,218 @@
+---
+title: "Type1Encoding"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Type1-Schriftkodierung dar."
+type: docs
+weight: 114
+url: /de/java/com.aspose.font/type1encoding/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFontEncoding](../../com.aspose.font/ifontencoding), [com.aspose.font.ISupportsNameAddressing](../../com.aspose.font/isupportsnameaddressing)
+```
+public class Type1Encoding implements IFontEncoding, ISupportsNameAddressing
+```
+
+Stellt die Type1-Schriftkodierung dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [decodeToGid(long charCode)](#decodeToGid-long-) | Dekodiert Gid zu Unicode. |
+| [decodeToGidParameterized(IEncodingParameters parameters, long charCode)](#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-) | Parametrisierte Dekodiermethode. |
+| [encode(long gid, long charCode)](#encode-long-long-) | Kodiert den Glyph. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getNameToCharCodeIndex()](#getNameToCharCodeIndex--) | Gibt die Zuordnung von Namen zu Zeichencode‑Kodierung zurück. |
+| [gidToUnicode(GlyphId gid)](#gidToUnicode-com.aspose.font.GlyphId-) | Dekodiert Gid zu Unicode. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [unicodeToGid(long unicode)](#unicodeToGid-long-) | Gibt GlyphId für Unicode zurück. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### decodeToGid(long charCode) {#decodeToGid-long-}
+```
+public GlyphId decodeToGid(long charCode)
+```
+
+
+Dekodiert Gid zu Unicode. Glyph‑Id ist eine eindeutige Nummer für ein Glyph, die vom Font‑Typ abhängt. Zum Beispiel: Die Id von Type1 ist ein Glyph‑Name, eine Instanz der Klasse ( GlyphStringId ). Die Id von TTF ist ein int‑Index, eine Instanz der Klasse ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| charCode | long | Zeichencode, für den der Glyph‑Bezeichner ermittelt werden soll. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to character code passed.
+### decodeToGidParameterized(IEncodingParameters parameters, long charCode) {#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-}
+```
+public GlyphId decodeToGidParameterized(IEncodingParameters parameters, long charCode)
+```
+
+
+Parametrisierte Dekodiermethode. Nicht unterstützt für den Font‑Typ Type1.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| parameters | [IEncodingParameters](../../com.aspose.font/iencodingparameters) | Nicht unterstützt für den Font‑Typ Type1. |
+| charCode | long | Nicht unterstützt für den Font‑Typ Type1. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Not supported for Type1 Font type.
+### encode(long gid, long charCode) {#encode-long-long-}
+```
+public void encode(long gid, long charCode)
+```
+
+
+Kodiert das Glyph. Für TTF‑Fonts ist der Zeichencode Unicode. Nicht unterstützt für Font‑Typen vom Typ Type1.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| gid | long | Glyph-ID. |
+| charCode | long | Zeichencode, der mit der Glyph‑Id verknüpft ist. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNameToCharCodeIndex() {#getNameToCharCodeIndex--}
+```
+public NameToCodeMap getNameToCharCodeIndex()
+```
+
+
+Gibt die Zuordnung von Namen zu Zeichencode‑Kodierung zurück. Hinweis: Der Zeichencode ist kein Unicode. Der Zeichencode ist ein Zeichen‑Index in der Font‑Kodierungstabelle "table".
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - Name to character code encoding map.
+### gidToUnicode(GlyphId gid) {#gidToUnicode-com.aspose.font.GlyphId-}
+```
+public long gidToUnicode(GlyphId gid)
+```
+
+
+Dekodiert Gid zu Unicode. Glyph‑Id ist eine eindeutige Nummer für ein Glyph, die vom Font‑Typ abhängt. Zum Beispiel: Die Id von Type1 ist ein Glyph‑Name, eine Instanz der Klasse ( GlyphStringId ). Die Id von TTF ist ein int‑Index, eine Instanz der Klasse ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| gid | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑Bezeichner des zu dekodierenden Symbols. |
+
+**Returns:**
+long – Unicode‑Wert, der zur übergebenen Glyph‑Id gehört.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unicodeToGid(long unicode) {#unicodeToGid-long-}
+```
+public GlyphId unicodeToGid(long unicode)
+```
+
+
+Gibt GlyphId für Unicode zurück. Oder notdef, falls das Font keinen Glyph für das Unicode enthält. Glyph‑Id ist eine eindeutige Nummer für ein Glyph, die vom Font‑Typ abhängt. Zum Beispiel: Die Id von Type1 ist ein Glyph‑Name, eine Instanz der Klasse ( GlyphStringId ). Die Id von TTF ist ein int‑Index, eine Instanz der Klasse ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| unicode | long | Unicode, für den der Glyph‑Bezeichner ermittelt werden soll. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to unicode passed.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/type1font/_index.md
+++ b/german/java/com.aspose.font/type1font/_index.md
@@ -1,0 +1,545 @@
+---
+title: "Type1Font"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Type1-Schrift dar."
+type: docs
+weight: 115
+url: /de/java/com.aspose.font/type1font/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Font](../../com.aspose.font/font)
+```
+public class Type1Font extends Font
+```
+
+Stellt die Type1-Schrift dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Konvertiert die Font in ein anderes Format. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Gibt ein Array aller Glyph-IDs zurück, die in der Font verfügbar sind. |
+| [getClass()](#getClass--) |  |
+| [getEncoding()](#getEncoding--) | Liefert Font‑Kodierung. |
+| [getFontDefinition()](#getFontDefinition--) | Liefert Font‑Definition. |
+| [getFontFamily()](#getFontFamily--) | Liefert Font‑Familie. |
+| [getFontName()](#getFontName--) | Liefert Font‑Face‑Name. |
+| [getFontNames()](#getFontNames--) | Liefert Font‑Namen. |
+| [getFontSaver()](#getFontSaver--) | Liefert Font‑Speicherfunktionalität. |
+| [getFontStyle()](#getFontStyle--) | Liefert Font‑Stil. |
+| [getFontType()](#getFontType--) | Liefert Font‑Typ. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Font‑Glyph‑Zugriff. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Gibt Glyph nach Glyph-ID zurück. |
+| [getGlyphById(String id)](#getGlyphById-java.lang.String-) | Gibt Glyph nach Glyph-ID zurück. |
+| [getGlyphById(long id)](#getGlyphById-long-) | Gibt Glyph nach Glyph-ID zurück. |
+| [getGlyphIdType()](#getGlyphIdType--) | Glyph id Typenspezifikation. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Liest Glyphenrepräsentation für Text. |
+| [getMetrics()](#getMetrics--) | Liefert Font‑Metriken. |
+| [getNumGlyphs()](#getNumGlyphs--) | Ermittelt die Anzahl der Glyphen im Font. |
+| [getPostscriptNames()](#getPostscriptNames--) | Liest Postscript-Schriftnamen. |
+| [getStyle()](#getStyle--) | Liefert Font‑Stil. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Öffnet einen Font mithilfe eines FontDefinition-Objekts. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Öffnet einen Font mithilfe des Font-Typs und eines Byte-Arrays mit Font-Daten. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Öffnet einen Font mithilfe des Font-Typs und einer Stream-Quelle. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Öffnet einen Font mithilfe des Font-Typs und des Font-Dateinamens. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Speichert den Font im Originalformat. |
+| [save(String fileName)](#save-java.lang.String-) | Speichert den Font im Originalformat. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Speichert den Font im angegebenen Format. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Der Setter für die Schriftfamilie ist noch nicht implementiert. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Der Setter für den Schriftartnamen ist noch nicht implementiert. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Der Setter für den Stil ist noch nicht implementiert. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public Font convert(FontType fontType)
+```
+
+
+Konvertiert die Font in ein anderes Format.
+
+> ```
+> Note: TTF Font type is now supported only.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Font-Formattyp, in den konvertiert werden soll. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public GlyphId[] getAllGlyphIds()
+```
+
+
+Gibt ein Array aller glyph ids zurück, die in der Font verfügbar sind. Ein glyph id ist eine eindeutige Nummer für ein glyph, die vom Schrifttyp abhängt. Type1 Font glyph id kann eine Instanz der Klasse ( GlyphStringId ) oder ( GlyphUInt32Id ) Klasse sein.
+
+**Returns:**
+com.aspose.font.GlyphId[]
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncoding() {#getEncoding--}
+```
+public IFontEncoding getEncoding()
+```
+
+
+Liefert Font‑Kodierung.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public FontDefinition getFontDefinition()
+```
+
+
+Liefert Font‑Definition.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public String getFontFamily()
+```
+
+
+Liefert Font‑Familie.
+
+**Returns:**
+java.lang.String - Font‑Familie.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Liefert Font‑Face‑Name.
+
+**Returns:**
+java.lang.String - Font‑Face‑Name.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Liefert Font‑Namen.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Liefert Font‑Speicherfunktionalität.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public int getFontStyle()
+```
+
+
+Ermittelt den Font-Stil. Dies ist ein Wert, der berechnet und in einem generalisierten Typ dargestellt wird.
+
+**Returns:**
+int - Font-Stil. In der Regel eine Kombination von Konstanten‑Flag‑Werten der FontStyle‑Klasse oder 0.
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Ermittelt den Font-Typ. Gibt den Wert FontType.Type1 zurück.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Schriftzeichen-Glyph-Zugriff. Ruft Glyphs und Glyph-Identifikatoren ab.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public Glyph getGlyphById(GlyphId id)
+```
+
+
+Gibt ein glyph anhand eines glyph ids zurück. Ein glyph id ist eine eindeutige Nummer für ein glyph, die vom Schrifttyp abhängt. Type1 Font glyph id kann eine Instanz der Klasse ( GlyphStringId ) oder ( GlyphUInt32Id ) Klasse sein.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) |  |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph)
+### getGlyphById(String id) {#getGlyphById-java.lang.String-}
+```
+public Glyph getGlyphById(String id)
+```
+
+
+Gibt Glyph nach Glyph-ID zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| id | java.lang.String | Glyph-ID. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(long id) {#getGlyphById-long-}
+```
+public Glyph getGlyphById(long id)
+```
+
+
+Gibt Glyph nach Glyph-ID zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| id | long | Glyph-ID. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public GlyphIdType getGlyphIdType()
+```
+
+
+Glyph id Typenspezifikation.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype)
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Liest Glyphenrepräsentation für Text.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| text | java.lang.String | Eingabetext. |
+
+**Returns:**
+com.aspose.font.GlyphId[] – GlyphId-Array.
+### getMetrics() {#getMetrics--}
+```
+public IFontMetrics getMetrics()
+```
+
+
+Liefert Font‑Metriken.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Ermittelt die Anzahl der Glyphen im Font.
+
+**Returns:**
+int – Anzahl der Glyphs in der Schrift.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Liest Postscript-Schriftnamen.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names
+### getStyle() {#getStyle--}
+```
+public String getStyle()
+```
+
+
+Ermittelt den Schriftstil. Dies ist ein Roh-String-Wert, der von der Schriftdatei bereitgestellt wird.
+
+**Returns:**
+java.lang.String – Schriftstil.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Öffnet einen Font mithilfe eines FontDefinition-Objekts.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Schriftdefinitions-Objekt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und eines Byte-Arrays mit Font-Daten.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fontData | byte[] | Byte-Array, aus dem die Schrift geladen wird. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und einer Stream-Quelle.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Stream-Quelle für die Schrift. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und des Font-Dateinamens.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fileName | java.lang.String | Schriftdateiname. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Speichert den Font im Originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Stream zum Speichern der Schrift. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Speichert den Font im Originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fileName | java.lang.String | Datei zum Speichern der Schrift. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Speichert den Font im angegebenen Format.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Stream zum Speichern der Schrift |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | gewünschtes Format |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public void setFontFamily(String value)
+```
+
+
+Der Setter für die Schriftfamilie ist noch nicht implementiert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Neue Schriftfamilie. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public void setFontName(String value)
+```
+
+
+Der Setter für den Schriftartnamen ist noch nicht implementiert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Neuer Schriftartname. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public void setStyle(String value)
+```
+
+
+Der Style-Setter ist noch nicht implementiert. Dies ist ein Rohzeichenfolgenwert, der von der Font-Datei bereitgestellt wird.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Neuer Schriftstil. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/type1fontmetrics/_index.md
+++ b/german/java/com.aspose.font/type1fontmetrics/_index.md
@@ -1,0 +1,555 @@
+---
+title: "Type1FontMetrics"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Type1-Schriftmetriken dar."
+type: docs
+weight: 116
+url: /de/java/com.aspose.font/type1fontmetrics/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.FontMetrics](../../com.aspose.font/fontmetrics)
+```
+public class Type1FontMetrics extends FontMetrics
+```
+
+Stellt die Type1-Schriftmetriken dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAscender()](#getAscender--) | Liefert Aufstiegswert. |
+| [getAscender(double fontSize)](#getAscender-double-) | Gibt den Ascender für eine bestimmte Schriftgröße zurück. |
+| [getCapHeight()](#getCapHeight--) | Liefert den Cap‑Höhenwert. |
+| [getClass()](#getClass--) |  |
+| [getDescender()](#getDescender--) | Liefert Descender-Wert. |
+| [getDescender(double fontSize)](#getDescender-double-) | Gibt den Descender für eine bestimmte Schriftgröße zurück. |
+| [getFontBBox()](#getFontBBox--) | Liefert den FontBBox-Wert. |
+| [getFontMatrix()](#getFontMatrix--) | Liefert die Font-Transformationsmatrix. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Gibt das Glyph-Bbox zurück. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Gibt die Glyph-Breite zurück. |
+| [getItalicAngle()](#getItalicAngle--) | Liefert den Kursivwinkelwert. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Gibt den Kerning-Wert für das Glyph-Paar zurück. |
+| [getLineGap()](#getLineGap--) | Liest den LineGap-Wert. |
+| [getStdHW()](#getStdHW--) | Liefert den StdHW-Wert. |
+| [getStdVW()](#getStdVW--) | Liefert den StdVW-Wert. |
+| [getTypoAscender()](#getTypoAscender--) | Liest den TypoAscender-Wert. |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Gibt den typografischen Ascender für eine bestimmte Schriftgröße zurück. |
+| [getTypoDescender()](#getTypoDescender--) | Liest den TypoDescender-Wert. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Gibt den typografischen Descender für eine bestimmte Schriftgröße zurück. |
+| [getTypoLineGap()](#getTypoLineGap--) | Liest den TypoLineGap-Wert. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Gibt den Zeilenabstand für eine bestimmte Schriftgröße zurück. |
+| [getUnderlinePosition()](#getUnderlinePosition--) | Liefert den Unterstreichungspositionswert. |
+| [getUnderlineThickness()](#getUnderlineThickness--) | Liefert den Unterstreichungsdickenwert. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Liefert den Unterstreichungs-UnitsPerEM-Wert. |
+| [getWeight()](#getWeight--) | Liefert das Gewicht. |
+| [getXHeight()](#getXHeight--) | Liefert den XHeight-Wert. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Liest den IsFixedPitch-Wert. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Misst die Zeichenkette und gibt die Zeichenkettenbreite zurück. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAscender(double value)](#setAscender-double-) | Setzt den Ascender-Wert. |
+| [setDescender(double value)](#setDescender-double-) | Setzt den Descender-Wert. |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) | Setzt die Glyph-Breite. |
+| [setTypoAscender(double value)](#setTypoAscender-double-) | Setzt den TypoAscender-Wert. |
+| [setTypoDescender(double value)](#setTypoDescender-double-) | Setzt den TypoDescender-Wert. |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAscender() {#getAscender--}
+```
+public double getAscender()
+```
+
+
+Liefert Aufstiegswert.
+
+**Returns:**
+double - Ascender-Wert.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public double getAscender(double fontSize)
+```
+
+
+Gibt den Ascender für eine bestimmte Schriftgröße zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Ascender-Wert.
+### getCapHeight() {#getCapHeight--}
+```
+public double getCapHeight()
+```
+
+
+Liefert den Cap‑Höhenwert.
+
+**Returns:**
+double - Cap-Höhenwert.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescender() {#getDescender--}
+```
+public double getDescender()
+```
+
+
+Liefert Descender-Wert.
+
+**Returns:**
+double - Descender-Wert.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public double getDescender(double fontSize)
+```
+
+
+Gibt den Descender für eine bestimmte Schriftgröße zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Descender-Wert.
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+Liefert den FontBBox-Wert.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - FontBBox value.
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+Liefert die Font-Transformationsmatrix.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - Font transformation matrix.
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Gibt das Glyph-Bbox zurück. Gibt FontBBox zurück, wenn das BBox für das Glyph nicht definiert war. Kann von spezifischen Font-Encoding-Erben überschrieben werden.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑Bezeichner. |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox.
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Gibt die Glyphenbreite zurück. Kann von spezifischen Font-Encoding-Erben überschrieben werden.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑Bezeichner. |
+
+**Returns:**
+double - Glyphenbreite.
+### getItalicAngle() {#getItalicAngle--}
+```
+public double getItalicAngle()
+```
+
+
+Liefert den Kursivwinkelwert.
+
+**Returns:**
+double - Kursivwinkelwert.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Gibt den Kerning-Wert für das Glyph-Paar zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Erste Glyphe im Paar. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Schriftgröße. |
+
+**Returns:**
+double - Kerning-Wert.
+### getLineGap() {#getLineGap--}
+```
+public double getLineGap()
+```
+
+
+Liest den LineGap-Wert.
+
+**Returns:**
+double - LineGap-Wert.
+### getStdHW() {#getStdHW--}
+```
+public double getStdHW()
+```
+
+
+Liefert den StdHW-Wert.
+
+**Returns:**
+double - StdHW-Wert.
+### getStdVW() {#getStdVW--}
+```
+public double getStdVW()
+```
+
+
+Liefert den StdVW-Wert.
+
+**Returns:**
+double - StdVW-Wert.
+### getTypoAscender() {#getTypoAscender--}
+```
+public double getTypoAscender()
+```
+
+
+Liest den TypoAscender-Wert.
+
+**Returns:**
+double - TypoAscender-Wert.
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public double getTypoAscender(double fontSize)
+```
+
+
+Gibt den typografischen Ascender für eine bestimmte Schriftgröße zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Typografischer Aufsteigerwert.
+### getTypoDescender() {#getTypoDescender--}
+```
+public double getTypoDescender()
+```
+
+
+Liest den TypoDescender-Wert.
+
+**Returns:**
+double - TypoDescender-Wert.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public double getTypoDescender(double fontSize)
+```
+
+
+Gibt den typografischen Descender für eine bestimmte Schriftgröße zurück.
+
+param fontSize Schriftgröße.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double |  |
+
+**Returns:**
+double - Typografischer Abstiegwert.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public double getTypoLineGap()
+```
+
+
+Liest den TypoLineGap-Wert.
+
+**Returns:**
+double - TypoLineGap-Wert.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public double getTypoLineGap(double fontSize)
+```
+
+
+Gibt den Zeilenabstand für eine bestimmte Schriftgröße zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Zeilenabstandswert.
+### getUnderlinePosition() {#getUnderlinePosition--}
+```
+public double getUnderlinePosition()
+```
+
+
+Liefert den Unterstreichungspositionswert.
+
+**Returns:**
+double - Unterstreichungspositionswert.
+### getUnderlineThickness() {#getUnderlineThickness--}
+```
+public double getUnderlineThickness()
+```
+
+
+Liefert den Unterstreichungsdickenwert.
+
+**Returns:**
+double - Unterstreichungsdickenwert.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Liefert den Unterstreichungs-UnitsPerEM-Wert.
+
+**Returns:**
+long - Unterstreichungs-UnitsPerEM-Wert.
+### getWeight() {#getWeight--}
+```
+public String getWeight()
+```
+
+
+Liefert das Gewicht.
+
+**Returns:**
+java.lang.String - Gewicht.
+### getXHeight() {#getXHeight--}
+```
+public double getXHeight()
+```
+
+
+Liefert den XHeight-Wert.
+
+**Returns:**
+double - XHeight-Wert.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+Liest den IsFixedPitch-Wert.
+
+**Returns:**
+boolean - IsFixedPitch-Wert.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public double measureString(String unicode, double fontSize)
+```
+
+
+Misst die Zeichenkette und gibt die Zeichenkettenbreite zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| unicode | java.lang.String | Unicode-Zeichenkette. |
+| fontSize | double | Schriftgröße. |
+
+**Returns:**
+double - Zeichenkettenbreite.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAscender(double value) {#setAscender-double-}
+```
+public void setAscender(double value)
+```
+
+
+Setzt den Ascender-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | Aufsteigerwert. |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public void setDescender(double value)
+```
+
+
+Setzt den Descender-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | Abstiegwert. |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Setzt die Glyph-Breite.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑Bezeichner. |
+| Wert | double | Neue Breite. |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public void setTypoAscender(double value)
+```
+
+
+Setzt den TypoAscender-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | TypoAscender-Wert. |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public void setTypoDescender(double value)
+```
+
+
+Setzt den TypoDescender-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | TypoDescender-Wert. |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public void setUnitsPerEM(long value)
+```
+
+
+Setzt den UnitsPerEM-Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/type1metricfont/_index.md
+++ b/german/java/com.aspose.font/type1metricfont/_index.md
@@ -1,0 +1,574 @@
+---
+title: "Type1MetricFont"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Type1-Metrik-Schriftimplementierung."
+type: docs
+weight: 117
+url: /de/java/com.aspose.font/type1metricfont/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Font](../../com.aspose.font/font), [com.aspose.font.Type1Font](../../com.aspose.font/type1font)
+```
+public class Type1MetricFont extends Type1Font
+```
+
+Type1-Metrik-Schriftart-Implementierung. Diese Type1-Schriftart wird ausschließlich anhand von Metriken erstellt. Glyph‑Abruffunktionen und einige andere, die eine echte Schriftart benötigen, sind nicht erlaubt; nicht erlaubte Funktionen werfen die Ausnahme Type1NotSupportedException. Andere Eigenschaften (FontName, Weight, Metrics und Encoding) werden aus der Metrikdatei übernommen.
+
+--------------------
+
+> ```
+> Note: If metrics file defines Encoding as "FontSpecific", user should provide the specific encoding with following way:
+>      string[] zapfDingbatsEncoding = new string[256] {null, null, ... , "space", "a1", ...};
+>      FontEnvironment.Current.FontSpecificEncodings.RegisterEncoding("ZapfDingbats", zapfDingbatsEncoding);
+>  ```
+> 
+>      System::ArrayPtr<System::String> zapfDingbatsEncoding = System::MakeArray<System::String>({nullptr, nullptr, ..., u"space", u"a1", ...});
+>      FontEnvironment::get_Current()->get_FontSpecificEncodings()->RegisterEncoding(u"ZapfDingbats", zapfDingbatsEncoding);
+>  
+> ```
+> ```
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Konvertiert die Font in ein anderes Format. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Gibt alle Glyph‑IDs zurück, die in der Font verfügbar sind. |
+| [getClass()](#getClass--) |  |
+| [getEncoding()](#getEncoding--) | Kodierung ist in der Metrikdatei definiert. |
+| [getFontDefinition()](#getFontDefinition--) | Liefert Font‑Definition. |
+| [getFontFamily()](#getFontFamily--) | Liefert Font‑Familie. |
+| [getFontName()](#getFontName--) | Ermittelt den Font‑Namen. |
+| [getFontNames()](#getFontNames--) | Liefert Font‑Namen. |
+| [getFontSaver()](#getFontSaver--) | Liefert Font‑Speicherfunktionalität. |
+| [getFontStyle()](#getFontStyle--) | Liefert Font‑Stil. |
+| [getFontType()](#getFontType--) | Liefert Font‑Typ. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Font‑Glyph‑Zugriff. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Gibt das Glyph anhand der Glyph‑ID zurück. |
+| [getGlyphById(String id)](#getGlyphById-java.lang.String-) | Gibt das Glyph anhand der Glyph‑ID zurück. |
+| [getGlyphById(long id)](#getGlyphById-long-) | Gibt Glyph nach Glyph-ID zurück. |
+| [getGlyphIdType()](#getGlyphIdType--) | Glyph id Typenspezifikation. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Liest Glyphenrepräsentation für Text. |
+| [getMetrics()](#getMetrics--) | Liefert Font‑Metriken. |
+| [getNumGlyphs()](#getNumGlyphs--) | Ermittelt die Anzahl der Glyphen im Font. |
+| [getPostscriptNames()](#getPostscriptNames--) | Liest Postscript-Schriftnamen. |
+| [getStyle()](#getStyle--) | Liefert Font‑Stil. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Öffnet einen Font mithilfe eines FontDefinition-Objekts. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Öffnet einen Font mithilfe des Font-Typs und eines Byte-Arrays mit Font-Daten. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Öffnet einen Font mithilfe des Font-Typs und einer Stream-Quelle. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Öffnet einen Font mithilfe des Font-Typs und des Font-Dateinamens. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Speichert den Font im Originalformat. |
+| [save(String fileName)](#save-java.lang.String-) | Speichert den Font im Originalformat. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Speichert den Font im angegebenen Format. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Der Setter für die Schriftfamilie ist noch nicht implementiert. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Der Setter für den Schriftartnamen ist noch nicht implementiert. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Der Setter für den Stil ist noch nicht implementiert. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public Font convert(FontType fontType)
+```
+
+
+Konvertiert die Font in ein anderes Format.
+
+> ```
+> Note: TTF Font type is now supported only.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Font-Formattyp, in den konvertiert werden soll. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public GlyphId[] getAllGlyphIds()
+```
+
+
+Gibt alle Glyph‑IDs zurück, die in der Font verfügbar sind. Nicht unterstützt für den Typ Type1MetricFont.
+
+**Returns:**
+com.aspose.font.GlyphId[] - Alle Glyph‑Bezeichner, die in der Font verfügbar sind.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncoding() {#getEncoding--}
+```
+public IFontEncoding getEncoding()
+```
+
+
+Kodierung ist in der Metrikdatei definiert. StandardAdobeEncoding: Die Kodierung wird automatisch gefüllt.
+
+--------------------
+
+> ```
+> FontSpecific:
+>         user should provide the specific encoding with following way:
+>      string[] zapfDingbatsEncoding = new string[256] {null, null, ... , "space", "a1", ...};
+>      FontEnvironment.Current.FontSpecificEncodings.RegisterEncoding("ZapfDingbats", zapfDingbatsEncoding);
+>  ```
+> 
+>      System::ArrayPtr<System::String> zapfDingbatsEncoding = System::MakeArray<System::String>({nullptr, nullptr, ..., u"space", u"a1", ...});
+>      FontEnvironment::get_Current()->get_FontSpecificEncodings()->RegisterEncoding(u"ZapfDingbats", zapfDingbatsEncoding);
+>  
+> ```
+> ```
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding)
+### getFontDefinition() {#getFontDefinition--}
+```
+public FontDefinition getFontDefinition()
+```
+
+
+Liefert Font‑Definition.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public String getFontFamily()
+```
+
+
+Liefert Font‑Familie.
+
+**Returns:**
+java.lang.String - Font‑Familie.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Ermittelt den Font‑Namen.
+
+**Returns:**
+java.lang.String - Schriftartname.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Liefert Font‑Namen.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Liefert Font‑Speicherfunktionalität.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public int getFontStyle()
+```
+
+
+Ermittelt den Font-Stil. Dies ist ein Wert, der berechnet und in einem generalisierten Typ dargestellt wird.
+
+**Returns:**
+int - Ermittelt den Font‑Stil. In der Regel eine Kombination von Konstanten‑Flag‑Werten der FontStyle‑Klasse oder 0.
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Ermittelt den Font-Typ. Gibt den Wert FontType.Type1 zurück.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Schriftzeichen-Glyph-Zugriff. Ruft Glyphs und Glyph-Identifikatoren ab.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public Glyph getGlyphById(GlyphId id)
+```
+
+
+Gibt das Glyph anhand der Glyph‑ID zurück. Nicht unterstützt für den Typ (@code Type1MetricFont\}.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑Bezeichner. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(String id) {#getGlyphById-java.lang.String-}
+```
+public Glyph getGlyphById(String id)
+```
+
+
+Gibt das Glyph anhand der Glyph‑ID zurück. Nicht unterstützt für den Typ (@code Type1MetricFont\}.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| id | java.lang.String | Glyph‑Bezeichner. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(long id) {#getGlyphById-long-}
+```
+public Glyph getGlyphById(long id)
+```
+
+
+Gibt Glyph nach Glyph-ID zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| id | long | Glyph-ID. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public GlyphIdType getGlyphIdType()
+```
+
+
+Glyph id Typenspezifikation.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype)
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Liest Glyphenrepräsentation für Text.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| text | java.lang.String | Eingabetext. |
+
+**Returns:**
+com.aspose.font.GlyphId[] – GlyphId-Array.
+### getMetrics() {#getMetrics--}
+```
+public IFontMetrics getMetrics()
+```
+
+
+Liefert Font‑Metriken.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Ermittelt die Anzahl der Glyphen im Font.
+
+**Returns:**
+int – Anzahl der Glyphs in der Schrift.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Liest Postscript-Schriftnamen.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names
+### getStyle() {#getStyle--}
+```
+public String getStyle()
+```
+
+
+Liefert Font‑Stil.
+
+**Returns:**
+java.lang.String – Schriftstil.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Öffnet einen Font mithilfe eines FontDefinition-Objekts.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Schriftdefinitions-Objekt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und eines Byte-Arrays mit Font-Daten.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fontData | byte[] | Byte-Array, aus dem die Schrift geladen wird. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und einer Stream-Quelle.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Stream-Quelle für die Schrift. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Öffnet einen Font mithilfe des Font-Typs und des Font-Dateinamens.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Schrifttyp. |
+| fileName | java.lang.String | Schriftdateiname. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Speichert den Font im Originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Stream zum Speichern der Schrift. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Speichert den Font im Originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fileName | java.lang.String | Datei zum Speichern der Schrift. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Speichert den Font im angegebenen Format.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Stream zum Speichern der Schrift |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | gewünschtes Format |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public void setFontFamily(String value)
+```
+
+
+Der Setter für die Schriftfamilie ist noch nicht implementiert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Neue Schriftfamilie. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public void setFontName(String value)
+```
+
+
+Der Setter für den Schriftartnamen ist noch nicht implementiert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Neuer Schriftartname. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public void setStyle(String value)
+```
+
+
+Der Style-Setter ist noch nicht implementiert. Dies ist ein Rohzeichenfolgenwert, der von der Font-Datei bereitgestellt wird.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Neuer Schriftstil. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/unicodeplatformspecificid/_index.md
+++ b/german/java/com.aspose.font/unicodeplatformspecificid/_index.md
@@ -1,0 +1,277 @@
+---
+title: "UnicodePlatformSpecificId"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt die Unicode-Plattform‑spezifische Aufzählung dar."
+type: docs
+weight: 143
+url: /de/java/com.aspose.font/unicodeplatformspecificid/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum UnicodePlatformSpecificId extends Enum<UnicodePlatformSpecificId>
+```
+
+Stellt die Unicode-Plattform‑spezifische Aufzählung dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [Default](#Default) | Wert 0 Standardsemantik (Unicode 1.0). |
+| [ISO10646_1993](#ISO10646-1993) | Wert 2 ISO 10646 1993 Semantik (veraltet). |
+| [Unicode1_1](#Unicode1-1) | Wert 1 Unicode 1.1 Semantik. |
+| [Unicode2_0](#Unicode2-0) | Wert 3 Unicode 2.0 oder spätere Semantik. |
+| [Unicode2_0_Full](#Unicode2-0-Full) | Wert 4 Unicode 2.0 und folgende Semantik (nicht‑BMP‑Zeichen erlaubt), Unicode‑vollständiges Repertoire. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Default {#Default}
+```
+public static final UnicodePlatformSpecificId Default
+```
+
+
+Wert 0 Standardsemantik (Unicode 1.0).
+
+### ISO10646_1993 {#ISO10646-1993}
+```
+public static final UnicodePlatformSpecificId ISO10646_1993
+```
+
+
+Wert 2 ISO 10646 1993 Semantik (veraltet).
+
+### Unicode1_1 {#Unicode1-1}
+```
+public static final UnicodePlatformSpecificId Unicode1_1
+```
+
+
+Wert 1 Unicode 1.1 Semantik.
+
+### Unicode2_0 {#Unicode2-0}
+```
+public static final UnicodePlatformSpecificId Unicode2_0
+```
+
+
+Wert 3 Unicode 2.0 oder spätere Semantik. Nur Unicode‑BMP.
+
+### Unicode2_0_Full {#Unicode2-0-Full}
+```
+public static final UnicodePlatformSpecificId Unicode2_0_Full
+```
+
+
+Wert 4 Unicode 2.0 und folgende Semantik (nicht‑BMP‑Zeichen erlaubt), Unicode‑vollständiges Repertoire.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static UnicodePlatformSpecificId valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[UnicodePlatformSpecificId](../../com.aspose.font/unicodeplatformspecificid)
+### values() {#values--}
+```
+public static UnicodePlatformSpecificId[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.UnicodePlatformSpecificId[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/version16dot16/_index.md
+++ b/german/java/com.aspose.font/version16dot16/_index.md
@@ -1,0 +1,227 @@
+---
+title: "Version16Dot16"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt den Version16Dot16-Datentyp dar"
+type: docs
+weight: 118
+url: /de/java/com.aspose.font/version16dot16/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Cloneable
+```
+public class Version16Dot16 implements Cloneable
+```
+
+Stellt den Version16Dot16-Datentyp dar
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Version16Dot16()](#Version16Dot16--) | Konstruktor |
+| [Version16Dot16(int majorNumber, int minorNumber)](#Version16Dot16-int-int-) | Konstruktor |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clone()](#clone--) | Erstelle eine Kopie des  Version16Dot16  Objekts. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMajorNumber()](#getMajorNumber--) | Gibt die Hauptversionsnummer zurück. |
+| [getMinorNumber()](#getMinorNumber--) | Gibt die Nebenversionsnummer zurück. |
+| [getRawBytes()](#getRawBytes--) | Liefert alle Rohbits für die Version16Dot16 Versionsnummer als Byte-Array mit einer Größe von 4 Bytes. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setMajorNumber(int value)](#setMajorNumber-int-) | Setzt die Hauptversionsnummer. |
+| [setMinorNumber(int value)](#setMinorNumber-int-) | Setzt die Nebenversionsnummer. |
+| [toString()](#toString--) | Gibt den Versionswert als formatierte Zeichenkette zurück, zum Beispiel "0.5", "1.1", "3.0" usw. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Version16Dot16() {#Version16Dot16--}
+```
+public Version16Dot16()
+```
+
+
+Konstruktor
+
+### Version16Dot16(int majorNumber, int minorNumber) {#Version16Dot16-int-int-}
+```
+public Version16Dot16(int majorNumber, int minorNumber)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| majorNumber | int | Hauptversionsnummer |
+| minorNumber | int | Nebenversionsnummer |
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Erstelle eine Kopie des  Version16Dot16  Objekts.
+
+**Returns:**
+java.lang.Object - Objekt vom Typ  Version16Dot16
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMajorNumber() {#getMajorNumber--}
+```
+public int getMajorNumber()
+```
+
+
+Liefert die Hauptversionsnummer. Der Wert ist nur in hexadezimaler Schreibweise sinnvoll, zum Beispiel hat die Version 0.5 für 'maxp' in tatsächlichen Schriftdateien 4 Bytes: \{0, 0, 80, 0\}, was die hexadezimale Darstellung 0x00005000 hat. Nach dem Lesen dieser Version aus der Schriftdatei werden die Haupt- und Neben-Nummern für das Objekt  Version16Dot16  0 bzw. 20480 sein. Und diese Werte in hexadezimaler Form sind 0x0000 und 0x5000.
+
+**Returns:**
+int - Hauptversionsnummer.
+### getMinorNumber() {#getMinorNumber--}
+```
+public int getMinorNumber()
+```
+
+
+Liefert die Nebenversionsnummer. Der Wert ist nur in hexadezimaler Schreibweise sinnvoll, zum Beispiel hat die Version 0.5 für 'maxp' in tatsächlichen Schriftdateien 4 Bytes: \{0, 0, 80, 0\}, was die hexadezimale Darstellung 0x00005000 hat. Nach dem Lesen dieser Version aus der Schriftdatei werden die Haupt- und Neben-Nummern für das Objekt  Version16Dot16  0 bzw. 20480 sein. Und diese Werte in hexadezimaler Form sind 0x0000 und 0x5000.
+
+**Returns:**
+int - Nebenversionsnummer.
+### getRawBytes() {#getRawBytes--}
+```
+public byte[] getRawBytes()
+```
+
+
+Liefert alle Rohbits für die Version16Dot16 Versionsnummer als Byte-Array mit einer Größe von 4 Bytes.
+
+**Returns:**
+byte[] - Alle Rohbits für die Version16Dot16 Versionsnummer als Byte-Array mit einer Größe von 4 Bytes.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setMajorNumber(int value) {#setMajorNumber-int-}
+```
+public void setMajorNumber(int value)
+```
+
+
+Setzt die Hauptversionsnummer. Der Wert ist nur in hexadezimaler Schreibweise sinnvoll, zum Beispiel hat die Version 0.5 für 'maxp' in tatsächlichen Schriftdateien 4 Bytes: \{0, 0, 80, 0\}, was die hexadezimale Darstellung 0x00005000 hat. Nach dem Lesen dieser Version aus der Schriftdatei werden die Haupt- und Neben-Nummern für das Objekt  Version16Dot16  0 bzw. 20480 sein. Und diese Werte in hexadezimaler Form sind 0x0000 und 0x5000.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int | Hauptversionsnummer. |
+
+### setMinorNumber(int value) {#setMinorNumber-int-}
+```
+public void setMinorNumber(int value)
+```
+
+
+Setzt die Nebenversionsnummer. Der Wert ist nur in hexadezimaler Schreibweise sinnvoll, zum Beispiel hat die Version 0.5 für 'maxp' in tatsächlichen Schriftdateien 4 Bytes: \{0, 0, 80, 0\}, was die hexadezimale Darstellung 0x00005000 hat. Nach dem Lesen dieser Version aus der Schriftdatei werden die Haupt- und Neben-Nummern für das Objekt  Version16Dot16  0 bzw. 20480 sein. Und diese Werte in hexadezimaler Form sind 0x0000 und 0x5000.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int | Nebenversionsnummer. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+Gibt den Versionswert als formatierte Zeichenkette zurück, zum Beispiel "0.5", "1.1", "3.0" usw.
+
+**Returns:**
+java.lang.String - Objekt vom Typ  String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.font/woffformatexception/_index.md
+++ b/german/java/com.aspose.font/woffformatexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "WoffFormatException"
+second_title: "Aspose.Font für Java API-Referenz"
+description: "Stellt eine mit der WOFF-Schriftverarbeitung zusammenhängende Ausnahme dar."
+type: docs
+weight: 119
+url: /de/java/com.aspose.font/woffformatexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException
+```
+public class WoffFormatException extends IllegalStateException
+```
+
+Stellt eine mit der WOFF-Schriftverarbeitung zusammenhängende Ausnahme dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [WoffFormatException()](#WoffFormatException--) | Initialisiert ein neues WoffFormatException-Objekt. |
+| [WoffFormatException(String message)](#WoffFormatException-java.lang.String-) | Initialisiert ein neues WoffFormatException-Objekt. |
+| [WoffFormatException(String message, RuntimeException innerException)](#WoffFormatException-java.lang.String-java.lang.RuntimeException-) | Initialisiert ein neues WoffFormatException-Objekt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### WoffFormatException() {#WoffFormatException--}
+```
+public WoffFormatException()
+```
+
+
+Initialisiert ein neues WoffFormatException-Objekt.
+
+### WoffFormatException(String message) {#WoffFormatException-java.lang.String-}
+```
+public WoffFormatException(String message)
+```
+
+
+Initialisiert ein neues WoffFormatException-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+
+### WoffFormatException(String message, RuntimeException innerException) {#WoffFormatException-java.lang.String-java.lang.RuntimeException-}
+```
+public WoffFormatException(String message, RuntimeException innerException)
+```
+
+
+Initialisiert ein neues WoffFormatException-Objekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Nachricht | java.lang.String | Eine Nachricht, die den Fehler beschreibt. |
+| innerException | java.lang.RuntimeException | Die Ausnahme, die die aktuelle Ausnahme verursacht. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **German** (`de`) generated by RDA.

- Pages translated: 151/151
- Errors: 0
- Source: `english/java`
- Output: `german/java`

🤖 Generated by RDA