### PR TITLE
[auto] Translate JAVA API Reference to Italian

### DIFF
--- a/italian/java/_index.md
+++ b/italian/java/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Aspose.Font per Java"
+type: docs
+weight: 11
+url: /it/java/
+description: "I Riferimenti API di Aspose.Font per Java contengono esempi, frammenti di codice e documentazione API. Fornisce pacchetti, classi, interfacce e altri dettagli dell'API."
+is_root: true
+---
+## Packages
+| Pacchetto | Descrizione |
+| --- | --- |
+| [com.aspose.font](./com.aspose.font) | Il **com.aspose.font** è un pacchetto radice per tutte le classi che gestiscono i font. |
+| [com.aspose.font.textutils](./com.aspose.font.textutils) | Il pacchetto **com.aspose.font.text.utils** fornisce classi e interfacce per l'elaborazione del testo. |

--- a/italian/java/com.aspose.font.textutils/_index.md
+++ b/italian/java/com.aspose.font.textutils/_index.md
@@ -1,0 +1,32 @@
+---
+title: "com.aspose.font.textutils"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Il pacchetto com.aspose.font.text.utils fornisce classi e interfacce per l'elaborazione del testo."
+type: docs
+weight: 11
+url: /it/java/com.aspose.font.textutils/
+---
+
+Il pacchetto **com.aspose.font.text.utils** fornisce classi e interfacce per l'elaborazione del testo.
+
+
+## Classi
+
+| Classe | Descrizione |
+| --- | --- |
+| [TextUtilsFactory](../com.aspose.font.textutils/textutilsfactory) | Fornisce funzionalità per recuperare i creatori degli oggetti di servizio di testo. |
+
+## Interfacce
+
+| Interfaccia | Descrizione |
+| --- | --- |
+| [IFontMorseDecoder](../com.aspose.font.textutils/ifontmorsedecoder) | Dichiara la funzionalità di decodificare il codice Morse in glifi del font specificato. |
+| [IFontMorseEncoder](../com.aspose.font.textutils/ifontmorseencoder) | Dichiara la funzionalità di codificare il testo in codice Morse e ottenere il risultato come glifi del font. |
+| [IMorseDecoder](../com.aspose.font.textutils/imorsedecoder) | Dichiara la funzionalità di decifrare il codice Morse. |
+| [IMorseEncoder](../com.aspose.font.textutils/imorseencoder) | Dichiara la funzionalità di codificare il testo in codice Morse. |
+
+## Enumerazioni
+
+| Enum | Descrizione |
+| --- | --- |
+| [MorseAlphabets](../com.aspose.font.textutils/morsealphabets) | Rappresenta l'insieme di alfabeti supportati per il codice Morse |

--- a/italian/java/com.aspose.font.textutils/ifontmorsedecoder/_index.md
+++ b/italian/java/com.aspose.font.textutils/ifontmorsedecoder/_index.md
@@ -1,0 +1,180 @@
+---
+title: "IFontMorseDecoder"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Dichiara la funzionalità di decodificare il codice Morse in glifi del font specificato."
+type: docs
+weight: 11
+url: /it/java/com.aspose.font.textutils/ifontmorsedecoder/
+---```
+public interface IFontMorseDecoder
+```
+
+Declares functionality to decode Morse code into glyphs of the specified font.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [decode(String morseText, IFont font)](#decode-java.lang.String-com.aspose.font.IFont-) | Deciphers Morse code into glyphs of the specified font. |
+| [decode(String morseText, IFont font, MorseAlphabets alphabet)](#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-) | Deciphers Morse code into glyphs of the specified font. |
+| [decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator)](#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-) | Deciphers Morse code into glyphs of the specified font. |
+| [decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-char-) | Deciphers Morse code into glyphs of the specified font. |
+| [decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)](#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-) | Deciphers Morse code and draws result in PNG-format. |
+| [decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet)](#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-) | Deciphers Morse code and draws result in PNG-format. |
+| [decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator)](#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-) | Deciphers Morse code and draws result in PNG-format. |
+| [decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-char-) | Deciphers Morse code and draws result in PNG-format. |
+### decode(String morseText, IFont font) {#decode-java.lang.String-com.aspose.font.IFont-}
+```
+public abstract GlyphId[] decode(String morseText, IFont font)
+```
+
+
+Deciphers Morse code into glyphs of the specified font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs (glyph identifiers) related to decoded text.
+### decode(String morseText, IFont font, MorseAlphabets alphabet) {#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract GlyphId[] decode(String morseText, IFont font, MorseAlphabets alphabet)
+```
+
+
+Deciphers Morse code into glyphs of the specified font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs (glyph identifiers) related to decoded text.
+### decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator) {#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract GlyphId[] decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Deciphers Morse code into glyphs of the specified font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs (glyph identifiers) related to decoded text.
+### decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract GlyphId[] decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Deciphers Morse code into glyphs of the specified font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+| outputSeparator | char | Symbol used to separate words in decoded text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs (glyph identifiers) related to decoded text.
+### decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth) {#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-}
+```
+public abstract InputStream decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)
+```
+
+
+Deciphers Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+
+**Returns:**
+java.io.InputStream - Decoded text in PNG-format as stream of bytes.
+### decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet) {#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract InputStream decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet)
+```
+
+
+Deciphers Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+java.io.InputStream - Decoded text in PNG-format as stream of bytes.
+### decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator) {#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract InputStream decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Deciphers Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.io.InputStream - Decoded text in PNG-format as stream of bytes.
+### decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract InputStream decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Deciphers Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+| outputSeparator | char | Symbol used to separate words in decoded text. |
+
+**Returns:**
+java.io.InputStream - Decoded text in PNG-format as stream of bytes.

--- a/italian/java/com.aspose.font.textutils/ifontmorseencoder/_index.md
+++ b/italian/java/com.aspose.font.textutils/ifontmorseencoder/_index.md
@@ -1,0 +1,262 @@
+---
+title: "IFontMorseEncoder"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Dichiara la funzionalità di codificare il testo in codice Morse e ottenere il risultato come glifi del font."
+type: docs
+weight: 12
+url: /it/java/com.aspose.font.textutils/ifontmorseencoder/
+---```
+public interface IFontMorseEncoder
+```
+
+Declares functionality to encode text by Morse code and get result as font glyphs.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [encode(String text, IFont font)](#encode-java.lang.String-com.aspose.font.IFont-) | Encodes text in Morse code and returns result as set of glyphs(glyphId). |
+| [encode(String text, IFont font, char inputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-char-) | Encodes text in Morse code and returns result as set of glyphs(glyphId). |
+| [encode(String text, IFont font, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-char-char-) | Encodes text in Morse code and returns result as set of glyphs(glyphId). |
+| [encode(String text, IFont font, MorseAlphabets alphabet)](#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-) | Encodes text by Morse code and returns result as set of glyphs(glyph identifiers). |
+| [encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-) | Encodes text by Morse code and returns result as set of glyphs(glyph identifiers). |
+| [encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-char-) | Encodes text by Morse code and returns result as set of glyphs(glyph identifiers). |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-) | Encodes text in Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-char-) | Encodes text in Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-char-char-) | Encodes text in Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-) | Encodes text by Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-) | Encodes text by Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-char-) | Encodes text by Morse code and draws result in PNG-format. |
+### encode(String text, IFont font) {#encode-java.lang.String-com.aspose.font.IFont-}
+```
+public abstract GlyphId[] encode(String text, IFont font)
+```
+
+
+Encodes text in Morse code and returns result as set of glyphs(glyphId). Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, char inputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-char-}
+```
+public abstract GlyphId[] encode(String text, IFont font, char inputSeparator)
+```
+
+
+Encodes text in Morse code and returns result as set of glyphs(glyphId). Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-char-char-}
+```
+public abstract GlyphId[] encode(String text, IFont font, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text in Morse code and returns result as set of glyphs(glyphId). Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, MorseAlphabets alphabet) {#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract GlyphId[] encode(String text, IFont font, MorseAlphabets alphabet)
+```
+
+
+Encodes text by Morse code and returns result as set of glyphs(glyph identifiers).
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract GlyphId[] encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Encodes text by Morse code and returns result as set of glyphs(glyph identifiers).
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract GlyphId[] encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text by Morse code and returns result as set of glyphs(glyph identifiers).
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)
+```
+
+
+Encodes text in Morse code and draws result in PNG-format. Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-char-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator)
+```
+
+
+Encodes text in Morse code and draws result in PNG-format. Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-char-char-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text in Morse code and draws result in PNG-format. Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet)
+```
+
+
+Encodes text by Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Encodes text by Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text by Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.

--- a/italian/java/com.aspose.font.textutils/imorsedecoder/_index.md
+++ b/italian/java/com.aspose.font.textutils/imorsedecoder/_index.md
@@ -1,0 +1,86 @@
+---
+title: "IMorseDecoder"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Dichiara la funzionalità di decifrare il codice Morse."
+type: docs
+weight: 13
+url: /it/java/com.aspose.font.textutils/imorsedecoder/
+---```
+public interface IMorseDecoder
+```
+
+Declares functionality to decipher Morse code.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [decode(String morseText)](#decode-java.lang.String-) | Deciphers Morse code. |
+| [decode(String morseText, MorseAlphabets alphabet)](#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-) | Deciphers Morse code. |
+| [decode(String morseText, MorseAlphabets alphabet, char inputSeparator)](#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-) | Deciphers Morse code. |
+| [decode(String morseText, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-char-) | Deciphers Morse code. |
+### decode(String morseText) {#decode-java.lang.String-}
+```
+public abstract String decode(String morseText)
+```
+
+
+Deciphers Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+
+**Returns:**
+java.lang.String - Decoded text.
+### decode(String morseText, MorseAlphabets alphabet) {#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract String decode(String morseText, MorseAlphabets alphabet)
+```
+
+
+Deciphers Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+java.lang.String - Decoded text.
+### decode(String morseText, MorseAlphabets alphabet, char inputSeparator) {#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract String decode(String morseText, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Deciphers Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.lang.String - Decoded text.
+### decode(String morseText, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract String decode(String morseText, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Deciphers Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+| outputSeparator | char | Symbol used to separate words in decoded text. |
+
+**Returns:**
+java.lang.String - Decoded text.

--- a/italian/java/com.aspose.font.textutils/imorseencoder/_index.md
+++ b/italian/java/com.aspose.font.textutils/imorseencoder/_index.md
@@ -1,0 +1,121 @@
+---
+title: "IMorseEncoder"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Dichiara la funzionalità di codificare il testo in codice Morse."
+type: docs
+weight: 14
+url: /it/java/com.aspose.font.textutils/imorseencoder/
+---```
+public interface IMorseEncoder
+```
+
+Declares functionality to encode text by Morse code.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [encode(String text)](#encode-java.lang.String-) | Encodes text by Morse code. |
+| [encode(String text, char inputSeparator)](#encode-java.lang.String-char-) | Encodes text by Morse code. |
+| [encode(String text, char inputSeparator, char outputSeparator)](#encode-java.lang.String-char-char-) | Encodes text by Morse code. |
+| [encode(String text, MorseAlphabets alphabet)](#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-) | Encodes text by Morse code. |
+| [encode(String text, MorseAlphabets alphabet, char inputSeparator)](#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-) | Encodes text by Morse code. |
+| [encode(String text, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-char-) | Encodes text by Morse code. |
+### encode(String text) {#encode-java.lang.String-}
+```
+public abstract String encode(String text)
+```
+
+
+Encodes text by Morse code. Heuristic analysis is used to calculate the alphabet of the input text. The alphabet is selected by the first word.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+
+**Returns:**
+java.lang.String - Encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, char inputSeparator) {#encode-java.lang.String-char-}
+```
+public abstract String encode(String text, char inputSeparator)
+```
+
+
+Encodes text by Morse code. Heuristic analysis is used to calculate the alphabet of the input text. The alphabet is selected by the first word.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+java.lang.String - Encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, char inputSeparator, char outputSeparator) {#encode-java.lang.String-char-char-}
+```
+public abstract String encode(String text, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text by Morse code. Heuristic analysis is used to calculate the alphabet of the input text. The alphabet is selected by the first word.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.lang.String - Encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, MorseAlphabets alphabet) {#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract String encode(String text, MorseAlphabets alphabet)
+```
+
+
+Encodes text by Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+java.lang.String - Encoded text, ie "... --- ..." for the input text "SOS".
+### encode(String text, MorseAlphabets alphabet, char inputSeparator) {#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract String encode(String text, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Encodes text by Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+java.lang.String - Encoded text, ie "... --- ..." for the input text "SOS".
+### encode(String text, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract String encode(String text, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text by Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.lang.String - Encoded text, ie "... --- ..." for the input text "SOS".

--- a/italian/java/com.aspose.font.textutils/morsealphabets/_index.md
+++ b/italian/java/com.aspose.font.textutils/morsealphabets/_index.md
@@ -1,0 +1,304 @@
+---
+title: "MorseAlphabets"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'insieme di alfabeti supportati per il codice Morse"
+type: docs
+weight: 15
+url: /it/java/com.aspose.font.textutils/morsealphabets/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum MorseAlphabets extends Enum<MorseAlphabets>
+```
+
+Rappresenta l'insieme di alfabeti supportati per il codice Morse
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [Arabic](#Arabic) | L'alfabeto di codice arabo. |
+| [Cyrillic](#Cyrillic) | L'alfabeto di codice cirillico. |
+| [Greek](#Greek) | L'alfabeto Morse greco. |
+| [Hebrew](#Hebrew) | L'alfabeto di codice ebraico. |
+| [Kurdish](#Kurdish) | L'alfabeto di codice curdo. |
+| [Latin](#Latin) | L'alfabeto Morse latino. |
+| [Persian](#Persian) | L'alfabeto di codice persiano (Farsi). |
+| [Portuguese](#Portuguese) | L'alfabeto di codice portoghese. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Arabic {#Arabic}
+```
+public static final MorseAlphabets Arabic
+```
+
+
+L'alfabeto di codice arabo.
+
+### Cyrillic {#Cyrillic}
+```
+public static final MorseAlphabets Cyrillic
+```
+
+
+L'alfabeto di codice cirillico.
+
+### Greek {#Greek}
+```
+public static final MorseAlphabets Greek
+```
+
+
+L'alfabeto Morse greco.
+
+### Hebrew {#Hebrew}
+```
+public static final MorseAlphabets Hebrew
+```
+
+
+L'alfabeto di codice ebraico.
+
+### Kurdish {#Kurdish}
+```
+public static final MorseAlphabets Kurdish
+```
+
+
+L'alfabeto di codice curdo.
+
+### Latin {#Latin}
+```
+public static final MorseAlphabets Latin
+```
+
+
+L'alfabeto Morse latino.
+
+### Persian {#Persian}
+```
+public static final MorseAlphabets Persian
+```
+
+
+L'alfabeto di codice persiano (Farsi).
+
+### Portuguese {#Portuguese}
+```
+public static final MorseAlphabets Portuguese
+```
+
+
+L'alfabeto di codice portoghese.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static MorseAlphabets valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[MorseAlphabets](../../com.aspose.font.textutils/morsealphabets)
+### values() {#values--}
+```
+public static MorseAlphabets[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.textutils.MorseAlphabets[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font.textutils/textutilsfactory/_index.md
+++ b/italian/java/com.aspose.font.textutils/textutilsfactory/_index.md
@@ -1,0 +1,215 @@
+---
+title: "TextUtilsFactory"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Fornisce funzionalità per recuperare i creatori degli oggetti di servizio di testo."
+type: docs
+weight: 10
+url: /it/java/com.aspose.font.textutils/textutilsfactory/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TextUtilsFactory
+```
+
+Fornisce funzionalità per recuperare i creatori degli oggetti di servizio di testo.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [TextUtilsFactory()](#TextUtilsFactory--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontCharactersMerger(Font primaryFont, Font secondaryFont, FontType outType)](#getFontCharactersMerger-com.aspose.font.Font-com.aspose.font.Font-com.aspose.font.FontType-) |  |
+| [getFontMorseDecoder()](#getFontMorseDecoder--) | Ottiene l'istanza di IFontMorseDecoder. |
+| [getFontMorseEncoder()](#getFontMorseEncoder--) | Ottiene l'istanza di IFontMorseEncoder. |
+| [getMorseDecoder()](#getMorseDecoder--) | Ottiene l'istanza di IMorseDecoder. |
+| [getMorseEncoder()](#getMorseEncoder--) | Ottiene l'istanza di IMorseEncoder. |
+| [hashCode()](#hashCode--) |  |
+| [isCffSimpleFontMerging(Font primaryFont, Font secondaryFont, FontType outType)](#isCffSimpleFontMerging-com.aspose.font.Font-com.aspose.font.Font-com.aspose.font.FontType-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TextUtilsFactory() {#TextUtilsFactory--}
+```
+public TextUtilsFactory()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontCharactersMerger(Font primaryFont, Font secondaryFont, FontType outType) {#getFontCharactersMerger-com.aspose.font.Font-com.aspose.font.Font-com.aspose.font.FontType-}
+```
+public FontCharactersMerger getFontCharactersMerger(Font primaryFont, Font secondaryFont, FontType outType)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| primaryFont | [Font](../../com.aspose.font/font) |  |
+| secondaryFont | [Font](../../com.aspose.font/font) |  |
+| outType | [FontType](../../com.aspose.font/fonttype) |  |
+
+**Returns:**
+[FontCharactersMerger](../../com.aspose.font/fontcharactersmerger)
+### getFontMorseDecoder() {#getFontMorseDecoder--}
+```
+public IFontMorseDecoder getFontMorseDecoder()
+```
+
+
+Ottiene l'istanza di IFontMorseDecoder.
+
+**Returns:**
+[IFontMorseDecoder](../../com.aspose.font.textutils/ifontmorsedecoder) - The  IFontMorseDecoder  instance.
+### getFontMorseEncoder() {#getFontMorseEncoder--}
+```
+public IFontMorseEncoder getFontMorseEncoder()
+```
+
+
+Ottiene l'istanza di IFontMorseEncoder.
+
+**Returns:**
+[IFontMorseEncoder](../../com.aspose.font.textutils/ifontmorseencoder) - The  IFontMorseEncoder  instance.
+### getMorseDecoder() {#getMorseDecoder--}
+```
+public IMorseDecoder getMorseDecoder()
+```
+
+
+Ottiene l'istanza di IMorseDecoder.
+
+**Returns:**
+[IMorseDecoder](../../com.aspose.font.textutils/imorsedecoder) - The  IMorseDecoder  instance.
+### getMorseEncoder() {#getMorseEncoder--}
+```
+public IMorseEncoder getMorseEncoder()
+```
+
+
+Ottiene l'istanza di IMorseEncoder.
+
+**Returns:**
+[IMorseEncoder](../../com.aspose.font.textutils/imorseencoder) - The  IMorseEncoder  instance.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isCffSimpleFontMerging(Font primaryFont, Font secondaryFont, FontType outType) {#isCffSimpleFontMerging-com.aspose.font.Font-com.aspose.font.Font-com.aspose.font.FontType-}
+```
+public static boolean isCffSimpleFontMerging(Font primaryFont, Font secondaryFont, FontType outType)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| primaryFont | [Font](../../com.aspose.font/font) |  |
+| secondaryFont | [Font](../../com.aspose.font/font) |  |
+| outType | [FontType](../../com.aspose.font/fonttype) |  |
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/_index.md
+++ b/italian/java/com.aspose.font/_index.md
@@ -1,0 +1,165 @@
+---
+title: "com.aspose.font"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Il com.aspose.font è un pacchetto radice per tutte le classi che gestiscono i font."
+type: docs
+weight: 10
+url: /it/java/com.aspose.font/
+---
+
+Il **com.aspose.font** è un pacchetto radice per tutte le classi che gestiscono i font.
+
+
+## Classi
+
+| Classe | Descrizione |
+| --- | --- |
+| [AxisRecord](../com.aspose.font/axisrecord) | Rappresenta la struttura del record Axis. |
+| [AxisValue](../com.aspose.font/axisvalue) | Rappresenta il record AxisValue. |
+| [AxisValueTableBase](../com.aspose.font/axisvaluetablebase) | Classe base per la struttura della tabella Axis Value. |
+| [AxisValueTableFormat1](../com.aspose.font/axisvaluetableformat1) | Rappresenta il formato 1 della tabella Axis value. |
+| [AxisValueTableFormat2](../com.aspose.font/axisvaluetableformat2) | Rappresenta il formato 2 della tabella Axis value. |
+| [AxisValueTableFormat3](../com.aspose.font/axisvaluetableformat3) | Rappresenta il formato 3 della tabella Axis value. |
+| [AxisValueTableFormat4](../com.aspose.font/axisvaluetableformat4) | Rappresenta il formato 4 della tabella Axis value. |
+| [ByteContentStreamSource](../com.aspose.font/bytecontentstreamsource) | Rappresenta una sorgente di flusso basata sullo stream \_content. |
+| [CffEncoding](../com.aspose.font/cffencoding) | Rappresenta la codifica CFF \_font. |
+| [CffFont](../com.aspose.font/cfffont) | Rappresenta il Compact Font Format (CFF). |
+| [CffFontException](../com.aspose.font/cfffontexception) | Rappresenta un'eccezione comune di elaborazione relativa ai font in formato CFF. |
+| [CffFontMetrics](../com.aspose.font/cfffontmetrics) | Implementazione delle metriche dei font CFF |
+| [CffFontsSettings](../com.aspose.font/cfffontssettings) | Fornisce impostazioni comuni ai font CFF. |
+| [CffParsingException](../com.aspose.font/cffparsingexception) | Rappresenta un'eccezione di parsing per i font in formato cff. |
+| [ClosePath](../com.aspose.font/closepath) | Rappresenta l'operazione ClosePath. |
+| [CompositeGlyph](../com.aspose.font/compositeglyph) | Rappresenta un glifo composito del font. |
+| [CompositeGlyphComponent](../com.aspose.font/compositeglyphcomponent) | Rappresenta il componente del glifo composito (glifo con matrice di posizionamento). |
+| [CompositeGlyphComponentList](../com.aspose.font/compositeglyphcomponentlist) | Rappresenta l'elenco dei componenti del glifo composito. |
+| [CompressionUtils](../com.aspose.font/compressionutils) | Fornisce metodi di utilità per la compressione e la decompressione. |
+| [CurveTo](../com.aspose.font/curveto) | Rappresenta l'operazione CurveTo. |
+| [EncodingException](../com.aspose.font/encodingexception) | Rappresenta un'eccezione di codifica. |
+| [FileSystemStreamSource](../com.aspose.font/filesystemstreamsource) | Rappresenta una sorgente di flusso basata sul file system. |
+| [Font](../com.aspose.font/font) | Rappresenta la classe base Font. |
+| [FontAgrumentException](../com.aspose.font/fontagrumentexception) | Rappresenta un'eccezione di argomento Font. |
+| [FontBBox](../com.aspose.font/fontbbox) | rappresenta il bounding box del font. |
+| [FontCharactersMerger](../com.aspose.font/fontcharactersmerger) | Dichiara la funzionalità per unire font di diversi tipi. |
+| [FontConversionException](../com.aspose.font/fontconversionexception) | Rappresenta un'eccezione di conversione Font. |
+| [FontCreationException](../com.aspose.font/fontcreationexception) | Rappresenta un'eccezione di creazione Font. |
+| [FontDefinition](../com.aspose.font/fontdefinition) | Rappresenta la definizione del set di file Font. |
+| [FontEnvironment](../com.aspose.font/fontenvironment) | Fornisce informazioni sull'ambiente e sulla piattaforma corrente. |
+| [FontException](../com.aspose.font/fontexception) | Rappresenta un'eccezione comune relativa all'elaborazione del Font. |
+| [FontFactory](../com.aspose.font/fontfactory) | Contiene funzionalità per aprire font di diversi tipi e altri metodi per creare vari oggetti. |
+| [FontFileDefinition](../com.aspose.font/fontfiledefinition) | Rappresenta la definizione del file Font. |
+| [FontMergeException](../com.aspose.font/fontmergeexception) | Rappresenta un'eccezione di unione Font. |
+| [FontMetrics](../com.aspose.font/fontmetrics) | Rappresenta le metriche del font. |
+| [FontNotSupportedOperationException](../com.aspose.font/fontnotsupportedoperationexception) | Rappresenta un'eccezione di operazione non supportata. |
+| [FontSpecificEncodings](../com.aspose.font/fontspecificencodings) | Rappresenta codifiche specifiche per Font consapevoli del consumatore. |
+| [FontStyle](../com.aspose.font/fontstyle) | Enumerazione degli stili del Font |
+| [GaspRange](../com.aspose.font/gasprange) | L'array di record GaspRange fornisce comportamenti consigliati per varie dimensioni ppem |
+| [Glyph](../com.aspose.font/glyph) | Rappresenta un glifo del Font. |
+| [GlyphId](../com.aspose.font/glyphid) | Rappresenta gli ID dei glifi, disponibili nel Font. |
+| [GlyphIdList](../com.aspose.font/glyphidlist) | Rappresenta l'elenco degli ID dei glifi. |
+| [GlyphOutlineRenderer](../com.aspose.font/glyphoutlinerenderer) | Rappresenta il renderer del contorno del glifo. |
+| [GlyphRendererBase](../com.aspose.font/glyphrendererbase) | Rappresenta la classe base per i renderer dei glifi. |
+| [GlyphStringId](../com.aspose.font/glyphstringid) | Rappresenta l'ID del glifo di stringa. |
+| [GlyphUInt32Id](../com.aspose.font/glyphuint32id) | Rappresenta l'ID del glifo intero. |
+| [HelpersFactory](../com.aspose.font/helpersfactory) | Crea oggetti relativi allo spazio dei nomi TtfHelpers |
+| [IncorrectFontDataException](../com.aspose.font/incorrectfontdataexception) | Rappresenta le eccezioni per i casi in cui alcuni valori dell'oggetto Font sono invalidi. |
+| [License](../com.aspose.font/license) | Fornisce metodi per licenziare il componente. |
+| [LicenseFlags](../com.aspose.font/licenseflags) | Rappresenta un wrapper di supporto per i flag di incorporamento dalla tabella 'OS/2' (campo fsType). |
+| [LicenseRestrictionException](../com.aspose.font/licenserestrictionexception) | Rappresenta l'eccezione che può essere lanciata al tentativo di eseguire funzionalità limitate in modalità di valutazione. |
+| [LineTo](../com.aspose.font/lineto) | Rappresenta l'operazione LineTo. |
+| [MSLanguageId](../com.aspose.font/mslanguageid) | Enumerazione degli ID lingua della piattaforma Microsoft. |
+| [MacLanguageId](../com.aspose.font/maclanguageid) | Enumerazione degli ID lingua della piattaforma Macintosh. |
+| [Metered](../com.aspose.font/metered) | Fornisce metodi per impostare la chiave misurata. |
+| [MoveTo](../com.aspose.font/moveto) | Rappresenta l'operazione MoveTo. |
+| [MultiLanguageString](../com.aspose.font/multilanguagestring) | Rappresenta una stringa multilingua. |
+| [NameId](../com.aspose.font/nameid) | Rappresenta l'enumerazione NameId. |
+| [NameIndexDataProvider](../com.aspose.font/nameindexdataprovider) | Fornisce impostazioni comuni ai font CFF. |
+| [NameRecord](../com.aspose.font/namerecord) | Rappresenta la struttura NameRecord della tabella 'name' |
+| [NameToCodeMap](../com.aspose.font/nametocodemap) | Rappresenta la mappa nome-codice. |
+| [PathSegmentCollection](../com.aspose.font/pathsegmentcollection) | Rappresenta una collezione di segmenti di percorso. |
+| [RenderingUtils](../com.aspose.font/renderingutils) | Fornisce metodi di utilità per il rendering. |
+| [SegmentPath](../com.aspose.font/segmentpath) | Rappresenta il percorso di rendering. |
+| [StreamSource](../com.aspose.font/streamsource) | Definisce un modo per ottenere un flusso di file quando è necessario. |
+| [StringIndexDataProvider](../com.aspose.font/stringindexdataprovider) | Dichiara la funzionalità per accedere alla struttura CFF String INDEX. |
+| [SvgConversionException](../com.aspose.font/svgconversionexception) | Rappresenta l'eccezione di conversione del Font per il formato SVG. |
+| [TopDictDataProvider](../com.aspose.font/topdictdataprovider) | Dichiara la funzionalità per leggere/aggiornare la struttura CFF Top DICT. |
+| [TransformationMatrix](../com.aspose.font/transformationmatrix) | Represents 3x3 matrix | A B 0 |  | C D 0 |  | TX TY 1 | . |
+| [TtcFontFileDefinition](../com.aspose.font/ttcfontfiledefinition) | Rappresenta la definizione del file per il Font TTC. |
+| [TtcFontSource](../com.aspose.font/ttcfontsource) | Rappresenta la sorgente del Font TTC. |
+| [TtfCMapFormat0Table](../com.aspose.font/ttfcmapformat0table) | Rappresenta la sottotabella Format0 CMap del file TTF Font. |
+| [TtfCMapFormat10Table](../com.aspose.font/ttfcmapformat10table) | Rappresenta la sottotabella Format10 CMap del file TTF Font. |
+| [TtfCMapFormat12Table](../com.aspose.font/ttfcmapformat12table) | Rappresenta la sottotabella Format8 CMap del file TTF Font. |
+| [TtfCMapFormat2Table](../com.aspose.font/ttfcmapformat2table) | Rappresenta la sottotabella Format2 CMap del file TTF Font. |
+| [TtfCMapFormat4Table](../com.aspose.font/ttfcmapformat4table) | Rappresenta la sottotabella Format4 CMap del file TTF Font. |
+| [TtfCMapFormat6Table](../com.aspose.font/ttfcmapformat6table) | Rappresenta la sottotabella Format6 CMap del file TTF Font. |
+| [TtfCMapFormat8Table](../com.aspose.font/ttfcmapformat8table) | Rappresenta la sottotabella Format8 CMap del file TTF Font. |
+| [TtfCMapFormatBaseTable](../com.aspose.font/ttfcmapformatbasetable) | Rappresenta la classe base della sottotabella CMap. |
+| [TtfCMapTable](../com.aspose.font/ttfcmaptable) | Rappresenta la tabella "cmap" del file TTF Font. |
+| [TtfCMapTable.TtfCMapSubtableDescription](../com.aspose.font/ttfcmaptable.ttfcmapsubtabledescription) | Fornisce brevi informazioni sulla sottotabella CMap. |
+| [TtfCffTable](../com.aspose.font/ttfcfftable) | Rappresenta la tabella "cff" del file TTF Font. |
+| [TtfCvtTable](../com.aspose.font/ttfcvttable) | Rappresenta la Control Value Table (CVT) del file TTF Font. |
+| [TtfEncoding](../com.aspose.font/ttfencoding) | Rappresenta la codifica del Font TTF. |
+| [TtfEncodingParameters](../com.aspose.font/ttfencodingparameters) | Rappresenta i parametri di codifica TTF. |
+| [TtfFont](../com.aspose.font/ttffont) | Rappresenta il TrueType Font (TTF). |
+| [TtfFontMetrics](../com.aspose.font/ttffontmetrics) | Rappresenta le metriche del Font TTF. |
+| [TtfFpgmTable](../com.aspose.font/ttffpgmtable) | Rappresenta la tabella "fpgm" del file TTF Font. |
+| [TtfGaspTable](../com.aspose.font/ttfgasptable) | Rappresenta la tabella "gasp" del file TTF Font. |
+| [TtfGlyfTable](../com.aspose.font/ttfglyftable) | Rappresenta la tabella "glyf" del file TTF font. |
+| [TtfHeadTable](../com.aspose.font/ttfheadtable) | Rappresenta la tabella "head" del file TTF Font. |
+| [TtfHheaTable](../com.aspose.font/ttfhheatable) | Rappresenta la tabella "hhea" del file di font TTF. |
+| [TtfHmtxTable](../com.aspose.font/ttfhmtxtable) | Rappresenta la tabella "hmtx" del file di font TTF. |
+| [TtfHmtxTable.LongHorMetric](../com.aspose.font/ttfhmtxtable.longhormetric) | Rappresenta il record delle metriche. |
+| [TtfHmtxTable.MetricList](../com.aspose.font/ttfhmtxtable.metriclist) | Rappresenta l'elenco delle metriche |
+| [TtfLocaTable](../com.aspose.font/ttflocatable) | Rappresenta la tabella "loca" del file di font TTF. |
+| [TtfLocaTable.OffsetsList](../com.aspose.font/ttflocatable.offsetslist) | Rappresenta l'elenco degli offset dei glifi. |
+| [TtfLtshTable](../com.aspose.font/ttfltshtable) | Rappresenta la tabella Linear Threshold del file di font TTF. |
+| [TtfMaxpTable](../com.aspose.font/ttfmaxptable) | Rappresenta la tabella "maxp" del file di font TTF |
+| [TtfNameTable](../com.aspose.font/ttfnametable) | Rappresenta la tabella "name" del file di font TTF. |
+| [TtfOs2Table](../com.aspose.font/ttfos2table) | Rappresenta la tabella "OS/2" del file di font TTF. |
+| [TtfPostTable](../com.aspose.font/ttfposttable) | Rappresenta la tabella "post" del file di font TTF |
+| [TtfPrepTable](../com.aspose.font/ttfpreptable) | Rappresenta la tabella "prep" del file di font TTF. |
+| [TtfStatTable](../com.aspose.font/ttfstattable) |  |
+| [TtfTableBase](../com.aspose.font/ttftablebase) | Rappresenta la definizione della tabella TTF. |
+| [TtfTableRepository](../com.aspose.font/ttftablerepository) | repository delle tabelle TTF |
+| [TtfVheaTable](../com.aspose.font/ttfvheatable) | Rappresenta la tabella "hhea" del file di font TTF. |
+| [TtfVmtxTable](../com.aspose.font/ttfvmtxtable) | Rappresenta la tabella "vmtx" del file di font TTF. |
+| [TtfVmtxTable.LongVerMetric](../com.aspose.font/ttfvmtxtable.longvermetric) | Rappresenta il record delle metriche verticali. |
+| [Type1Encoding](../com.aspose.font/type1encoding) | Rappresenta la codifica del Font Type1. |
+| [Type1Font](../com.aspose.font/type1font) | Rappresenta il Font Type1. |
+| [Type1FontMetrics](../com.aspose.font/type1fontmetrics) | Rappresenta le metriche del Font Type1. |
+| [Type1MetricFont](../com.aspose.font/type1metricfont) | Implementazione del font metric Type1. |
+| [Version16Dot16](../com.aspose.font/version16dot16) | Rappresenta il tipo di dato Version16Dot16 |
+| [WoffFormatException](../com.aspose.font/woffformatexception) | Rappresenta l'eccezione relativa all'elaborazione dei font WOFF. |
+
+## Interfacce
+
+| Interfaccia | Descrizione |
+| --- | --- |
+| [ICffIndexDataProvider](../com.aspose.font/icffindexdataprovider) | Interfaccia di base per accedere alle strutture INDEX dei font CFF. |
+| [IEncodingParameters](../com.aspose.font/iencodingparameters) | Interfaccia comune per supportare i parametri di codifica. |
+| [IFont](../com.aspose.font/ifont) | Dichiara la funzionalità comune per tutti i formati di carattere. |
+| [IFontCharactersMerger](../com.aspose.font/ifontcharactersmerger) | Dichiara la funzionalità di supporto per unire i font TrueType. |
+| [IFontEncoding](../com.aspose.font/ifontencoding) | Definisce un'interfaccia per la codifica dei font. |
+| [IFontMetrics](../com.aspose.font/ifontmetrics) | Definisce un'interfaccia per gli strumenti di metriche dei font. |
+| [IFontSaver](../com.aspose.font/ifontsaver) | Definisce un'interfaccia per la funzionalità di salvataggio dei font. |
+| [IGlyphAccessor](../com.aspose.font/iglyphaccessor) | Definisce la funzionalità per recuperare gli identificatori di glifo specificati e i glifi. |
+| [IGlyphOutlinePainter](../com.aspose.font/iglyphoutlinepainter) | Definisce un metodo di contorno per disegnare i glifi. |
+| [IGlyphPainter](../com.aspose.font/iglyphpainter) | Definisce un modo per disegnare i glifi. |
+| [IGlyphRenderer](../com.aspose.font/iglyphrenderer) | Interfaccia utilizzata per renderizzare i glifi. |
+| [IPathSegment](../com.aspose.font/ipathsegment) | Rappresenta l'interfaccia di qualsiasi segmento di percorso. |
+| [ISupportsNameAddressing](../com.aspose.font/isupportsnameaddressing) | Definisce i membri specifici per le codifiche che supportano l'indirizzamento per nome del glifo |
+
+## Enumerazioni
+
+| Enum | Descrizione |
+| --- | --- |
+| [CffIndexProviderType](../com.aspose.font/cffindexprovidertype) | Specifica le strutture INDEX supportate dalla famiglia di interfacce del provider di indice. |
+| [CffUpdateStringIndexStrategy](../com.aspose.font/cffupdatestringindexstrategy) | Specifica come aggiungere stringhe allo storage CFF String INDEX. |
+| [FontSavingFormats](../com.aspose.font/fontsavingformats) | Specifica il tipo di Font. |
+| [FontType](../com.aspose.font/fonttype) | Specifica il tipo di Font. |
+| [GlyphIdType](../com.aspose.font/glyphidtype) | Specifica i tipi di ID del glifo. |
+| [GlyphState](../com.aspose.font/glyphstate) | Specifica lo stato del glifo. |
+| [MSPlatformSpecificId](../com.aspose.font/msplatformspecificid) | Rappresenta l'enumerazione PlatformSpecificId della piattaforma Microsoft. |
+| [MacPlatformSpecificId](../com.aspose.font/macplatformspecificid) | Rappresenta l'enumerazione PlatformSpecificId della piattaforma Macintosh. |
+| [PlatformId](../com.aspose.font/platformid) | Rappresenta l'enumerazione PlatformId. |
+| [RangeGaspBehaviorFlags](../com.aspose.font/rangegaspbehaviorflags) | Flag che descrivono il comportamento desiderato del rasterizzatore. |
+| [UnicodePlatformSpecificId](../com.aspose.font/unicodeplatformspecificid) | Rappresenta l'enumerazione specifica della piattaforma Unicode. |

--- a/italian/java/com.aspose.font/axisrecord/_index.md
+++ b/italian/java/com.aspose.font/axisrecord/_index.md
@@ -1,0 +1,177 @@
+---
+title: "AxisRecord"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la struttura del record Axis."
+type: docs
+weight: 10
+url: /it/java/com.aspose.font/axisrecord/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class AxisRecord
+```
+
+Rappresenta la struttura Axis Record. Spec: il record dell'asse fornisce informazioni su un singolo asse di design.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [AxisRecord(String tag, int axisNameId, int axisOrdering)](#AxisRecord-java.lang.String-int-int-) | Costruttore |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisNameId()](#getAxisNameId--) | Restituisce il campo axisNameID. |
+| [getAxisOrdering()](#getAxisOrdering--) | Restituisce il campo axisOrdering. |
+| [getClass()](#getClass--) |  |
+| [getTag()](#getTag--) | Restituisce un tag che identifica l'asse di variazione di design. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisRecord(String tag, int axisNameId, int axisOrdering) {#AxisRecord-java.lang.String-int-int-}
+```
+public AxisRecord(String tag, int axisNameId, int axisOrdering)
+```
+
+
+Costruttore
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| tag | java.lang.String | Tag, spec: Un tag che identifica l'asse di variazione di design |
+| axisNameId | int | L'ID nome per le voci nella tabella 'name' che forniscono una stringa visualizzabile per questo asse |
+| axisOrdering | int | Il valore che le applicazioni possono utilizzare per determinare l'ordinamento primario dei nomi dei font, o per l'ordinamento delle etichette quando si compongono nomi di famiglia o di font. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisNameId() {#getAxisNameId--}
+```
+public int getAxisNameId()
+```
+
+
+Restituisce il campo axisNameID. Spec: Il campo axisNameID fornisce un ID nome che può essere usato per ottenere stringhe dalla tabella 'name' che possono essere utilizzate per riferirsi all'asse nelle interfacce utente dell'applicazione.
+
+**Returns:**
+int - Il campo axisNameID.
+### getAxisOrdering() {#getAxisOrdering--}
+```
+public int getAxisOrdering()
+```
+
+
+Restituisce il campo axisOrdering. Spec: Un valore che le applicazioni possono utilizzare per determinare l'ordinamento primario dei nomi dei font, o per l'ordinamento delle etichette quando si compongono nomi di famiglia o di font.
+
+**Returns:**
+int - Il campo axisOrdering.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getTag() {#getTag--}
+```
+public String getTag()
+```
+
+
+Restituisce un tag che identifica l'asse di variazione di design. Spec: Ogni record dell'asse ha un tag che designa l'asse. I valori dei tag devono seguire le regole per i tag degli assi descritte nel Registro dei Tag degli Assi di Variazione di Design OpenType.
+
+**Returns:**
+java.lang.String - Un tag che identifica l'asse di variazione di design.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/axisvalue/_index.md
+++ b/italian/java/com.aspose.font/axisvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: "AxisValue"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta il record AxisValue."
+type: docs
+weight: 11
+url: /it/java/com.aspose.font/axisvalue/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class AxisValue
+```
+
+Rappresenta il record AxisValue.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [AxisValue(int axisIndex, float value)](#AxisValue-int-float-) | Costruttore |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisIndex()](#getAxisIndex--) | Ottiene il campo axisIndex. |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Ottiene un valore numerico per questo valore di attributo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValue(int axisIndex, float value) {#AxisValue-int-float-}
+```
+public AxisValue(int axisIndex, float value)
+```
+
+
+Costruttore
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| axisIndex | int | Indice a base zero nell'array dei record degli assi che identifica l'asse a cui si applica questo valore. Deve essere inferiore a designAxisCount. |
+| valore | float | Il valore numerico per questo valore di attributo. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisIndex() {#getAxisIndex--}
+```
+public int getAxisIndex()
+```
+
+
+Ottiene il campo axisIndex. Specifica: indice a base zero nell'array dei record degli assi che identifica l'asse a cui si applica questo valore. Deve essere inferiore a designAxisCount.
+
+**Returns:**
+int - Il campo axisIndex.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public float getValue()
+```
+
+
+Ottiene un valore numerico per questo valore di attributo.
+
+**Returns:**
+float - Un valore numerico per questo valore di attributo.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/axisvaluetablebase/_index.md
+++ b/italian/java/com.aspose.font/axisvaluetablebase/_index.md
@@ -1,0 +1,168 @@
+---
+title: "AxisValueTableBase"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Classe base per la struttura della tabella Axis Value."
+type: docs
+weight: 12
+url: /it/java/com.aspose.font/axisvaluetablebase/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class AxisValueTableBase
+```
+
+Classe base per la struttura Axis Value Table. Spec: le Axis Value Tables forniscono dettagli riguardo a un valore di attributo di stile specifico su un asse specifico di variazione di design, o una combinazione di valori di assi di variazione di design, e la relazione di tali valori con le etichette usate come elementi nei nomi di sottogruppo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Restituisce il campo dei flag della tabella dei valori dell'asse. |
+| [getFormat()](#getFormat--) | Restituisce l'identificatore del formato (numero di versione). |
+| [getValueName()](#getValueName--) | Restituisce il nome dalla tabella 'name' che fornisce una stringa visualizzabile per questo valore di attributo. |
+| [getValueNameId()](#getValueNameId--) | Restituisce l'ID del nome per le voci nella tabella 'name' che forniscono una stringa visualizzabile per questo valore di attributo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Restituisce il campo dei flag della tabella dei valori dell'asse.
+
+**Returns:**
+int - Il campo dei flag della tabella dei valori dell'asse.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Restituisce l'identificatore del formato (numero di versione).
+
+**Returns:**
+int - L'identificatore del formato (numero di versione).
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Restituisce il nome dalla tabella 'name' che fornisce una stringa visualizzabile per questo valore di attributo.
+
+**Returns:**
+java.lang.String - Il nome dalla tabella 'name' che fornisce una stringa di visualizzazione per questo valore di attributo.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Restituisce l'ID del nome per le voci nella tabella 'name' che forniscono una stringa visualizzabile per questo valore di attributo.
+
+**Returns:**
+int - L'ID nome per le voci nella tabella 'name' che fornisce una stringa di visualizzazione per questo valore di attributo.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/axisvaluetableflags/_index.md
+++ b/italian/java/com.aspose.font/axisvaluetableflags/_index.md
@@ -1,0 +1,259 @@
+---
+title: "TtfStatTable.AxisValueTableFlags"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Specifica i flag della tabella dei valori dell'asse."
+type: docs
+weight: 10
+url: /it/java/com.aspose.font/ttfstattable.axisvaluetableflags/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum TtfStatTable.AxisValueTableFlags extends Enum<TtfStatTable.AxisValueTableFlags>
+```
+
+Specifica i flag della tabella dei valori dell'asse.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ElidableAxisValueName](#ElidableAxisValueName) | Se impostato, indica che il valore dell'asse rappresenta il valore "normale" per l'asse e può essere omesso durante la composizione delle stringhe di nome. |
+| [OlderSiblingFontAttribute](#OlderSiblingFontAttribute) | Se impostato, questa tabella dei valori dell'asse fornisce informazioni sui valori dell'asse applicabili ad altri caratteri all'interno della stessa famiglia di caratteri. |
+| [Reserved](#Reserved) | Riservato per uso futuro |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ElidableAxisValueName {#ElidableAxisValueName}
+```
+public static final TtfStatTable.AxisValueTableFlags ElidableAxisValueName
+```
+
+
+Se impostato, indica che il valore dell'asse rappresenta il valore "normale" per l'asse e può essere omesso durante la composizione delle stringhe di nome.
+
+### OlderSiblingFontAttribute {#OlderSiblingFontAttribute}
+```
+public static final TtfStatTable.AxisValueTableFlags OlderSiblingFontAttribute
+```
+
+
+Se impostato, questa tabella dei valori dell'asse fornisce informazioni sui valori dell'asse applicabili ad altri caratteri all'interno della stessa famiglia di caratteri. Viene utilizzata se gli altri caratteri sono stati rilasciati in precedenza e non includono informazioni sui valori di alcuni assi. Se versioni più recenti degli altri caratteri includono le informazioni stesse e sono presenti, allora questa tabella viene ignorata.
+
+### Reserved {#Reserved}
+```
+public static final TtfStatTable.AxisValueTableFlags Reserved
+```
+
+
+Riservato per uso futuro
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static TtfStatTable.AxisValueTableFlags valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[AxisValueTableFlags](../../com.aspose.font/axisvaluetableflags)
+### values() {#values--}
+```
+public static TtfStatTable.AxisValueTableFlags[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.TtfStatTable.AxisValueTableFlags[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/axisvaluetableformat1/_index.md
+++ b/italian/java/com.aspose.font/axisvaluetableformat1/_index.md
@@ -1,0 +1,211 @@
+---
+title: "AxisValueTableFormat1"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta il formato 1 della tabella Axis value."
+type: docs
+weight: 13
+url: /it/java/com.aspose.font/axisvaluetableformat1/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.AxisValueTableBase](../../com.aspose.font/axisvaluetablebase)
+```
+public class AxisValueTableFormat1 extends AxisValueTableBase
+```
+
+Rappresenta il formato 1 della tabella Axis value.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [AxisValueTableFormat1(int flags, int valueNameId, int axisIndex, float value)](#AxisValueTableFormat1-int-int-int-float-) | Costruttore |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisIndex()](#getAxisIndex--) | Restituisce l'indice a base zero nell'array dei record degli assi che identifica l'asse di variazione di design a cui si applica la tabella dei valori dell'asse. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Restituisce il campo dei flag della tabella dei valori dell'asse. |
+| [getFormat()](#getFormat--) | Restituisce l'identificatore del formato (numero di versione). |
+| [getValue()](#getValue--) | Il valore numerico per questo valore di attributo. |
+| [getValueName()](#getValueName--) | Restituisce il nome dalla tabella 'name' che fornisce una stringa visualizzabile per questo valore di attributo. |
+| [getValueNameId()](#getValueNameId--) | Restituisce l'ID del nome per le voci nella tabella 'name' che forniscono una stringa visualizzabile per questo valore di attributo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValueTableFormat1(int flags, int valueNameId, int axisIndex, float value) {#AxisValueTableFormat1-int-int-int-float-}
+```
+public AxisValueTableFormat1(int flags, int valueNameId, int axisIndex, float value)
+```
+
+
+Costruttore
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flag | int | Flag |
+| valueNameId | int | L'ID del nome per le voci nella tabella 'name' che forniscono una stringa visualizzabile per questo valore di attributo |
+| axisIndex | int | Spec: Indice a base zero nell'array dei record degli assi che identifica l'asse di variazione di design a cui si applica la tabella dei valori dell'asse. Deve essere inferiore a designAxisCount. |
+| valore | float | Il valore numerico per questo valore di attributo. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisIndex() {#getAxisIndex--}
+```
+public int getAxisIndex()
+```
+
+
+Restituisce l'indice a base zero nell'array dei record degli assi che identifica l'asse di variazione di design a cui si applica la tabella dei valori dell'asse.
+
+**Returns:**
+int - Indice a base zero nell'array di record dell'asse che identifica l'asse di variazione di design a cui si applica la tabella dei valori dell'asse.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Restituisce il campo dei flag della tabella dei valori dell'asse.
+
+**Returns:**
+int - Il campo dei flag della tabella dei valori dell'asse.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Restituisce l'identificatore del formato (numero di versione).
+
+**Returns:**
+int - L'identificatore del formato (numero di versione).
+### getValue() {#getValue--}
+```
+public float getValue()
+```
+
+
+Il valore numerico per questo valore di attributo.
+
+**Returns:**
+float - Il valore numerico per questo valore di attributo.
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Restituisce il nome dalla tabella 'name' che fornisce una stringa visualizzabile per questo valore di attributo.
+
+**Returns:**
+java.lang.String - Il nome dalla tabella 'name' che fornisce una stringa di visualizzazione per questo valore di attributo.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Restituisce l'ID del nome per le voci nella tabella 'name' che forniscono una stringa visualizzabile per questo valore di attributo.
+
+**Returns:**
+int - L'ID nome per le voci nella tabella 'name' che fornisce una stringa di visualizzazione per questo valore di attributo.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/axisvaluetableformat2/_index.md
+++ b/italian/java/com.aspose.font/axisvaluetableformat2/_index.md
@@ -1,0 +1,235 @@
+---
+title: "AxisValueTableFormat2"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta il formato 2 della tabella Axis value."
+type: docs
+weight: 14
+url: /it/java/com.aspose.font/axisvaluetableformat2/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.AxisValueTableBase](../../com.aspose.font/axisvaluetablebase)
+```
+public class AxisValueTableFormat2 extends AxisValueTableBase
+```
+
+Rappresenta il formato 2 della tabella Axis value.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [AxisValueTableFormat2(int flags, int valueNameId, int axisIndex, float nominalValue, float rangeMinValue, float rangeMaxValue)](#AxisValueTableFormat2-int-int-int-float-float-float-) | Costruttore |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisIndex()](#getAxisIndex--) | Restituisce l'indice Zero-base nell'array di record dell'asse che identifica l'asse di variazione di design a cui si applica la tabella dei valori dell'asse. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Restituisce il campo dei flag della tabella dei valori dell'asse. |
+| [getFormat()](#getFormat--) | Restituisce l'identificatore del formato (numero di versione). |
+| [getNominalValue()](#getNominalValue--) | Un valore numerico nominale |
+| [getRangeMaxValue()](#getRangeMaxValue--) | Il valore massimo per un intervallo associato all'ID nome specificato. |
+| [getRangeMinValue()](#getRangeMinValue--) | Il valore minimo per un intervallo associato all'ID nome specificato. |
+| [getValueName()](#getValueName--) | Restituisce il nome dalla tabella 'name' che fornisce una stringa visualizzabile per questo valore di attributo. |
+| [getValueNameId()](#getValueNameId--) | Restituisce l'ID del nome per le voci nella tabella 'name' che forniscono una stringa visualizzabile per questo valore di attributo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValueTableFormat2(int flags, int valueNameId, int axisIndex, float nominalValue, float rangeMinValue, float rangeMaxValue) {#AxisValueTableFormat2-int-int-int-float-float-float-}
+```
+public AxisValueTableFormat2(int flags, int valueNameId, int axisIndex, float nominalValue, float rangeMinValue, float rangeMaxValue)
+```
+
+
+Costruttore
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flag | int | Flag |
+| valueNameId | int | L'ID del nome per le voci nella tabella 'name' che forniscono una stringa visualizzabile per questo valore di attributo |
+| axisIndex | int | Spec: Indice a base zero nell'array dei record degli assi che identifica l'asse di variazione di design a cui si applica la tabella dei valori dell'asse. Deve essere inferiore a designAxisCount. |
+| nominalValue | float | Il valore numerico nominale per questo valore di attributo. |
+| rangeMinValue | float | Il valore minimo per un intervallo associato all'ID nome specificato. |
+| rangeMaxValue | float | Il valore massimo per un intervallo associato all'ID nome specificato. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisIndex() {#getAxisIndex--}
+```
+public int getAxisIndex()
+```
+
+
+Restituisce l'indice Zero-base nell'array di record dell'asse che identifica l'asse di variazione di design a cui si applica la tabella dei valori dell'asse.
+
+**Returns:**
+int - L'indice a base zero nell'array di record dell'asse che identifica l'asse di variazione di design a cui si applica la tabella dei valori dell'asse.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Restituisce il campo dei flag della tabella dei valori dell'asse.
+
+**Returns:**
+int - Il campo dei flag della tabella dei valori dell'asse.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Restituisce l'identificatore del formato (numero di versione).
+
+**Returns:**
+int - L'identificatore del formato (numero di versione).
+### getNominalValue() {#getNominalValue--}
+```
+public float getNominalValue()
+```
+
+
+Un valore numerico nominale
+
+**Returns:**
+float - Un valore numerico nominale
+### getRangeMaxValue() {#getRangeMaxValue--}
+```
+public float getRangeMaxValue()
+```
+
+
+Il valore massimo per un intervallo associato all'ID nome specificato.
+
+**Returns:**
+float - Il valore massimo per un intervallo associato all'ID nome specificato.
+### getRangeMinValue() {#getRangeMinValue--}
+```
+public float getRangeMinValue()
+```
+
+
+Il valore minimo per un intervallo associato all'ID nome specificato.
+
+**Returns:**
+float - Il valore minimo per un intervallo associato all'ID nome specificato.
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Restituisce il nome dalla tabella 'name' che fornisce una stringa visualizzabile per questo valore di attributo.
+
+**Returns:**
+java.lang.String - Il nome dalla tabella 'name' che fornisce una stringa di visualizzazione per questo valore di attributo.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Restituisce l'ID del nome per le voci nella tabella 'name' che forniscono una stringa visualizzabile per questo valore di attributo.
+
+**Returns:**
+int - L'ID nome per le voci nella tabella 'name' che fornisce una stringa di visualizzazione per questo valore di attributo.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/axisvaluetableformat3/_index.md
+++ b/italian/java/com.aspose.font/axisvaluetableformat3/_index.md
@@ -1,0 +1,223 @@
+---
+title: "AxisValueTableFormat3"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta il formato 3 della tabella Axis value."
+type: docs
+weight: 15
+url: /it/java/com.aspose.font/axisvaluetableformat3/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.AxisValueTableBase](../../com.aspose.font/axisvaluetablebase)
+```
+public class AxisValueTableFormat3 extends AxisValueTableBase
+```
+
+Rappresenta il formato 3 della tabella Axis value.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [AxisValueTableFormat3(int flags, int valueNameId, int axisIndex, float value, float linkedValue)](#AxisValueTableFormat3-int-int-int-float-float-) | Costruttore |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisIndex()](#getAxisIndex--) | Restituisce l'indice a base zero nell'array dei record degli assi che identifica l'asse di variazione di design a cui si applica la tabella dei valori dell'asse. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Restituisce il campo dei flag della tabella dei valori dell'asse. |
+| [getFormat()](#getFormat--) | Restituisce l'identificatore del formato (numero di versione). |
+| [getLinkedValue()](#getLinkedValue--) | Il valore numerico per una mappatura collegata allo stile da questo valore. |
+| [getValue()](#getValue--) | Il valore numerico per questo valore di attributo. |
+| [getValueName()](#getValueName--) | Restituisce il nome dalla tabella 'name' che fornisce una stringa visualizzabile per questo valore di attributo. |
+| [getValueNameId()](#getValueNameId--) | Restituisce l'ID del nome per le voci nella tabella 'name' che forniscono una stringa visualizzabile per questo valore di attributo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValueTableFormat3(int flags, int valueNameId, int axisIndex, float value, float linkedValue) {#AxisValueTableFormat3-int-int-int-float-float-}
+```
+public AxisValueTableFormat3(int flags, int valueNameId, int axisIndex, float value, float linkedValue)
+```
+
+
+Costruttore
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flag | int | Flag |
+| valueNameId | int | L'ID del nome per le voci nella tabella 'name' che forniscono una stringa visualizzabile per questo valore di attributo |
+| axisIndex | int | Spec: Indice a base zero nell'array dei record degli assi che identifica l'asse di variazione di design a cui si applica la tabella dei valori dell'asse. Deve essere inferiore a designAxisCount. |
+| valore | float | Il valore numerico per questo valore di attributo. |
+| linkedValue | float | Il valore numerico per una mappatura collegata allo stile da questo valore. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisIndex() {#getAxisIndex--}
+```
+public int getAxisIndex()
+```
+
+
+Restituisce l'indice a base zero nell'array dei record degli assi che identifica l'asse di variazione di design a cui si applica la tabella dei valori dell'asse.
+
+**Returns:**
+int - Indice a base zero nell'array di record dell'asse che identifica l'asse di variazione di design a cui si applica la tabella dei valori dell'asse.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Restituisce il campo dei flag della tabella dei valori dell'asse.
+
+**Returns:**
+int - Il campo dei flag della tabella dei valori dell'asse.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Restituisce l'identificatore del formato (numero di versione).
+
+**Returns:**
+int - L'identificatore del formato (numero di versione).
+### getLinkedValue() {#getLinkedValue--}
+```
+public float getLinkedValue()
+```
+
+
+Il valore numerico per una mappatura collegata allo stile da questo valore.
+
+**Returns:**
+float - Il valore numerico per una mappatura collegata allo stile da questo valore.
+### getValue() {#getValue--}
+```
+public float getValue()
+```
+
+
+Il valore numerico per questo valore di attributo.
+
+**Returns:**
+float - Il valore numerico per questo valore di attributo.
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Restituisce il nome dalla tabella 'name' che fornisce una stringa visualizzabile per questo valore di attributo.
+
+**Returns:**
+java.lang.String - Il nome dalla tabella 'name' che fornisce una stringa di visualizzazione per questo valore di attributo.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Restituisce l'ID del nome per le voci nella tabella 'name' che forniscono una stringa visualizzabile per questo valore di attributo.
+
+**Returns:**
+int - L'ID nome per le voci nella tabella 'name' che fornisce una stringa di visualizzazione per questo valore di attributo.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/axisvaluetableformat4/_index.md
+++ b/italian/java/com.aspose.font/axisvaluetableformat4/_index.md
@@ -1,0 +1,199 @@
+---
+title: "AxisValueTableFormat4"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta il formato 4 della tabella Axis value."
+type: docs
+weight: 16
+url: /it/java/com.aspose.font/axisvaluetableformat4/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.AxisValueTableBase](../../com.aspose.font/axisvaluetablebase)
+```
+public class AxisValueTableFormat4 extends AxisValueTableBase
+```
+
+Rappresenta il formato 4 della tabella Axis value.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [AxisValueTableFormat4(int flags, int valueNameId, AxisValue[] axisValues)](#AxisValueTableFormat4-int-int-com.aspose.font.AxisValue---) | Costruttore |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisValues()](#getAxisValues--) | Array di record AxisValue che forniscono la combinazione di valori degli assi, uno per ciascun asse contributivo. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Restituisce il campo dei flag della tabella dei valori dell'asse. |
+| [getFormat()](#getFormat--) | Restituisce l'identificatore del formato (numero di versione). |
+| [getValueName()](#getValueName--) | Restituisce il nome dalla tabella 'name' che fornisce una stringa visualizzabile per questo valore di attributo. |
+| [getValueNameId()](#getValueNameId--) | Restituisce l'ID del nome per le voci nella tabella 'name' che forniscono una stringa visualizzabile per questo valore di attributo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValueTableFormat4(int flags, int valueNameId, AxisValue[] axisValues) {#AxisValueTableFormat4-int-int-com.aspose.font.AxisValue---}
+```
+public AxisValueTableFormat4(int flags, int valueNameId, AxisValue[] axisValues)
+```
+
+
+Costruttore
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flag | int | Flag |
+| valueNameId | int | L'ID del nome per le voci nella tabella 'name' che forniscono una stringa visualizzabile per questo valore di attributo |
+| axisValues | [AxisValue\[\]](../../com.aspose.font/axisvalue) | Array di record AxisValue che forniscono la combinazione di valori degli assi, uno per ciascun asse contributivo. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisValues() {#getAxisValues--}
+```
+public AxisValue[] getAxisValues()
+```
+
+
+Array di record AxisValue che forniscono la combinazione di valori degli assi, uno per ciascun asse contributivo.
+
+**Returns:**
+com.aspose.font.AxisValue[] - Array di record AxisValue che forniscono la combinazione di valori degli assi, uno per ciascun asse contributivo.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Restituisce il campo dei flag della tabella dei valori dell'asse.
+
+**Returns:**
+int - Il campo dei flag della tabella dei valori dell'asse.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Restituisce l'identificatore del formato (numero di versione).
+
+**Returns:**
+int - L'identificatore del formato (numero di versione).
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Restituisce il nome dalla tabella 'name' che fornisce una stringa visualizzabile per questo valore di attributo.
+
+**Returns:**
+java.lang.String - Il nome dalla tabella 'name' che fornisce una stringa di visualizzazione per questo valore di attributo.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Restituisce l'ID del nome per le voci nella tabella 'name' che forniscono una stringa visualizzabile per questo valore di attributo.
+
+**Returns:**
+int - L'ID nome per le voci nella tabella 'name' che fornisce una stringa di visualizzazione per questo valore di attributo.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/bytecontentstreamsource/_index.md
+++ b/italian/java/com.aspose.font/bytecontentstreamsource/_index.md
@@ -1,0 +1,200 @@
+---
+title: "ByteContentStreamSource"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta una sorgente di flusso basata su _content stream."
+type: docs
+weight: 17
+url: /it/java/com.aspose.font/bytecontentstreamsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.StreamSource](../../com.aspose.font/streamsource)
+```
+public class ByteContentStreamSource extends StreamSource
+```
+
+Rappresenta una sorgente di flusso basata sullo stream \_content.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ByteContentStreamSource(byte[] fileContent)](#ByteContentStreamSource-byte---) | Inizializza un nuovo oggetto  ByteContentStreamSource  . |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Clona l'oggetto ByteContentStreamSource. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontStream()](#getFontStream--) | Restituisce lo stream del file Font. |
+| [getOffset()](#getOffset--) | Ottiene l'offset all'interno della sorgente. |
+| [hashCode()](#hashCode--) |  |
+| [mustCloseAfterUse()](#mustCloseAfterUse--) | Gli eredi possono impedire la chiusura del stream. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOffset(long value)](#setOffset-long-) | Imposta l'offset all'interno della sorgente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ByteContentStreamSource(byte[] fileContent) {#ByteContentStreamSource-byte---}
+```
+public ByteContentStreamSource(byte[] fileContent)
+```
+
+
+Inizializza un nuovo oggetto  ByteContentStreamSource  .
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fileContent | byte[] | Byte del file. |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Clona l'oggetto ByteContentStreamSource.
+
+**Returns:**
+java.lang.Object
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontStream() {#getFontStream--}
+```
+public InputStream getFontStream()
+```
+
+
+Restituisce lo stream del file Font. Non dimenticare di chiudere lo stream dopo l'uso.
+
+**Returns:**
+java.io.InputStream - stream del file Font.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset all'interno della sorgente.
+
+**Returns:**
+long - Offset all'interno della sorgente.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### mustCloseAfterUse() {#mustCloseAfterUse--}
+```
+public boolean mustCloseAfterUse()
+```
+
+
+Gli eredi possono impedire la chiusura del stream. Restituisce true se la sorgente di stream desidera che il stream venga chiuso dopo l'uso. Altrimenti restituisce false.
+
+**Returns:**
+boolean - True se la sorgente di stream desidera che il stream venga chiuso dopo l'uso, altrimenti false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOffset(long value) {#setOffset-long-}
+```
+public void setOffset(long value)
+```
+
+
+Imposta l'offset all'interno della sorgente.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long | Offset all'interno della sorgente. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/cffencoding/_index.md
+++ b/italian/java/com.aspose.font/cffencoding/_index.md
@@ -1,0 +1,256 @@
+---
+title: "CffEncoding"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la codifica _font CFF."
+type: docs
+weight: 18
+url: /it/java/com.aspose.font/cffencoding/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFontEncoding](../../com.aspose.font/ifontencoding), [com.aspose.font.ISupportsNameAddressing](../../com.aspose.font/isupportsnameaddressing)
+```
+public class CffEncoding implements IFontEncoding, ISupportsNameAddressing
+```
+
+Rappresenta la codifica CFF \_font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [decodeToGid(long charCode)](#decodeToGid-long-) | Ottiene Gid per il charCode fornito. |
+| [decodeToGidParameterized(IEncodingParameters parameters, long charCode)](#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-) | Metodo di decodifica parametrizzato. |
+| [encode(long gid, long charCode)](#encode-long-long-) | Codifica il glifo. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getNameToCharCodeIndex()](#getNameToCharCodeIndex--) | Restituisce la mappa di codifica nome a codice carattere. |
+| [getNameToGidIndex()](#getNameToGidIndex--) | Restituisce la mappa di codifica nome a codice carattere. |
+| [getNameToSidIndex()](#getNameToSidIndex--) | Restituisce la mappa di codifica nome a codice carattere. |
+| [getSidName(int sid)](#getSidName-int-) | Ottiene il nome per il SID specificato. |
+| [gidToUnicode(GlyphId gid)](#gidToUnicode-com.aspose.font.GlyphId-) | Decodifica Gid in unicode. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [unicodeToGid(long unicode)](#unicodeToGid-long-) | Decodifica un Unicode e restituisce l'ID del glifo. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### decodeToGid(long charCode) {#decodeToGid-long-}
+```
+public GlyphId decodeToGid(long charCode)
+```
+
+
+Ottiene Gid per il charCode fornito. Questo metodo è progettato per CFF CIDFonts, dove charCode deve essere un valore CID valido. Glyph id è un numero unico per un glifo, che dipende dal tipo \\_font. Il glyph id del Font CFF può essere un'istanza della classe ( GlyphStringId ) o della classe ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| charCode | long | Codice carattere (CID) per cui ottenere l'identificatore del glifo. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to CID passed.
+### decodeToGidParameterized(IEncodingParameters parameters, long charCode) {#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-}
+```
+public GlyphId decodeToGidParameterized(IEncodingParameters parameters, long charCode)
+```
+
+
+Metodo di decodifica parametrizzato. Non supportato per il tipo di Font CFF.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| parameters | [IEncodingParameters](../../com.aspose.font/iencodingparameters) | Implementazione dell'interfaccia IEncodingParameters. |
+| charCode | long | Codice carattere per cui ottenere l'identificatore del glifo. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to charCode passed.
+### encode(long gid, long charCode) {#encode-long-long-}
+```
+public void encode(long gid, long charCode)
+```
+
+
+Codifica il glifo. Non supportato per i tipi di Font CFF.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| gid | long | Glyph id |
+| charCode | long | CharCode associato all'ID glifo. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNameToCharCodeIndex() {#getNameToCharCodeIndex--}
+```
+public NameToCodeMap getNameToCharCodeIndex()
+```
+
+
+Restituisce la mappa nome‑codice carattere della codifica. Nota: il codice carattere non è un unicode. Il codice carattere è un indice di carattere nella \"tabella\" di codifica del Font.
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - Name to character code encoding map.
+### getNameToGidIndex() {#getNameToGidIndex--}
+```
+public NameToCodeMap getNameToGidIndex()
+```
+
+
+Restituisce la mappa nome‑codice carattere della codifica. Nota: il codice carattere non è un unicode. Il codice carattere è un indice di carattere nella \"tabella\" di codifica del Font.
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - Name to character code encoding map.
+### getNameToSidIndex() {#getNameToSidIndex--}
+```
+public NameToCodeMap getNameToSidIndex()
+```
+
+
+Restituisce la mappa nome‑codice carattere della codifica. Nota: il codice carattere non è un unicode. Il codice carattere è un indice di carattere nella \"tabella\" di codifica del Font.
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - Name to character code encoding map.
+### getSidName(int sid) {#getSidName-int-}
+```
+public String getSidName(int sid)
+```
+
+
+Ottiene il nome per il SID specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| sid | int | Identificatore stringa. |
+
+**Returns:**
+java.lang.String - Nome dall'INDEX di String se trovato.
+### gidToUnicode(GlyphId gid) {#gidToUnicode-com.aspose.font.GlyphId-}
+```
+public long gidToUnicode(GlyphId gid)
+```
+
+
+Decodifica Gid in unicode. Glyph id è un numero unico per un glifo, che dipende dal tipo \\_font. Il glyph id del Font CFF può essere un'istanza della classe ( GlyphStringId ) o della classe ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| gid | [GlyphId](../../com.aspose.font/glyphid) | Identificatore del glifo del simbolo da decodificare. |
+
+**Returns:**
+long - Valore Unicode relativo all'id del glifo passato.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unicodeToGid(long unicode) {#unicodeToGid-long-}
+```
+public GlyphId unicodeToGid(long unicode)
+```
+
+
+Decodifica un unicode e restituisce l'ID glifo. Glyph id è un numero unico per un glifo, che dipende dal tipo \\_font. Il glyph id del Font CFF può essere un'istanza della classe ( GlyphStringId ) o della classe ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| unicode | long | Unicode per cui ottenere l'identificatore del glifo. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to unicode passed.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/cfffont/_index.md
+++ b/italian/java/com.aspose.font/cfffont/_index.md
@@ -1,0 +1,604 @@
+---
+title: "CffFont"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta Compact Font Format CFF."
+type: docs
+weight: 19
+url: /it/java/com.aspose.font/cfffont/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Font](../../com.aspose.font/font)
+```
+public class CffFont extends Font
+```
+
+Rappresenta il Compact Font Format (CFF).
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Converte il Font in un altro formato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Restituisce un array di tutti gli ID glifo, disponibili nel Font. |
+| [getClass()](#getClass--) |  |
+| [getCommonFontsSettings()](#getCommonFontsSettings--) | Ottiene le impostazioni comuni ai font CFF. |
+| [getEncoding()](#getEncoding--) | Ottiene la codifica del Font. |
+| [getFontDefinition()](#getFontDefinition--) | Ottiene la definizione del font. |
+| [getFontFamily()](#getFontFamily--) | Ottiene la famiglia del Font. |
+| [getFontName()](#getFontName--) | Ottiene il nome del Font face. |
+| [getFontNames()](#getFontNames--) | Ottiene i nomi del Font. |
+| [getFontSaver()](#getFontSaver--) | Ottiene la funzionalità di salvataggio del Font. |
+| [getFontStyle()](#getFontStyle--) | Ottiene lo stile del Font. |
+| [getFontType()](#getFontType--) | Ottiene il tipo di Font. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Accessor dei glifi del Font. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Restituisce il glifo per ID glifo. |
+| [getGlyphById(String glyphName)](#getGlyphById-java.lang.String-) | Restituisce il glifo per nome glifo. |
+| [getGlyphById(long id)](#getGlyphById-long-) | Restituisce il glifo per ID glifo. |
+| [getGlyphIdType()](#getGlyphIdType--) | Ottiene la specifica del tipo di ID glifo. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Ottiene la rappresentazione dei glifi per il testo. |
+| [getIndexDataProvider(CffIndexProviderType indexType)](#getIndexDataProvider-com.aspose.font.CffIndexProviderType-) | Ottiene il provider per il tipo di struttura CFF INDEX specificato. |
+| [getMetrics()](#getMetrics--) | Ottiene le metriche del Font. |
+| [getNumGlyphs()](#getNumGlyphs--) | Ottiene il numero di glifi nel Font. |
+| [getPostscriptNames()](#getPostscriptNames--) | Ottiene i nomi del font Postscript. |
+| [getStyle()](#getStyle--) | Ottiene lo stile del Font. |
+| [getTopDictDataProvider()](#getTopDictDataProvider--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isCidKeyedFont()](#isCidKeyedFont--) | Ottiene il valore che indica che il font è cid-keyed. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Apre un font, utilizzando l'oggetto FontDefinition. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Apre un font, utilizzando il tipo di font e l'array di byte dei dati del font. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Apre un font, utilizzando il tipo di font e la sorgente stream. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Apre un font, utilizzando il tipo di font e il nome del file del font. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Salva il Font nel formato originale. |
+| [save(String fileName)](#save-java.lang.String-) | Salva il Font nel formato originale. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Salva il Font nel formato specificato. |
+| [setCommonFontsSettings(CffFontsSettings value)](#setCommonFontsSettings-com.aspose.font.CffFontsSettings-) | Specifica le impostazioni comuni ai font CFF. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Il setter della famiglia del font non è ancora implementato. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Il setter del nome del font non è ancora implementato. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Il setter dello stile non è ancora implementato. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public Font convert(FontType fontType)
+```
+
+
+Converte il Font in un altro formato. Nota: il tipo di Font TTF è ora supportato solo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di formato del Font in cui convertire. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public GlyphId[] getAllGlyphIds()
+```
+
+
+Restituisce un array di tutti gli ID dei glifi disponibili nel font. L'ID del glifo è un numero unico per un glifo, dipendente dal tipo di font. L'ID del glifo del font CFF può essere un'istanza della classe ( GlyphStringId ) o della classe ( GlyphUInt32Id ).
+
+**Returns:**
+com.aspose.font.GlyphId[]
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCommonFontsSettings() {#getCommonFontsSettings--}
+```
+public CffFontsSettings getCommonFontsSettings()
+```
+
+
+Ottiene le impostazioni comuni ai font CFF. Queste impostazioni sono utilizzate in diversi scenari e possono essere modificate per ciascun font individuale.
+
+**Returns:**
+[CffFontsSettings](../../com.aspose.font/cfffontssettings) - Font definition.
+### getEncoding() {#getEncoding--}
+```
+public IFontEncoding getEncoding()
+```
+
+
+Ottiene la codifica del Font.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public FontDefinition getFontDefinition()
+```
+
+
+Ottiene la definizione del font.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public String getFontFamily()
+```
+
+
+Ottiene la famiglia del Font.
+
+**Returns:**
+java.lang.String - Famiglia del Font.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Ottiene il nome del Font face.
+
+**Returns:**
+java.lang.String - Nome del Font face.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Ottiene i nomi del Font.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Ottiene la funzionalità di salvataggio del Font.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public int getFontStyle()
+```
+
+
+Ottiene lo stile del Font. Questo è un valore calcolato e rappresentato in tipo generalizzato.
+
+**Returns:**
+int - Stile del Font. Di solito, una combinazione di valori di flag costanti della classe FontStyle o 0.
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Ottiene il tipo di font. Restituisce il valore FontType.CFF.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Accessor dei glifi del font. Recupera i glifi e gli identificatori dei glifi.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public Glyph getGlyphById(GlyphId id)
+```
+
+
+Restituisce il glifo per ID glifo. L'ID del glifo è un numero unico per un glifo, dipendente dal tipo di font. L'ID del glifo del font CFF può essere un'istanza della classe ( GlyphStringId ) o della classe ( GlyphInt32Id ).
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | ID glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(String glyphName) {#getGlyphById-java.lang.String-}
+```
+public Glyph getGlyphById(String glyphName)
+```
+
+
+Restituisce il glifo per nome glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphName | java.lang.String | Nome del glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(long id) {#getGlyphById-long-}
+```
+public Glyph getGlyphById(long id)
+```
+
+
+Restituisce il glifo per ID glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| id | long | ID glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public GlyphIdType getGlyphIdType()
+```
+
+
+Ottiene la specifica del tipo di ID glifo.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype) - Glyph id type specification.
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Ottiene la rappresentazione dei glifi per il testo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| text | java.lang.String | Testo di input. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - array di GlyphId.
+### getIndexDataProvider(CffIndexProviderType indexType) {#getIndexDataProvider-com.aspose.font.CffIndexProviderType-}
+```
+public ICffIndexDataProvider getIndexDataProvider(CffIndexProviderType indexType)
+```
+
+
+Ottiene il provider per il tipo di struttura CFF INDEX specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indexType | [CffIndexProviderType](../../com.aspose.font/cffindexprovidertype) | Tipo di struttura INDEX. |
+
+**Returns:**
+[ICffIndexDataProvider](../../com.aspose.font/icffindexdataprovider) - Implementation of ( ICffIndexDataProvider ) interface.
+### getMetrics() {#getMetrics--}
+```
+public IFontMetrics getMetrics()
+```
+
+
+Ottiene le metriche del Font.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Ottiene il numero di glifi nel Font.
+
+**Returns:**
+int - Numero di glifi nel Font.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Ottiene i nomi del font Postscript.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names.
+### getStyle() {#getStyle--}
+```
+public String getStyle()
+```
+
+
+Ottiene lo stile del Font. Questo è un valore stringa grezzo fornito dal file Font.
+
+**Returns:**
+java.lang.String - Stile del Font.
+### getTopDictDataProvider() {#getTopDictDataProvider--}
+```
+public TopDictDataProvider getTopDictDataProvider()
+```
+
+
+
+
+**Returns:**
+[TopDictDataProvider](../../com.aspose.font/topdictdataprovider)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isCidKeyedFont() {#isCidKeyedFont--}
+```
+public boolean isCidKeyedFont()
+```
+
+
+Ottiene il valore che indica che il font è cid-keyed.
+
+**Returns:**
+boolean - Valore che indica che il font è cid-keyed.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Apre un font, utilizzando l'oggetto FontDefinition.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Oggetto definizione del Font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Apre un font, utilizzando il tipo di font e l'array di byte dei dati del font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fontData | byte[] | Array di byte da cui caricare il font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Apre un font, utilizzando il tipo di font e la sorgente stream.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Sorgente stream per il font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Apre un font, utilizzando il tipo di font e il nome del file del font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fileName | java.lang.String | Nome file del font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Salva il Font nel formato originale.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Stream per salvare il font. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Salva il Font nel formato originale.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fileName | java.lang.String | File per salvare il font. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Salva il Font nel formato specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| stream | java.io.OutputStream | stream per salvare il font |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | formato desiderato |
+
+### setCommonFontsSettings(CffFontsSettings value) {#setCommonFontsSettings-com.aspose.font.CffFontsSettings-}
+```
+public void setCommonFontsSettings(CffFontsSettings value)
+```
+
+
+Specifica le impostazioni comuni ai font CFF.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [CffFontsSettings](../../com.aspose.font/cfffontssettings) | Definizione del font. |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public void setFontFamily(String value)
+```
+
+
+Il setter della famiglia del font non è ancora implementato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Nuova famiglia di Font. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public void setFontName(String value)
+```
+
+
+Il setter del nome del font non è ancora implementato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Nuovo nome faccia del Font. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public void setStyle(String value)
+```
+
+
+Il setter dello stile non è ancora implementato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Nuovo stile del Font. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/cfffontexception/_index.md
+++ b/italian/java/com.aspose.font/cfffontexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "CffFontException"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta un'eccezione comune di elaborazione relativa ai font in formato CFF."
+type: docs
+weight: 20
+url: /it/java/com.aspose.font/cfffontexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class CffFontException extends FontException
+```
+
+Rappresenta un'eccezione comune di elaborazione relativa ai font in formato CFF.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [CffFontException()](#CffFontException--) | Inizializza un nuovo oggetto CffFontException. |
+| [CffFontException(String message)](#CffFontException-java.lang.String-) | Inizializza un nuovo oggetto CffFontException. |
+| [CffFontException(String message, RuntimeException innerException)](#CffFontException-java.lang.String-java.lang.RuntimeException-) | Inizializza un nuovo oggetto CffFontException. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CffFontException() {#CffFontException--}
+```
+public CffFontException()
+```
+
+
+Inizializza un nuovo oggetto CffFontException.
+
+### CffFontException(String message) {#CffFontException-java.lang.String-}
+```
+public CffFontException(String message)
+```
+
+
+Inizializza un nuovo oggetto CffFontException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+
+### CffFontException(String message, RuntimeException innerException) {#CffFontException-java.lang.String-java.lang.RuntimeException-}
+```
+public CffFontException(String message, RuntimeException innerException)
+```
+
+
+Inizializza un nuovo oggetto CffFontException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+| innerException | java.lang.RuntimeException | L'eccezione che è la causa dell'eccezione corrente. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/cfffontmetrics/_index.md
+++ b/italian/java/com.aspose.font/cfffontmetrics/_index.md
@@ -1,0 +1,483 @@
+---
+title: "CffFontMetrics"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Implementazione delle metriche dei font CFF"
+type: docs
+weight: 21
+url: /it/java/com.aspose.font/cfffontmetrics/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.FontMetrics](../../com.aspose.font/fontmetrics)
+```
+public class CffFontMetrics extends FontMetrics
+```
+
+Implementazione delle metriche dei font CFF
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAscender()](#getAscender--) | Restituisce il valore Ascender. |
+| [getAscender(double fontSize)](#getAscender-double-) | Restituisce l'ascender per una dimensione specifica del Font. |
+| [getClass()](#getClass--) |  |
+| [getDescender()](#getDescender--) | Restituisce il valore Descender. |
+| [getDescender(double fontSize)](#getDescender-double-) | Restituisce il descender per una dimensione specifica del Font. |
+| [getFontBBox()](#getFontBBox--) | Restituisce il valore FontBBox. |
+| [getFontMatrix()](#getFontMatrix--) | Restituisce il valore FontMatrix. |
+| [getFontMatrixForGlyph(GlyphId glyphId)](#getFontMatrixForGlyph-com.aspose.font.GlyphId-) | Calcola la matrice di trasformazione per il glifo specificato dall'ID. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Restituisce il Bbox del glifo. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Restituisce la larghezza del glifo. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Restituisce il valore di kerning per la coppia di glifi. |
+| [getLineGap()](#getLineGap--) | Ottiene il valore LineGap. |
+| [getTypoAscender()](#getTypoAscender--) | Ottiene il valore TypoAscender. |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Restituisce l'ascendente tipografico per una dimensione specifica del Font. |
+| [getTypoDescender()](#getTypoDescender--) | Ottiene il valore TypoDescender. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Restituisce il discendente tipografico per una dimensione specifica del font. |
+| [getTypoLineGap()](#getTypoLineGap--) | Ottiene il valore TypoLineGap. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Restituisce il gap di linea per una dimensione specifica del Font. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Ottiene il valore UnitsPerEM. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Ottiene il valore IsFixedPitch. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Misura la stringa e restituisce la larghezza della stringa. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAscender(double value)](#setAscender-double-) | Imposta il valore Ascender. |
+| [setDescender(double value)](#setDescender-double-) | Imposta il valore Descender. |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) |  |
+| [setTypoAscender(double value)](#setTypoAscender-double-) | Imposta il valore TypoAscender. |
+| [setTypoDescender(double value)](#setTypoDescender-double-) | Imposta il valore TypoDescender. |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) | Imposta il valore UnitsPerEM. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAscender() {#getAscender--}
+```
+public double getAscender()
+```
+
+
+Restituisce il valore Ascender.
+
+**Returns:**
+double - valore Ascender.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public double getAscender(double fontSize)
+```
+
+
+Restituisce l'ascender per una dimensione specifica del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - valore Ascender.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescender() {#getDescender--}
+```
+public double getDescender()
+```
+
+
+Restituisce il valore Descender.
+
+**Returns:**
+double - valore Descender.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public double getDescender(double fontSize)
+```
+
+
+Restituisce il descender per una dimensione specifica del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - valore Descender.
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+Restituisce il valore FontBBox.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - FontBBox value.
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+Restituisce il valore FontMatrix.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - FontMatrix value.
+### getFontMatrixForGlyph(GlyphId glyphId) {#getFontMatrixForGlyph-com.aspose.font.GlyphId-}
+```
+public TransformationMatrix getFontMatrixForGlyph(GlyphId glyphId)
+```
+
+
+Calcola la matrice di trasformazione per il glifo specificato dall'ID.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificatore del glifo. |
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - Glyph transformation matrix.
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Restituisce il Bbox del glifo. Restituisce FontBBox se il BBox non era definito per il glifo. Può essere sovrascritto da eredi di codifica del font specifici.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificatore del glifo. |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox.
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Restituisce la larghezza del glifo. Può essere sovrascritta da eredi di codifica del Font specifici.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificatore del glifo. |
+
+**Returns:**
+double - Larghezza del glyph.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Restituisce il valore di kerning per la coppia di glifi.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Primo glyph nella coppia. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Dimensione del Font. |
+
+**Returns:**
+double - Valore del kerning.
+### getLineGap() {#getLineGap--}
+```
+public double getLineGap()
+```
+
+
+Ottiene il valore LineGap.
+
+**Returns:**
+double - Valore del LineGap.
+### getTypoAscender() {#getTypoAscender--}
+```
+public double getTypoAscender()
+```
+
+
+Ottiene il valore TypoAscender.
+
+**Returns:**
+double - Valore del TypoAscender.
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public double getTypoAscender(double fontSize)
+```
+
+
+Restituisce l'ascendente tipografico per una dimensione specifica del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - Valore del Typographic ascender.
+### getTypoDescender() {#getTypoDescender--}
+```
+public double getTypoDescender()
+```
+
+
+Ottiene il valore TypoDescender.
+
+**Returns:**
+double - Valore del TypoDescender.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public double getTypoDescender(double fontSize)
+```
+
+
+Restituisce il discendente tipografico per una dimensione specifica del font.
+
+param fontSize Dimensione del font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double |  |
+
+**Returns:**
+double - Valore del Typographic descender.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public double getTypoLineGap()
+```
+
+
+Ottiene il valore TypoLineGap.
+
+**Returns:**
+double - Valore del TypoLineGap.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public double getTypoLineGap(double fontSize)
+```
+
+
+Restituisce il gap di linea per una dimensione specifica del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - Valore del Line gap.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Ottiene il valore UnitsPerEM.
+
+**Returns:**
+long - Valore del UnitsPerEM.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+Ottiene il valore IsFixedPitch.
+
+**Returns:**
+boolean - Valore del IsFixedPitch.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public double measureString(String unicode, double fontSize)
+```
+
+
+Misura la stringa e restituisce la larghezza della stringa.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| unicode | java.lang.String | Stringa Unicode. |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - Larghezza del String.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAscender(double value) {#setAscender-double-}
+```
+public void setAscender(double value)
+```
+
+
+Imposta il valore Ascender.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore del Ascender. |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public void setDescender(double value)
+```
+
+
+Imposta il valore Descender.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore del Descender. |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Imposta la larghezza del glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) |  |
+| valore | double |  |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public void setTypoAscender(double value)
+```
+
+
+Imposta il valore TypoAscender.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore del TypoAscender. |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public void setTypoDescender(double value)
+```
+
+
+Imposta il valore TypoDescender.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore del TypoDescender. |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public void setUnitsPerEM(long value)
+```
+
+
+Imposta il valore UnitsPerEM.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long | Valore del UnitsPerEM. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/cfffontssettings/_index.md
+++ b/italian/java/com.aspose.font/cfffontssettings/_index.md
@@ -1,0 +1,162 @@
+---
+title: "CffFontsSettings"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Fornisce impostazioni comuni ai font CFF."
+type: docs
+weight: 22
+url: /it/java/com.aspose.font/cfffontssettings/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class CffFontsSettings
+```
+
+Fornisce impostazioni comuni ai font CFF.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [CffFontsSettings()](#CffFontsSettings--) | Costruttore |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getUpdateStringsStrategy()](#getUpdateStringsStrategy--) | Ottiene la strategia per aggiornare le stringhe nella struttura CFF String INDEX. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUpdateStringStrategy(CffUpdateStringIndexStrategy updateStringsStrategy)](#setUpdateStringStrategy-com.aspose.font.CffUpdateStringIndexStrategy-) | Specifica la strategia per aggiornare le stringhe nella struttura CFF String INDEX. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CffFontsSettings() {#CffFontsSettings--}
+```
+public CffFontsSettings()
+```
+
+
+Costruttore
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUpdateStringsStrategy() {#getUpdateStringsStrategy--}
+```
+public CffUpdateStringIndexStrategy getUpdateStringsStrategy()
+```
+
+
+Ottiene la strategia per aggiornare le stringhe nella struttura CFF String INDEX. L'opzione AddStringAsIs è utilizzata per impostazione predefinita.
+
+**Returns:**
+[CffUpdateStringIndexStrategy](../../com.aspose.font/cffupdatestringindexstrategy)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUpdateStringStrategy(CffUpdateStringIndexStrategy updateStringsStrategy) {#setUpdateStringStrategy-com.aspose.font.CffUpdateStringIndexStrategy-}
+```
+public void setUpdateStringStrategy(CffUpdateStringIndexStrategy updateStringsStrategy)
+```
+
+
+Specifica la strategia per aggiornare le stringhe nella struttura CFF String INDEX.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| updateStringsStrategy | [CffUpdateStringIndexStrategy](../../com.aspose.font/cffupdatestringindexstrategy) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/cffindexprovidertype/_index.md
+++ b/italian/java/com.aspose.font/cffindexprovidertype/_index.md
@@ -1,0 +1,250 @@
+---
+title: "CffIndexProviderType"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Specifica le strutture INDEX supportate dalla famiglia di interfacce del provider di indice."
+type: docs
+weight: 133
+url: /it/java/com.aspose.font/cffindexprovidertype/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum CffIndexProviderType extends Enum<CffIndexProviderType>
+```
+
+Specifica le strutture INDEX supportate dalla famiglia di interfacce del provider di indice.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [NameIndex](#NameIndex) | Name INDEX |
+| [StringIndex](#StringIndex) | String INDEX |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NameIndex {#NameIndex}
+```
+public static final CffIndexProviderType NameIndex
+```
+
+
+Name INDEX
+
+### StringIndex {#StringIndex}
+```
+public static final CffIndexProviderType StringIndex
+```
+
+
+String INDEX
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static CffIndexProviderType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[CffIndexProviderType](../../com.aspose.font/cffindexprovidertype)
+### values() {#values--}
+```
+public static CffIndexProviderType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.CffIndexProviderType[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/cffparsingexception/_index.md
+++ b/italian/java/com.aspose.font/cffparsingexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "CffParsingException"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta un'eccezione di parsing per i font in formato cff."
+type: docs
+weight: 23
+url: /it/java/com.aspose.font/cffparsingexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception), [com.aspose.font.CffFontException](../../com.aspose.font/cfffontexception)
+```
+public class CffParsingException extends CffFontException
+```
+
+Rappresenta un'eccezione di parsing per i font in formato cff. L'eccezione può essere sollevata in caso di errori durante il processo di parsing del font.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [CffParsingException()](#CffParsingException--) | Inizializza un nuovo oggetto CffParsingException. |
+| [CffParsingException(String message)](#CffParsingException-java.lang.String-) | Inizializza un nuovo oggetto CffParsingException. |
+| [CffParsingException(String message, RuntimeException innerException)](#CffParsingException-java.lang.String-java.lang.RuntimeException-) | Inizializza un nuovo oggetto CffParsingException. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CffParsingException() {#CffParsingException--}
+```
+public CffParsingException()
+```
+
+
+Inizializza un nuovo oggetto CffParsingException.
+
+### CffParsingException(String message) {#CffParsingException-java.lang.String-}
+```
+public CffParsingException(String message)
+```
+
+
+Inizializza un nuovo oggetto CffParsingException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+
+### CffParsingException(String message, RuntimeException innerException) {#CffParsingException-java.lang.String-java.lang.RuntimeException-}
+```
+public CffParsingException(String message, RuntimeException innerException)
+```
+
+
+Inizializza un nuovo oggetto CffParsingException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+| innerException | java.lang.RuntimeException | L'eccezione che è la causa dell'eccezione corrente. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/cffupdatestringindexstrategy/_index.md
+++ b/italian/java/com.aspose.font/cffupdatestringindexstrategy/_index.md
@@ -1,0 +1,250 @@
+---
+title: "CffUpdateStringIndexStrategy"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Specifica come aggiungere stringhe allo storage CFF String INDEX."
+type: docs
+weight: 134
+url: /it/java/com.aspose.font/cffupdatestringindexstrategy/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum CffUpdateStringIndexStrategy extends Enum<CffUpdateStringIndexStrategy>
+```
+
+Specifica come aggiungere stringhe allo storage CFF String INDEX. Quando proviamo ad aggiungere una stringa nello CFF String INDEX, può verificarsi la situazione che questa stringa sia già presente nello String INDEX. Usando l'opzione SearchForDuplicates possiamo forzare la ricerca nello String INDEX per rilevare se questa stringa è già presente o meno. Questo approccio salva spazio nella struttura String INDEX, ma richiede più tempo per aggiungere la stringa.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [AddStringAsIs](#AddStringAsIs) | Specifica che non devono essere eseguiti controlli per duplicati quando si aggiunge una stringa. |
+| [SearchForDuplicates](#SearchForDuplicates) | Specifica che la ricerca della stringa da aggiungere deve essere eseguita nella struttura String INDEX per evitare l'aggiunta di duplicati. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AddStringAsIs {#AddStringAsIs}
+```
+public static final CffUpdateStringIndexStrategy AddStringAsIs
+```
+
+
+Specifica che non devono essere eseguiti controlli per duplicati quando si aggiunge una stringa. Questo approccio è più veloce, ma può comportare un utilizzo inefficiente della memoria per String INDEX.
+
+### SearchForDuplicates {#SearchForDuplicates}
+```
+public static final CffUpdateStringIndexStrategy SearchForDuplicates
+```
+
+
+Specifica che la ricerca della stringa da aggiungere deve essere eseguita nella struttura String INDEX per evitare l'aggiunta di duplicati.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static CffUpdateStringIndexStrategy valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[CffUpdateStringIndexStrategy](../../com.aspose.font/cffupdatestringindexstrategy)
+### values() {#values--}
+```
+public static CffUpdateStringIndexStrategy[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.CffUpdateStringIndexStrategy[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/closepath/_index.md
+++ b/italian/java/com.aspose.font/closepath/_index.md
@@ -1,0 +1,200 @@
+---
+title: "ClosePath"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'operazione ClosePath."
+type: docs
+weight: 24
+url: /it/java/com.aspose.font/closepath/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IPathSegment](../../com.aspose.font/ipathsegment)
+```
+public class ClosePath implements IPathSegment
+```
+
+Rappresenta l'operazione ClosePath.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clone()](#clone--) | Crea un nuovo oggetto che è una copia dell'istanza corrente. |
+| [copy()](#copy--) | Crea una copia dell'oggetto segmento. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getX()](#getX--) | Restituisce la coordinata x. |
+| [getY()](#getY--) | Restituisce la coordinata y. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [shift(double dx, double dy)](#shift-double-double-) | Esegue lo spostamento per le coordinate x e y. |
+| [toString()](#toString--) |  |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Trasforma le coordinate con la matrice di trasformazione. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Crea un nuovo oggetto che è una copia dell'istanza corrente.
+
+**Returns:**
+java.lang.Object - Un nuovo oggetto che è una copia di questa istanza.
+### copy() {#copy--}
+```
+public IPathSegment copy()
+```
+
+
+Crea una copia dell'oggetto segmento.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getX() {#getX--}
+```
+public double getX()
+```
+
+
+Restituisce la coordinata x.
+
+**Returns:**
+double - Coordinata x.
+### getY() {#getY--}
+```
+public double getY()
+```
+
+
+Restituisce la coordinata y.
+
+**Returns:**
+double - Coordinata y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public void shift(double dx, double dy)
+```
+
+
+Esegue lo spostamento per le coordinate x e y.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| dx | double | Valore dx. |
+| dy | double | Valore dy. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public void transform(TransformationMatrix matrix)
+```
+
+
+Trasforma le coordinate con la matrice di trasformazione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrice di trasformazione della trasformazione. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/compositeglyph/_index.md
+++ b/italian/java/com.aspose.font/compositeglyph/_index.md
@@ -1,0 +1,245 @@
+---
+title: "CompositeGlyph"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta un glifo composito del font."
+type: docs
+weight: 25
+url: /it/java/com.aspose.font/compositeglyph/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Glyph](../../com.aspose.font/glyph)
+```
+public class CompositeGlyph extends Glyph
+```
+
+Rappresenta un glifo composito del font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clone()](#clone--) | Restituisce una copia del glifo. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getComponents()](#getComponents--) | Ottiene l'elenco dei componenti. |
+| [getGlyphBBox()](#getGlyphBBox--) | Ottiene il BBox del glifo. |
+| [getLeftSidebearingX()](#getLeftSidebearingX--) | Ottiene la coordinata x del margine laterale del glifo. |
+| [getLeftSidebearingY()](#getLeftSidebearingY--) | Ottiene la coordinata y del margine laterale del glifo. |
+| [getPath()](#getPath--) | Ottiene il percorso del glifo. |
+| [getSourceResolution()](#getSourceResolution--) | Ottiene la risoluzione del set di comandi sorgente. |
+| [getState()](#getState--) | Ottiene lo stato del glifo. |
+| [getWidthVectorX()](#getWidthVectorX--) | Ottiene il vettore di larghezza del glifo. |
+| [getWidthVectorY()](#getWidthVectorY--) | Ottiene il vettore di larghezza del glifo. |
+| [hashCode()](#hashCode--) |  |
+| [isEmpty()](#isEmpty--) | Vero se il glifo non contiene istruzioni di disegno. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Restituisce una copia del glifo.
+
+**Returns:**
+java.lang.Object - Copia del Glifo
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getComponents() {#getComponents--}
+```
+public CompositeGlyphComponentList getComponents()
+```
+
+
+Ottiene l'elenco dei componenti.
+
+**Returns:**
+[CompositeGlyphComponentList](../../com.aspose.font/compositeglyphcomponentlist) - Components list.
+### getGlyphBBox() {#getGlyphBBox--}
+```
+public FontBBox getGlyphBBox()
+```
+
+
+Ottiene il BBox del glifo.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox
+### getLeftSidebearingX() {#getLeftSidebearingX--}
+```
+public double getLeftSidebearingX()
+```
+
+
+Ottiene la coordinata x del margine laterale del glifo.
+
+**Returns:**
+double - Coordinata x del margine laterale del glifo.
+### getLeftSidebearingY() {#getLeftSidebearingY--}
+```
+public double getLeftSidebearingY()
+```
+
+
+Ottiene la coordinata y del margine laterale del glifo.
+
+**Returns:**
+double - Coordinata y del margine laterale del glifo.
+### getPath() {#getPath--}
+```
+public SegmentPath getPath()
+```
+
+
+Ottiene il percorso del glifo.
+
+**Returns:**
+[SegmentPath](../../com.aspose.font/segmentpath) - Glyph path.
+### getSourceResolution() {#getSourceResolution--}
+```
+public int getSourceResolution()
+```
+
+
+Ottiene la risoluzione del set di comandi sorgente.
+
+**Returns:**
+int - Risoluzione del set di comandi sorgente.
+### getState() {#getState--}
+```
+public GlyphState getState()
+```
+
+
+Ottiene lo stato del glifo.
+
+**Returns:**
+[GlyphState](../../com.aspose.font/glyphstate) - Glyph state.
+### getWidthVectorX() {#getWidthVectorX--}
+```
+public double getWidthVectorX()
+```
+
+
+Ottiene il vettore di larghezza del glifo. Coordinata x.
+
+**Returns:**
+double - Vettore di larghezza del glifo. Coordinata x.
+### getWidthVectorY() {#getWidthVectorY--}
+```
+public double getWidthVectorY()
+```
+
+
+Ottiene il vettore di larghezza del glifo. Coordinata y.
+
+**Returns:**
+double - Vettore di larghezza del glifo. Coordinata y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+Vero se il glifo non contiene istruzioni di disegno.
+
+**Returns:**
+boolean - Vero se il glifo non contiene istruzioni di disegno.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/compositeglyphcomponent/_index.md
+++ b/italian/java/com.aspose.font/compositeglyphcomponent/_index.md
@@ -1,0 +1,146 @@
+---
+title: "CompositeGlyphComponent"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta il glifo componente composito con matrice di posizionamento."
+type: docs
+weight: 26
+url: /it/java/com.aspose.font/compositeglyphcomponent/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class CompositeGlyphComponent
+```
+
+Rappresenta il componente del glifo composito (glifo con matrice di posizionamento).
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGlyph()](#getGlyph--) | Ottiene il glifo componente. |
+| [getMatrix()](#getMatrix--) | Ottiene la matrice di trasformazione del componente. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyph() {#getGlyph--}
+```
+public Glyph getGlyph()
+```
+
+
+Ottiene il glifo componente.
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - The component glyph.
+### getMatrix() {#getMatrix--}
+```
+public TransformationMatrix getMatrix()
+```
+
+
+Ottiene la matrice di trasformazione del componente.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - The component transformation matrix.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/compositeglyphcomponentlist/_index.md
+++ b/italian/java/com.aspose.font/compositeglyphcomponentlist/_index.md
@@ -1,0 +1,565 @@
+---
+title: "CompositeGlyphComponentList"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'elenco dei componenti del glifo composito."
+type: docs
+weight: 27
+url: /it/java/com.aspose.font/compositeglyphcomponentlist/
+---
+**Inheritance:**
+java.lang.Object, java.util.AbstractCollection, java.util.AbstractList, java.util.ArrayList
+```
+public class CompositeGlyphComponentList extends ArrayList<CompositeGlyphComponent>
+```
+
+Rappresenta l'elenco dei componenti del glifo composito.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>toArray(T[] arg0)](#-T-toArray-T---) |  |
+| [add(E arg0)](#add-E-) |  |
+| [add(int arg0, E arg1)](#add-int-E-) |  |
+| [addAll(int arg0, Collection<? extends E> arg1)](#addAll-int-java.util.Collection---extends-E--) |  |
+| [addAll(Collection<? extends E> arg0)](#addAll-java.util.Collection---extends-E--) |  |
+| [clear()](#clear--) |  |
+| [clone()](#clone--) |  |
+| [contains(Object arg0)](#contains-java.lang.Object-) |  |
+| [containsAll(Collection<?> arg0)](#containsAll-java.util.Collection----) |  |
+| [ensureCapacity(int arg0)](#ensureCapacity-int-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [forEach(Consumer<? super E> arg0)](#forEach-java.util.function.Consumer---super-E--) |  |
+| [get(int arg0)](#get-int-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object arg0)](#indexOf-java.lang.Object-) |  |
+| [isEmpty()](#isEmpty--) |  |
+| [iterator()](#iterator--) |  |
+| [lastIndexOf(Object arg0)](#lastIndexOf-java.lang.Object-) |  |
+| [listIterator()](#listIterator--) |  |
+| [listIterator(int arg0)](#listIterator-int-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(int arg0)](#remove-int-) |  |
+| [remove(Object arg0)](#remove-java.lang.Object-) |  |
+| [removeAll(Collection<?> arg0)](#removeAll-java.util.Collection----) |  |
+| [removeIf(Predicate<? super E> arg0)](#removeIf-java.util.function.Predicate---super-E--) |  |
+| [replaceAll(UnaryOperator<E> arg0)](#replaceAll-java.util.function.UnaryOperator-E--) |  |
+| [retainAll(Collection<?> arg0)](#retainAll-java.util.Collection----) |  |
+| [set(int arg0, E arg1)](#set-int-E-) |  |
+| [size()](#size--) |  |
+| [sort(Comparator<? super E> arg0)](#sort-java.util.Comparator---super-E--) |  |
+| [spliterator()](#spliterator--) |  |
+| [subList(int arg0, int arg1)](#subList-int-int-) |  |
+| [toArray()](#toArray--) |  |
+| [toString()](#toString--) |  |
+| [trimToSize()](#trimToSize--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>toArray(T[] arg0) {#-T-toArray-T---}
+```
+public T[] <T>toArray(T[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | T[] |  |
+
+**Returns:**
+T[]
+### add(E arg0) {#add-E-}
+```
+public boolean add(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+boolean
+### add(int arg0, E arg1) {#add-int-E-}
+```
+public void add(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+### addAll(int arg0, Collection<? extends E> arg1) {#addAll-int-java.util.Collection---extends-E--}
+```
+public boolean addAll(int arg0, Collection<? extends E> arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### addAll(Collection<? extends E> arg0) {#addAll-java.util.Collection---extends-E--}
+```
+public boolean addAll(Collection<? extends E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### contains(Object arg0) {#contains-java.lang.Object-}
+```
+public boolean contains(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### containsAll(Collection<?> arg0) {#containsAll-java.util.Collection----}
+```
+public boolean containsAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### ensureCapacity(int arg0) {#ensureCapacity-int-}
+```
+public void ensureCapacity(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### forEach(Consumer<? super E> arg0) {#forEach-java.util.function.Consumer---super-E--}
+```
+public void forEach(Consumer<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.function.Consumer<? super E> |  |
+
+### get(int arg0) {#get-int-}
+```
+public E get(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object arg0) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public Iterator<E> iterator()
+```
+
+
+
+
+**Returns:**
+java.util.Iterator<E>
+### lastIndexOf(Object arg0) {#lastIndexOf-java.lang.Object-}
+```
+public int lastIndexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### listIterator() {#listIterator--}
+```
+public ListIterator<E> listIterator()
+```
+
+
+
+
+**Returns:**
+java.util.ListIterator<E>
+### listIterator(int arg0) {#listIterator-int-}
+```
+public ListIterator<E> listIterator(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+java.util.ListIterator<E>
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(int arg0) {#remove-int-}
+```
+public E remove(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### remove(Object arg0) {#remove-java.lang.Object-}
+```
+public boolean remove(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### removeAll(Collection<?> arg0) {#removeAll-java.util.Collection----}
+```
+public boolean removeAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### removeIf(Predicate<? super E> arg0) {#removeIf-java.util.function.Predicate---super-E--}
+```
+public boolean removeIf(Predicate<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.function.Predicate<? super E> |  |
+
+**Returns:**
+boolean
+### replaceAll(UnaryOperator<E> arg0) {#replaceAll-java.util.function.UnaryOperator-E--}
+```
+public void replaceAll(UnaryOperator<E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.function.UnaryOperator<E> |  |
+
+### retainAll(Collection<?> arg0) {#retainAll-java.util.Collection----}
+```
+public boolean retainAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### set(int arg0, E arg1) {#set-int-E-}
+```
+public E set(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+**Returns:**
+E
+### size() {#size--}
+```
+public int size()
+```
+
+
+
+
+**Returns:**
+int
+### sort(Comparator<? super E> arg0) {#sort-java.util.Comparator---super-E--}
+```
+public void sort(Comparator<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.Comparator<? super E> |  |
+
+### spliterator() {#spliterator--}
+```
+public Spliterator<E> spliterator()
+```
+
+
+
+
+**Returns:**
+java.util.Spliterator<E>
+### subList(int arg0, int arg1) {#subList-int-int-}
+```
+public List<E> subList(int arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | int |  |
+
+**Returns:**
+java.util.List<E>
+### toArray() {#toArray--}
+```
+public Object[] toArray()
+```
+
+
+
+
+**Returns:**
+java.lang.Object[]
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### trimToSize() {#trimToSize--}
+```
+public void trimToSize()
+```
+
+
+
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/compressionutils/_index.md
+++ b/italian/java/com.aspose.font/compressionutils/_index.md
@@ -1,0 +1,168 @@
+---
+title: "CompressionUtils"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Fornisce metodi di utilità per la compressione e la decompressione."
+type: docs
+weight: 28
+url: /it/java/com.aspose.font/compressionutils/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class CompressionUtils
+```
+
+Fornisce metodi di utilità per la compressione e la decompressione.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [CompressionUtils()](#CompressionUtils--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [decodeByBrotli(byte[] input)](#decodeByBrotli-byte---) | Decomprime l'array di byte compresso con Brotli fornito. |
+| [encodeByBrotli(byte[] buff, int buffLength)](#encodeByBrotli-byte---int-) | Comprime l'array di byte fornito usando l'algoritmo Brotli. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CompressionUtils() {#CompressionUtils--}
+```
+public CompressionUtils()
+```
+
+
+### decodeByBrotli(byte[] input) {#decodeByBrotli-byte---}
+```
+public static byte[] decodeByBrotli(byte[] input)
+```
+
+
+Decomprime l'array di byte compresso con Brotli fornito.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| input | byte[] | I dati compressi. |
+
+**Returns:**
+byte[] - L'array di byte decompresso.
+### encodeByBrotli(byte[] buff, int buffLength) {#encodeByBrotli-byte---int-}
+```
+public static byte[] encodeByBrotli(byte[] buff, int buffLength)
+```
+
+
+Comprime l'array di byte fornito usando l'algoritmo Brotli.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| buff | byte[] | Il buffer di input da comprimere. |
+| buffLength | int | La lunghezza dei dati da comprimere. |
+
+**Returns:**
+byte[] - L'array di byte compresso.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/curveto/_index.md
+++ b/italian/java/com.aspose.font/curveto/_index.md
@@ -1,0 +1,244 @@
+---
+title: "CurveTo"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'operazione CurveTo."
+type: docs
+weight: 29
+url: /it/java/com.aspose.font/curveto/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IPathSegment](../../com.aspose.font/ipathsegment)
+```
+public class CurveTo implements IPathSegment
+```
+
+Rappresenta l'operazione CurveTo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clone()](#clone--) | Crea un nuovo oggetto che è una copia dell'istanza corrente. |
+| [copy()](#copy--) | Crea una copia dell'oggetto segmento. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getX1()](#getX1--) | Ottiene la coordinata x1. |
+| [getX2()](#getX2--) | Ottiene la coordinata x2. |
+| [getX3()](#getX3--) | Ottiene la coordinata x3. |
+| [getY1()](#getY1--) | Ottiene la coordinata y1. |
+| [getY2()](#getY2--) | Ottiene la coordinata y2. |
+| [getY3()](#getY3--) | Ottiene la coordinata y3. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [shift(double dx, double dy)](#shift-double-double-) | Esegue lo spostamento per le coordinate x e y. |
+| [toString()](#toString--) |  |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Trasforma le coordinate con la matrice di trasformazione. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Crea un nuovo oggetto che è una copia dell'istanza corrente.
+
+**Returns:**
+java.lang.Object - Un nuovo oggetto che è una copia di questa istanza.
+### copy() {#copy--}
+```
+public IPathSegment copy()
+```
+
+
+Crea una copia dell'oggetto segmento.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getX1() {#getX1--}
+```
+public double getX1()
+```
+
+
+Ottiene la coordinata x1.
+
+**Returns:**
+double - Coordinata x1.
+### getX2() {#getX2--}
+```
+public double getX2()
+```
+
+
+Ottiene la coordinata x2.
+
+**Returns:**
+double - Coordinata x2.
+### getX3() {#getX3--}
+```
+public double getX3()
+```
+
+
+Ottiene la coordinata x3.
+
+**Returns:**
+double - Coordinata x3.
+### getY1() {#getY1--}
+```
+public double getY1()
+```
+
+
+Ottiene la coordinata y1.
+
+**Returns:**
+double - Coordinata y1.
+### getY2() {#getY2--}
+```
+public double getY2()
+```
+
+
+Ottiene la coordinata y2.
+
+**Returns:**
+double - Coordinata y2.
+### getY3() {#getY3--}
+```
+public double getY3()
+```
+
+
+Ottiene la coordinata y3.
+
+**Returns:**
+double - Coordinata y3.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public void shift(double dx, double dy)
+```
+
+
+Esegue lo spostamento per le coordinate x e y.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| dx | double | Valore dx. |
+| dy | double | Valore dy. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public void transform(TransformationMatrix matrix)
+```
+
+
+Trasforma le coordinate con la matrice di trasformazione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrice di trasformazione. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/encodingexception/_index.md
+++ b/italian/java/com.aspose.font/encodingexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "EncodingException"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta un'eccezione di codifica."
+type: docs
+weight: 30
+url: /it/java/com.aspose.font/encodingexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class EncodingException extends FontException
+```
+
+Rappresenta un'eccezione di codifica. L'eccezione può essere generata in caso di problemi con la codifica/decodifica del testo.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [EncodingException()](#EncodingException--) | Inizializza un nuovo oggetto EncodingException. |
+| [EncodingException(String message)](#EncodingException-java.lang.String-) | Inizializza un nuovo oggetto EncodingException. |
+| [EncodingException(String message, RuntimeException innerException)](#EncodingException-java.lang.String-java.lang.RuntimeException-) | Inizializza un nuovo oggetto EncodingException. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EncodingException() {#EncodingException--}
+```
+public EncodingException()
+```
+
+
+Inizializza un nuovo oggetto EncodingException.
+
+### EncodingException(String message) {#EncodingException-java.lang.String-}
+```
+public EncodingException(String message)
+```
+
+
+Inizializza un nuovo oggetto EncodingException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+
+### EncodingException(String message, RuntimeException innerException) {#EncodingException-java.lang.String-java.lang.RuntimeException-}
+```
+public EncodingException(String message, RuntimeException innerException)
+```
+
+
+Inizializza un nuovo oggetto EncodingException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+| innerException | java.lang.RuntimeException | L'eccezione che è la causa dell'eccezione corrente. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/filesystemstreamsource/_index.md
+++ b/italian/java/com.aspose.font/filesystemstreamsource/_index.md
@@ -1,0 +1,225 @@
+---
+title: "FileSystemStreamSource"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta una sorgente di flusso basata sul file system."
+type: docs
+weight: 31
+url: /it/java/com.aspose.font/filesystemstreamsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.StreamSource](../../com.aspose.font/streamsource)
+```
+public class FileSystemStreamSource extends StreamSource
+```
+
+Rappresenta una sorgente di flusso basata sul file system.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FileSystemStreamSource(String fileName)](#FileSystemStreamSource-java.lang.String-) | Inizializza un nuovo  FileSystemStreamSource  oggetto. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Clona l'oggetto FileSystemStreamSource. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileName()](#getFileName--) | Ottiene il nome del file. |
+| [getFontStream()](#getFontStream--) | Restituisce lo stream del file Font. |
+| [getOffset()](#getOffset--) | Ottiene l'offset all'interno della sorgente. |
+| [hashCode()](#hashCode--) |  |
+| [mustCloseAfterUse()](#mustCloseAfterUse--) | Gli eredi possono impedire la chiusura del stream. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFileName(String value)](#setFileName-java.lang.String-) | Imposta il nome del file. |
+| [setOffset(long value)](#setOffset-long-) | Imposta l'offset all'interno della sorgente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileSystemStreamSource(String fileName) {#FileSystemStreamSource-java.lang.String-}
+```
+public FileSystemStreamSource(String fileName)
+```
+
+
+Inizializza un nuovo  FileSystemStreamSource  oggetto.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fileName | java.lang.String | Nome file. |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Clona l'oggetto FileSystemStreamSource.
+
+**Returns:**
+java.lang.Object - Copia dell'oggetto FileSystemStreamSource.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Ottiene il nome del file.
+
+**Returns:**
+java.lang.String - Nome del file.
+### getFontStream() {#getFontStream--}
+```
+public InputStream getFontStream()
+```
+
+
+Restituisce lo stream del file Font. Non dimenticare di chiudere lo stream dopo l'uso.
+
+**Returns:**
+java.io.InputStream - stream del file Font.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset all'interno della sorgente.
+
+**Returns:**
+long - Offset all'interno della sorgente.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### mustCloseAfterUse() {#mustCloseAfterUse--}
+```
+public boolean mustCloseAfterUse()
+```
+
+
+Gli eredi possono impedire la chiusura del stream. Restituisce true se la sorgente di stream desidera che il stream venga chiuso dopo l'uso. Altrimenti restituisce false.
+
+**Returns:**
+boolean - True se la sorgente di stream desidera che il stream venga chiuso dopo l'uso, altrimenti false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFileName(String value) {#setFileName-java.lang.String-}
+```
+public void setFileName(String value)
+```
+
+
+Imposta il nome del file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Nome file. |
+
+### setOffset(long value) {#setOffset-long-}
+```
+public void setOffset(long value)
+```
+
+
+Imposta l'offset all'interno della sorgente.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long | Offset all'interno della sorgente. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/font/_index.md
+++ b/italian/java/com.aspose.font/font/_index.md
@@ -1,0 +1,526 @@
+---
+title: "Font"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la classe base Font."
+type: docs
+weight: 32
+url: /it/java/com.aspose.font/font/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFont](../../com.aspose.font/ifont), [com.aspose.font.IGlyphAccessor](../../com.aspose.font/iglyphaccessor), [com.aspose.font.IFontSaver](../../com.aspose.font/ifontsaver)
+```
+public abstract class Font implements IFont, IGlyphAccessor, IFontSaver
+```
+
+Rappresenta la classe base Font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Converte il Font in un altro formato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Restituisce tutti gli ID dei glifi disponibili nel Font. |
+| [getClass()](#getClass--) |  |
+| [getEncoding()](#getEncoding--) | Ottiene la codifica del Font. |
+| [getFontDefinition()](#getFontDefinition--) | Ottiene la definizione del Font. |
+| [getFontFamily()](#getFontFamily--) | Ottiene la famiglia del Font. |
+| [getFontName()](#getFontName--) | Ottiene il nome del Font face. |
+| [getFontNames()](#getFontNames--) | Ottiene i nomi del Font. |
+| [getFontSaver()](#getFontSaver--) | Ottiene la funzionalità di salvataggio del Font. |
+| [getFontStyle()](#getFontStyle--) | Ottiene lo stile del Font. |
+| [getFontType()](#getFontType--) | Ottiene il tipo di Font. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Accessor dei glifi del Font. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Restituisce il glifo per ID glifo. |
+| [getGlyphIdType()](#getGlyphIdType--) | Specificazione del tipo di ID glifo. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Ottiene la rappresentazione dei glifi per il testo. |
+| [getMetrics()](#getMetrics--) | Ottiene le metriche del Font. |
+| [getNumGlyphs()](#getNumGlyphs--) | Ottiene il numero di glifi nel Font. |
+| [getPostscriptNames()](#getPostscriptNames--) | Ottiene i nomi dei font PostScript. |
+| [getStyle()](#getStyle--) | Ottiene lo stile del Font. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Apre un font, utilizzando l'oggetto FontDefinition. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Apre un font, utilizzando il tipo di font e l'array di byte dei dati del font. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Apre un font, utilizzando il tipo di font e la sorgente stream. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Apre un font, utilizzando il tipo di font e il nome del file del font. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Salva il Font nel formato originale. |
+| [save(String fileName)](#save-java.lang.String-) | Salva il Font nel formato originale. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Salva il Font nel formato specificato. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Imposta la famiglia del Font. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Imposta il nome del Font face. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Imposta lo stile del Font. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public abstract Font convert(FontType fontType)
+```
+
+
+Converte il Font in un altro formato.
+
+--------------------
+
+> ```
+> Note: TTF Font type is now supported only.
+> ```
+
+fontType Tipo di formato del Font in cui convertire.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) |  |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public abstract GlyphId[] getAllGlyphIds()
+```
+
+
+Restituisce tutti gli ID dei glifi disponibili nel Font. L'ID del glifo è un numero unico per un glifo, dipendente dal tipo di font. per esempio: l'ID di Type1 è un nome di glifo, istanza di ( GlyphStringId ) class. L'ID di TTF è un indice intero, istanza di ( GlyphInt32Id ) class.
+
+**Returns:**
+com.aspose.font.GlyphId[] - Identificatori dei glifi.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncoding() {#getEncoding--}
+```
+public abstract IFontEncoding getEncoding()
+```
+
+
+Ottiene la codifica del Font.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public abstract FontDefinition getFontDefinition()
+```
+
+
+Ottiene la definizione del Font.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public abstract String getFontFamily()
+```
+
+
+Ottiene la famiglia del Font.
+
+**Returns:**
+java.lang.String - Famiglia del Font.
+### getFontName() {#getFontName--}
+```
+public abstract String getFontName()
+```
+
+
+Ottiene il nome del Font face.
+
+**Returns:**
+java.lang.String - Nome del Font face.
+### getFontNames() {#getFontNames--}
+```
+public abstract MultiLanguageString getFontNames()
+```
+
+
+Ottiene i nomi del Font.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Ottiene la funzionalità di salvataggio del Font.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public abstract int getFontStyle()
+```
+
+
+Ottiene lo stile del Font. Questo è un valore calcolato e rappresentato in tipo generalizzato.
+
+**Returns:**
+int - Stile del Font. Di solito, una combinazione di valori di flag costanti della classe FontStyle o 0.
+### getFontType() {#getFontType--}
+```
+public abstract FontType getFontType()
+```
+
+
+Ottiene il tipo di Font.
+
+--------------------
+
+> ```
+> Type1, TrueType etc.
+> ```
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Accessor dei glifi del font. Recupera i glifi e gli identificatori dei glifi.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public abstract Glyph getGlyphById(GlyphId id)
+```
+
+
+Restituisce il glifo per ID glifo. L'ID del glifo è un numero unico per un glifo, dipendente dal tipo di font. GlyphId - oggetto derivato. per esempio: l'ID di Type1 è un nome di glifo, istanza di ( GlyphStringId ) class. L'ID di TTF è un indice intero, istanza di ( GlyphInt32Id ) class.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | ID glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public abstract GlyphIdType getGlyphIdType()
+```
+
+
+Specificazione del tipo di ID glifo. Per i consumatori che hanno bisogno di conoscere il vero tipo di 'bytes[]'.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype) - Id type specification
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Ottiene la rappresentazione dei glifi per il testo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| text | java.lang.String | Testo di input. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - array di GlyphId.
+### getMetrics() {#getMetrics--}
+```
+public abstract IFontMetrics getMetrics()
+```
+
+
+Ottiene le metriche del Font.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public abstract int getNumGlyphs()
+```
+
+
+Ottiene il numero di glifi nel Font.
+
+**Returns:**
+int - Numero di glifi nel Font.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public abstract MultiLanguageString getPostscriptNames()
+```
+
+
+Ottiene i nomi dei font PostScript.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript font names.
+### getStyle() {#getStyle--}
+```
+public abstract String getStyle()
+```
+
+
+Ottiene lo stile del Font. Questo è un valore stringa grezzo fornito dal file Font.
+
+**Returns:**
+java.lang.String - Stile del Font.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Apre un font, utilizzando l'oggetto FontDefinition.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Oggetto definizione del Font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Apre un font, utilizzando il tipo di font e l'array di byte dei dati del font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fontData | byte[] | Array di byte da cui caricare il font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Apre un font, utilizzando il tipo di font e la sorgente stream.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Sorgente stream per il font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Apre un font, utilizzando il tipo di font e il nome del file del font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fileName | java.lang.String | Nome file del font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Salva il Font nel formato originale.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Stream per salvare il font. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Salva il Font nel formato originale.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fileName | java.lang.String | File per salvare il font. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Salva il Font nel formato specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| stream | java.io.OutputStream | stream per salvare il font |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | formato desiderato |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public abstract void setFontFamily(String value)
+```
+
+
+Imposta la famiglia del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Nuova famiglia di Font. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public abstract void setFontName(String value)
+```
+
+
+Imposta il nome del Font face.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Nuovo nome faccia del Font. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public abstract void setStyle(String value)
+```
+
+
+Imposta lo stile del Font. Questo è un valore stringa grezzo fornito dal file Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Nuovo stile del Font. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fontagrumentexception/_index.md
+++ b/italian/java/com.aspose.font/fontagrumentexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontAgrumentException"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta un'eccezione di argomento Font."
+type: docs
+weight: 33
+url: /it/java/com.aspose.font/fontagrumentexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontAgrumentException extends FontException
+```
+
+Rappresenta l'eccezione di argomento del carattere. L'eccezione può essere sollevata in caso di utilizzi impropri degli argomenti.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FontAgrumentException()](#FontAgrumentException--) | Inizializza un nuovo oggetto FontAgrumentException. |
+| [FontAgrumentException(String message)](#FontAgrumentException-java.lang.String-) | Inizializza un nuovo oggetto FontAgrumentException. |
+| [FontAgrumentException(String message, RuntimeException innerException)](#FontAgrumentException-java.lang.String-java.lang.RuntimeException-) | Inizializza un nuovo oggetto FontAgrumentException. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontAgrumentException() {#FontAgrumentException--}
+```
+public FontAgrumentException()
+```
+
+
+Inizializza un nuovo oggetto FontAgrumentException.
+
+### FontAgrumentException(String message) {#FontAgrumentException-java.lang.String-}
+```
+public FontAgrumentException(String message)
+```
+
+
+Inizializza un nuovo oggetto FontAgrumentException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+
+### FontAgrumentException(String message, RuntimeException innerException) {#FontAgrumentException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontAgrumentException(String message, RuntimeException innerException)
+```
+
+
+Inizializza un nuovo oggetto FontAgrumentException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+| innerException | java.lang.RuntimeException | L'eccezione che è la causa dell'eccezione corrente. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fontbbox/_index.md
+++ b/italian/java/com.aspose.font/fontbbox/_index.md
@@ -1,0 +1,168 @@
+---
+title: "FontBBox"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "rappresenta il bounding box del font."
+type: docs
+weight: 34
+url: /it/java/com.aspose.font/fontbbox/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontBBox
+```
+
+rappresenta il bounding box del font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getXMax()](#getXMax--) | Ottiene il valore XMax. |
+| [getXMin()](#getXMin--) | Ottiene il valore XMin. |
+| [getYMax()](#getYMax--) | Ottiene il valore YMax. |
+| [getYMin()](#getYMin--) | Ottiene il valore YMin. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getXMax() {#getXMax--}
+```
+public double getXMax()
+```
+
+
+Ottiene il valore XMax.
+
+**Returns:**
+double - valore XMax.
+### getXMin() {#getXMin--}
+```
+public double getXMin()
+```
+
+
+Ottiene il valore XMin.
+
+**Returns:**
+double - valore XMin.
+### getYMax() {#getYMax--}
+```
+public double getYMax()
+```
+
+
+Ottiene il valore YMax.
+
+**Returns:**
+double - valore YMax.
+### getYMin() {#getYMin--}
+```
+public double getYMin()
+```
+
+
+Ottiene il valore YMin.
+
+**Returns:**
+double - valore YMin.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fontcharactersmerger/_index.md
+++ b/italian/java/com.aspose.font/fontcharactersmerger/_index.md
@@ -1,0 +1,200 @@
+---
+title: "FontCharactersMerger"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Dichiara la funzionalità per unire font di diversi tipi."
+type: docs
+weight: 35
+url: /it/java/com.aspose.font/fontcharactersmerger/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class FontCharactersMerger
+```
+
+Dichiara la funzionalità per unire font di tipi diversi. È necessaria una coppia di font per l'operazione di fusione. Un font di questa coppia è considerato primario. Ciò significa che molte caratteristiche, relative al font finale unito, come metriche, struttura di codifica e altre, saranno prese da questo font primario. L'altro font della coppia (secondario) fornisce solo i glifi per il font finale unito.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPrimaryFont()](#getPrimaryFont--) | Ottiene il font primario. |
+| [getSecondaryFont()](#getSecondaryFont--) | Ottiene il font secondario. |
+| [hashCode()](#hashCode--) |  |
+| [mergeFonts(GlyphId[] primaryFontGlyphs, GlyphId[] secondaryFontGlyphs, String newFontName)](#mergeFonts-com.aspose.font.GlyphId---com.aspose.font.GlyphId---java.lang.String-) | Unisce i font in base agli elenchi di glifi forniti. |
+| [mergeFonts(int[] primaryFontCharCodes, int[] secondaryFontCharCodes, String newFontName)](#mergeFonts-int---int---java.lang.String-) | Unisce i font in base agli elenchi di codici carattere forniti. |
+| [mergeFonts(Map<Integer,GlyphId> primaryFontDict, Map<Integer,GlyphId> secondaryFontDict, String newFontName)](#mergeFonts-java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.lang.String-) | Questa versione del metodo è progettata per i casi in cui si desidera impostare esplicitamente i codici carattere per i glifi nel font risultante. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPrimaryFont() {#getPrimaryFont--}
+```
+public abstract Font getPrimaryFont()
+```
+
+
+Ottiene il font primario.
+
+**Returns:**
+[Font](../../com.aspose.font/font) - The primary font.
+### getSecondaryFont() {#getSecondaryFont--}
+```
+public abstract Font getSecondaryFont()
+```
+
+
+Ottiene il font secondario.
+
+**Returns:**
+[Font](../../com.aspose.font/font) - The secondary font.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### mergeFonts(GlyphId[] primaryFontGlyphs, GlyphId[] secondaryFontGlyphs, String newFontName) {#mergeFonts-com.aspose.font.GlyphId---com.aspose.font.GlyphId---java.lang.String-}
+```
+public abstract Font mergeFonts(GlyphId[] primaryFontGlyphs, GlyphId[] secondaryFontGlyphs, String newFontName)
+```
+
+
+Unisce i font in base agli elenchi di glifi forniti. Cerca un codice carattere per ogni glifo fornito e aggiunge il codice carattere trovato con il glifo corrispondente nel nuovo font risultante.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| primaryFontGlyphs | [GlyphId\[\]](../../com.aspose.font/glyphid) | Elenco dei glifi da prendere dal font primario. |
+| secondaryFontGlyphs | [GlyphId\[\]](../../com.aspose.font/glyphid) | Elenco dei glifi da prendere dal font secondario. |
+| newFontName | java.lang.String | Nome desiderato per il font risultante. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Merged font
+### mergeFonts(int[] primaryFontCharCodes, int[] secondaryFontCharCodes, String newFontName) {#mergeFonts-int---int---java.lang.String-}
+```
+public abstract Font mergeFonts(int[] primaryFontCharCodes, int[] secondaryFontCharCodes, String newFontName)
+```
+
+
+Unisce i font in base agli elenchi di codici carattere forniti. Per creare il font risultante desiderato, basta fornire i codici dei simboli dai font originali che si desidera includere nel font risultante. I glifi relativi ai codici forniti saranno trovati automaticamente. Ad esempio, se si desidera includere i glifi relativi alle lettere A e B dal primo font e i glifi relativi alle lettere C e D dal secondo font, basta chiamare questo metodo così: `mergeFonts(new uint[] { 'A', 'B' }, new uint[] { 'C', 'D' }, \"NewFont\")`
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| primaryFontCharCodes | int[] | Codici da prendere dal font primario. |
+| secondaryFontCharCodes | int[] | Codici da prendere dal font secondario. |
+| newFontName | java.lang.String | Nome desiderato per il font risultante. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Merged font.
+### mergeFonts(Map<Integer,GlyphId> primaryFontDict, Map<Integer,GlyphId> secondaryFontDict, String newFontName) {#mergeFonts-java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.lang.String-}
+```
+public abstract Font mergeFonts(Map<Integer,GlyphId> primaryFontDict, Map<Integer,GlyphId> secondaryFontDict, String newFontName)
+```
+
+
+Questa versione del metodo è progettata per i casi in cui si desidera impostare esplicitamente i codici carattere per i glifi nel font risultante. Non è obbligatorio che il codice per il glifo fornito sia incluso nel font originale. Lo scopo del codice fornito è che venga associato all'identificatore del glifo corrispondente nel font risultante. Pertanto, la regola per elaborare ogni coppia passata tramite il parametro dizionario [code, glyph identifier] è che solo l'identificatore del glifo verrà prelevato dal font originale e poi sarà collegato al codice corrispondente nel font risultante. Questo può essere utile quando alcuni codici del primo font confliggono con gli stessi codici del secondo font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| primaryFontDict | java.util.Map<java.lang.Integer,com.aspose.font.GlyphId> | Dizionario con coppie [symbol code, glyph identifier] dal font primario. |
+| secondaryFontDict | java.util.Map<java.lang.Integer,com.aspose.font.GlyphId> | Dizionario con coppie [symbol code, glyph identifier] dal font secondario. |
+| newFontName | java.lang.String | Nome desiderato per il font risultante. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Merged font.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fontconversionexception/_index.md
+++ b/italian/java/com.aspose.font/fontconversionexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontConversionException"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta un'eccezione di conversione Font."
+type: docs
+weight: 36
+url: /it/java/com.aspose.font/fontconversionexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontConversionException extends FontException
+```
+
+Rappresenta un'eccezione di conversione del font. L'eccezione può essere generata in caso di errori durante il processo di conversione del font.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FontConversionException()](#FontConversionException--) | Inizializza un nuovo oggetto  FontConversionException  . |
+| [FontConversionException(String message)](#FontConversionException-java.lang.String-) | Inizializza un nuovo oggetto  FontConversionException  . |
+| [FontConversionException(String message, RuntimeException innerException)](#FontConversionException-java.lang.String-java.lang.RuntimeException-) | Inizializza un nuovo oggetto  FontConversionException  . |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontConversionException() {#FontConversionException--}
+```
+public FontConversionException()
+```
+
+
+Inizializza un nuovo oggetto  FontConversionException  .
+
+### FontConversionException(String message) {#FontConversionException-java.lang.String-}
+```
+public FontConversionException(String message)
+```
+
+
+Inizializza un nuovo oggetto  FontConversionException  .
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+
+### FontConversionException(String message, RuntimeException innerException) {#FontConversionException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontConversionException(String message, RuntimeException innerException)
+```
+
+
+Inizializza un nuovo oggetto  FontConversionException  .
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+| innerException | java.lang.RuntimeException | L'eccezione che è la causa dell'eccezione corrente. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fontcreationexception/_index.md
+++ b/italian/java/com.aspose.font/fontcreationexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontCreationException"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta un'eccezione di creazione Font."
+type: docs
+weight: 37
+url: /it/java/com.aspose.font/fontcreationexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontCreationException extends FontException
+```
+
+Rappresenta l'eccezione di creazione del Font. L'eccezione può essere sollevata in caso di errori durante il processo di creazione del font.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FontCreationException()](#FontCreationException--) | Inizializza un nuovo oggetto FontCreationException. |
+| [FontCreationException(String message)](#FontCreationException-java.lang.String-) | Inizializza un nuovo oggetto FontCreationException. |
+| [FontCreationException(String message, RuntimeException innerException)](#FontCreationException-java.lang.String-java.lang.RuntimeException-) | Inizializza un nuovo oggetto FontCreationException. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontCreationException() {#FontCreationException--}
+```
+public FontCreationException()
+```
+
+
+Inizializza un nuovo oggetto FontCreationException.
+
+### FontCreationException(String message) {#FontCreationException-java.lang.String-}
+```
+public FontCreationException(String message)
+```
+
+
+Inizializza un nuovo oggetto FontCreationException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+
+### FontCreationException(String message, RuntimeException innerException) {#FontCreationException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontCreationException(String message, RuntimeException innerException)
+```
+
+
+Inizializza un nuovo oggetto FontCreationException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+| innerException | java.lang.RuntimeException | L'eccezione che è la causa dell'eccezione corrente. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fontdefinition/_index.md
+++ b/italian/java/com.aspose.font/fontdefinition/_index.md
@@ -1,0 +1,390 @@
+---
+title: "FontDefinition"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la definizione del set di file Font."
+type: docs
+weight: 38
+url: /it/java/com.aspose.font/fontdefinition/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontDefinition
+```
+
+Rappresenta la definizione del set di file Font. Questa classe contiene campi che non sono correlati ai dati interni del font. Questi campi descrivono il posizionamento del font e altri dati necessari per caricare il font da una qualche fonte di font (file, memoria, ecc).
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FontDefinition(FontType fontType, String fileExtension, StreamSource streamSource)](#FontDefinition-com.aspose.font.FontType-java.lang.String-com.aspose.font.StreamSource-) | Crea la definizione Font a singolo file. |
+| [FontDefinition(FontType fontType, StreamSource streamSource)](#FontDefinition-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Crea la definizione Font a singolo file. |
+| [FontDefinition(String fontName, FontType fontType, String fileExtension, StreamSource streamSource)](#FontDefinition-java.lang.String-com.aspose.font.FontType-java.lang.String-com.aspose.font.StreamSource-) | Crea la definizione Font a singolo file. |
+| [FontDefinition(FontType fontType, FontFileDefinition fileDefinition)](#FontDefinition-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-) | Crea la definizione Font a singolo file. |
+| [FontDefinition(String fontName, FontType fontType, FontFileDefinition fileDefinition)](#FontDefinition-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-) | Crea la definizione Font a singolo file. |
+| [FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition fileDefinition)](#FontDefinition-java.lang.String-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-) | Crea la definizione Font a singolo file. |
+| [FontDefinition(FontType fontType, FontFileDefinition[] fileDefinitions)](#FontDefinition-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---) | Crea la definizione Font a più file. |
+| [FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition[] fileDefinitions)](#FontDefinition-java.lang.String-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---) | Crea la definizione Font a più file. |
+| [FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition fileDefinition)](#FontDefinition-com.aspose.font.MultiLanguageString-com.aspose.font.MultiLanguageString-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-) | Crea la definizione Font a più file. |
+| [FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition[] fileDefinitions)](#FontDefinition-com.aspose.font.MultiLanguageString-com.aspose.font.MultiLanguageString-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---) | Crea la definizione Font a più file. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileDefinitions()](#getFileDefinitions--) | Ottiene la collezione delle definizioni dei file. |
+| [getFontName()](#getFontName--) | Restituisce il nome del Font. |
+| [getFontNames()](#getFontNames--) | Ottiene i nomi del Font come un MultiLanguageString. |
+| [getFontType()](#getFontType--) | Ottiene il tipo di Font. |
+| [getPostscriptName()](#getPostscriptName--) | Ottiene il nome del Font postscript. |
+| [getPostscriptNames()](#getPostscriptNames--) | Ottiene i nomi del Font postscript come un MultiLanguageString. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(StreamSource source, FontType fontType)](#open-com.aspose.font.StreamSource-com.aspose.font.FontType-) | Restituisce FontDefinition per la sorgente di stream del font e il tipo di font. |
+| [open(String fileName, FontType fontType)](#open-java.lang.String-com.aspose.font.FontType-) | Restituisce FontDefinition per il file del font e il tipo di font. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontDefinition(FontType fontType, String fileExtension, StreamSource streamSource) {#FontDefinition-com.aspose.font.FontType-java.lang.String-com.aspose.font.StreamSource-}
+```
+public FontDefinition(FontType fontType, String fileExtension, StreamSource streamSource)
+```
+
+
+Crea la definizione Font a singolo file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fileExtension | java.lang.String | Estensione del file Font. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Sorgente di stream del Font. |
+
+### FontDefinition(FontType fontType, StreamSource streamSource) {#FontDefinition-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public FontDefinition(FontType fontType, StreamSource streamSource)
+```
+
+
+Crea la definizione Font a singolo file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Sorgente di stream del Font. |
+
+### FontDefinition(String fontName, FontType fontType, String fileExtension, StreamSource streamSource) {#FontDefinition-java.lang.String-com.aspose.font.FontType-java.lang.String-com.aspose.font.StreamSource-}
+```
+public FontDefinition(String fontName, FontType fontType, String fileExtension, StreamSource streamSource)
+```
+
+
+Crea la definizione Font a singolo file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontName | java.lang.String | Nome del font. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fileExtension | java.lang.String | Estensione del file Font. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Sorgente di stream del Font. |
+
+### FontDefinition(FontType fontType, FontFileDefinition fileDefinition) {#FontDefinition-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-}
+```
+public FontDefinition(FontType fontType, FontFileDefinition fileDefinition)
+```
+
+
+Crea la definizione Font a singolo file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fileDefinition | [FontFileDefinition](../../com.aspose.font/fontfiledefinition) | FontFileDefinition. |
+
+### FontDefinition(String fontName, FontType fontType, FontFileDefinition fileDefinition) {#FontDefinition-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-}
+```
+public FontDefinition(String fontName, FontType fontType, FontFileDefinition fileDefinition)
+```
+
+
+Crea la definizione Font a singolo file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontName | java.lang.String | Nome del font. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fileDefinition | [FontFileDefinition](../../com.aspose.font/fontfiledefinition) | FontFileDefinition. |
+
+### FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition fileDefinition) {#FontDefinition-java.lang.String-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-}
+```
+public FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition fileDefinition)
+```
+
+
+Crea la definizione Font a singolo file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontName | java.lang.String | Nome del font. |
+| postscriptName | java.lang.String | Nome del Font Postscript. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fileDefinition | [FontFileDefinition](../../com.aspose.font/fontfiledefinition) | FontFileDefinition. |
+
+### FontDefinition(FontType fontType, FontFileDefinition[] fileDefinitions) {#FontDefinition-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---}
+```
+public FontDefinition(FontType fontType, FontFileDefinition[] fileDefinitions)
+```
+
+
+Crea la definizione Font a più file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fileDefinitions | [FontFileDefinition\[\]](../../com.aspose.font/fontfiledefinition) | Array di oggetti FontFileDefinition. |
+
+### FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition[] fileDefinitions) {#FontDefinition-java.lang.String-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---}
+```
+public FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition[] fileDefinitions)
+```
+
+
+Crea la definizione Font a più file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontName | java.lang.String | Nome del font. |
+| postscriptName | java.lang.String | Nome del Font Postscript. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fileDefinitions | [FontFileDefinition\[\]](../../com.aspose.font/fontfiledefinition) | Array di oggetti FontFileDefinition. |
+
+### FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition fileDefinition) {#FontDefinition-com.aspose.font.MultiLanguageString-com.aspose.font.MultiLanguageString-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-}
+```
+public FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition fileDefinition)
+```
+
+
+Crea la definizione Font a più file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Nomi del Font. |
+| postscriptNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Nomi del Font Postscript. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fileDefinition | [FontFileDefinition](../../com.aspose.font/fontfiledefinition) | FontFileDefinition. |
+
+### FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition[] fileDefinitions) {#FontDefinition-com.aspose.font.MultiLanguageString-com.aspose.font.MultiLanguageString-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---}
+```
+public FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition[] fileDefinitions)
+```
+
+
+Crea la definizione Font a più file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Nomi del Font. |
+| postscriptNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Nomi del Font Postscript. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fileDefinitions | [FontFileDefinition\[\]](../../com.aspose.font/fontfiledefinition) | Array di oggetti FontFileDefinition. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileDefinitions() {#getFileDefinitions--}
+```
+public FontFileDefinition[] getFileDefinitions()
+```
+
+
+Ottiene la collezione delle definizioni dei file.
+
+**Returns:**
+com.aspose.font.FontFileDefinition[] - Collezione delle definizioni dei file.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Restituisce il nome del Font.
+
+**Returns:**
+java.lang.String - Nome del font.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Ottiene i nomi del Font come un MultiLanguageString.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names as a  MultiLanguageString .
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Ottiene il tipo di Font.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getPostscriptName() {#getPostscriptName--}
+```
+public String getPostscriptName()
+```
+
+
+Ottiene il nome del Font postscript.
+
+**Returns:**
+java.lang.String - Nome del Font Postscript.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Ottiene i nomi del Font postscript come un MultiLanguageString.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names as a  MultiLanguageString .
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(StreamSource source, FontType fontType) {#open-com.aspose.font.StreamSource-com.aspose.font.FontType-}
+```
+public static FontDefinition open(StreamSource source, FontType fontType)
+```
+
+
+Restituisce FontDefinition per la sorgente di stream del font e il tipo di font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| source | [StreamSource](../../com.aspose.font/streamsource) | Sorgente di stream del Font. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - FontDefinition.
+### open(String fileName, FontType fontType) {#open-java.lang.String-com.aspose.font.FontType-}
+```
+public static FontDefinition open(String fileName, FontType fontType)
+```
+
+
+Restituisce FontDefinition per il file del font e il tipo di font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fileName | java.lang.String | Nome file del font. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - FontDefinition.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fontenvironment/_index.md
+++ b/italian/java/com.aspose.font/fontenvironment/_index.md
@@ -1,0 +1,193 @@
+---
+title: "FontEnvironment"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Fornisce informazioni sull'ambiente e sulla piattaforma corrente."
+type: docs
+weight: 39
+url: /it/java/com.aspose.font/fontenvironment/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontEnvironment
+```
+
+Fornisce informazioni sull'ambiente e sulla piattaforma corrente.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCffCommonFontsSettings()](#getCffCommonFontsSettings--) | Impostazioni comuni ai font CFF. |
+| [getClass()](#getClass--) |  |
+| [getCurrent()](#getCurrent--) | Ottiene l'ambiente corrente. |
+| [getCurrentPlatformId()](#getCurrentPlatformId--) | Ottiene l'ID della piattaforma corrente. |
+| [getFontSpecificEncodings()](#getFontSpecificEncodings--) | Memorizza codifiche specifiche per i Font orientati al consumatore. |
+| [getStrictness()](#getStrictness--) | Alcuni Font possono contenere dati inattesi, funzionalità non specificate o possono essere approssimativamente ritagliati. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setStrictness(FontEnvironment.ParsingStrictness value)](#setStrictness-com.aspose.font.FontEnvironment.ParsingStrictness-) | Alcuni Font possono contenere dati inattesi, funzionalità non specificate o possono essere approssimativamente ritagliati. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCffCommonFontsSettings() {#getCffCommonFontsSettings--}
+```
+public static CffFontsSettings getCffCommonFontsSettings()
+```
+
+
+Impostazioni comuni ai font CFF.
+
+**Returns:**
+[CffFontsSettings](../../com.aspose.font/cfffontssettings)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCurrent() {#getCurrent--}
+```
+public static FontEnvironment getCurrent()
+```
+
+
+Ottiene l'ambiente corrente.
+
+**Returns:**
+[FontEnvironment](../../com.aspose.font/fontenvironment) - Current environment.
+### getCurrentPlatformId() {#getCurrentPlatformId--}
+```
+public int getCurrentPlatformId()
+```
+
+
+Ottiene l'ID della piattaforma corrente.
+
+**Returns:**
+int - ID della piattaforma corrente.
+### getFontSpecificEncodings() {#getFontSpecificEncodings--}
+```
+public FontSpecificEncodings getFontSpecificEncodings()
+```
+
+
+Memorizza codifiche specifiche per i Font orientati al consumatore. Ad esempio, PDF utilizza codifiche specifiche Adobe Symbol e ZapfDingbats.
+
+**Returns:**
+[FontSpecificEncodings](../../com.aspose.font/fontspecificencodings) - Specific encodings for consumer-aware Fonts.
+### getStrictness() {#getStrictness--}
+```
+public FontEnvironment.ParsingStrictness getStrictness()
+```
+
+
+Alcuni Font possono contenere dati inattesi, funzionalità non specificate o possono essere approssimativamente ritagliati. Si consiglia l'impostazione tollerante per i consumatori che desiderano aprire qualsiasi font indipendentemente da eventuali inadeguatezze del Font. Le strutture interne dei Font non sono garantite come coerenti. Si consiglia l'impostazione rigorosa per i consumatori che desiderano aprire principalmente Font validi e solidi.
+
+**Returns:**
+[ParsingStrictness](../../com.aspose.font/parsingstrictness) - Strictness.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setStrictness(FontEnvironment.ParsingStrictness value) {#setStrictness-com.aspose.font.FontEnvironment.ParsingStrictness-}
+```
+public void setStrictness(FontEnvironment.ParsingStrictness value)
+```
+
+
+Alcuni Font possono contenere dati inattesi, funzionalità non specificate o possono essere approssimativamente ritagliati. Si consiglia l'impostazione tollerante per i consumatori che desiderano aprire qualsiasi font indipendentemente da eventuali inadeguatezze del Font. Le strutture interne dei Font non sono garantite come coerenti. Si consiglia l'impostazione rigorosa per i consumatori che desiderano aprire principalmente Font validi e solidi.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ParsingStrictness](../../com.aspose.font/parsingstrictness) | Rigorosità. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fontexception/_index.md
+++ b/italian/java/com.aspose.font/fontexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontException"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta un'eccezione comune relativa all'elaborazione del Font."
+type: docs
+weight: 40
+url: /it/java/com.aspose.font/fontexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException
+```
+public class FontException extends IllegalStateException
+```
+
+Rappresenta un'eccezione comune relativa all'elaborazione del Font.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FontException()](#FontException--) | Inizializza un nuovo oggetto  FontException  . |
+| [FontException(String message)](#FontException-java.lang.String-) | Inizializza un nuovo oggetto  FontException  . |
+| [FontException(String message, RuntimeException innerException)](#FontException-java.lang.String-java.lang.RuntimeException-) | Inizializza un nuovo oggetto  FontException  . |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontException() {#FontException--}
+```
+public FontException()
+```
+
+
+Inizializza un nuovo oggetto  FontException  .
+
+### FontException(String message) {#FontException-java.lang.String-}
+```
+public FontException(String message)
+```
+
+
+Inizializza un nuovo oggetto  FontException  .
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+
+### FontException(String message, RuntimeException innerException) {#FontException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontException(String message, RuntimeException innerException)
+```
+
+
+Inizializza un nuovo oggetto  FontException  .
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+| innerException | java.lang.RuntimeException | L'eccezione che è la causa dell'eccezione corrente. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fontfactory/_index.md
+++ b/italian/java/com.aspose.font/fontfactory/_index.md
@@ -1,0 +1,204 @@
+---
+title: "FontFactory"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Contiene funzionalità per aprire font di diversi tipi e altri metodi per creare vari oggetti."
+type: docs
+weight: 41
+url: /it/java/com.aspose.font/fontfactory/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontFactory
+```
+
+Contiene funzionalità per aprire font di diversi tipi e altri metodi per creare vari oggetti.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FontFactory()](#FontFactory--) | Costruttore |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Apre un font, utilizzando l'oggetto FontDefinition. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Apre un font, utilizzando il tipo di font e l'array di byte dei dati del font. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Apre un font, utilizzando il tipo di font e la sorgente stream. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Apre un font, utilizzando il tipo di font e il nome del file del font. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontFactory() {#FontFactory--}
+```
+public FontFactory()
+```
+
+
+Costruttore
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public Font open(FontDefinition fontDefinition)
+```
+
+
+Apre un font, utilizzando l'oggetto FontDefinition.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Oggetto definizione del Font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public Font open(FontType fontType, byte[] fontData)
+```
+
+
+Apre un font, utilizzando il tipo di font e l'array di byte dei dati del font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fontData | byte[] | Array di byte da cui caricare il font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Apre un font, utilizzando il tipo di font e la sorgente stream.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Sorgente stream per il font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public Font open(FontType fontType, String fileName)
+```
+
+
+Apre un font, utilizzando il tipo di font e il nome del file del font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fileName | java.lang.String | Nome file del font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fontfiledefinition/_index.md
+++ b/italian/java/com.aspose.font/fontfiledefinition/_index.md
@@ -1,0 +1,231 @@
+---
+title: "FontFileDefinition"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la definizione del file Font."
+type: docs
+weight: 42
+url: /it/java/com.aspose.font/fontfiledefinition/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontFileDefinition
+```
+
+Rappresenta la definizione del file Font.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FontFileDefinition(StreamSource streamSource)](#FontFileDefinition-com.aspose.font.StreamSource-) | Crea una definizione di file utilizzando solo il contenuto del file. |
+| [FontFileDefinition(String fileExtension, StreamSource streamSource)](#FontFileDefinition-java.lang.String-com.aspose.font.StreamSource-) | Crea una definizione di file utilizzando solo il contenuto del file. |
+| [FontFileDefinition(String fileExtension, StreamSource streamSource, long offset)](#FontFileDefinition-java.lang.String-com.aspose.font.StreamSource-long-) | Crea una definizione di file utilizzando solo il contenuto del file. |
+| [FontFileDefinition(File fontFile)](#FontFileDefinition-java.io.File-) | Crea una definizione di file usando il file di carattere (rappresentato da File) e il contenuto del file. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileExtension()](#getFileExtension--) | Ottiene l'estensione del file. |
+| [getFileName()](#getFileName--) | Ottiene il nome del file. |
+| [getOffset()](#getOffset--) | Ottiene l'offset all'interno dello stream. |
+| [getStreamSource()](#getStreamSource--) | Ottiene la sorgente dello stream. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontFileDefinition(StreamSource streamSource) {#FontFileDefinition-com.aspose.font.StreamSource-}
+```
+public FontFileDefinition(StreamSource streamSource)
+```
+
+
+Crea una definizione di file utilizzando solo il contenuto del file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Sorgente di stream del Font. |
+
+### FontFileDefinition(String fileExtension, StreamSource streamSource) {#FontFileDefinition-java.lang.String-com.aspose.font.StreamSource-}
+```
+public FontFileDefinition(String fileExtension, StreamSource streamSource)
+```
+
+
+Crea una definizione di file utilizzando solo il contenuto del file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fileExtension | java.lang.String | Estensione del file Font. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Sorgente di stream del Font. |
+
+### FontFileDefinition(String fileExtension, StreamSource streamSource, long offset) {#FontFileDefinition-java.lang.String-com.aspose.font.StreamSource-long-}
+```
+public FontFileDefinition(String fileExtension, StreamSource streamSource, long offset)
+```
+
+
+Crea una definizione di file utilizzando solo il contenuto del file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fileExtension | java.lang.String | Estensione del file Font. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Sorgente di stream del Font. |
+| offset | long | Offset ai dati del carattere nella sorgente del flusso. |
+
+### FontFileDefinition(File fontFile) {#FontFileDefinition-java.io.File-}
+```
+public FontFileDefinition(File fontFile)
+```
+
+
+Crea una definizione di file usando il file di carattere (rappresentato da File) e il contenuto del file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontFile | java.io.File | Oggetto File. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileExtension() {#getFileExtension--}
+```
+public String getFileExtension()
+```
+
+
+Ottiene l'estensione del file.
+
+**Returns:**
+java.lang.String - Estensione del file.
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Ottiene il nome del file.
+
+**Returns:**
+java.lang.String - Nome del file.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset all'interno dello stream.
+
+**Returns:**
+long - Offset all'interno del flusso.
+### getStreamSource() {#getStreamSource--}
+```
+public StreamSource getStreamSource()
+```
+
+
+Ottiene la sorgente dello stream.
+
+**Returns:**
+[StreamSource](../../com.aspose.font/streamsource) - The stream source.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fontmergeexception/_index.md
+++ b/italian/java/com.aspose.font/fontmergeexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontMergeException"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta un'eccezione di unione Font."
+type: docs
+weight: 43
+url: /it/java/com.aspose.font/fontmergeexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontMergeException extends FontException
+```
+
+Rappresenta l'eccezione di unione dei font. L'eccezione può essere sollevata in caso di errori durante l'unione dei font.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FontMergeException()](#FontMergeException--) | Inizializza un nuovo oggetto FontMergeException. |
+| [FontMergeException(String message)](#FontMergeException-java.lang.String-) | Inizializza un nuovo oggetto FontMergeException. |
+| [FontMergeException(String message, RuntimeException innerException)](#FontMergeException-java.lang.String-java.lang.RuntimeException-) | Inizializza un nuovo oggetto FontMergeException. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontMergeException() {#FontMergeException--}
+```
+public FontMergeException()
+```
+
+
+Inizializza un nuovo oggetto FontMergeException.
+
+### FontMergeException(String message) {#FontMergeException-java.lang.String-}
+```
+public FontMergeException(String message)
+```
+
+
+Inizializza un nuovo oggetto FontMergeException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+
+### FontMergeException(String message, RuntimeException innerException) {#FontMergeException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontMergeException(String message, RuntimeException innerException)
+```
+
+
+Inizializza un nuovo oggetto FontMergeException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+| innerException | java.lang.RuntimeException | L'eccezione che è la causa dell'eccezione corrente. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fontmetrics/_index.md
+++ b/italian/java/com.aspose.font/fontmetrics/_index.md
@@ -1,0 +1,470 @@
+---
+title: "FontMetrics"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta le metriche del font."
+type: docs
+weight: 44
+url: /it/java/com.aspose.font/fontmetrics/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFontMetrics](../../com.aspose.font/ifontmetrics)
+```
+public abstract class FontMetrics implements IFontMetrics
+```
+
+Rappresenta le metriche del font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAscender()](#getAscender--) | Restituisce il valore Ascender. |
+| [getAscender(double fontSize)](#getAscender-double-) | Restituisce l'ascender per una dimensione specifica del Font. |
+| [getClass()](#getClass--) |  |
+| [getDescender()](#getDescender--) | Restituisce il valore Descender. |
+| [getDescender(double fontSize)](#getDescender-double-) | Restituisce il descender per una dimensione specifica del Font. |
+| [getFontBBox()](#getFontBBox--) | Restituisce il valore FontBBox. |
+| [getFontMatrix()](#getFontMatrix--) | Restituisce il valore FontMatrix. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Restituisce il Bbox del glifo. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Restituisce la larghezza del glifo. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Restituisce il valore di kerning per la coppia di glifi. |
+| [getLineGap()](#getLineGap--) | Ottiene il valore LineGap. |
+| [getTypoAscender()](#getTypoAscender--) | Ottiene il valore TypoAscender. |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Restituisce l'ascendente tipografico per una dimensione specifica del Font. |
+| [getTypoDescender()](#getTypoDescender--) | Ottiene il valore TypoDescender. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Restituisce il discendente tipografico per una dimensione specifica del font. |
+| [getTypoLineGap()](#getTypoLineGap--) | Ottiene il valore TypoLineGap. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Restituisce il gap di linea per una dimensione specifica del Font. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Ottiene il valore UnitsPerEM. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Ottiene il valore IsFixedPitch. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Misura la stringa e restituisce la larghezza della stringa. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAscender(double value)](#setAscender-double-) | Imposta il valore Ascender. |
+| [setDescender(double value)](#setDescender-double-) | Imposta il valore Descender. |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) | Imposta la larghezza del glifo. |
+| [setTypoAscender(double value)](#setTypoAscender-double-) | Imposta il valore TypoAscender. |
+| [setTypoDescender(double value)](#setTypoDescender-double-) | Imposta il valore TypoDescender. |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) | Imposta il valore UnitsPerEM. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAscender() {#getAscender--}
+```
+public double getAscender()
+```
+
+
+Restituisce il valore Ascender.
+
+**Returns:**
+double - valore Ascender.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public double getAscender(double fontSize)
+```
+
+
+Restituisce l'ascender per una dimensione specifica del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - valore Ascender.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescender() {#getDescender--}
+```
+public double getDescender()
+```
+
+
+Restituisce il valore Descender.
+
+**Returns:**
+double - valore Descender.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public double getDescender(double fontSize)
+```
+
+
+Restituisce il descender per una dimensione specifica del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - valore Descender.
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+Restituisce il valore FontBBox.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - FontBBox value.
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+Restituisce il valore FontMatrix.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - FontMatrix value.
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Restituisce il Bbox del glifo. Restituisce FontBBox se il BBox non era definito per il glifo. Può essere sovrascritto da eredi di codifica del font specifici.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificatore del glifo. |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox.
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Restituisce la larghezza del glyph. Può essere sovrascritto da eredi della codifica del font specifici.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificatore del glifo. |
+
+**Returns:**
+double - Larghezza del glyph.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Restituisce il valore di kerning per la coppia di glifi.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Primo glyph nella coppia. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Dimensione del Font. |
+
+**Returns:**
+double - Valore del kerning.
+### getLineGap() {#getLineGap--}
+```
+public double getLineGap()
+```
+
+
+Ottiene il valore LineGap.
+
+**Returns:**
+double - Valore del LineGap.
+### getTypoAscender() {#getTypoAscender--}
+```
+public double getTypoAscender()
+```
+
+
+Ottiene il valore TypoAscender.
+
+**Returns:**
+double - Valore del TypoAscender.
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public double getTypoAscender(double fontSize)
+```
+
+
+Restituisce l'ascendente tipografico per una dimensione specifica del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - Valore del Typographic ascender.
+### getTypoDescender() {#getTypoDescender--}
+```
+public double getTypoDescender()
+```
+
+
+Ottiene il valore TypoDescender.
+
+**Returns:**
+double - Valore del TypoDescender.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public double getTypoDescender(double fontSize)
+```
+
+
+Restituisce il discendente tipografico per una dimensione specifica del font.
+
+param fontSize Dimensione del font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double |  |
+
+**Returns:**
+double - Valore del Typographic descender.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public double getTypoLineGap()
+```
+
+
+Ottiene il valore TypoLineGap.
+
+**Returns:**
+double - Valore del TypoLineGap.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public double getTypoLineGap(double fontSize)
+```
+
+
+Restituisce il gap di linea per una dimensione specifica del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - Valore del Line gap.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Ottiene il valore UnitsPerEM.
+
+**Returns:**
+long - Valore del UnitsPerEM.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+Ottiene il valore IsFixedPitch.
+
+**Returns:**
+boolean - Valore del IsFixedPitch.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public abstract double measureString(String unicode, double fontSize)
+```
+
+
+Misura la stringa e restituisce la larghezza della stringa.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| unicode | java.lang.String | Stringa Unicode. |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - Larghezza del String.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAscender(double value) {#setAscender-double-}
+```
+public void setAscender(double value)
+```
+
+
+Imposta il valore Ascender.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore del Ascender. |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public void setDescender(double value)
+```
+
+
+Imposta il valore Descender.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore del Descender. |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public abstract void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Imposta la larghezza del glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificatore del glifo. |
+| valore | double | Nuova larghezza. |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public void setTypoAscender(double value)
+```
+
+
+Imposta il valore TypoAscender.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore del TypoAscender. |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public void setTypoDescender(double value)
+```
+
+
+Imposta il valore TypoDescender.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore del TypoDescender. |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public void setUnitsPerEM(long value)
+```
+
+
+Imposta il valore UnitsPerEM.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long | Valore del UnitsPerEM. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fontnotsupportedoperationexception/_index.md
+++ b/italian/java/com.aspose.font/fontnotsupportedoperationexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontNotSupportedOperationException"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta un'eccezione di operazione non supportata."
+type: docs
+weight: 45
+url: /it/java/com.aspose.font/fontnotsupportedoperationexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontNotSupportedOperationException extends FontException
+```
+
+Rappresenta un'eccezione di operazione non supportata. L'eccezione può essere generata nel caso in cui qualche operazione non sia supportata per un particolare tipo di carattere.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FontNotSupportedOperationException()](#FontNotSupportedOperationException--) | Inizializza un nuovo oggetto FontNotSupportedOperationException. |
+| [FontNotSupportedOperationException(String message)](#FontNotSupportedOperationException-java.lang.String-) | Inizializza un nuovo oggetto FontNotSupportedOperationException. |
+| [FontNotSupportedOperationException(String message, RuntimeException innerException)](#FontNotSupportedOperationException-java.lang.String-java.lang.RuntimeException-) | Inizializza un nuovo oggetto FontNotSupportedOperationException. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontNotSupportedOperationException() {#FontNotSupportedOperationException--}
+```
+public FontNotSupportedOperationException()
+```
+
+
+Inizializza un nuovo oggetto FontNotSupportedOperationException.
+
+### FontNotSupportedOperationException(String message) {#FontNotSupportedOperationException-java.lang.String-}
+```
+public FontNotSupportedOperationException(String message)
+```
+
+
+Inizializza un nuovo oggetto FontNotSupportedOperationException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+
+### FontNotSupportedOperationException(String message, RuntimeException innerException) {#FontNotSupportedOperationException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontNotSupportedOperationException(String message, RuntimeException innerException)
+```
+
+
+Inizializza un nuovo oggetto FontNotSupportedOperationException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+| innerException | java.lang.RuntimeException | L'eccezione che è la causa dell'eccezione corrente. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fontsavingformats/_index.md
+++ b/italian/java/com.aspose.font/fontsavingformats/_index.md
@@ -1,0 +1,277 @@
+---
+title: "FontSavingFormats"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Specifica il tipo di Font."
+type: docs
+weight: 135
+url: /it/java/com.aspose.font/fontsavingformats/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum FontSavingFormats extends Enum<FontSavingFormats>
+```
+
+Specifica il tipo di Font.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [OTF](#OTF) | Font OpenType. |
+| [SVG](#SVG) | SVG(Scalable Vector Graphics) formato di carattere |
+| [TTF](#TTF) | TTF (TrueType) formato di carattere. |
+| [WOFF](#WOFF) | WOFF(Web Open Font Format). |
+| [WOFF2](#WOFF2) | Formato file WOFF 2.0 |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OTF {#OTF}
+```
+public static final FontSavingFormats OTF
+```
+
+
+Font OpenType. Il formato OpenType è un'estensione del formato TrueType, aggiungendo il supporto per i dati dei font PostScript.
+
+### SVG {#SVG}
+```
+public static final FontSavingFormats SVG
+```
+
+
+SVG(Scalable Vector Graphics) formato di carattere
+
+### TTF {#TTF}
+```
+public static final FontSavingFormats TTF
+```
+
+
+TTF (TrueType) formato di carattere.
+
+### WOFF {#WOFF}
+```
+public static final FontSavingFormats WOFF
+```
+
+
+WOFF(Web Open Font Format).
+
+### WOFF2 {#WOFF2}
+```
+public static final FontSavingFormats WOFF2
+```
+
+
+Formato file WOFF 2.0
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static FontSavingFormats valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[FontSavingFormats](../../com.aspose.font/fontsavingformats)
+### values() {#values--}
+```
+public static FontSavingFormats[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.FontSavingFormats[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fontspecificencodings/_index.md
+++ b/italian/java/com.aspose.font/fontspecificencodings/_index.md
@@ -1,0 +1,139 @@
+---
+title: "FontSpecificEncodings"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta codifiche specifiche per Font consapevoli del consumatore."
+type: docs
+weight: 46
+url: /it/java/com.aspose.font/fontspecificencodings/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontSpecificEncodings
+```
+
+Rappresenta codifiche specifiche per Font consapevoli del consumatore.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [registerEncoding(String fontName, String[] encoding)](#registerEncoding-java.lang.String-java.lang.String---) | Registra la codifica per Font consapevoli del consumatore. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### registerEncoding(String fontName, String[] encoding) {#registerEncoding-java.lang.String-java.lang.String---}
+```
+public void registerEncoding(String fontName, String[] encoding)
+```
+
+
+Registra la codifica per Font consapevoli del consumatore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontName | java.lang.String | Nome del font. |
+| codifica | java.lang.String[] | Codifica. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fontstyle/_index.md
+++ b/italian/java/com.aspose.font/fontstyle/_index.md
@@ -1,0 +1,155 @@
+---
+title: "FontStyle"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Enumerazione degli stili del Font"
+type: docs
+weight: 47
+url: /it/java/com.aspose.font/fontstyle/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class FontStyle
+```
+
+Enumerazione degli stili del Font
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [Bold](#Bold) | Specifica lo stile grassetto del Font. |
+| [Italic](#Italic) | Specifica lo stile corsivo del Font. |
+| [Regular](#Regular) | Specifica lo stile normale del Font. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Bold {#Bold}
+```
+public static final int Bold
+```
+
+
+Specifica lo stile grassetto del Font.
+
+### Italic {#Italic}
+```
+public static final int Italic
+```
+
+
+Specifica lo stile corsivo del Font.
+
+### Regular {#Regular}
+```
+public static final int Regular
+```
+
+
+Specifica lo stile normale del Font.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/fonttype/_index.md
+++ b/italian/java/com.aspose.font/fonttype/_index.md
@@ -1,0 +1,268 @@
+---
+title: "FontType"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Specifica il tipo di Font."
+type: docs
+weight: 136
+url: /it/java/com.aspose.font/fonttype/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum FontType extends Enum<FontType>
+```
+
+Specifica il tipo di Font.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CFF](#CFF) | CFF (Compact font format) Tipo di font. |
+| [OTF](#OTF) | Font OpenType. |
+| [TTF](#TTF) | TTF (TrueType) Tipo di font e correlati. |
+| [Type1](#Type1) | Tipo di font Type1. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CFF {#CFF}
+```
+public static final FontType CFF
+```
+
+
+CFF (Compact font format) Tipo di font.
+
+### OTF {#OTF}
+```
+public static final FontType OTF
+```
+
+
+Font OpenType. Il formato OpenType è un'estensione del formato TrueType, aggiungendo il supporto per i dati dei font PostScript.
+
+### TTF {#TTF}
+```
+public static final FontType TTF
+```
+
+
+TTF (TrueType) Tipo di font e correlati.
+
+### Type1 {#Type1}
+```
+public static final FontType Type1
+```
+
+
+Tipo di font Type1.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static FontType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype)
+### values() {#values--}
+```
+public static FontType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.FontType[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/gasprange/_index.md
+++ b/italian/java/com.aspose.font/gasprange/_index.md
@@ -1,0 +1,163 @@
+---
+title: "GaspRange"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "L'array di record GaspRange fornisce comportamenti consigliati per varie dimensioni ppem"
+type: docs
+weight: 48
+url: /it/java/com.aspose.font/gasprange/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class GaspRange
+```
+
+L'array di record GaspRange fornisce comportamenti consigliati per varie dimensioni ppem
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [GaspRange(int rangeMaxPPEM, AsFoEnumSet<RangeGaspBehaviorFlags> rangeGaspBehaviorFlags)](#GaspRange-int-com.aspose.font.util.AsFoEnumSet-com.aspose.font.RangeGaspBehaviorFlags--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getRangeGaspBehaviorFlags()](#getRangeGaspBehaviorFlags--) | Restituisce i flag che descrivono il comportamento desiderato del rasterizzatore. |
+| [getRangeMaxPPEM()](#getRangeMaxPPEM--) | Restituisce il limite superiore dell'intervallo, in PPEM. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GaspRange(int rangeMaxPPEM, AsFoEnumSet<RangeGaspBehaviorFlags> rangeGaspBehaviorFlags) {#GaspRange-int-com.aspose.font.util.AsFoEnumSet-com.aspose.font.RangeGaspBehaviorFlags--}
+```
+public GaspRange(int rangeMaxPPEM, AsFoEnumSet<RangeGaspBehaviorFlags> rangeGaspBehaviorFlags)
+```
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| rangeMaxPPEM | int |  |
+| rangeGaspBehaviorFlags | com.aspose.font.util.AsFoEnumSet<com.aspose.font.RangeGaspBehaviorFlags> |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getRangeGaspBehaviorFlags() {#getRangeGaspBehaviorFlags--}
+```
+public AsFoEnumSet<RangeGaspBehaviorFlags> getRangeGaspBehaviorFlags()
+```
+
+
+Restituisce i flag che descrivono il comportamento desiderato del rasterizzatore.
+
+**Returns:**
+[AsFoEnumSet](../../com.aspose.font.util/asfoenumset) - The flags describing desired rasterizer behavior.
+### getRangeMaxPPEM() {#getRangeMaxPPEM--}
+```
+public int getRangeMaxPPEM()
+```
+
+
+Restituisce il limite superiore dell'intervallo, in PPEM.
+
+**Returns:**
+int - Il limite superiore dell'intervallo, in PPEM.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/glyph/_index.md
+++ b/italian/java/com.aspose.font/glyph/_index.md
@@ -1,0 +1,237 @@
+---
+title: "Glyph"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta un glifo del Font."
+type: docs
+weight: 49
+url: /it/java/com.aspose.font/glyph/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Cloneable
+```
+public class Glyph implements Cloneable
+```
+
+Rappresenta un glifo del Font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clone()](#clone--) | Restituisce una copia del glifo. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGlyphBBox()](#getGlyphBBox--) | Ottiene il BBox del glifo. |
+| [getLeftSidebearingX()](#getLeftSidebearingX--) | Ottiene la coordinata x del margine laterale del glifo. |
+| [getLeftSidebearingY()](#getLeftSidebearingY--) | Ottiene la coordinata y del margine laterale del glifo. |
+| [getPath()](#getPath--) | Ottiene il percorso del glifo. |
+| [getSourceResolution()](#getSourceResolution--) | Ottiene la risoluzione del set di comandi sorgente. |
+| [getState()](#getState--) | Ottiene lo stato del glifo. |
+| [getWidthVectorX()](#getWidthVectorX--) | Ottiene il vettore di larghezza del glifo. |
+| [getWidthVectorY()](#getWidthVectorY--) | Ottiene il vettore di larghezza del glifo. |
+| [hashCode()](#hashCode--) |  |
+| [isEmpty()](#isEmpty--) | Vero se il glifo non contiene istruzioni di disegno. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Restituisce una copia del glifo.
+
+**Returns:**
+java.lang.Object - Copia del glifo.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphBBox() {#getGlyphBBox--}
+```
+public FontBBox getGlyphBBox()
+```
+
+
+Ottiene il BBox del glifo.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox
+### getLeftSidebearingX() {#getLeftSidebearingX--}
+```
+public double getLeftSidebearingX()
+```
+
+
+Ottiene la coordinata x del margine laterale del glifo.
+
+**Returns:**
+double - Coordinata x del margine laterale del glifo.
+### getLeftSidebearingY() {#getLeftSidebearingY--}
+```
+public double getLeftSidebearingY()
+```
+
+
+Ottiene la coordinata y del margine laterale del glifo.
+
+**Returns:**
+double - Coordinata y del margine laterale del glifo.
+### getPath() {#getPath--}
+```
+public SegmentPath getPath()
+```
+
+
+Ottiene il percorso del glifo.
+
+**Returns:**
+[SegmentPath](../../com.aspose.font/segmentpath) - Glyph path.
+### getSourceResolution() {#getSourceResolution--}
+```
+public int getSourceResolution()
+```
+
+
+Ottiene la risoluzione del set di comandi sorgente.
+
+**Returns:**
+int - Risoluzione del set di comandi sorgente.
+### getState() {#getState--}
+```
+public GlyphState getState()
+```
+
+
+Ottiene lo stato del glifo.
+
+**Returns:**
+[GlyphState](../../com.aspose.font/glyphstate) - Glyph state.
+### getWidthVectorX() {#getWidthVectorX--}
+```
+public double getWidthVectorX()
+```
+
+
+Ottiene il vettore di larghezza del glifo. Coordinata x.
+
+**Returns:**
+double - Vettore di larghezza del glifo. Coordinata x.
+### getWidthVectorY() {#getWidthVectorY--}
+```
+public double getWidthVectorY()
+```
+
+
+Ottiene il vettore di larghezza del glifo. Coordinata y.
+
+**Returns:**
+double - Vettore di larghezza del glifo. Coordinata y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+Vero se il glifo non contiene istruzioni di disegno.
+
+**Returns:**
+boolean - Vero se il glifo non contiene istruzioni di disegno.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/glyphid/_index.md
+++ b/italian/java/com.aspose.font/glyphid/_index.md
@@ -1,0 +1,180 @@
+---
+title: "GlyphId"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta gli ID glifo disponibili nel Font."
+type: docs
+weight: 50
+url: /it/java/com.aspose.font/glyphid/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class GlyphId
+```
+
+Rappresenta gli ID glifo, disponibili nel Font. L'ID glifo è un numero unico per un glifo, dipendente dal tipo di font. Per esempio: l'ID di Type1 è un nome di glifo, istanza della classe ( GlyphStringId ). L'ID di TTF è un indice int, istanza della classe ( GlyphUInt32Id ).
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Restituisce true se due ID di glifo non sono uguali. |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) | Restituisce il codice hash dell'oggetto. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(GlyphId obj1, Object obj2)](#op-Equality-com.aspose.font.GlyphId-java.lang.Object-) | Restituisce true se due ID di glifo sono uguali. |
+| [op_Inequality(GlyphId obj1, Object obj2)](#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-) | Restituisce true se due ID di glifo non sono uguali. |
+| [toGlyphStringId()](#toGlyphStringId--) | Cast virtuale a GlyphStringId. |
+| [toGlyphUInt32Id()](#toGlyphUInt32Id--) | Conversione virtuale a GlyphUInt32Id. |
+| [toString()](#toString--) | Restituisce la rappresentazione stringa dell'ID glifo. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Restituisce true se due ID di glifo non sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj | java.lang.Object | Identificatore del glifo da confrontare. |
+
+**Returns:**
+boolean - Risultato del confronto.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public abstract int hashCode()
+```
+
+
+Restituisce il codice hash dell'oggetto.
+
+**Returns:**
+int - Codice hash dell'oggetto.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(GlyphId obj1, Object obj2) {#op-Equality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Equality(GlyphId obj1, Object obj2)
+```
+
+
+Restituisce true se due ID di glifo sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Primo identificatore del glifo da confrontare. |
+| obj2 | java.lang.Object | Secondo identificatore del glifo da confrontare. |
+
+**Returns:**
+boolean - Risultato del confronto.
+### op_Inequality(GlyphId obj1, Object obj2) {#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Inequality(GlyphId obj1, Object obj2)
+```
+
+
+Restituisce true se due ID di glifo non sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Primo identificatore del glifo da confrontare. |
+| obj2 | java.lang.Object | Secondo identificatore del glifo da confrontare. |
+
+**Returns:**
+boolean - Risultato del confronto.
+### toGlyphStringId() {#toGlyphStringId--}
+```
+public GlyphStringId toGlyphStringId()
+```
+
+
+Cast virtuale a GlyphStringId. GlyphStringId sovrascrive per restituire l'istanza.
+
+**Returns:**
+[GlyphStringId](../../com.aspose.font/glyphstringid) - null
+### toGlyphUInt32Id() {#toGlyphUInt32Id--}
+```
+public GlyphUInt32Id toGlyphUInt32Id()
+```
+
+
+Conversione virtuale a GlyphUInt32Id. GlyphUInt32Id sovrascrive per restituire l'istanza.
+
+**Returns:**
+[GlyphUInt32Id](../../com.aspose.font/glyphuint32id) - null
+### toString() {#toString--}
+```
+public abstract String toString()
+```
+
+
+Restituisce la rappresentazione stringa dell'ID glifo.
+
+**Returns:**
+java.lang.String - identificatore del glifo
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/glyphidlist/_index.md
+++ b/italian/java/com.aspose.font/glyphidlist/_index.md
@@ -1,0 +1,613 @@
+---
+title: "GlyphIdList"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'elenco degli ID dei glifi."
+type: docs
+weight: 51
+url: /it/java/com.aspose.font/glyphidlist/
+---
+**Inheritance:**
+java.lang.Object, java.util.AbstractCollection, java.util.AbstractList, java.util.ArrayList
+```
+public class GlyphIdList extends ArrayList<GlyphId>
+```
+
+Rappresenta l'elenco degli ID dei glifi.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>toArray(T[] arg0)](#-T-toArray-T---) |  |
+| [add(E arg0)](#add-E-) |  |
+| [add(GlyphId glyphId)](#add-com.aspose.font.GlyphId-) | Aggiunge l'id del glifo all'elenco. |
+| [add(int arg0, E arg1)](#add-int-E-) |  |
+| [addAll(int arg0, Collection<? extends E> arg1)](#addAll-int-java.util.Collection---extends-E--) |  |
+| [addAll(Collection<? extends E> arg0)](#addAll-java.util.Collection---extends-E--) |  |
+| [clear()](#clear--) | Cancella l'elenco. |
+| [clone()](#clone--) |  |
+| [contains(GlyphId glyphId)](#contains-com.aspose.font.GlyphId-) | Restituisce true nel caso in cui l'ID glifo sia nella lista. |
+| [contains(Object arg0)](#contains-java.lang.Object-) |  |
+| [containsAll(Collection<?> arg0)](#containsAll-java.util.Collection----) |  |
+| [ensureCapacity(int arg0)](#ensureCapacity-int-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [forEach(Consumer<? super E> arg0)](#forEach-java.util.function.Consumer---super-E--) |  |
+| [get(int index)](#get-int-) | Restituisce l'ID glifo in base all'indice. |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object arg0)](#indexOf-java.lang.Object-) |  |
+| [isEmpty()](#isEmpty--) |  |
+| [iterator()](#iterator--) |  |
+| [lastIndexOf(Object arg0)](#lastIndexOf-java.lang.Object-) |  |
+| [listIterator()](#listIterator--) |  |
+| [listIterator(int arg0)](#listIterator-int-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(GlyphId glyphId)](#remove-com.aspose.font.GlyphId-) | Rimuove l'ID glifo dalla lista. |
+| [remove(int arg0)](#remove-int-) |  |
+| [remove(Object arg0)](#remove-java.lang.Object-) |  |
+| [removeAll(Collection<?> arg0)](#removeAll-java.util.Collection----) |  |
+| [removeIf(Predicate<? super E> arg0)](#removeIf-java.util.function.Predicate---super-E--) |  |
+| [replaceAll(UnaryOperator<E> arg0)](#replaceAll-java.util.function.UnaryOperator-E--) |  |
+| [retainAll(Collection<?> arg0)](#retainAll-java.util.Collection----) |  |
+| [set(int arg0, E arg1)](#set-int-E-) |  |
+| [size()](#size--) |  |
+| [sort(Comparator<? super E> arg0)](#sort-java.util.Comparator---super-E--) |  |
+| [spliterator()](#spliterator--) |  |
+| [subList(int arg0, int arg1)](#subList-int-int-) |  |
+| [toArray()](#toArray--) |  |
+| [toString()](#toString--) |  |
+| [trimToSize()](#trimToSize--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>toArray(T[] arg0) {#-T-toArray-T---}
+```
+public T[] <T>toArray(T[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | T[] |  |
+
+**Returns:**
+T[]
+### add(E arg0) {#add-E-}
+```
+public boolean add(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+boolean
+### add(GlyphId glyphId) {#add-com.aspose.font.GlyphId-}
+```
+public boolean add(GlyphId glyphId)
+```
+
+
+Aggiunge l'id del glifo all'elenco.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | identificatore del glifo |
+
+**Returns:**
+boolean
+### add(int arg0, E arg1) {#add-int-E-}
+```
+public void add(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+### addAll(int arg0, Collection<? extends E> arg1) {#addAll-int-java.util.Collection---extends-E--}
+```
+public boolean addAll(int arg0, Collection<? extends E> arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### addAll(Collection<? extends E> arg0) {#addAll-java.util.Collection---extends-E--}
+```
+public boolean addAll(Collection<? extends E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Cancella l'elenco.
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### contains(GlyphId glyphId) {#contains-com.aspose.font.GlyphId-}
+```
+public boolean contains(GlyphId glyphId)
+```
+
+
+Restituisce true nel caso in cui l'ID glifo sia nella lista.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | identificatore del glifo |
+
+**Returns:**
+boolean - true nel caso in cui l'ID glifo sia nella lista, altrimenti false
+### contains(Object arg0) {#contains-java.lang.Object-}
+```
+public boolean contains(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### containsAll(Collection<?> arg0) {#containsAll-java.util.Collection----}
+```
+public boolean containsAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### ensureCapacity(int arg0) {#ensureCapacity-int-}
+```
+public void ensureCapacity(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### forEach(Consumer<? super E> arg0) {#forEach-java.util.function.Consumer---super-E--}
+```
+public void forEach(Consumer<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.function.Consumer<? super E> |  |
+
+### get(int index) {#get-int-}
+```
+public GlyphId get(int index)
+```
+
+
+Restituisce l'ID glifo in base all'indice.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice del glifo nella lista |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object arg0) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public Iterator<E> iterator()
+```
+
+
+
+
+**Returns:**
+java.util.Iterator<E>
+### lastIndexOf(Object arg0) {#lastIndexOf-java.lang.Object-}
+```
+public int lastIndexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### listIterator() {#listIterator--}
+```
+public ListIterator<E> listIterator()
+```
+
+
+
+
+**Returns:**
+java.util.ListIterator<E>
+### listIterator(int arg0) {#listIterator-int-}
+```
+public ListIterator<E> listIterator(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+java.util.ListIterator<E>
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(GlyphId glyphId) {#remove-com.aspose.font.GlyphId-}
+```
+public boolean remove(GlyphId glyphId)
+```
+
+
+Rimuove l'ID glifo dalla lista.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | identificatore del glifo |
+
+**Returns:**
+boolean - true se l'elemento è stato rimosso con successo; altrimenti, false
+### remove(int arg0) {#remove-int-}
+```
+public E remove(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### remove(Object arg0) {#remove-java.lang.Object-}
+```
+public boolean remove(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### removeAll(Collection<?> arg0) {#removeAll-java.util.Collection----}
+```
+public boolean removeAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### removeIf(Predicate<? super E> arg0) {#removeIf-java.util.function.Predicate---super-E--}
+```
+public boolean removeIf(Predicate<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.function.Predicate<? super E> |  |
+
+**Returns:**
+boolean
+### replaceAll(UnaryOperator<E> arg0) {#replaceAll-java.util.function.UnaryOperator-E--}
+```
+public void replaceAll(UnaryOperator<E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.function.UnaryOperator<E> |  |
+
+### retainAll(Collection<?> arg0) {#retainAll-java.util.Collection----}
+```
+public boolean retainAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### set(int arg0, E arg1) {#set-int-E-}
+```
+public E set(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+**Returns:**
+E
+### size() {#size--}
+```
+public int size()
+```
+
+
+
+
+**Returns:**
+int
+### sort(Comparator<? super E> arg0) {#sort-java.util.Comparator---super-E--}
+```
+public void sort(Comparator<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.Comparator<? super E> |  |
+
+### spliterator() {#spliterator--}
+```
+public Spliterator<E> spliterator()
+```
+
+
+
+
+**Returns:**
+java.util.Spliterator<E>
+### subList(int arg0, int arg1) {#subList-int-int-}
+```
+public List<E> subList(int arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | int |  |
+
+**Returns:**
+java.util.List<E>
+### toArray() {#toArray--}
+```
+public Object[] toArray()
+```
+
+
+
+
+**Returns:**
+java.lang.Object[]
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### trimToSize() {#trimToSize--}
+```
+public void trimToSize()
+```
+
+
+
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/glyphidtype/_index.md
+++ b/italian/java/com.aspose.font/glyphidtype/_index.md
@@ -1,0 +1,250 @@
+---
+title: "GlyphIdType"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Specifica i tipi di ID del glifo."
+type: docs
+weight: 137
+url: /it/java/com.aspose.font/glyphidtype/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum GlyphIdType extends Enum<GlyphIdType>
+```
+
+Specifica i tipi di ID del glifo.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ASCIIStringName](#ASCIIStringName) | Nome glifo in stringa ASCII. |
+| [Int32Index](#Int32Index) | Indice glifo intero. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ASCIIStringName {#ASCIIStringName}
+```
+public static final GlyphIdType ASCIIStringName
+```
+
+
+Nome glifo in stringa ASCII.
+
+### Int32Index {#Int32Index}
+```
+public static final GlyphIdType Int32Index
+```
+
+
+Indice glifo intero.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static GlyphIdType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype)
+### values() {#values--}
+```
+public static GlyphIdType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.GlyphIdType[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/glyphoutlinerenderer/_index.md
+++ b/italian/java/com.aspose.font/glyphoutlinerenderer/_index.md
@@ -1,0 +1,238 @@
+---
+title: "GlyphOutlineRenderer"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta il renderer del contorno del glifo."
+type: docs
+weight: 52
+url: /it/java/com.aspose.font/glyphoutlinerenderer/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.GlyphRendererBase](../../com.aspose.font/glyphrendererbase)
+```
+public class GlyphOutlineRenderer extends GlyphRendererBase
+```
+
+Rappresenta il renderer del contorno del glifo.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [GlyphOutlineRenderer(IGlyphOutlinePainter painter)](#GlyphOutlineRenderer-com.aspose.font.IGlyphOutlinePainter-) | Inizializza un nuovo oggetto GlyphOutlineRenderer. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [renderGlyph(IFont font, GlyphId glyphId)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-) | Renderizza il glifo. |
+| [renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renderizza il glifo, un obiettivo di questa versione sovraccaricata - da utilizzare con la cache per i glifi. |
+| [renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-) | Renderizza il glifo. |
+| [renderGlyph(IFont font, long glyphIndex)](#renderGlyph-com.aspose.font.IFont-long-) | Renderizza il glifo |
+| [renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-) | Renderizza il glifo. |
+| [renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renderizza il glifo usando un percorso di glifo indipendente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlyphOutlineRenderer(IGlyphOutlinePainter painter) {#GlyphOutlineRenderer-com.aspose.font.IGlyphOutlinePainter-}
+```
+public GlyphOutlineRenderer(IGlyphOutlinePainter painter)
+```
+
+
+Inizializza un nuovo oggetto GlyphOutlineRenderer.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| painter | [IGlyphOutlinePainter](../../com.aspose.font/iglyphoutlinepainter) | Pittore di glifi. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### renderGlyph(IFont font, GlyphId glyphId) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId)
+```
+
+
+Renderizza il glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Il Font che contiene il glifo. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Indice fisico del glifo all'interno del Font. Nota che questo non è un unicode. |
+
+### renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderizza il glifo, un obiettivo di questa versione sovraccaricata - da utilizzare con la cache per i glifi.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Il Font che contiene il glifo. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Indice fisico del glifo all'interno del Font. Nota che questo non è un unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glifo da renderizzare. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrice applicata alle coordinate del glifo. |
+
+### renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderizza il glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Il Font che contiene il glifo. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Indice fisico del glifo all'interno del Font. Nota che questo non è un unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrice applicata alle coordinate del glifo. |
+
+### renderGlyph(IFont font, long glyphIndex) {#renderGlyph-com.aspose.font.IFont-long-}
+```
+public void renderGlyph(IFont font, long glyphIndex)
+```
+
+
+Renderizza il glifo
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Il Font che contiene il glifo. |
+| glyphIndex | long | Indice fisico del glifo all'interno del Font. Nota che questo non è un unicode. |
+
+### renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderizza il glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Il Font che contiene il glifo. |
+| glyphIndex | long | Indice fisico del glifo all'interno del Font. Nota che questo non è un unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrice applicata alle coordinate del glifo. |
+
+### renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public void renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderizza il glifo usando un percorso di glifo indipendente. La famiglia di funzioni RenderGlyph() modifica il percorso del glifo durante il rendering. Ciò porta alla necessità di ricaricare nuovamente questo glifo. Questa funzione utilizza una copia del percorso del glifo e non modifica il percorso originale, quindi lo stesso glifo può essere riutilizzato più volte. Questa versione della funzione è destinata all'uso con la cache dei glifi.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Il Font che contiene il glifo. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Indice fisico del glifo all'interno del Font. Nota che questo non è un unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glifo da renderizzare. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrice applicata alle coordinate del glifo. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/glyphrendererbase/_index.md
+++ b/italian/java/com.aspose.font/glyphrendererbase/_index.md
@@ -1,0 +1,223 @@
+---
+title: "GlyphRendererBase"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la classe base per i renderer dei glifi."
+type: docs
+weight: 53
+url: /it/java/com.aspose.font/glyphrendererbase/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IGlyphRenderer](../../com.aspose.font/iglyphrenderer)
+```
+public abstract class GlyphRendererBase implements IGlyphRenderer
+```
+
+Rappresenta la classe base per i renderer dei glifi.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [renderGlyph(IFont font, GlyphId glyphId)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-) | Renderizza il glifo. |
+| [renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renderizza il glifo, un obiettivo di questa versione sovraccaricata - da utilizzare con la cache per i glifi. |
+| [renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-) | Renderizza il glifo. |
+| [renderGlyph(IFont font, long glyphIndex)](#renderGlyph-com.aspose.font.IFont-long-) | Renderizza il glifo |
+| [renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-) | Renderizza il glifo. |
+| [renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renderizza il glifo usando un percorso di glifo indipendente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### renderGlyph(IFont font, GlyphId glyphId) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId)
+```
+
+
+Renderizza il glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Il Font che contiene il glifo. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Indice fisico del glifo all'interno del Font. Nota che questo non è un unicode. |
+
+### renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderizza il glifo, un obiettivo di questa versione sovraccaricata - da utilizzare con la cache per i glifi.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Il Font che contiene il glifo. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Indice fisico del glifo all'interno del Font. Nota che questo non è un unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glifo da renderizzare. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrice applicata alle coordinate del glifo. |
+
+### renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderizza il glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Il Font che contiene il glifo. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Indice fisico del glifo all'interno del Font. Nota che questo non è un unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrice applicata alle coordinate del glifo. |
+
+### renderGlyph(IFont font, long glyphIndex) {#renderGlyph-com.aspose.font.IFont-long-}
+```
+public void renderGlyph(IFont font, long glyphIndex)
+```
+
+
+Renderizza il glifo
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Il Font che contiene il glifo. |
+| glyphIndex | long | Indice fisico del glifo all'interno del Font. Nota che questo non è un unicode. |
+
+### renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderizza il glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Il Font che contiene il glifo. |
+| glyphIndex | long | Indice fisico del glifo all'interno del Font. Nota che questo non è un unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrice applicata alle coordinate del glifo. |
+
+### renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public void renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderizza il glifo usando un percorso di glifo indipendente. La famiglia di funzioni RenderGlyph() modifica il percorso del glifo durante il rendering. Ciò porta alla necessità di ricaricare nuovamente questo glifo. Questa funzione utilizza una copia del percorso del glifo e non modifica il percorso originale, quindi lo stesso glifo può essere riutilizzato più volte. Questa versione della funzione è destinata all'uso con la cache dei glifi.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Il Font che contiene il glifo. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Indice fisico del glifo all'interno del Font. Nota che questo non è un unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glifo da renderizzare. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrice applicata alle coordinate del glifo. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/glyphstate/_index.md
+++ b/italian/java/com.aspose.font/glyphstate/_index.md
@@ -1,0 +1,250 @@
+---
+title: "GlyphState"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Specifica lo stato del glifo."
+type: docs
+weight: 138
+url: /it/java/com.aspose.font/glyphstate/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum GlyphState extends Enum<GlyphState>
+```
+
+Specifica lo stato del glifo.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ParsedWithErrors](#ParsedWithErrors) | Il glifo è stato analizzato con errori. |
+| [Success](#Success) | Il glifo è stato analizzato con successo. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ParsedWithErrors {#ParsedWithErrors}
+```
+public static final GlyphState ParsedWithErrors
+```
+
+
+Il glifo è stato analizzato con errori.
+
+### Success {#Success}
+```
+public static final GlyphState Success
+```
+
+
+Il glifo è stato analizzato con successo.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static GlyphState valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[GlyphState](../../com.aspose.font/glyphstate)
+### values() {#values--}
+```
+public static GlyphState[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.GlyphState[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/glyphstringid/_index.md
+++ b/italian/java/com.aspose.font/glyphstringid/_index.md
@@ -1,0 +1,234 @@
+---
+title: "GlyphStringId"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'ID del glifo di stringa."
+type: docs
+weight: 54
+url: /it/java/com.aspose.font/glyphstringid/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.GlyphId](../../com.aspose.font/glyphid)
+```
+public class GlyphStringId extends GlyphId
+```
+
+Rappresenta l'ID del glifo di stringa.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [GlyphStringId(String value)](#GlyphStringId-java.lang.String-) | Inizializza un nuovo oggetto GlyphStringID. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Restituisce true se gli ID delle stringhe sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getNotDefId()](#getNotDefId--) | Ottiene l'ID del glifo non definito. |
+| [getValue()](#getValue--) | Ottiene il valore della stringa. |
+| [hashCode()](#hashCode--) | Implementazione di GetHashCode. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(GlyphId obj1, Object obj2)](#op-Equality-com.aspose.font.GlyphId-java.lang.Object-) | Restituisce true se due ID di glifo sono uguali. |
+| [op_Inequality(GlyphId obj1, Object obj2)](#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-) | Restituisce true se due ID di glifo non sono uguali. |
+| [setValue(String value)](#setValue-java.lang.String-) | Imposta il valore della stringa. |
+| [toGlyphStringId()](#toGlyphStringId--) | Converti GlyphId in GlyphStringId |
+| [toGlyphUInt32Id()](#toGlyphUInt32Id--) | Conversione virtuale a GlyphUInt32Id. |
+| [toString()](#toString--) | Restituisce il valore stringa dell'ID glifo. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlyphStringId(String value) {#GlyphStringId-java.lang.String-}
+```
+public GlyphStringId(String value)
+```
+
+
+Inizializza un nuovo oggetto GlyphStringID.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Identificatore del glifo. |
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Restituisce true se gli ID delle stringhe sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj | java.lang.Object | Identificatore di stringa del glifo da confrontare. |
+
+**Returns:**
+boolean - Risultato del confronto
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNotDefId() {#getNotDefId--}
+```
+public static GlyphStringId getNotDefId()
+```
+
+
+Ottiene l'ID del glifo non definito.
+
+**Returns:**
+[GlyphStringId](../../com.aspose.font/glyphstringid) - Not defined glyph id.
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Ottiene il valore della stringa.
+
+**Returns:**
+java.lang.String - Valore stringa.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Implementazione di GetHashCode.
+
+**Returns:**
+int - Codice hash dell'oggetto.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(GlyphId obj1, Object obj2) {#op-Equality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Equality(GlyphId obj1, Object obj2)
+```
+
+
+Restituisce true se due ID di glifo sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Primo identificatore del glifo da confrontare. |
+| obj2 | java.lang.Object | Secondo identificatore del glifo da confrontare. |
+
+**Returns:**
+boolean - Risultato del confronto.
+### op_Inequality(GlyphId obj1, Object obj2) {#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Inequality(GlyphId obj1, Object obj2)
+```
+
+
+Restituisce true se due ID di glifo non sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Primo identificatore del glifo da confrontare. |
+| obj2 | java.lang.Object | Secondo identificatore del glifo da confrontare. |
+
+**Returns:**
+boolean - Risultato del confronto.
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Imposta il valore della stringa.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Valore stringa. |
+
+### toGlyphStringId() {#toGlyphStringId--}
+```
+public GlyphStringId toGlyphStringId()
+```
+
+
+Converti GlyphId in GlyphStringId
+
+**Returns:**
+[GlyphStringId](../../com.aspose.font/glyphstringid) - this
+### toGlyphUInt32Id() {#toGlyphUInt32Id--}
+```
+public GlyphUInt32Id toGlyphUInt32Id()
+```
+
+
+Conversione virtuale a GlyphUInt32Id. GlyphUInt32Id sovrascrive per restituire l'istanza.
+
+**Returns:**
+[GlyphUInt32Id](../../com.aspose.font/glyphuint32id) - null
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+Restituisce il valore stringa dell'ID glifo.
+
+**Returns:**
+java.lang.String - Identificatore del glifo.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/glyphuint32id/_index.md
+++ b/italian/java/com.aspose.font/glyphuint32id/_index.md
@@ -1,0 +1,268 @@
+---
+title: "GlyphUInt32Id"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'ID del glifo intero."
+type: docs
+weight: 55
+url: /it/java/com.aspose.font/glyphuint32id/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.GlyphId](../../com.aspose.font/glyphid)
+```
+public class GlyphUInt32Id extends GlyphId
+```
+
+Rappresenta l'ID del glifo intero.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [GlyphUInt32Id(long value)](#GlyphUInt32Id-long-) | Inizializza un nuovo oggetto GlyphUInt32Id. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Restituisce true se gli ID sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getNotDefId()](#getNotDefId--) | Ottiene l'ID del glifo non definito. |
+| [getValue()](#getValue--) | Ottiene il valore int dell'ID. |
+| [hashCode()](#hashCode--) | Implementazione di GetHashCode. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(GlyphId obj1, Object obj2)](#op-Equality-com.aspose.font.GlyphId-java.lang.Object-) | Restituisce true se due ID di glifo sono uguali. |
+| [op_Equality(GlyphUInt32Id obj1, Object obj2)](#op-Equality-com.aspose.font.GlyphUInt32Id-java.lang.Object-) | Implementazione dell'operatore di uguaglianza. |
+| [op_Inequality(GlyphId obj1, Object obj2)](#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-) | Restituisce true se due ID di glifo non sono uguali. |
+| [op_Inequality(GlyphUInt32Id obj1, Object obj2)](#op-Inequality-com.aspose.font.GlyphUInt32Id-java.lang.Object-) | Implementazione dell'operatore di disuguaglianza. |
+| [setValue(long value)](#setValue-long-) | Imposta il valore int dell'ID. |
+| [toGlyphStringId()](#toGlyphStringId--) | Cast virtuale a GlyphStringId. |
+| [toGlyphUInt32Id()](#toGlyphUInt32Id--) | Cast GlyphId a GlyphUInt32Id |
+| [toString()](#toString--) | Ottiene la rappresentazione stringa del valore intero. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlyphUInt32Id(long value) {#GlyphUInt32Id-long-}
+```
+public GlyphUInt32Id(long value)
+```
+
+
+Inizializza un nuovo oggetto GlyphUInt32Id.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long | Identificatore del glifo. |
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Restituisce true se gli ID sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj | java.lang.Object | identificatore del glifo da confrontare |
+
+**Returns:**
+boolean - risultato del confronto
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNotDefId() {#getNotDefId--}
+```
+public static GlyphUInt32Id getNotDefId()
+```
+
+
+Ottiene l'ID del glifo non definito.
+
+**Returns:**
+[GlyphUInt32Id](../../com.aspose.font/glyphuint32id) - Not defined glyph id.
+### getValue() {#getValue--}
+```
+public long getValue()
+```
+
+
+Ottiene il valore int dell'ID.
+
+**Returns:**
+long - Valore Int dell'ID.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Implementazione di GetHashCode.
+
+**Returns:**
+int - codice hash dell'oggetto
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(GlyphId obj1, Object obj2) {#op-Equality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Equality(GlyphId obj1, Object obj2)
+```
+
+
+Restituisce true se due ID di glifo sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Primo identificatore del glifo da confrontare. |
+| obj2 | java.lang.Object | Secondo identificatore del glifo da confrontare. |
+
+**Returns:**
+boolean - Risultato del confronto.
+### op_Equality(GlyphUInt32Id obj1, Object obj2) {#op-Equality-com.aspose.font.GlyphUInt32Id-java.lang.Object-}
+```
+public static boolean op_Equality(GlyphUInt32Id obj1, Object obj2)
+```
+
+
+Implementazione dell'operatore di uguaglianza.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj1 | [GlyphUInt32Id](../../com.aspose.font/glyphuint32id) | primo identificatore del glifo da confrontare |
+| obj2 | java.lang.Object | secondo identificatore del glifo da confrontare |
+
+**Returns:**
+boolean - risultato del confronto
+### op_Inequality(GlyphId obj1, Object obj2) {#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Inequality(GlyphId obj1, Object obj2)
+```
+
+
+Restituisce true se due ID di glifo non sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Primo identificatore del glifo da confrontare. |
+| obj2 | java.lang.Object | Secondo identificatore del glifo da confrontare. |
+
+**Returns:**
+boolean - Risultato del confronto.
+### op_Inequality(GlyphUInt32Id obj1, Object obj2) {#op-Inequality-com.aspose.font.GlyphUInt32Id-java.lang.Object-}
+```
+public static boolean op_Inequality(GlyphUInt32Id obj1, Object obj2)
+```
+
+
+Implementazione dell'operatore di disuguaglianza.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj1 | [GlyphUInt32Id](../../com.aspose.font/glyphuint32id) | primo identificatore del glifo da confrontare |
+| obj2 | java.lang.Object | secondo identificatore del glifo da confrontare |
+
+**Returns:**
+boolean - risultato del confronto
+### setValue(long value) {#setValue-long-}
+```
+public void setValue(long value)
+```
+
+
+Imposta il valore int dell'ID.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long | Valore intero dell'ID. |
+
+### toGlyphStringId() {#toGlyphStringId--}
+```
+public GlyphStringId toGlyphStringId()
+```
+
+
+Cast virtuale a GlyphStringId. GlyphStringId sovrascrive per restituire l'istanza.
+
+**Returns:**
+[GlyphStringId](../../com.aspose.font/glyphstringid) - null
+### toGlyphUInt32Id() {#toGlyphUInt32Id--}
+```
+public GlyphUInt32Id toGlyphUInt32Id()
+```
+
+
+Cast GlyphId a GlyphUInt32Id
+
+**Returns:**
+[GlyphUInt32Id](../../com.aspose.font/glyphuint32id) - this
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+Ottiene la rappresentazione stringa del valore intero.
+
+**Returns:**
+java.lang.String - identificatore del glifo
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/helpersfactory/_index.md
+++ b/italian/java/com.aspose.font/helpersfactory/_index.md
@@ -1,0 +1,141 @@
+---
+title: "HelpersFactory"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Crea oggetti relativi allo spazio dei nomi TtfHelpers"
+type: docs
+weight: 56
+url: /it/java/com.aspose.font/helpersfactory/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class HelpersFactory
+```
+
+Crea oggetti relativi allo spazio dei nomi TtfHelpers
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontCharactersMerger(TtfFont font1, TtfFont font2)](#getFontCharactersMerger-com.aspose.font.TtfFont-com.aspose.font.TtfFont-) | Crea un'istanza di IFontCharactersMerger |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontCharactersMerger(TtfFont font1, TtfFont font2) {#getFontCharactersMerger-com.aspose.font.TtfFont-com.aspose.font.TtfFont-}
+```
+public static IFontCharactersMerger getFontCharactersMerger(TtfFont font1, TtfFont font2)
+```
+
+
+Crea un'istanza di IFontCharactersMerger
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font1 | [TtfFont](../../com.aspose.font/ttffont) | Primo font da unire, questo font sarà considerato il font primario |
+| font2 | [TtfFont](../../com.aspose.font/ttffont) | Secondo font da unire |
+
+**Returns:**
+[IFontCharactersMerger](../../com.aspose.font/ifontcharactersmerger) -  IFontCharactersMerger  instance
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/icffindexdataprovider/_index.md
+++ b/italian/java/com.aspose.font/icffindexdataprovider/_index.md
@@ -1,0 +1,38 @@
+---
+title: "ICffIndexDataProvider"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Interfaccia di base per accedere alle strutture INDEX dei font CFF."
+type: docs
+weight: 120
+url: /it/java/com.aspose.font/icffindexdataprovider/
+---```
+public interface ICffIndexDataProvider
+```
+
+Basic interface for accessing INDEX structures of CFF fonts.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getCount()](#getCount--) | The number of objects in the CFF INDEX structure. |
+| [getRawBytes()](#getRawBytes--) | Gets all the bytes of the CFF INDEX structure. |
+### getCount() {#getCount--}
+```
+public abstract int getCount()
+```
+
+
+The number of objects in the CFF INDEX structure.
+
+**Returns:**
+int
+### getRawBytes() {#getRawBytes--}
+```
+public abstract byte[] getRawBytes()
+```
+
+
+Gets all the bytes of the CFF INDEX structure.
+
+**Returns:**
+byte[] - Bytes of the CFF INDEX structure

--- a/italian/java/com.aspose.font/iencodingparameters/_index.md
+++ b/italian/java/com.aspose.font/iencodingparameters/_index.md
@@ -1,0 +1,12 @@
+---
+title: "IEncodingParameters"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Interfaccia comune per supportare i parametri di codifica."
+type: docs
+weight: 121
+url: /it/java/com.aspose.font/iencodingparameters/
+---```
+public interface IEncodingParameters
+```
+
+Common interface to support encoding parameters. Some font types can have multiple encoding algorithms/maps. So, this interface should be used to create concrete font encoding parameters.

--- a/italian/java/com.aspose.font/ifont/_index.md
+++ b/italian/java/com.aspose.font/ifont/_index.md
@@ -1,0 +1,223 @@
+---
+title: "IFont"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Dichiara la funzionalità comune per tutti i formati di carattere."
+type: docs
+weight: 122
+url: /it/java/com.aspose.font/ifont/
+---```
+public interface IFont
+```
+
+Declares common functionality for all font formats. Implemented by Font classes.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Converts the Font into another format. |
+| [getEncoding()](#getEncoding--) | Gets Font encoding. |
+| [getFontDefinition()](#getFontDefinition--) | Gets Font definition. |
+| [getFontFamily()](#getFontFamily--) | Gets Font family. |
+| [getFontName()](#getFontName--) | Gets Font face name. |
+| [getFontNames()](#getFontNames--) | Gets Font names. |
+| [getFontSaver()](#getFontSaver--) | Gets Font save functionality. |
+| [getFontStyle()](#getFontStyle--) | Gets Font style. |
+| [getFontType()](#getFontType--) | Gets Font type. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Gets Font glyph accessor. |
+| [getMetrics()](#getMetrics--) | Gets Font metrics. |
+| [getNumGlyphs()](#getNumGlyphs--) | Gets number of glyphs in the Font. |
+| [getPostscriptNames()](#getPostscriptNames--) | Gets postscript Font names. |
+| [getStyle()](#getStyle--) | Gets Font style. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Sets Font family. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Sets Font face name. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Sets Font style. |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public abstract Font convert(FontType fontType)
+```
+
+
+Converts the Font into another format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | type to convert to font into |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - font converted into format specified
+### getEncoding() {#getEncoding--}
+```
+public abstract IFontEncoding getEncoding()
+```
+
+
+Gets Font encoding.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public abstract FontDefinition getFontDefinition()
+```
+
+
+Gets Font definition.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public abstract String getFontFamily()
+```
+
+
+Gets Font family.
+
+**Returns:**
+java.lang.String - Font family.
+### getFontName() {#getFontName--}
+```
+public abstract String getFontName()
+```
+
+
+Gets Font face name.
+
+**Returns:**
+java.lang.String - Font face name.
+### getFontNames() {#getFontNames--}
+```
+public abstract MultiLanguageString getFontNames()
+```
+
+
+Gets Font names.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public abstract IFontSaver getFontSaver()
+```
+
+
+Gets Font save functionality.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public abstract int getFontStyle()
+```
+
+
+Gets Font style. This is a value computed and represented in generalized type.
+
+**Returns:**
+int - Font style. Usually, a combination of FontStyle class constant flag values or 0.
+### getFontType() {#getFontType--}
+```
+public abstract FontType getFontType()
+```
+
+
+Gets Font type.
+
+--------------------
+
+> ```
+> Type1, TrueType etc.
+> ```
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public abstract IGlyphAccessor getGlyphAccessor()
+```
+
+
+Gets Font glyph accessor. Retrieves glyphs and glyph identifiers.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getMetrics() {#getMetrics--}
+```
+public abstract IFontMetrics getMetrics()
+```
+
+
+Gets Font metrics.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public abstract int getNumGlyphs()
+```
+
+
+Gets number of glyphs in the Font.
+
+**Returns:**
+int - Number of glyphs in the Font..
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public abstract MultiLanguageString getPostscriptNames()
+```
+
+
+Gets postscript Font names.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names.
+### getStyle() {#getStyle--}
+```
+public abstract String getStyle()
+```
+
+
+Gets Font style. This is a raw string value provided by Font file.
+
+**Returns:**
+java.lang.String - Font style.
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public abstract void setFontFamily(String value)
+```
+
+
+Sets Font family.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | java.lang.String | New Font family. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public abstract void setFontName(String value)
+```
+
+
+Sets Font face name.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | java.lang.String | New Font face name. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public abstract void setStyle(String value)
+```
+
+
+Sets Font style. This is a raw string value provided by Font file.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | java.lang.String | New Font style. |
+

--- a/italian/java/com.aspose.font/ifontcharactersmerger/_index.md
+++ b/italian/java/com.aspose.font/ifontcharactersmerger/_index.md
@@ -1,0 +1,70 @@
+---
+title: "IFontCharactersMerger"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Dichiara la funzionalità di supporto per unire i font TrueType."
+type: docs
+weight: 123
+url: /it/java/com.aspose.font/ifontcharactersmerger/
+---```
+public interface IFontCharactersMerger
+```
+
+Declares helpers functionality to merge TrueType fonts. Font which is passed by parameter font1 considered as primary. It means that many characteristics, related to final merged font, such as metrics, encoding structure and others, will be taken from this primary font.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [mergeFonts(GlyphId[] font1Glyphs, GlyphId[] font2Glyphs, String newFontName)](#mergeFonts-com.aspose.font.GlyphId---com.aspose.font.GlyphId---java.lang.String-) | Merges fonts based on glyphs lists passed. |
+| [mergeFonts(int[] font1CharCodes, int[] font2CharCodes, String newFontName)](#mergeFonts-int---int---java.lang.String-) | Merges fonts based on character codes lists passed. |
+| [mergeFonts(Map<Integer,GlyphId> font1Dict, Map<Integer,GlyphId> font2Dict, String newFontName)](#mergeFonts-java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.lang.String-) | This method version designed for cases when you want to set character codes for glyphs in resultant font explicitly. |
+### mergeFonts(GlyphId[] font1Glyphs, GlyphId[] font2Glyphs, String newFontName) {#mergeFonts-com.aspose.font.GlyphId---com.aspose.font.GlyphId---java.lang.String-}
+```
+public abstract TtfFont mergeFonts(GlyphId[] font1Glyphs, GlyphId[] font2Glyphs, String newFontName)
+```
+
+
+Merges fonts based on glyphs lists passed. Searches for a character code for every glyph passed and add found character code with correspondent glyph into resultant new font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font1Glyphs | [GlyphId\[\]](../../com.aspose.font/glyphid) | List of glyphs from first font |
+| font2Glyphs | [GlyphId\[\]](../../com.aspose.font/glyphid) | List of glyphs from second font |
+| newFontName | java.lang.String | Desired name for resultant font |
+
+**Returns:**
+[TtfFont](../../com.aspose.font/ttffont) - Merged font
+### mergeFonts(int[] font1CharCodes, int[] font2CharCodes, String newFontName) {#mergeFonts-int---int---java.lang.String-}
+```
+public abstract TtfFont mergeFonts(int[] font1CharCodes, int[] font2CharCodes, String newFontName)
+```
+
+
+Merges fonts based on character codes lists passed. To create desired resultant font just pass symbol codes from original fonts you want to include into resultant font. Glyphs related to codes passed will be found automatically. For example, if you want to include into resultant font glyphs related to letters A and B from first font and glyphs, related to letters C and D from second font, just call this method like this:  MergeFonts(new uint[] \{ 'A', 'B' \}, new uint[] \{ 'C', 'D' \}, "NewFont") 
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font1CharCodes | int[] | Codes to take from first font |
+| font2CharCodes | int[] | Codes to take from second font |
+| newFontName | java.lang.String | Desired name for resultant font |
+
+**Returns:**
+[TtfFont](../../com.aspose.font/ttffont) - Merged font
+### mergeFonts(Map<Integer,GlyphId> font1Dict, Map<Integer,GlyphId> font2Dict, String newFontName) {#mergeFonts-java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.lang.String-}
+```
+public abstract TtfFont mergeFonts(Map<Integer,GlyphId> font1Dict, Map<Integer,GlyphId> font2Dict, String newFontName)
+```
+
+
+This method version designed for cases when you want to set character codes for glyphs in resultant font explicitly. It's not mandatory that code for glyph you provided is included in original font. The sense of code passed is that it will be associated with correspondent glyph identifier in resultant font. So, rule to process every pair passed by dictionary parameter[code, glyph ideitifier] is that only glyph identifer will be taken from original font and then it will be linked with correspondent code in resultant font. It can be helpful when some codes from first font conflict with same codes from second font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font1Dict | java.util.Map<java.lang.Integer,com.aspose.font.GlyphId> | Dictionary with pairs [symbol code, glyph identifier] from first font |
+| font2Dict | java.util.Map<java.lang.Integer,com.aspose.font.GlyphId> | Dictionary with pairs [symbol code, glyph identifier] from second font |
+| newFontName | java.lang.String | Desired name for resultant font |
+
+**Returns:**
+[TtfFont](../../com.aspose.font/ttffont) - Merged font

--- a/italian/java/com.aspose.font/ifontencoding/_index.md
+++ b/italian/java/com.aspose.font/ifontencoding/_index.md
@@ -1,0 +1,96 @@
+---
+title: "IFontEncoding"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Definisce un'interfaccia per la codifica dei font."
+type: docs
+weight: 124
+url: /it/java/com.aspose.font/ifontencoding/
+---```
+public interface IFontEncoding
+```
+
+Defines an interface for Font encoding.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [decodeToGid(long charCode)](#decodeToGid-long-) | Decodes a character code and returns glyph id. |
+| [decodeToGidParameterized(IEncodingParameters parameters, long charCode)](#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-) | Parameterized decode method. |
+| [encode(long gid, long charCode)](#encode-long-long-) | Encodes the glyph. |
+| [gidToUnicode(GlyphId gid)](#gidToUnicode-com.aspose.font.GlyphId-) | Decodes Gid to unicode. |
+| [unicodeToGid(long unicode)](#unicodeToGid-long-) | Decodes a unicode and returns glyph id. |
+### decodeToGid(long charCode) {#decodeToGid-long-}
+```
+public abstract GlyphId decodeToGid(long charCode)
+```
+
+
+Decodes a character code and returns glyph id. Glyph id is a unique number for a glyph, which is font type dependent. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| charCode | long | Character code to get glyph identifier for. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to charCode passed.
+### decodeToGidParameterized(IEncodingParameters parameters, long charCode) {#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-}
+```
+public abstract GlyphId decodeToGidParameterized(IEncodingParameters parameters, long charCode)
+```
+
+
+Parameterized decode method. Some font types can have multiple encoding algorithms/maps. So,  IEncodingParameters  interface is used to create concrete font encoding parameters.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| parameters | [IEncodingParameters](../../com.aspose.font/iencodingparameters) | Implementation of  IEncodingParameters  interface. |
+| charCode | long | Character code to get glyph identifier for. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to char code passed.
+### encode(long gid, long charCode) {#encode-long-long-}
+```
+public abstract void encode(long gid, long charCode)
+```
+
+
+Encodes the glyph. For TTF Fonts the charCode is unicode.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| gid | long | Glyph id. |
+| charCode | long | Character code associated with the glyph id. |
+
+### gidToUnicode(GlyphId gid) {#gidToUnicode-com.aspose.font.GlyphId-}
+```
+public abstract long gidToUnicode(GlyphId gid)
+```
+
+
+Decodes Gid to unicode. Glyph id is a unique number for a glyph, which is font type dependent. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| gid | [GlyphId](../../com.aspose.font/glyphid) | Glyph identifier of symbol to decode. |
+
+**Returns:**
+long - Unicode value related to glyph id passed.
+### unicodeToGid(long unicode) {#unicodeToGid-long-}
+```
+public abstract GlyphId unicodeToGid(long unicode)
+```
+
+
+Decodes a unicode and returns glyph id. Glyph id is a unique number for a glyph, which is font type dependent. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| unicode | long | Unicode to get glyph identifier for. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to unicode passed.

--- a/italian/java/com.aspose.font/ifontmetrics/_index.md
+++ b/italian/java/com.aspose.font/ifontmetrics/_index.md
@@ -1,0 +1,357 @@
+---
+title: "IFontMetrics"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Definisce un'interfaccia per gli strumenti di metriche dei font."
+type: docs
+weight: 125
+url: /it/java/com.aspose.font/ifontmetrics/
+---```
+public interface IFontMetrics
+```
+
+Defines an interface for Font metrics tools.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getAscender()](#getAscender--) | Gets ascender value of the Font in font units. |
+| [getAscender(double fontSize)](#getAscender-double-) | Returns ascender for specific Font size. |
+| [getDescender()](#getDescender--) | Gets descender value of the Font in font units. |
+| [getDescender(double fontSize)](#getDescender-double-) | Returns descender for specific Font size. |
+| [getFontBBox()](#getFontBBox--) | Gets Font bounding box. |
+| [getFontMatrix()](#getFontMatrix--) | Gets Font transformation matrix. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Returns glyph BBox. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Returns glyph width. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Returns kerning value for the glyph pair. |
+| [getLineGap()](#getLineGap--) | Gets LineGap value of the Font in Font units. |
+| [getTypoAscender()](#getTypoAscender--) | Gets typographic ascender value of the Font in font units |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Returns typographic ascender for specific Font size. |
+| [getTypoDescender()](#getTypoDescender--) | Gets typographic descender value of the Font in Font units. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Returns typographic descender for specific Font size. |
+| [getTypoLineGap()](#getTypoLineGap--) | Gets typographic LineGap value of the Font in Font units. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Returns line gap for specific Font size. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Gets Gets units per em. |
+| [isFixedPitch()](#isFixedPitch--) | True, if the Font is monospaced. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Measures string and returns string width. |
+| [setAscender(double value)](#setAscender-double-) |  |
+| [setDescender(double value)](#setDescender-double-) |  |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) | Specifies glyph width. |
+| [setTypoAscender(double value)](#setTypoAscender-double-) |  |
+| [setTypoDescender(double value)](#setTypoDescender-double-) |  |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) |  |
+### getAscender() {#getAscender--}
+```
+public abstract double getAscender()
+```
+
+
+Gets ascender value of the Font in font units.
+
+**Returns:**
+double - Ascender value of the Font in font units.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public abstract double getAscender(double fontSize)
+```
+
+
+Returns ascender for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Ascender value.
+### getDescender() {#getDescender--}
+```
+public abstract double getDescender()
+```
+
+
+Gets descender value of the Font in font units.
+
+**Returns:**
+double - Descender value of the Font in font units.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public abstract double getDescender(double fontSize)
+```
+
+
+Returns descender for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Descender value.
+### getFontBBox() {#getFontBBox--}
+```
+public abstract FontBBox getFontBBox()
+```
+
+
+Gets Font bounding box.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Font bounding box.
+### getFontMatrix() {#getFontMatrix--}
+```
+public abstract TransformationMatrix getFontMatrix()
+```
+
+
+Gets Font transformation matrix.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - Font transformation matrix.
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public abstract FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Returns glyph BBox.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | glyph identifier |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - glyph BBox
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public abstract double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Returns glyph width.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph identifier. |
+
+**Returns:**
+double - Glyph width.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public abstract double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Returns kerning value for the glyph pair.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | First glyph in pair. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Font size. |
+
+**Returns:**
+double - Kerning value.
+### getLineGap() {#getLineGap--}
+```
+public abstract double getLineGap()
+```
+
+
+Gets LineGap value of the Font in Font units.
+
+**Returns:**
+double - LineGap value of the Font in Font units.
+### getTypoAscender() {#getTypoAscender--}
+```
+public abstract double getTypoAscender()
+```
+
+
+Gets typographic ascender value of the Font in font units
+
+**Returns:**
+double - Typographic ascender value of the Font in font units
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public abstract double getTypoAscender(double fontSize)
+```
+
+
+Returns typographic ascender for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Typographic ascender value.
+### getTypoDescender() {#getTypoDescender--}
+```
+public abstract double getTypoDescender()
+```
+
+
+Gets typographic descender value of the Font in Font units.
+
+**Returns:**
+double - Typographic descender value of the Font in Font units.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public abstract double getTypoDescender(double fontSize)
+```
+
+
+Returns typographic descender for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Typographic descender value.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public abstract double getTypoLineGap()
+```
+
+
+Gets typographic LineGap value of the Font in Font units.
+
+**Returns:**
+double - Typographic LineGap value of the Font in Font units.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public abstract double getTypoLineGap(double fontSize)
+```
+
+
+Returns line gap for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Line gap value.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public abstract long getUnitsPerEM()
+```
+
+
+Gets Gets units per em.
+
+**Returns:**
+long - Units per em.
+### isFixedPitch() {#isFixedPitch--}
+```
+public abstract boolean isFixedPitch()
+```
+
+
+True, if the Font is monospaced.
+
+**Returns:**
+boolean - True, if the Font is monospaced.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public abstract double measureString(String unicode, double fontSize)
+```
+
+
+Measures string and returns string width.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| unicode | java.lang.String | Unicode string. |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - String width.
+### setAscender(double value) {#setAscender-double-}
+```
+public abstract void setAscender(double value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | double |  |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public abstract void setDescender(double value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | double |  |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public abstract void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Specifies glyph width.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph identifier. |
+| value | double | Glyph width value. |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public abstract void setTypoAscender(double value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | double |  |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public abstract void setTypoDescender(double value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | double |  |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public abstract void setUnitsPerEM(long value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | long |  |
+

--- a/italian/java/com.aspose.font/ifontsaver/_index.md
+++ b/italian/java/com.aspose.font/ifontsaver/_index.md
@@ -1,0 +1,59 @@
+---
+title: "IFontSaver"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Definisce un'interfaccia per la funzionalità di salvataggio dei font."
+type: docs
+weight: 126
+url: /it/java/com.aspose.font/ifontsaver/
+---```
+public interface IFontSaver
+```
+
+Defines an interface for Font save functionality.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Saves the Font into original format. |
+| [save(String fileName)](#save-java.lang.String-) | Saves the Font into original format. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Saves the Font into format specified. |
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public abstract void save(OutputStream stream)
+```
+
+
+Saves the Font into original format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| stream | java.io.OutputStream | stream to save font |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public abstract void save(String fileName)
+```
+
+
+Saves the Font into original format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fileName | java.lang.String | file to save font |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public abstract void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Saves the Font into format specified.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| stream | java.io.OutputStream | stream to save font |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | desired format |
+

--- a/italian/java/com.aspose.font/iglyphaccessor/_index.md
+++ b/italian/java/com.aspose.font/iglyphaccessor/_index.md
@@ -1,0 +1,70 @@
+---
+title: "IGlyphAccessor"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Definisce la funzionalità per recuperare gli identificatori di glifo specificati e i glifi."
+type: docs
+weight: 127
+url: /it/java/com.aspose.font/iglyphaccessor/
+---```
+public interface IGlyphAccessor
+```
+
+Defines functionality to retrieve specified glyph identifiers and glyphs.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Returns all glyph ids, available in the Font. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Returns glyph by glyph id. |
+| [getGlyphIdType()](#getGlyphIdType--) | Glyph id type specification. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Get glyphs representation for text. |
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public abstract GlyphId[] getAllGlyphIds()
+```
+
+
+Returns all glyph ids, available in the Font. Glyph id is a unique number for a glyph, which is font type dependent. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyph identifiers.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public abstract Glyph getGlyphById(GlyphId id)
+```
+
+
+Returns glyph by glyph id. Glyph id is a unique number for a glyph, which is font type dependent. GlyphId - derived object. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | glyph ID. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public abstract GlyphIdType getGlyphIdType()
+```
+
+
+Glyph id type specification.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype) - Id type specification.
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public abstract GlyphId[] getGlyphsForText(String text)
+```
+
+
+Get glyphs representation for text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Input text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - GlyphId array.

--- a/italian/java/com.aspose.font/iglyphoutlinepainter/_index.md
+++ b/italian/java/com.aspose.font/iglyphoutlinepainter/_index.md
@@ -1,0 +1,70 @@
+---
+title: "IGlyphOutlinePainter"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Definisce un metodo di contorno per disegnare i glifi."
+type: docs
+weight: 128
+url: /it/java/com.aspose.font/iglyphoutlinepainter/
+---
+**All Implemented Interfaces:**
+[com.aspose.font.IGlyphPainter](../../com.aspose.font/iglyphpainter)
+```
+public interface IGlyphOutlinePainter extends IGlyphPainter
+```
+
+Definisce un metodo di contorno per disegnare i glifi.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [closePath()](#closePath--) | Elabora l'operazione ClosePath. |
+| [curveTo(CurveTo curveTo)](#curveTo-com.aspose.font.CurveTo-) | Elabora l'operazione CurveTo. |
+| [lineTo(LineTo lineTo)](#lineTo-com.aspose.font.LineTo-) | Elabora l'operazione LineTo. |
+| [moveTo(MoveTo moveTo)](#moveTo-com.aspose.font.MoveTo-) | Processa l'operazione MoveTo. |
+### closePath() {#closePath--}
+```
+public abstract void closePath()
+```
+
+
+Elabora l'operazione ClosePath.
+
+### curveTo(CurveTo curveTo) {#curveTo-com.aspose.font.CurveTo-}
+```
+public abstract void curveTo(CurveTo curveTo)
+```
+
+
+Elabora l'operazione CurveTo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| curveTo | [CurveTo](../../com.aspose.font/curveto) | Riferimento CurveTo |
+
+### lineTo(LineTo lineTo) {#lineTo-com.aspose.font.LineTo-}
+```
+public abstract void lineTo(LineTo lineTo)
+```
+
+
+Elabora l'operazione LineTo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| lineTo | [LineTo](../../com.aspose.font/lineto) | Riferimento LineTo |
+
+### moveTo(MoveTo moveTo) {#moveTo-com.aspose.font.MoveTo-}
+```
+public abstract void moveTo(MoveTo moveTo)
+```
+
+
+Processa l'operazione MoveTo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| moveTo | [MoveTo](../../com.aspose.font/moveto) | Riferimento MoveTo |
+

--- a/italian/java/com.aspose.font/iglyphpainter/_index.md
+++ b/italian/java/com.aspose.font/iglyphpainter/_index.md
@@ -1,0 +1,12 @@
+---
+title: "IGlyphPainter"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Definisce un modo per disegnare i glifi."
+type: docs
+weight: 129
+url: /it/java/com.aspose.font/iglyphpainter/
+---```
+public interface IGlyphPainter
+```
+
+Defines a way to draw glyphs.

--- a/italian/java/com.aspose.font/iglyphrenderer/_index.md
+++ b/italian/java/com.aspose.font/iglyphrenderer/_index.md
@@ -1,0 +1,112 @@
+---
+title: "IGlyphRenderer"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Interfaccia utilizzata per renderizzare i glifi."
+type: docs
+weight: 130
+url: /it/java/com.aspose.font/iglyphrenderer/
+---```
+public interface IGlyphRenderer
+```
+
+Interface used to render glyphs.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [renderGlyph(IFont font, GlyphId glyphId)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-) | Renders glyph. |
+| [renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renders glyph, an objective of this overloaded version - to be used with cache for glyphs. |
+| [renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-) | Renders glyph. |
+| [renderGlyph(IFont font, long glyphIndex)](#renderGlyph-com.aspose.font.IFont-long-) | Renders glyph. |
+| [renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-) | Renders glyph. |
+| [renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renders glyph using independent glyph path. |
+### renderGlyph(IFont font, GlyphId glyphId) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-}
+```
+public abstract void renderGlyph(IFont font, GlyphId glyphId)
+```
+
+
+Renders glyph.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physical glyph index inside font. Note that this is not a unicode. |
+
+### renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public abstract void renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renders glyph, an objective of this overloaded version - to be used with cache for glyphs.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physical glyph index inside font. Note that this is not a unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glyph to render. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix that is applied to glyph coordinates. |
+
+### renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-}
+```
+public abstract void renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renders glyph.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physical glyph index inside font. Note that this is not a unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix that is applied to glyph coordinates. |
+
+### renderGlyph(IFont font, long glyphIndex) {#renderGlyph-com.aspose.font.IFont-long-}
+```
+public abstract void renderGlyph(IFont font, long glyphIndex)
+```
+
+
+Renders glyph.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphIndex | long | Physical glyph index inside font. Note that this is not a unicode. |
+
+### renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-}
+```
+public abstract void renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renders glyph.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphIndex | long | Physical glyph index inside font. Note that this is not a unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix that is applied to glyph coordinates. |
+
+### renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public abstract void renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renders glyph using independent glyph path. RenderGlyph() function family changes glyph path on rendering. It then leads to necessity reload this glyph again. This function uses copy of glyph path and doesn't changes original glyph path, so the same glyph could be reused multiple times. This version of function is intended for use with cache of glyphs.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physical glyph index inside font. Note that this is not a unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glyph to render. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix that is applied to glyph coordinates. |
+

--- a/italian/java/com.aspose.font/incorrectfontdataexception/_index.md
+++ b/italian/java/com.aspose.font/incorrectfontdataexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "IncorrectFontDataException"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta le eccezioni per i casi in cui alcuni valori dell'oggetto Font sono invalidi."
+type: docs
+weight: 57
+url: /it/java/com.aspose.font/incorrectfontdataexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class IncorrectFontDataException extends FontException
+```
+
+Rappresenta le eccezioni per i casi in cui alcuni valori dell'oggetto Font sono invalidi.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [IncorrectFontDataException()](#IncorrectFontDataException--) | Inizializza un nuovo oggetto FontAgrumentException. |
+| [IncorrectFontDataException(String message)](#IncorrectFontDataException-java.lang.String-) | Inizializza un nuovo oggetto FontAgrumentException. |
+| [IncorrectFontDataException(String message, RuntimeException innerException)](#IncorrectFontDataException-java.lang.String-java.lang.RuntimeException-) | Inizializza un nuovo oggetto FontAgrumentException. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IncorrectFontDataException() {#IncorrectFontDataException--}
+```
+public IncorrectFontDataException()
+```
+
+
+Inizializza un nuovo oggetto FontAgrumentException.
+
+### IncorrectFontDataException(String message) {#IncorrectFontDataException-java.lang.String-}
+```
+public IncorrectFontDataException(String message)
+```
+
+
+Inizializza un nuovo oggetto FontAgrumentException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+
+### IncorrectFontDataException(String message, RuntimeException innerException) {#IncorrectFontDataException-java.lang.String-java.lang.RuntimeException-}
+```
+public IncorrectFontDataException(String message, RuntimeException innerException)
+```
+
+
+Inizializza un nuovo oggetto FontAgrumentException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+| innerException | java.lang.RuntimeException | L'eccezione che è la causa dell'eccezione corrente. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ipathsegment/_index.md
+++ b/italian/java/com.aspose.font/ipathsegment/_index.md
@@ -1,0 +1,59 @@
+---
+title: "IPathSegment"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'interfaccia di qualsiasi segmento di percorso."
+type: docs
+weight: 131
+url: /it/java/com.aspose.font/ipathsegment/
+---
+**All Implemented Interfaces:**
+java.lang.Cloneable
+```
+public interface IPathSegment extends Cloneable
+```
+
+Rappresenta l'interfaccia di qualsiasi segmento di percorso.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [copy()](#copy--) | Crea una copia dell'oggetto segmento. |
+| [shift(double dx, double dy)](#shift-double-double-) | Esegue lo spostamento per le coordinate x e y. |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Trasforma le coordinate con la matrice di trasformazione. |
+### copy() {#copy--}
+```
+public abstract IPathSegment copy()
+```
+
+
+Crea una copia dell'oggetto segmento.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public abstract void shift(double dx, double dy)
+```
+
+
+Esegue lo spostamento per le coordinate x e y.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| dx | double | Valore dx. |
+| dy | double | Valore dy. |
+
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public abstract void transform(TransformationMatrix matrix)
+```
+
+
+Trasforma le coordinate con la matrice di trasformazione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrice di trasformazione. |
+

--- a/italian/java/com.aspose.font/isupportsnameaddressing/_index.md
+++ b/italian/java/com.aspose.font/isupportsnameaddressing/_index.md
@@ -1,0 +1,27 @@
+---
+title: "ISupportsNameAddressing"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Definisce i membri specifici per le codifiche che supportano l'indirizzamento per nome del glifo"
+type: docs
+weight: 132
+url: /it/java/com.aspose.font/isupportsnameaddressing/
+---```
+public interface ISupportsNameAddressing
+```
+
+Defines members that are specific to encodings that support glyph name addressing
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getNameToCharCodeIndex()](#getNameToCharCodeIndex--) | Returns name to code map object. |
+### getNameToCharCodeIndex() {#getNameToCharCodeIndex--}
+```
+public abstract NameToCodeMap getNameToCharCodeIndex()
+```
+
+
+Returns name to code map object.
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - name to code map object.

--- a/italian/java/com.aspose.font/license/_index.md
+++ b/italian/java/com.aspose.font/license/_index.md
@@ -1,0 +1,193 @@
+---
+title: "Licenza"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Fornisce metodi per licenziare il componente."
+type: docs
+weight: 58
+url: /it/java/com.aspose.font/license/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class License
+```
+
+Fornisce metodi per licenziare il componente.
+
+In questo esempio, si cercherà di trovare un file di licenza denominato MyLicense.lic nella cartella che contiene il componente, nella cartella che contiene l'assembly chiamante, nella cartella dell'assembly di ingresso e poi nelle risorse incorporate dell'assembly chiamante.
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [License()](#License--) | Inizializza una nuova istanza di questa classe. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLicense(InputStream stream)](#setLicense-java.io.InputStream-) | Licenzia il componente. |
+| [setLicense(String licenseName)](#setLicense-java.lang.String-) | Licenzia il componente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### License() {#License--}
+```
+public License()
+```
+
+
+Inizializza una nuova istanza di questa classe.
+
+In questo esempio, si cercherà di trovare un file di licenza denominato MyLicense.lic nella cartella che contiene il componente, nella cartella che contiene l'assembly chiamante, nella cartella dell'assembly di ingresso e poi nelle risorse incorporate dell'assembly chiamante.
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLicense(InputStream stream) {#setLicense-java.io.InputStream-}
+```
+public void setLicense(InputStream stream)
+```
+
+
+Licenzia il componente.
+
+Uno stream che contiene la licenza.
+
+Utilizza questo metodo per caricare una licenza da uno stream.
+
+License license = new License();
+license.setLicense(myStream);
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| stream | java.io.InputStream | Stream di licenza |
+
+### setLicense(String licenseName) {#setLicense-java.lang.String-}
+```
+public void setLicense(String licenseName)
+```
+
+
+Licenzia il componente.
+
+Cerca di trovare la licenza nei seguenti percorsi:
+
+1. Percorso esplicito.
+
+2. La cartella del file jar del componente.
+
+In questo esempio, si cercherà di trovare un file di licenza denominato MyLicense.lic nella cartella che contiene il componente, nella cartella che contiene l'assembly chiamante, nella cartella dell'assembly di ingresso e poi nelle risorse incorporate dell'assembly chiamante.
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| licenseName | java.lang.String | Può essere un nome file completo o abbreviato o il nome di una risorsa incorporata. Usa una stringa vuota per passare alla modalità di valutazione. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/licenseflags/_index.md
+++ b/italian/java/com.aspose.font/licenseflags/_index.md
@@ -1,0 +1,223 @@
+---
+title: "LicenseFlags"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta un wrapper di supporto per i flag di incorporamento dal campo fsType della tabella OS/2."
+type: docs
+weight: 59
+url: /it/java/com.aspose.font/licenseflags/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class LicenseFlags
+```
+
+Rappresenta un wrapper di supporto per i flag di incorporamento dalla tabella 'OS/2' (campo fsType).
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFSType()](#getFSType--) | Ottiene il valore grezzo fsType dalla tabella OS/2 o 0 se questo campo non esiste nella tabella. |
+| [hashCode()](#hashCode--) |  |
+| [isBitmapOnlyEmbedding()](#isBitmapOnlyEmbedding--) | Rileva se fsType consente l'incorporamento BitmapOnly. |
+| [isEditableEmbedding()](#isEditableEmbedding--) | Rileva se fsType consente l'incorporamento Editable. |
+| [isFSTypeAbsent()](#isFSTypeAbsent--) | Restituisce true se il flag fsType è assente nella tabella 'OS/2'. |
+| [isInstallableEmbedding()](#isInstallableEmbedding--) | Rileva se fsType è un incorporamento Installable. |
+| [isNoSubsettingEmbedding()](#isNoSubsettingEmbedding--) | Rileva se fsType consente l'incorporamento NoSubsetting. |
+| [isPreviewAndPrintEmbedding()](#isPreviewAndPrintEmbedding--) | Rileva se fsType consente l'incorporamento Preview and Print. |
+| [isReservedType()](#isReservedType--) | Rileva se il bit riservato (bit 0) è impostato per fsType. |
+| [isRestrictedLicenseEmbedding()](#isRestrictedLicenseEmbedding--) | Rileva se fsType è un incorporamento Restricted License. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFSType() {#getFSType--}
+```
+public int getFSType()
+```
+
+
+Ottiene il valore grezzo fsType dalla tabella OS/2 o 0 se questo campo non esiste nella tabella.
+
+**Returns:**
+int - Valore grezzo fsType dalla tabella OS/2 o 0 se questo campo non esiste nella tabella.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isBitmapOnlyEmbedding() {#isBitmapOnlyEmbedding--}
+```
+public boolean isBitmapOnlyEmbedding()
+```
+
+
+Rileva se fsType consente l'incorporamento BitmapOnly.
+
+**Returns:**
+boolean - Rileva se fsType consente l'incorporamento BitmapOnly.
+### isEditableEmbedding() {#isEditableEmbedding--}
+```
+public boolean isEditableEmbedding()
+```
+
+
+Rileva se fsType consente l'incorporamento Editable.
+
+**Returns:**
+boolean - Rileva se fsType consente l'incorporamento modificabile.
+### isFSTypeAbsent() {#isFSTypeAbsent--}
+```
+public boolean isFSTypeAbsent()
+```
+
+
+Restituisce true se il flag fsType è assente nella tabella 'OS/2'.
+
+**Returns:**
+boolean - Vero se il flag fsType è assente nella tabella 'OS/2'.
+### isInstallableEmbedding() {#isInstallableEmbedding--}
+```
+public boolean isInstallableEmbedding()
+```
+
+
+Rileva se fsType è un incorporamento Installable.
+
+**Returns:**
+boolean - Rileva se fsType è un incorporamento installabile.
+### isNoSubsettingEmbedding() {#isNoSubsettingEmbedding--}
+```
+public boolean isNoSubsettingEmbedding()
+```
+
+
+Rileva se fsType consente l'incorporamento NoSubsetting.
+
+**Returns:**
+boolean - Rileva se fsType consente l'incorporamento NoSubsetting.
+### isPreviewAndPrintEmbedding() {#isPreviewAndPrintEmbedding--}
+```
+public boolean isPreviewAndPrintEmbedding()
+```
+
+
+Rileva se fsType consente l'incorporamento Preview and Print.
+
+**Returns:**
+boolean - Rileva se fsType consente l'incorporamento di anteprima e stampa.
+### isReservedType() {#isReservedType--}
+```
+public boolean isReservedType()
+```
+
+
+Rileva se il bit riservato (bit 0) è impostato per fsType.
+
+**Returns:**
+boolean - Rileva se il bit riservato (bit 0) è impostato per fsType.
+### isRestrictedLicenseEmbedding() {#isRestrictedLicenseEmbedding--}
+```
+public boolean isRestrictedLicenseEmbedding()
+```
+
+
+Rileva se fsType è un incorporamento Restricted License.
+
+**Returns:**
+boolean - Rileva se fsType è un incorporamento con licenza restrittiva.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/licenserestrictionexception/_index.md
+++ b/italian/java/com.aspose.font/licenserestrictionexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "LicenseRestrictionException"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'eccezione che può essere lanciata al tentativo di eseguire funzionalità limitate in modalità di valutazione."
+type: docs
+weight: 60
+url: /it/java/com.aspose.font/licenserestrictionexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class LicenseRestrictionException extends FontException
+```
+
+Rappresenta l'eccezione che può essere lanciata al tentativo di eseguire funzionalità limitate in modalità di valutazione.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [LicenseRestrictionException()](#LicenseRestrictionException--) | Inizializza un nuovo oggetto FontCreationException. |
+| [LicenseRestrictionException(String message)](#LicenseRestrictionException-java.lang.String-) | Inizializza un nuovo oggetto FontCreationException. |
+| [LicenseRestrictionException(String message, RuntimeException innerException)](#LicenseRestrictionException-java.lang.String-java.lang.RuntimeException-) | Inizializza un nuovo oggetto FontCreationException. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LicenseRestrictionException() {#LicenseRestrictionException--}
+```
+public LicenseRestrictionException()
+```
+
+
+Inizializza un nuovo oggetto FontCreationException.
+
+### LicenseRestrictionException(String message) {#LicenseRestrictionException-java.lang.String-}
+```
+public LicenseRestrictionException(String message)
+```
+
+
+Inizializza un nuovo oggetto FontCreationException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+
+### LicenseRestrictionException(String message, RuntimeException innerException) {#LicenseRestrictionException-java.lang.String-java.lang.RuntimeException-}
+```
+public LicenseRestrictionException(String message, RuntimeException innerException)
+```
+
+
+Inizializza un nuovo oggetto FontCreationException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+| innerException | java.lang.RuntimeException | L'eccezione che è la causa dell'eccezione corrente. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/linespacingtype/_index.md
+++ b/italian/java/com.aspose.font/linespacingtype/_index.md
@@ -1,0 +1,250 @@
+---
+title: "RenderingUtils.LineSpacingType"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Tipo di interlinea."
+type: docs
+weight: 10
+url: /it/java/com.aspose.font/renderingutils.linespacingtype/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum RenderingUtils.LineSpacingType extends Enum<RenderingUtils.LineSpacingType>
+```
+
+Tipo di interlinea. Numero di pixel o percentuale dell'altezza del carattere.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [PercentOfFontHeight](#PercentOfFontHeight) | Il valore dell'interlinea è impostato in percentuale dell'altezza del carattere. |
+| [Pixels](#Pixels) | Il valore dell'interlinea è impostato in pixel. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PercentOfFontHeight {#PercentOfFontHeight}
+```
+public static final RenderingUtils.LineSpacingType PercentOfFontHeight
+```
+
+
+Il valore dell'interlinea è impostato in percentuale dell'altezza del carattere.
+
+### Pixels {#Pixels}
+```
+public static final RenderingUtils.LineSpacingType Pixels
+```
+
+
+Il valore dell'interlinea è impostato in pixel.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static RenderingUtils.LineSpacingType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[LineSpacingType](../../com.aspose.font/linespacingtype)
+### values() {#values--}
+```
+public static RenderingUtils.LineSpacingType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.RenderingUtils.LineSpacingType[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/lineto/_index.md
+++ b/italian/java/com.aspose.font/lineto/_index.md
@@ -1,0 +1,200 @@
+---
+title: "LineTo"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'operazione LineTo."
+type: docs
+weight: 61
+url: /it/java/com.aspose.font/lineto/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IPathSegment](../../com.aspose.font/ipathsegment)
+```
+public class LineTo implements IPathSegment
+```
+
+Rappresenta l'operazione LineTo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clone()](#clone--) | Crea un nuovo oggetto che è una copia dell'istanza corrente. |
+| [copy()](#copy--) | Crea una copia dell'oggetto segmento. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getX()](#getX--) | Restituisce la coordinata x. |
+| [getY()](#getY--) | Restituisce la coordinata y. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [shift(double dx, double dy)](#shift-double-double-) | Esegue lo spostamento per le coordinate x e y. |
+| [toString()](#toString--) |  |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Trasforma le coordinate con la matrice di trasformazione. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Crea un nuovo oggetto che è una copia dell'istanza corrente.
+
+**Returns:**
+java.lang.Object - Un nuovo oggetto che è una copia di questa istanza.
+### copy() {#copy--}
+```
+public IPathSegment copy()
+```
+
+
+Crea una copia dell'oggetto segmento.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getX() {#getX--}
+```
+public double getX()
+```
+
+
+Restituisce la coordinata x.
+
+**Returns:**
+double - Coordinata x.
+### getY() {#getY--}
+```
+public double getY()
+```
+
+
+Restituisce la coordinata y.
+
+**Returns:**
+double - Coordinata y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public void shift(double dx, double dy)
+```
+
+
+Esegue lo spostamento per le coordinate x e y.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| dx | double | Valore dx. |
+| dy | double | Valore dy. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public void transform(TransformationMatrix matrix)
+```
+
+
+Trasforma le coordinate con la matrice di trasformazione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrice di trasformazione. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/longhormetric/_index.md
+++ b/italian/java/com.aspose.font/longhormetric/_index.md
@@ -1,0 +1,185 @@
+---
+title: "TtfHmtxTable.LongHorMetric"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta il record delle metriche."
+type: docs
+weight: 10
+url: /it/java/com.aspose.font/ttfhmtxtable.longhormetric/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static class TtfHmtxTable.LongHorMetric
+```
+
+Rappresenta il record delle metriche.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [LongHorMetric()](#LongHorMetric--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clone()](#clone--) |  |
+| [equals(TtfHmtxTable.LongHorMetric obj1, TtfHmtxTable.LongHorMetric obj2)](#equals-com.aspose.font.TtfHmtxTable.LongHorMetric-com.aspose.font.TtfHmtxTable.LongHorMetric-) |  |
+| [equals(Object obj)](#equals-java.lang.Object-) |  |
+| [getAdvanceWidth()](#getAdvanceWidth--) | Ottiene il valore della larghezza di avanzamento. |
+| [getClass()](#getClass--) |  |
+| [getLeftSideBearing()](#getLeftSideBearing--) | Ottiene il valore del margine sinistro. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LongHorMetric() {#LongHorMetric--}
+```
+public LongHorMetric()
+```
+
+
+### clone() {#clone--}
+```
+public TtfHmtxTable.LongHorMetric clone()
+```
+
+
+
+
+**Returns:**
+[LongHorMetric](../../com.aspose.font/longhormetric)
+### equals(TtfHmtxTable.LongHorMetric obj1, TtfHmtxTable.LongHorMetric obj2) {#equals-com.aspose.font.TtfHmtxTable.LongHorMetric-com.aspose.font.TtfHmtxTable.LongHorMetric-}
+```
+public static boolean equals(TtfHmtxTable.LongHorMetric obj1, TtfHmtxTable.LongHorMetric obj2)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj1 | [LongHorMetric](../../com.aspose.font/longhormetric) |  |
+| obj2 | [LongHorMetric](../../com.aspose.font/longhormetric) |  |
+
+**Returns:**
+boolean
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdvanceWidth() {#getAdvanceWidth--}
+```
+public int getAdvanceWidth()
+```
+
+
+Ottiene il valore della larghezza di avanzamento.
+
+**Returns:**
+int - Valore della larghezza di avanzamento.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLeftSideBearing() {#getLeftSideBearing--}
+```
+public short getLeftSideBearing()
+```
+
+
+Ottiene il valore del margine sinistro.
+
+**Returns:**
+short - Valore del margine laterale sinistro.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/longvermetric/_index.md
+++ b/italian/java/com.aspose.font/longvermetric/_index.md
@@ -1,0 +1,185 @@
+---
+title: "TtfVmtxTable.LongVerMetric"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta il record delle metriche verticali."
+type: docs
+weight: 10
+url: /it/java/com.aspose.font/ttfvmtxtable.longvermetric/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static class TtfVmtxTable.LongVerMetric
+```
+
+Rappresenta il record delle metriche verticali.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [LongVerMetric()](#LongVerMetric--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clone()](#clone--) |  |
+| [equals(TtfVmtxTable.LongVerMetric obj1, TtfVmtxTable.LongVerMetric obj2)](#equals-com.aspose.font.TtfVmtxTable.LongVerMetric-com.aspose.font.TtfVmtxTable.LongVerMetric-) |  |
+| [equals(Object obj)](#equals-java.lang.Object-) |  |
+| [getAdvanceHeight()](#getAdvanceHeight--) | Ottiene il valore dell'altezza di avanzamento. |
+| [getClass()](#getClass--) |  |
+| [getTopSideBearing()](#getTopSideBearing--) | Ottiene il valore del bearing superiore. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LongVerMetric() {#LongVerMetric--}
+```
+public LongVerMetric()
+```
+
+
+### clone() {#clone--}
+```
+public TtfVmtxTable.LongVerMetric clone()
+```
+
+
+
+
+**Returns:**
+[LongVerMetric](../../com.aspose.font/longvermetric)
+### equals(TtfVmtxTable.LongVerMetric obj1, TtfVmtxTable.LongVerMetric obj2) {#equals-com.aspose.font.TtfVmtxTable.LongVerMetric-com.aspose.font.TtfVmtxTable.LongVerMetric-}
+```
+public static boolean equals(TtfVmtxTable.LongVerMetric obj1, TtfVmtxTable.LongVerMetric obj2)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj1 | [LongVerMetric](../../com.aspose.font/longvermetric) |  |
+| obj2 | [LongVerMetric](../../com.aspose.font/longvermetric) |  |
+
+**Returns:**
+boolean
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdvanceHeight() {#getAdvanceHeight--}
+```
+public int getAdvanceHeight()
+```
+
+
+Ottiene il valore dell'altezza di avanzamento.
+
+**Returns:**
+int - Il valore dell'altezza di avanzamento.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getTopSideBearing() {#getTopSideBearing--}
+```
+public short getTopSideBearing()
+```
+
+
+Ottiene il valore del bearing superiore.
+
+**Returns:**
+short - Il valore del bearing superiore.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/maclanguageid/_index.md
+++ b/italian/java/com.aspose.font/maclanguageid/_index.md
@@ -1,0 +1,1201 @@
+---
+title: "MacLanguageId"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Enumerazione degli ID lingua della piattaforma Macintosh."
+type: docs
+weight: 63
+url: /it/java/com.aspose.font/maclanguageid/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class MacLanguageId
+```
+
+Enumerazione degli ID lingua della piattaforma Macintosh.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [Afrikaans](#Afrikaans) | Valore LanguageId Afrikaans |
+| [Albanian](#Albanian) | Valore LanguageId Albanese |
+| [Amharic](#Amharic) | Valore LanguageId Amharico |
+| [Arabic](#Arabic) | Valore LanguageId Arabo |
+| [Armenian](#Armenian) | Valore LanguageId Armeno |
+| [Assamese](#Assamese) | Valore LanguageId Assamese |
+| [Aymara](#Aymara) | Aymara LanguageId valore |
+| [Azerbaijani_Arabic](#Azerbaijani-Arabic) | Azerbaijani (Arabic script) LanguageId valore |
+| [Azerbaijani_Cyrillic](#Azerbaijani-Cyrillic) | Azerbaijani (Cyrillic script) LanguageId valore |
+| [Azerbaijani_Roman](#Azerbaijani-Roman) | Azerbaijani (Roman script) LanguageId valore |
+| [Basque](#Basque) | Basque LanguageId valore |
+| [Bengali](#Bengali) | Bengali LanguageId valore |
+| [Breton](#Breton) | Breton LanguageId valore |
+| [Bulgarian](#Bulgarian) | Bulgarian LanguageId valore |
+| [Burmese](#Burmese) | Burmese LanguageId valore |
+| [Byelorussian](#Byelorussian) | Byelorussian LanguageId valore |
+| [Catalan](#Catalan) | Catalan LanguageId valore |
+| [Chinese_Simplified](#Chinese-Simplified) | Chinese (Simplified) LanguageId valore |
+| [Chinese_Traditional](#Chinese-Traditional) | Chinese (Traditional) LanguageId valore |
+| [Croatian](#Croatian) | Croatian LanguageId valore |
+| [Czech](#Czech) | Czech LanguageId valore |
+| [Danish](#Danish) | Danish LanguageId valore |
+| [Dutch](#Dutch) | Dutch LanguageId valore |
+| [Dzongkha](#Dzongkha) | Dzongkha LanguageId valore |
+| [English](#English) | English LanguageId valore |
+| [Esperanto](#Esperanto) | Esperanto LanguageId valore |
+| [Estonian](#Estonian) | Estonian LanguageId valore |
+| [Faroese](#Faroese) | Faroese LanguageId valore |
+| [Farsi_Persian](#Farsi-Persian) | Farsi/Persian LanguageId valore |
+| [Finnish](#Finnish) | Finnish LanguageId valore |
+| [Flemish](#Flemish) | Flemish LanguageId valore |
+| [French](#French) | Valore LanguageId francese |
+| [Galician](#Galician) | Valore LanguageId galiziano |
+| [Galla](#Galla) | Valore LanguageId galla |
+| [Georgian](#Georgian) | Valore LanguageId georgiano |
+| [German](#German) | Valore LanguageId tedesco |
+| [Greek](#Greek) | Valore LanguageId greco |
+| [Greek_Polytonic](#Greek-Polytonic) | Valore LanguageId greco (politonico) |
+| [Greenlandic](#Greenlandic) | Valore LanguageId groenlandese |
+| [Guarani](#Guarani) | Valore LanguageId guaraní |
+| [Gujarati](#Gujarati) | Valore LanguageId gujarati |
+| [Hebrew](#Hebrew) | Valore LanguageId ebraico |
+| [Hindi](#Hindi) | Valore LanguageId hindi |
+| [Hungarian](#Hungarian) | Valore LanguageId ungherese |
+| [Icelandic](#Icelandic) | Valore LanguageId islandese |
+| [Indonesian](#Indonesian) | Valore LanguageId indonesiano |
+| [Inuktitut](#Inuktitut) | Valore LanguageId inuktitut |
+| [Irish_Gaelic](#Irish-Gaelic) | Valore LanguageId gaelico irlandese |
+| [Irish_Gaelic_WDA](#Irish-Gaelic-WDA) | Valore LanguageId gaelico irlandese (con punto sopra) |
+| [Italian](#Italian) | Valore LanguageId italiano |
+| [Japanese](#Japanese) | Valore LanguageId giapponese |
+| [Javanese](#Javanese) | Valore LanguageId giavanese (scrittura romana) |
+| [Kannada](#Kannada) | Valore LanguageId kannada |
+| [Kashmiri](#Kashmiri) | Valore LanguageId kashmiri |
+| [Kazakh](#Kazakh) | Valore LanguageId kazako |
+| [Khmer](#Khmer) | Valore LanguageId khmer |
+| [Kinyarwanda_Ruanda](#Kinyarwanda-Ruanda) | Kinyarwanda/Ruanda LanguageId valore |
+| [Kirghiz](#Kirghiz) | Kirghiz LanguageId valore |
+| [Korean](#Korean) | Korean LanguageId valore |
+| [Kurdish](#Kurdish) | Kurdish LanguageId valore |
+| [Lao](#Lao) | Lao LanguageId valore |
+| [Latin](#Latin) | Latin LanguageId valore |
+| [Latvian](#Latvian) | Latvian LanguageId valore |
+| [Lithuanian](#Lithuanian) | Lithuanian LanguageId valore |
+| [Macedonian](#Macedonian) | Macedonian LanguageId valore |
+| [Malagasy](#Malagasy) | Malagasy LanguageId valore |
+| [Malay_Arabic](#Malay-Arabic) | Malay (Arabic script) LanguageId valore |
+| [Malay_Roman](#Malay-Roman) | Malay (Roman script) LanguageId valore |
+| [Malayalam](#Malayalam) | Malayalam LanguageId valore |
+| [Maltese](#Maltese) | Maltese LanguageId valore |
+| [Manx_Gaelic](#Manx-Gaelic) | Manx Gaelic LanguageId valore |
+| [Marathi](#Marathi) | Marathi LanguageId valore |
+| [Moldavian](#Moldavian) | Moldavian LanguageId valore |
+| [Mongolian_Cyrillic](#Mongolian-Cyrillic) | Mongolian (Cyrillic script) LanguageId valore |
+| [Mongolian_Mongolian](#Mongolian-Mongolian) | Mongolian (Mongolian script) LanguageId valore |
+| [Nepali](#Nepali) | Nepali LanguageId valore |
+| [Norwegian](#Norwegian) | Norwegian LanguageId valore |
+| [Nyanja_Chewa](#Nyanja-Chewa) | Nyanja/Chewa LanguageId valore |
+| [Oriya](#Oriya) | Oriya LanguageId valore |
+| [Pashto](#Pashto) | Pashto LanguageId valore |
+| [Polish](#Polish) | Polish LanguageId valore |
+| [Portuguese](#Portuguese) | Valore LanguageId portoghese |
+| [Punjabi](#Punjabi) | Valore LanguageId punjabi |
+| [Quechua](#Quechua) | Valore LanguageId quechua |
+| [Romanian](#Romanian) | Valore LanguageId rumeno |
+| [Rundi](#Rundi) | Valore LanguageId rundi |
+| [Russian](#Russian) | Valore LanguageId russo |
+| [Sami](#Sami) | Valore LanguageId sami |
+| [Sanskrit](#Sanskrit) | Valore LanguageId sanscrito |
+| [Scottish_Gaelic](#Scottish-Gaelic) | Valore LanguageId gaelico scozzese |
+| [Serbian](#Serbian) | Serbo LanguLanguageIdageID valore |
+| [Sindhi](#Sindhi) | Valore LanguageId sindhi |
+| [Sinhalese](#Sinhalese) | Valore LanguageId singalese |
+| [Slovak](#Slovak) | Valore LanguageId slovacco |
+| [Slovenian](#Slovenian) | Valore LanguageId sloveno |
+| [Somali](#Somali) | Valore LanguageId somalo |
+| [Spanish](#Spanish) | Valore LanguageId spagnolo |
+| [Sundanese](#Sundanese) | Sundanese (scrittura romana) LanguageId valore |
+| [Swahili](#Swahili) | Valore LanguageId swahili |
+| [Swedish](#Swedish) | Valore LanguageId svedese |
+| [Tagalog](#Tagalog) | Valore LanguageId tagalog |
+| [Tajiki](#Tajiki) | Valore LanguageId tagico |
+| [Tamil](#Tamil) | Tamil LanguagLanguageIdeID valore |
+| [Tatar](#Tatar) | Valore LanguageId tataro |
+| [Telugu](#Telugu) | Valore LanguageId telugu |
+| [Thai](#Thai) | Valore LanguageId tailandese |
+| [Tibetan](#Tibetan) | Valore LanguageId tibetano |
+| [Tigrinya](#Tigrinya) | Valore LanguageId tigrino |
+| [Tongan](#Tongan) | Valore LanguageId tongano |
+| [Turkish](#Turkish) | Valore LanguageId turco |
+| [Turkmen](#Turkmen) | Valore LanguageId turkmeno |
+| [Uighur](#Uighur) | Valore LanguageId uiguro |
+| [Ukrainian](#Ukrainian) | Valore LanguageId ucraino |
+| [Urdu](#Urdu) | Valore LanguageId urdu |
+| [Uzbek](#Uzbek) | Valore LanguageId uzbeco |
+| [Vietnamese](#Vietnamese) | Valore LanguageId vietnamita |
+| [Welsh](#Welsh) | Valore LanguageId gallese |
+| [Yiddish](#Yiddish) | Valore LanguageId yiddish |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getId()](#getId--) | Ottieni il valore intero. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Afrikaans {#Afrikaans}
+```
+public static final MacLanguageId Afrikaans
+```
+
+
+Valore LanguageId Afrikaans
+
+### Albanian {#Albanian}
+```
+public static final MacLanguageId Albanian
+```
+
+
+Valore LanguageId Albanese
+
+### Amharic {#Amharic}
+```
+public static final MacLanguageId Amharic
+```
+
+
+Valore LanguageId Amharico
+
+### Arabic {#Arabic}
+```
+public static final MacLanguageId Arabic
+```
+
+
+Valore LanguageId Arabo
+
+### Armenian {#Armenian}
+```
+public static final MacLanguageId Armenian
+```
+
+
+Valore LanguageId Armeno
+
+### Assamese {#Assamese}
+```
+public static final MacLanguageId Assamese
+```
+
+
+Valore LanguageId Assamese
+
+### Aymara {#Aymara}
+```
+public static final MacLanguageId Aymara
+```
+
+
+Aymara LanguageId valore
+
+### Azerbaijani_Arabic {#Azerbaijani-Arabic}
+```
+public static final MacLanguageId Azerbaijani_Arabic
+```
+
+
+Azerbaijani (Arabic script) LanguageId valore
+
+### Azerbaijani_Cyrillic {#Azerbaijani-Cyrillic}
+```
+public static final MacLanguageId Azerbaijani_Cyrillic
+```
+
+
+Azerbaijani (Cyrillic script) LanguageId valore
+
+### Azerbaijani_Roman {#Azerbaijani-Roman}
+```
+public static final MacLanguageId Azerbaijani_Roman
+```
+
+
+Azerbaijani (Roman script) LanguageId valore
+
+### Basque {#Basque}
+```
+public static final MacLanguageId Basque
+```
+
+
+Basque LanguageId valore
+
+### Bengali {#Bengali}
+```
+public static final MacLanguageId Bengali
+```
+
+
+Bengali LanguageId valore
+
+### Breton {#Breton}
+```
+public static final MacLanguageId Breton
+```
+
+
+Breton LanguageId valore
+
+### Bulgarian {#Bulgarian}
+```
+public static final MacLanguageId Bulgarian
+```
+
+
+Bulgarian LanguageId valore
+
+### Burmese {#Burmese}
+```
+public static final MacLanguageId Burmese
+```
+
+
+Burmese LanguageId valore
+
+### Byelorussian {#Byelorussian}
+```
+public static final MacLanguageId Byelorussian
+```
+
+
+Byelorussian LanguageId valore
+
+### Catalan {#Catalan}
+```
+public static final MacLanguageId Catalan
+```
+
+
+Catalan LanguageId valore
+
+### Chinese_Simplified {#Chinese-Simplified}
+```
+public static final MacLanguageId Chinese_Simplified
+```
+
+
+Chinese (Simplified) LanguageId valore
+
+### Chinese_Traditional {#Chinese-Traditional}
+```
+public static final MacLanguageId Chinese_Traditional
+```
+
+
+Chinese (Traditional) LanguageId valore
+
+### Croatian {#Croatian}
+```
+public static final MacLanguageId Croatian
+```
+
+
+Croatian LanguageId valore
+
+### Czech {#Czech}
+```
+public static final MacLanguageId Czech
+```
+
+
+Czech LanguageId valore
+
+### Danish {#Danish}
+```
+public static final MacLanguageId Danish
+```
+
+
+Danish LanguageId valore
+
+### Dutch {#Dutch}
+```
+public static final MacLanguageId Dutch
+```
+
+
+Dutch LanguageId valore
+
+### Dzongkha {#Dzongkha}
+```
+public static final MacLanguageId Dzongkha
+```
+
+
+Dzongkha LanguageId valore
+
+### English {#English}
+```
+public static final MacLanguageId English
+```
+
+
+English LanguageId valore
+
+### Esperanto {#Esperanto}
+```
+public static final MacLanguageId Esperanto
+```
+
+
+Esperanto LanguageId valore
+
+### Estonian {#Estonian}
+```
+public static final MacLanguageId Estonian
+```
+
+
+Estonian LanguageId valore
+
+### Faroese {#Faroese}
+```
+public static final MacLanguageId Faroese
+```
+
+
+Faroese LanguageId valore
+
+### Farsi_Persian {#Farsi-Persian}
+```
+public static final MacLanguageId Farsi_Persian
+```
+
+
+Farsi/Persian LanguageId valore
+
+### Finnish {#Finnish}
+```
+public static final MacLanguageId Finnish
+```
+
+
+Finnish LanguageId valore
+
+### Flemish {#Flemish}
+```
+public static final MacLanguageId Flemish
+```
+
+
+Flemish LanguageId valore
+
+### French {#French}
+```
+public static final MacLanguageId French
+```
+
+
+Valore LanguageId francese
+
+### Galician {#Galician}
+```
+public static final MacLanguageId Galician
+```
+
+
+Valore LanguageId galiziano
+
+### Galla {#Galla}
+```
+public static final MacLanguageId Galla
+```
+
+
+Valore LanguageId galla
+
+### Georgian {#Georgian}
+```
+public static final MacLanguageId Georgian
+```
+
+
+Valore LanguageId georgiano
+
+### German {#German}
+```
+public static final MacLanguageId German
+```
+
+
+Valore LanguageId tedesco
+
+### Greek {#Greek}
+```
+public static final MacLanguageId Greek
+```
+
+
+Valore LanguageId greco
+
+### Greek_Polytonic {#Greek-Polytonic}
+```
+public static final MacLanguageId Greek_Polytonic
+```
+
+
+Valore LanguageId greco (politonico)
+
+### Greenlandic {#Greenlandic}
+```
+public static final MacLanguageId Greenlandic
+```
+
+
+Valore LanguageId groenlandese
+
+### Guarani {#Guarani}
+```
+public static final MacLanguageId Guarani
+```
+
+
+Valore LanguageId guaraní
+
+### Gujarati {#Gujarati}
+```
+public static final MacLanguageId Gujarati
+```
+
+
+Valore LanguageId gujarati
+
+### Hebrew {#Hebrew}
+```
+public static final MacLanguageId Hebrew
+```
+
+
+Valore LanguageId ebraico
+
+### Hindi {#Hindi}
+```
+public static final MacLanguageId Hindi
+```
+
+
+Valore LanguageId hindi
+
+### Hungarian {#Hungarian}
+```
+public static final MacLanguageId Hungarian
+```
+
+
+Valore LanguageId ungherese
+
+### Icelandic {#Icelandic}
+```
+public static final MacLanguageId Icelandic
+```
+
+
+Valore LanguageId islandese
+
+### Indonesian {#Indonesian}
+```
+public static final MacLanguageId Indonesian
+```
+
+
+Valore LanguageId indonesiano
+
+### Inuktitut {#Inuktitut}
+```
+public static final MacLanguageId Inuktitut
+```
+
+
+Valore LanguageId inuktitut
+
+### Irish_Gaelic {#Irish-Gaelic}
+```
+public static final MacLanguageId Irish_Gaelic
+```
+
+
+Valore LanguageId gaelico irlandese
+
+### Irish_Gaelic_WDA {#Irish-Gaelic-WDA}
+```
+public static final MacLanguageId Irish_Gaelic_WDA
+```
+
+
+Valore LanguageId gaelico irlandese (con punto sopra)
+
+### Italian {#Italian}
+```
+public static final MacLanguageId Italian
+```
+
+
+Valore LanguageId italiano
+
+### Japanese {#Japanese}
+```
+public static final MacLanguageId Japanese
+```
+
+
+Valore LanguageId giapponese
+
+### Javanese {#Javanese}
+```
+public static final MacLanguageId Javanese
+```
+
+
+Valore LanguageId giavanese (scrittura romana)
+
+### Kannada {#Kannada}
+```
+public static final MacLanguageId Kannada
+```
+
+
+Valore LanguageId kannada
+
+### Kashmiri {#Kashmiri}
+```
+public static final MacLanguageId Kashmiri
+```
+
+
+Valore LanguageId kashmiri
+
+### Kazakh {#Kazakh}
+```
+public static final MacLanguageId Kazakh
+```
+
+
+Valore LanguageId kazako
+
+### Khmer {#Khmer}
+```
+public static final MacLanguageId Khmer
+```
+
+
+Valore LanguageId khmer
+
+### Kinyarwanda_Ruanda {#Kinyarwanda-Ruanda}
+```
+public static final MacLanguageId Kinyarwanda_Ruanda
+```
+
+
+Kinyarwanda/Ruanda LanguageId valore
+
+### Kirghiz {#Kirghiz}
+```
+public static final MacLanguageId Kirghiz
+```
+
+
+Kirghiz LanguageId valore
+
+### Korean {#Korean}
+```
+public static final MacLanguageId Korean
+```
+
+
+Korean LanguageId valore
+
+### Kurdish {#Kurdish}
+```
+public static final MacLanguageId Kurdish
+```
+
+
+Kurdish LanguageId valore
+
+### Lao {#Lao}
+```
+public static final MacLanguageId Lao
+```
+
+
+Lao LanguageId valore
+
+### Latin {#Latin}
+```
+public static final MacLanguageId Latin
+```
+
+
+Latin LanguageId valore
+
+### Latvian {#Latvian}
+```
+public static final MacLanguageId Latvian
+```
+
+
+Latvian LanguageId valore
+
+### Lithuanian {#Lithuanian}
+```
+public static final MacLanguageId Lithuanian
+```
+
+
+Lithuanian LanguageId valore
+
+### Macedonian {#Macedonian}
+```
+public static final MacLanguageId Macedonian
+```
+
+
+Macedonian LanguageId valore
+
+### Malagasy {#Malagasy}
+```
+public static final MacLanguageId Malagasy
+```
+
+
+Malagasy LanguageId valore
+
+### Malay_Arabic {#Malay-Arabic}
+```
+public static final MacLanguageId Malay_Arabic
+```
+
+
+Malay (Arabic script) LanguageId valore
+
+### Malay_Roman {#Malay-Roman}
+```
+public static final MacLanguageId Malay_Roman
+```
+
+
+Malay (Roman script) LanguageId valore
+
+### Malayalam {#Malayalam}
+```
+public static final MacLanguageId Malayalam
+```
+
+
+Malayalam LanguageId valore
+
+### Maltese {#Maltese}
+```
+public static final MacLanguageId Maltese
+```
+
+
+Maltese LanguageId valore
+
+### Manx_Gaelic {#Manx-Gaelic}
+```
+public static final MacLanguageId Manx_Gaelic
+```
+
+
+Manx Gaelic LanguageId valore
+
+### Marathi {#Marathi}
+```
+public static final MacLanguageId Marathi
+```
+
+
+Marathi LanguageId valore
+
+### Moldavian {#Moldavian}
+```
+public static final MacLanguageId Moldavian
+```
+
+
+Moldavian LanguageId valore
+
+### Mongolian_Cyrillic {#Mongolian-Cyrillic}
+```
+public static final MacLanguageId Mongolian_Cyrillic
+```
+
+
+Mongolian (Cyrillic script) LanguageId valore
+
+### Mongolian_Mongolian {#Mongolian-Mongolian}
+```
+public static final MacLanguageId Mongolian_Mongolian
+```
+
+
+Mongolian (Mongolian script) LanguageId valore
+
+### Nepali {#Nepali}
+```
+public static final MacLanguageId Nepali
+```
+
+
+Nepali LanguageId valore
+
+### Norwegian {#Norwegian}
+```
+public static final MacLanguageId Norwegian
+```
+
+
+Norwegian LanguageId valore
+
+### Nyanja_Chewa {#Nyanja-Chewa}
+```
+public static final MacLanguageId Nyanja_Chewa
+```
+
+
+Nyanja/Chewa LanguageId valore
+
+### Oriya {#Oriya}
+```
+public static final MacLanguageId Oriya
+```
+
+
+Oriya LanguageId valore
+
+### Pashto {#Pashto}
+```
+public static final MacLanguageId Pashto
+```
+
+
+Pashto LanguageId valore
+
+### Polish {#Polish}
+```
+public static final MacLanguageId Polish
+```
+
+
+Polish LanguageId valore
+
+### Portuguese {#Portuguese}
+```
+public static final MacLanguageId Portuguese
+```
+
+
+Valore LanguageId portoghese
+
+### Punjabi {#Punjabi}
+```
+public static final MacLanguageId Punjabi
+```
+
+
+Valore LanguageId punjabi
+
+### Quechua {#Quechua}
+```
+public static final MacLanguageId Quechua
+```
+
+
+Valore LanguageId quechua
+
+### Romanian {#Romanian}
+```
+public static final MacLanguageId Romanian
+```
+
+
+Valore LanguageId rumeno
+
+### Rundi {#Rundi}
+```
+public static final MacLanguageId Rundi
+```
+
+
+Valore LanguageId rundi
+
+### Russian {#Russian}
+```
+public static final MacLanguageId Russian
+```
+
+
+Valore LanguageId russo
+
+### Sami {#Sami}
+```
+public static final MacLanguageId Sami
+```
+
+
+Valore LanguageId sami
+
+### Sanskrit {#Sanskrit}
+```
+public static final MacLanguageId Sanskrit
+```
+
+
+Valore LanguageId sanscrito
+
+### Scottish_Gaelic {#Scottish-Gaelic}
+```
+public static final MacLanguageId Scottish_Gaelic
+```
+
+
+Valore LanguageId gaelico scozzese
+
+### Serbian {#Serbian}
+```
+public static final MacLanguageId Serbian
+```
+
+
+Serbo LanguLanguageIdageID valore
+
+### Sindhi {#Sindhi}
+```
+public static final MacLanguageId Sindhi
+```
+
+
+Valore LanguageId sindhi
+
+### Sinhalese {#Sinhalese}
+```
+public static final MacLanguageId Sinhalese
+```
+
+
+Valore LanguageId singalese
+
+### Slovak {#Slovak}
+```
+public static final MacLanguageId Slovak
+```
+
+
+Valore LanguageId slovacco
+
+### Slovenian {#Slovenian}
+```
+public static final MacLanguageId Slovenian
+```
+
+
+Valore LanguageId sloveno
+
+### Somali {#Somali}
+```
+public static final MacLanguageId Somali
+```
+
+
+Valore LanguageId somalo
+
+### Spanish {#Spanish}
+```
+public static final MacLanguageId Spanish
+```
+
+
+Valore LanguageId spagnolo
+
+### Sundanese {#Sundanese}
+```
+public static final MacLanguageId Sundanese
+```
+
+
+Sundanese (scrittura romana) LanguageId valore
+
+### Swahili {#Swahili}
+```
+public static final MacLanguageId Swahili
+```
+
+
+Valore LanguageId swahili
+
+### Swedish {#Swedish}
+```
+public static final MacLanguageId Swedish
+```
+
+
+Valore LanguageId svedese
+
+### Tagalog {#Tagalog}
+```
+public static final MacLanguageId Tagalog
+```
+
+
+Valore LanguageId tagalog
+
+### Tajiki {#Tajiki}
+```
+public static final MacLanguageId Tajiki
+```
+
+
+Valore LanguageId tagico
+
+### Tamil {#Tamil}
+```
+public static final MacLanguageId Tamil
+```
+
+
+Tamil LanguagLanguageIdeID valore
+
+### Tatar {#Tatar}
+```
+public static final MacLanguageId Tatar
+```
+
+
+Valore LanguageId tataro
+
+### Telugu {#Telugu}
+```
+public static final MacLanguageId Telugu
+```
+
+
+Valore LanguageId telugu
+
+### Thai {#Thai}
+```
+public static final MacLanguageId Thai
+```
+
+
+Valore LanguageId tailandese
+
+### Tibetan {#Tibetan}
+```
+public static final MacLanguageId Tibetan
+```
+
+
+Valore LanguageId tibetano
+
+### Tigrinya {#Tigrinya}
+```
+public static final MacLanguageId Tigrinya
+```
+
+
+Valore LanguageId tigrino
+
+### Tongan {#Tongan}
+```
+public static final MacLanguageId Tongan
+```
+
+
+Valore LanguageId tongano
+
+### Turkish {#Turkish}
+```
+public static final MacLanguageId Turkish
+```
+
+
+Valore LanguageId turco
+
+### Turkmen {#Turkmen}
+```
+public static final MacLanguageId Turkmen
+```
+
+
+Valore LanguageId turkmeno
+
+### Uighur {#Uighur}
+```
+public static final MacLanguageId Uighur
+```
+
+
+Valore LanguageId uiguro
+
+### Ukrainian {#Ukrainian}
+```
+public static final MacLanguageId Ukrainian
+```
+
+
+Valore LanguageId ucraino
+
+### Urdu {#Urdu}
+```
+public static final MacLanguageId Urdu
+```
+
+
+Valore LanguageId urdu
+
+### Uzbek {#Uzbek}
+```
+public static final MacLanguageId Uzbek
+```
+
+
+Valore LanguageId uzbeco
+
+### Vietnamese {#Vietnamese}
+```
+public static final MacLanguageId Vietnamese
+```
+
+
+Valore LanguageId vietnamita
+
+### Welsh {#Welsh}
+```
+public static final MacLanguageId Welsh
+```
+
+
+Valore LanguageId gallese
+
+### Yiddish {#Yiddish}
+```
+public static final MacLanguageId Yiddish
+```
+
+
+Valore LanguageId yiddish
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getId() {#getId--}
+```
+public int getId()
+```
+
+
+Ottieni il valore intero.
+
+**Returns:**
+int - Il valore intero.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/macplatformspecificid/_index.md
+++ b/italian/java/com.aspose.font/macplatformspecificid/_index.md
@@ -1,0 +1,529 @@
+---
+title: "MacPlatformSpecificId"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'enumerazione PlatformSpecificId della piattaforma Macintosh."
+type: docs
+weight: 140
+url: /it/java/com.aspose.font/macplatformspecificid/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum MacPlatformSpecificId extends Enum<MacPlatformSpecificId>
+```
+
+Rappresenta l'enumerazione PlatformSpecificId della piattaforma Macintosh.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [Arabic](#Arabic) | Valore specifico della piattaforma Arabic. |
+| [Armenian](#Armenian) | Valore specifico della piattaforma Armenian. |
+| [Bengali](#Bengali) | Valore specifico della piattaforma Bengali. |
+| [Burmese](#Burmese) | Valore specifico della piattaforma Burmese. |
+| [Devanagari](#Devanagari) | Valore specifico della piattaforma Devanagari. |
+| [Geez](#Geez) | Valore specifico della piattaforma Geez. |
+| [Georgian](#Georgian) | Valore specifico della piattaforma Georgian. |
+| [Greek](#Greek) | Valore specifico della piattaforma Greek. |
+| [Gujarati](#Gujarati) | Valore specifico della piattaforma Gujarati. |
+| [Gurmukhi](#Gurmukhi) | Valore specifico della piattaforma Gurmukhi. |
+| [Hebrew](#Hebrew) | Valore specifico della piattaforma Hebrew. |
+| [Japanese](#Japanese) | Valore specifico della piattaforma Japanese. |
+| [Kannada](#Kannada) | Valore specifico della piattaforma Kannada. |
+| [Khmer](#Khmer) | Valore specifico della piattaforma Khmer. |
+| [Korean](#Korean) | Valore specifico della piattaforma Korean. |
+| [Laotian](#Laotian) | Valore specifico della piattaforma Laotian. |
+| [Malayalam](#Malayalam) | Valore specifico della piattaforma Malayalam. |
+| [Mongolian](#Mongolian) | Valore specifico della piattaforma Mongolian. |
+| [Oriya](#Oriya) | Valore specifico della piattaforma Oriya. |
+| [RSymbol](#RSymbol) | Valore specifico della piattaforma RSymbol. |
+| [Roman](#Roman) | Valore specifico della piattaforma Roman. |
+| [Russian](#Russian) | Valore specifico della piattaforma Russian. |
+| [Simplified_Chinese](#Simplified-Chinese) | Valore specifico della piattaforma Simplified Chinese. |
+| [Sindhi](#Sindhi) | Valore specifico della piattaforma Sindhi. |
+| [Sinhalese](#Sinhalese) | Valore specifico della piattaforma Sinhalese. |
+| [Slavic](#Slavic) | Valore specifico della piattaforma Slava. |
+| [Tamil](#Tamil) | Valore specifico della piattaforma Tamil. |
+| [Telugu](#Telugu) | Valore specifico della piattaforma Telugu. |
+| [Thai](#Thai) | Valore specifico della piattaforma Thai. |
+| [Tibetan](#Tibetan) | Valore specifico della piattaforma Tibetana. |
+| [Traditional_Chinese](#Traditional-Chinese) | Valore specifico della piattaforma Cinese tradizionale. |
+| [Uninterpreted](#Uninterpreted) | Valore specifico della piattaforma non interpretato. |
+| [Vietnamese](#Vietnamese) | Valore specifico della piattaforma Vietnamita. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Arabic {#Arabic}
+```
+public static final MacPlatformSpecificId Arabic
+```
+
+
+Valore specifico della piattaforma Arabic.
+
+### Armenian {#Armenian}
+```
+public static final MacPlatformSpecificId Armenian
+```
+
+
+Valore specifico della piattaforma Armenian.
+
+### Bengali {#Bengali}
+```
+public static final MacPlatformSpecificId Bengali
+```
+
+
+Valore specifico della piattaforma Bengali.
+
+### Burmese {#Burmese}
+```
+public static final MacPlatformSpecificId Burmese
+```
+
+
+Valore specifico della piattaforma Burmese.
+
+### Devanagari {#Devanagari}
+```
+public static final MacPlatformSpecificId Devanagari
+```
+
+
+Valore specifico della piattaforma Devanagari.
+
+### Geez {#Geez}
+```
+public static final MacPlatformSpecificId Geez
+```
+
+
+Valore specifico della piattaforma Geez.
+
+### Georgian {#Georgian}
+```
+public static final MacPlatformSpecificId Georgian
+```
+
+
+Valore specifico della piattaforma Georgian.
+
+### Greek {#Greek}
+```
+public static final MacPlatformSpecificId Greek
+```
+
+
+Valore specifico della piattaforma Greek.
+
+### Gujarati {#Gujarati}
+```
+public static final MacPlatformSpecificId Gujarati
+```
+
+
+Valore specifico della piattaforma Gujarati.
+
+### Gurmukhi {#Gurmukhi}
+```
+public static final MacPlatformSpecificId Gurmukhi
+```
+
+
+Valore specifico della piattaforma Gurmukhi.
+
+### Hebrew {#Hebrew}
+```
+public static final MacPlatformSpecificId Hebrew
+```
+
+
+Valore specifico della piattaforma Hebrew.
+
+### Japanese {#Japanese}
+```
+public static final MacPlatformSpecificId Japanese
+```
+
+
+Valore specifico della piattaforma Japanese.
+
+### Kannada {#Kannada}
+```
+public static final MacPlatformSpecificId Kannada
+```
+
+
+Valore specifico della piattaforma Kannada.
+
+### Khmer {#Khmer}
+```
+public static final MacPlatformSpecificId Khmer
+```
+
+
+Valore specifico della piattaforma Khmer.
+
+### Korean {#Korean}
+```
+public static final MacPlatformSpecificId Korean
+```
+
+
+Valore specifico della piattaforma Korean.
+
+### Laotian {#Laotian}
+```
+public static final MacPlatformSpecificId Laotian
+```
+
+
+Valore specifico della piattaforma Laotian.
+
+### Malayalam {#Malayalam}
+```
+public static final MacPlatformSpecificId Malayalam
+```
+
+
+Valore specifico della piattaforma Malayalam.
+
+### Mongolian {#Mongolian}
+```
+public static final MacPlatformSpecificId Mongolian
+```
+
+
+Valore specifico della piattaforma Mongolian.
+
+### Oriya {#Oriya}
+```
+public static final MacPlatformSpecificId Oriya
+```
+
+
+Valore specifico della piattaforma Oriya.
+
+### RSymbol {#RSymbol}
+```
+public static final MacPlatformSpecificId RSymbol
+```
+
+
+Valore specifico della piattaforma RSymbol.
+
+### Roman {#Roman}
+```
+public static final MacPlatformSpecificId Roman
+```
+
+
+Valore specifico della piattaforma Roman.
+
+### Russian {#Russian}
+```
+public static final MacPlatformSpecificId Russian
+```
+
+
+Valore specifico della piattaforma Russian.
+
+### Simplified_Chinese {#Simplified-Chinese}
+```
+public static final MacPlatformSpecificId Simplified_Chinese
+```
+
+
+Valore specifico della piattaforma Simplified Chinese.
+
+### Sindhi {#Sindhi}
+```
+public static final MacPlatformSpecificId Sindhi
+```
+
+
+Valore specifico della piattaforma Sindhi.
+
+### Sinhalese {#Sinhalese}
+```
+public static final MacPlatformSpecificId Sinhalese
+```
+
+
+Valore specifico della piattaforma Sinhalese.
+
+### Slavic {#Slavic}
+```
+public static final MacPlatformSpecificId Slavic
+```
+
+
+Valore specifico della piattaforma Slava.
+
+### Tamil {#Tamil}
+```
+public static final MacPlatformSpecificId Tamil
+```
+
+
+Valore specifico della piattaforma Tamil.
+
+### Telugu {#Telugu}
+```
+public static final MacPlatformSpecificId Telugu
+```
+
+
+Valore specifico della piattaforma Telugu.
+
+### Thai {#Thai}
+```
+public static final MacPlatformSpecificId Thai
+```
+
+
+Valore specifico della piattaforma Thai.
+
+### Tibetan {#Tibetan}
+```
+public static final MacPlatformSpecificId Tibetan
+```
+
+
+Valore specifico della piattaforma Tibetana.
+
+### Traditional_Chinese {#Traditional-Chinese}
+```
+public static final MacPlatformSpecificId Traditional_Chinese
+```
+
+
+Valore specifico della piattaforma Cinese tradizionale.
+
+### Uninterpreted {#Uninterpreted}
+```
+public static final MacPlatformSpecificId Uninterpreted
+```
+
+
+Valore specifico della piattaforma non interpretato.
+
+### Vietnamese {#Vietnamese}
+```
+public static final MacPlatformSpecificId Vietnamese
+```
+
+
+Valore specifico della piattaforma Vietnamita.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static MacPlatformSpecificId valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[MacPlatformSpecificId](../../com.aspose.font/macplatformspecificid)
+### values() {#values--}
+```
+public static MacPlatformSpecificId[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.MacPlatformSpecificId[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/metered/_index.md
+++ b/italian/java/com.aspose.font/metered/_index.md
@@ -1,0 +1,185 @@
+---
+title: "A consumo"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Fornisce metodi per impostare la chiave misurata."
+type: docs
+weight: 64
+url: /it/java/com.aspose.font/metered/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class Metered
+```
+
+Fornisce metodi per impostare la chiave misurata.
+
+--------------------
+
+In questo esempio, verrà effettuato un tentativo di impostare la chiave pubblica e privata a consumo
+
+```
+The component jar file:
+  
+ 	Metered metered = new Metered();
+ 	matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Metered()](#Metered--) | Inizializza una nuova istanza di questa classe. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getConsumptionCredit()](#getConsumptionCredit--) | Ottiene il credito di consumo |
+| [getConsumptionQuantity()](#getConsumptionQuantity--) | Ottiene la dimensione del file di consumo |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setMeteredKey(String publicKey, String privateKey)](#setMeteredKey-java.lang.String-java.lang.String-) | Imposta la chiave pubblica e privata a consumo |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Metered() {#Metered--}
+```
+public Metered()
+```
+
+
+Inizializza una nuova istanza di questa classe.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConsumptionCredit() {#getConsumptionCredit--}
+```
+public static double getConsumptionCredit()
+```
+
+
+Ottiene il credito di consumo
+
+**Returns:**
+double - quantità di consumo
+### getConsumptionQuantity() {#getConsumptionQuantity--}
+```
+public static double getConsumptionQuantity()
+```
+
+
+Ottiene la dimensione del file di consumo
+
+**Returns:**
+double - quantità di consumo
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setMeteredKey(String publicKey, String privateKey) {#setMeteredKey-java.lang.String-java.lang.String-}
+```
+public void setMeteredKey(String publicKey, String privateKey)
+```
+
+
+Imposta la chiave pubblica e privata a consumo
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| publicKey | java.lang.String | chiave pubblica |
+| privateKey | java.lang.String | chiave privata |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/metriclist/_index.md
+++ b/italian/java/com.aspose.font/metriclist/_index.md
@@ -1,0 +1,162 @@
+---
+title: "TtfHmtxTable.MetricList"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'elenco delle metriche"
+type: docs
+weight: 11
+url: /it/java/com.aspose.font/ttfhmtxtable.metriclist/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static class TtfHmtxTable.MetricList
+```
+
+Rappresenta l'elenco delle metriche
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int glyphIndex)](#get-int-) | Ottiene le metriche per indice glifo. |
+| [getClass()](#getClass--) |  |
+| [getRawList()](#getRawList--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [size()](#size--) | Ottiene il conteggio delle metriche. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int glyphIndex) {#get-int-}
+```
+public TtfHmtxTable.LongHorMetric get(int glyphIndex)
+```
+
+
+Ottiene le metriche per indice glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphIndex | int | Indice glifo per cui ottenere le metriche. |
+
+**Returns:**
+[LongHorMetric](../../com.aspose.font/longhormetric) - Metrics record.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getRawList() {#getRawList--}
+```
+public System.Collections.Generic.List<TtfHmtxTable.LongHorMetric> getRawList()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List<com.aspose.font.TtfHmtxTable.LongHorMetric>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+Ottiene il conteggio delle metriche.
+
+**Returns:**
+int - Conteggio metriche.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/moveto/_index.md
+++ b/italian/java/com.aspose.font/moveto/_index.md
@@ -1,0 +1,200 @@
+---
+title: "MoveTo"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'operazione MoveTo."
+type: docs
+weight: 65
+url: /it/java/com.aspose.font/moveto/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IPathSegment](../../com.aspose.font/ipathsegment)
+```
+public class MoveTo implements IPathSegment
+```
+
+Rappresenta l'operazione MoveTo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clone()](#clone--) | Crea un nuovo oggetto che è una copia dell'istanza corrente. |
+| [copy()](#copy--) | Crea una copia dell'oggetto segmento. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getX()](#getX--) | Restituisce la coordinata x. |
+| [getY()](#getY--) | Restituisce la coordinata y. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [shift(double dx, double dy)](#shift-double-double-) | Esegue lo spostamento per le coordinate x e y. |
+| [toString()](#toString--) |  |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Trasforma le coordinate con la matrice di trasformazione. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Crea un nuovo oggetto che è una copia dell'istanza corrente.
+
+**Returns:**
+java.lang.Object - Un nuovo oggetto che è una copia di questa istanza.
+### copy() {#copy--}
+```
+public IPathSegment copy()
+```
+
+
+Crea una copia dell'oggetto segmento.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getX() {#getX--}
+```
+public double getX()
+```
+
+
+Restituisce la coordinata x.
+
+**Returns:**
+double - Coordinata x.
+### getY() {#getY--}
+```
+public double getY()
+```
+
+
+Restituisce la coordinata y.
+
+**Returns:**
+double - Coordinata y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public void shift(double dx, double dy)
+```
+
+
+Esegue lo spostamento per le coordinate x e y.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| dx | double | Valore dx. |
+| dy | double | Valore dy. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public void transform(TransformationMatrix matrix)
+```
+
+
+Trasforma le coordinate con la matrice di trasformazione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrice di trasformazione. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/mslanguageid/_index.md
+++ b/italian/java/com.aspose.font/mslanguageid/_index.md
@@ -1,0 +1,1984 @@
+---
+title: "MSLanguageId"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Enumerazione degli ID lingua della piattaforma Microsoft."
+type: docs
+weight: 62
+url: /it/java/com.aspose.font/mslanguageid/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class MSLanguageId
+```
+
+Enumerazione degli ID lingua della piattaforma Microsoft.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [Afrikaans](#Afrikaans) | Afrikaans (Regione: Sud Africa, SA) valore LanguageId |
+| [Albanian](#Albanian) | Albanese (Regione: Albania, SQI) valore LanguageId |
+| [Alsatian](#Alsatian) | Alsaziano (Regione: Francia) valore LanguageId |
+| [Amharic](#Amharic) | Amarico (Regione: Etiopia) valore LanguageId |
+| [Arabic_Algeria](#Arabic-Algeria) | Arabo (Regione: Algeria) valore LanguageId |
+| [Arabic_Bahrain](#Arabic-Bahrain) | Arabo (Regione: Bahrain) valore LanguageId |
+| [Arabic_Egypt](#Arabic-Egypt) | Arabo (Regione: Egitto) valore LanguageId |
+| [Arabic_Iraq](#Arabic-Iraq) | Arabo (Regione: Iraq) valore LanguageId |
+| [Arabic_Jordan](#Arabic-Jordan) | Arabo (Regione: Giordania) valore LanguageId |
+| [Arabic_Kuwait](#Arabic-Kuwait) | Arabo (Regione: Kuwait) valore LanguageId |
+| [Arabic_Lebanon](#Arabic-Lebanon) | Arabo (Regione: Libano) valore LanguageId |
+| [Arabic_Libya](#Arabic-Libya) | Arabo (Regione: Libia) valore LanguageId |
+| [Arabic_Morocco](#Arabic-Morocco) | Arabo (Regione: Marocco) valore LanguageId |
+| [Arabic_Oman](#Arabic-Oman) | Arabo (Regione: Oman) valore LanguageId |
+| [Arabic_Qatar](#Arabic-Qatar) | Arabo (Regione: Qatar) valore LanguageId |
+| [Arabic_Saudi_Arabia](#Arabic-Saudi-Arabia) | Arabo (Regione: Arabia Saudita) valore LanguageId |
+| [Arabic_Syria](#Arabic-Syria) | Arabo (Regione: Siria) valore LanguageId |
+| [Arabic_Tunisia](#Arabic-Tunisia) | Arabo (Regione: Tunisia) valore LanguageId |
+| [Arabic_U_A_E](#Arabic-U-A-E) | Arabo (Regione: U.A.E.) |
+| [Arabic_Yemen](#Arabic-Yemen) | Arabo (Regione: Yemen) valore LanguageId |
+| [Armenian](#Armenian) | Armeno (Regione: Armenia) valore LanguageId |
+| [Assamese](#Assamese) | Assamese (Regione: India) valore LanguageId |
+| [Azeri_Cyrillic](#Azeri-Cyrillic) | Azero (Cirillico, Regione: Azerbaigian) valore LanguageId |
+| [Azeri_Latin](#Azeri-Latin) | Azero (Latino, Regione: Azerbaigian) valore LanguageId |
+| [Bashkir](#Bashkir) | Bashkir (Regione: Russia) valore LanguageId |
+| [Basque](#Basque) | Basco (Regione: Paesi Baschi, EUQ) valore LanguageId |
+| [Belarusian](#Belarusian) | Bielorusso (Regione: Belarus, BEL) valore LanguageId |
+| [Bengali_Bangladesh](#Bengali-Bangladesh) | Bengalese (Regione: Bangladesh) valore LanguageId |
+| [Bengali_India](#Bengali-India) | Bengalese (Regione: India) valore LanguageId |
+| [Bosnian_Cyrillic](#Bosnian-Cyrillic) | Bosniaco (Cirillico, Regione: Bosnia ed Erzegovina) valore LanguageId |
+| [Bosnian_Latin](#Bosnian-Latin) | Bosniaco (Latino, Regione: Bosnia ed Erzegovina) valore LanguageId |
+| [Breton](#Breton) | Bretone (Regione: Francia) valore LanguageId |
+| [Bulgarian](#Bulgarian) | Bulgaro (Regione: Bulgaria, BGR) valore LanguageId |
+| [Catalan](#Catalan) | Catalano (Regione: Catalan, CAT) valore LanguageId |
+| [Chinese_Hong_Kong](#Chinese-Hong-Kong) | Cinese (Regione: Hong Kong S.A.R.) |
+| [Chinese_Macao](#Chinese-Macao) | Cinese (Regione: Macao S.A.R.) |
+| [Chinese_PRC](#Chinese-PRC) | Cinese (Regione: Repubblica Popolare Cinese) valore LanguageId |
+| [Chinese_Singapore](#Chinese-Singapore) | Cinese (Regione: Singapore) valore LanguageId |
+| [Chinese_Taiwan](#Chinese-Taiwan) | Cinese (Regione: Taiwan) valore LanguageId |
+| [Corsican](#Corsican) | Corso (Regione: Francia) valore LanguageId |
+| [Croatian](#Croatian) | Croato (Regione: Croazia, SHL) valore LanguageId |
+| [Croatian_Latin](#Croatian-Latin) | Croato (Latino, Regione: Bosnia ed Erzegovina) valore LanguageId |
+| [Czech](#Czech) | Ceco (Regione: Repubblica Ceca, CSY) valore LanguageId |
+| [Danish](#Danish) | Danese (Regione: Danimarca, DAN) valore LanguageId |
+| [Dari](#Dari) | Dari (Regione: Afghanistan) valore LanguageId |
+| [Divehi](#Divehi) | Divehi (Regione: Maldive) valore LanguageId |
+| [Dutch_Belgium](#Dutch-Belgium) | Olandese (Fiammingo, Regione: Belgio, NLB) valore LanguageId |
+| [Dutch_Netherlands](#Dutch-Netherlands) | Olandese (Standard, Regione: Paesi Bassi, NLD) valore LanguageId |
+| [English_Australia](#English-Australia) | Inglese (Australiano, Regione: Australia, ENA) valore LanguageId |
+| [English_Belize](#English-Belize) | Inglese (Regione: Belize) valore LanguageId |
+| [English_Canada](#English-Canada) | Inglese (Canadese, Regione: Canada, ENC) valore LanguageId |
+| [English_Caribbean](#English-Caribbean) | Inglese (Regione: Caribbean) valore LanguageId |
+| [English_India](#English-India) | Inglese (Regione: India) valore LanguageId |
+| [English_Ireland](#English-Ireland) | Inglese (Regione: Irlanda, ENI) valore LanguageId |
+| [English_Jamaica](#English-Jamaica) | Inglese (Regione: Giamaica) valore LanguageId |
+| [English_Malaysia](#English-Malaysia) | Inglese (Regione: Malesia) valore LanguageId |
+| [English_New_Zealand](#English-New-Zealand) | Inglese (Regione: Nuova Zelanda, ENZ) valore LanguageId |
+| [English_ROP](#English-ROP) | Inglese (Regione: Repubblica delle Filippine, ROP) valore LanguageId |
+| [English_Singapore](#English-Singapore) | Inglese (Regione: Singapore) valore LanguageId |
+| [English_South_Africa](#English-South-Africa) | Inglese (Regione: Sudafrica, SA) valore LanguageId |
+| [English_TT](#English-TT) | Inglese (Regione: Trinidad e Tobago, TT) valore LanguageId |
+| [English_United_Kingdom](#English-United-Kingdom) | Inglese (Britannico, Regione: Regno Unito, ENG) valore LanguageId |
+| [English_United_States](#English-United-States) | Inglese (Americano, Regione: Stati Uniti, ENU) valore LanguageId |
+| [English_Zimbabwe](#English-Zimbabwe) | Inglese (Regione: Zimbabwe) valore LanguageId |
+| [Estonian](#Estonian) | Estone (Regione: Estonia, ETI) valore LanguageId |
+| [Faroese](#Faroese) | Faroese (Regione: Isole Faroe) valore LanguageId |
+| [Filipino](#Filipino) | Filippino (Regione: Filippine) valore LanguageId |
+| [Finnish](#Finnish) | Finlandese (Regione: Finlandia, FIN) valore LanguageId |
+| [French_Belgium](#French-Belgium) | Francese (Belga, Regione: Belgio, FRB) valore LanguageId |
+| [French_Canada](#French-Canada) | Francese (Canadese, Regione: Canada, FRC) valore LanguageId |
+| [French_France](#French-France) | Francese (Standard, Regione: Francia, FRA) valore LanguageId |
+| [French_Luxembourg](#French-Luxembourg) | Francese (Regione: Lussemburgo, FRL) valore LanguageId |
+| [French_MC](#French-MC) | Francese (Regione: Principato di Monaco, MC) valore LanguageId |
+| [French_Switzerland](#French-Switzerland) | Francese (Svizzero, Regione: Svizzera, FRS) valore LanguageId |
+| [Frisian](#Frisian) | Frisone (Regione: Paesi Bassi, NLD) valore LanguageId |
+| [Galician](#Galician) | Galiziano (Regione: Galizia) valore LanguageId |
+| [Georgian](#Georgian) | Georgiano (Regione: Georgia) LanguageId value |
+| [German_Austria](#German-Austria) | Tedesco (Austriaco, Regione: Austria, DEA) LanguageId value |
+| [German_Germany](#German-Germany) | Tedesco (Standard, Regione: Germania, DEU) LanguageId value |
+| [German_Liechtenstein](#German-Liechtenstein) | Tedesco (Regione: Liechtenstein, DEC) LanguageId value |
+| [German_Luxembourg](#German-Luxembourg) | Tedesco (Regione: Lussemburgo, DEL) LanguageId value |
+| [German_Switzerland](#German-Switzerland) | Tedesco (Svizzero, Regione: Svizzera, DES) LanguageId value |
+| [Greek](#Greek) | Greco (Regione: Grecia, ELL) LanguageId value |
+| [Greenlandic](#Greenlandic) | Groenlandese (Regione: Groenlandia) LanguageId value |
+| [Gujarati](#Gujarati) | Gujarati (Regione: India) LanguageId value |
+| [Hausa](#Hausa) | Hausa (Latino, Regione: Nigeria) LanguageId value |
+| [Hebrew](#Hebrew) | Ebraico (Regione: Israele) LanguageId value |
+| [Hindi](#Hindi) | Hindi (Regione: India) LanguageId value |
+| [Hungarian](#Hungarian) | Ungherese (Regione: Ungheria, HUN) LanguageId value |
+| [Icelandic](#Icelandic) | Islandese (Regione: Islanda, ISL) LanguageId value |
+| [Igbo](#Igbo) | Igbo (Regione: Nigeria) LanguageId value |
+| [Indonesian](#Indonesian) | Indonesiano (Regione: Indonesia) LanguageId value |
+| [Inuktitut](#Inuktitut) | Inuktitut (Regione: Canada) LanguageId value |
+| [Inuktitut_Latin](#Inuktitut-Latin) | Inuktitut (Latino, Regione: Canada) LanguageId value |
+| [Irish](#Irish) | Irlandese (Regione: Irlanda) LanguageId value |
+| [Italian_Italy](#Italian-Italy) | Italiano (Standard, Regione: Italia, ITA) LanguageId value |
+| [Italian_Switzerland](#Italian-Switzerland) | Italiano (Svizzero, Regione: Svizzera, ITS) LanguageId value |
+| [Japanese](#Japanese) | Giapponese (Regione: Giappone) LanguageId value |
+| [Kannada](#Kannada) | Kannada (Regione: India) LanguageId value |
+| [Kazakh](#Kazakh) | Kazako (Regione: Kazakistan) LanguageId value |
+| [Khmer](#Khmer) | Khmer (Regione: Cambogia) LanguageId value |
+| [Kiche](#Kiche) | K\u2019iche (Regione: Guatemala) valore LanguageId |
+| [Kinyarwanda](#Kinyarwanda) | Kinyarwanda (Regione: Rwanda) valore LanguageId |
+| [Kiswahili](#Kiswahili) | Kiswahili (Regione: Kenya) valore LanguageId |
+| [Konkani](#Konkani) | Konkani (Regione: India) valore LanguageId |
+| [Korean](#Korean) | Korean (Regione: Corea) valore LanguageId |
+| [Kyrgyz](#Kyrgyz) | Kyrgyz (Regione: Kirghizistan) valore LanguageId |
+| [Lao](#Lao) | Lao (Regione: Lao P.D.R.) |
+| [Latvian](#Latvian) | Latvian (Regione: Lettonia, LVI) valore LanguageId |
+| [Lithuanian](#Lithuanian) | Lithuanian (Regione: Lituania, LTH) valore LanguageId |
+| [Lower_Sorbian](#Lower-Sorbian) | Lower Sorbian (Regione: Germania) valore LanguageId |
+| [Luxembourgish](#Luxembourgish) | Luxembourgish (Regione: Lussemburgo) valore LanguageId |
+| [Macedonian](#Macedonian) | Macedonian (Regione: Macedonia del Nord) valore LanguageId |
+| [Malay_Brunei_Darussalam](#Malay-Brunei-Darussalam) | Malay (Regione: Brunei Darussalam) valore LanguageId |
+| [Malay_Malaysia](#Malay-Malaysia) | Malay (Regione: Malesia) valore LanguageId |
+| [Malayalam](#Malayalam) | Malayalam (Regione: India) valore LanguageId |
+| [Maltese](#Maltese) | Maltese (Regione: Malta) valore LanguageId |
+| [Maori](#Maori) | Maori (Regione: Nuova Zelanda) valore LanguageId |
+| [Mapudungun](#Mapudungun) | Mapudungun (Regione: Cile) valore LanguageId |
+| [Marathi](#Marathi) | Marathi (Regione: India) valore LanguageId |
+| [Mohawk](#Mohawk) | Mohawk (Regione: Mohawk) valore LanguageId |
+| [Mongolian_Cyrillic](#Mongolian-Cyrillic) | Mongolian (Cirillico, Regione: Mongolia) valore LanguageId |
+| [Mongolian_Traditional](#Mongolian-Traditional) | Mongolian (Tradizionale, Regione: People\u2019s Republic of China) valore LanguageId |
+| [Nepali](#Nepali) | Nepali (Regione: Nepal) valore LanguageId |
+| [Norwegian_Bokmal](#Norwegian-Bokmal) | Norwegian (Bokmal, Regione: Norvegia, NOR) valore LanguageId |
+| [Norwegian_Nynorsk](#Norwegian-Nynorsk) | Norwegian (Nynorsk, Regione: Norvegia, NON) valore LanguageId |
+| [Occitan](#Occitan) | Occitano (Regione: Francia) valore LanguageId |
+| [Odia](#Odia) | Odia (precedentemente Oriya, Regione: India) valore LanguageId |
+| [Pashto](#Pashto) | Pashto (Regione: Afghanistan) valore LanguageId |
+| [Polish](#Polish) | Polacco (Regione: Polonia, PLK) valore LanguageId |
+| [Portuguese_Brazil](#Portuguese-Brazil) | Portoghese (Brasiliano, Regione: Brasile, PTB) valore LanguageId |
+| [Portuguese_Portugal](#Portuguese-Portugal) | Portoghese (Standard, Regione: Portogallo, PTG) valore LanguageId |
+| [Punjabi](#Punjabi) | Punjabi (Regione: India) valore LanguageId |
+| [Quechua_Bolivia](#Quechua-Bolivia) | Quechua (Regione: Bolivia) valore LanguageId |
+| [Quechua_Ecuador](#Quechua-Ecuador) | Quechua (Regione: Ecuador) valore LanguageId |
+| [Quechua_Peru](#Quechua-Peru) | Quechua (Regione: Perù) valore LanguageId |
+| [Romanian](#Romanian) | Rumeno (Regione: Romania, ROM) valore LanguageId |
+| [Romansh](#Romansh) | Romancio (Regione: Svizzera) valore LanguageId |
+| [Russian](#Russian) | Russo (Regione: Russia, RUS) valore LanguageId |
+| [Sami_Inari](#Sami-Inari) | Sami (Inari, Regione: Finlandia) valore LanguageId |
+| [Sami_Lule_Norway](#Sami-Lule-Norway) | Sami (Lule, Regione: Norvegia) valore LanguageId |
+| [Sami_Lule_Sweden](#Sami-Lule-Sweden) | Sami (Lule, Regione: Svezia) valore LanguageId |
+| [Sami_Northern_Finland](#Sami-Northern-Finland) | Sami (Settentrionale, Regione: Finlandia) valore LanguageId |
+| [Sami_Northern_Norway](#Sami-Northern-Norway) | Sami (Settentrionale, Regione: Norvegia) valore LanguageId |
+| [Sami_Northern_Sweden](#Sami-Northern-Sweden) | Sami (Settentrionale, Regione: Svezia) valore LanguageId |
+| [Sami_Skolt](#Sami-Skolt) | Sami (Skolt, Regione: Finlandia) valore LanguageId |
+| [Sami_Southern_Norway](#Sami-Southern-Norway) | Sami (Meridionale, Regione: Norvegia) valore LanguageId |
+| [Sami_Southern_Sweden](#Sami-Southern-Sweden) | Sami (Meridionale, Regione: Svezia) valore LanguageId |
+| [Sanskrit](#Sanskrit) | Sanskrit (Regione: India) valore LanguageId |
+| [Serbian_Cyrillic_BIH](#Serbian-Cyrillic-BIH) | Serbo (Cirillico, Regione: Bosnia ed Erzegovina) valore LanguageId |
+| [Serbian_Cyrillic_Serbia](#Serbian-Cyrillic-Serbia) | Serbo (Cirillico, Regione: Serbia) valore LanguageId |
+| [Serbian_Latin_BIH](#Serbian-Latin-BIH) | Serbo (latino, Regione: Bosnia ed Erzegovina) valore LanguageId |
+| [Serbian_Latin_Serbia](#Serbian-Latin-Serbia) | Serbo (latino, Regione: Serbia) valore LanguageId |
+| [Sesotho_Sa_Leboa](#Sesotho-Sa-Leboa) | Sesotho sa Leboa (Sotho del Nord, Regione: Sudafrica, SA) valore LanguageId |
+| [Setswana](#Setswana) | Setswana (Regione: Sudafrica, SA) valore LanguageId |
+| [Sinhala](#Sinhala) | Singalese (Regione: Sri Lanka) valore LanguageId |
+| [Slovak](#Slovak) | Slovacco (Regione: Slovacchia, SKY) valore LanguageId |
+| [Slovenian](#Slovenian) | Sloveno (Regione: Slovenia, SLV) valore LanguageId |
+| [Spanish_Argentina](#Spanish-Argentina) | Spagnolo (Regione: Argentina) valore LanguageId |
+| [Spanish_Bolivia](#Spanish-Bolivia) | Spagnolo (Regione: Bolivia) valore LanguageId |
+| [Spanish_Chile](#Spanish-Chile) | Spagnolo (Regione: Cile) valore LanguageId |
+| [Spanish_Colombia](#Spanish-Colombia) | Spagnolo (Regione: Colombia) valore LanguageId |
+| [Spanish_Costa_Rica](#Spanish-Costa-Rica) | Spagnolo (Regione: Costa Rica) valore LanguageId |
+| [Spanish_Dominican_Republic](#Spanish-Dominican-Republic) | Spagnolo (Regione: Repubblica Dominicana) valore LanguageId |
+| [Spanish_Ecuador](#Spanish-Ecuador) | Spagnolo (Regione: Ecuador) valore LanguageId |
+| [Spanish_El_Salvador](#Spanish-El-Salvador) | Spagnolo (Regione: El Salvador) valore LanguageId |
+| [Spanish_Guatemala](#Spanish-Guatemala) | Spagnolo (Regione: Guatemala) valore LanguageId |
+| [Spanish_Honduras](#Spanish-Honduras) | Spagnolo (Regione: Honduras) valore LanguageId |
+| [Spanish_Mexico](#Spanish-Mexico) | Spagnolo (messicano, Regione: Messico, ESM) valore LanguageId |
+| [Spanish_Modern_Sort](#Spanish-Modern-Sort) | Spagnolo (ordinamento moderno, Regione: Spagna, ESN) valore LanguageId |
+| [Spanish_Nicaragua](#Spanish-Nicaragua) | Spagnolo (Regione: Nicaragua) valore LanguageId |
+| [Spanish_Panama](#Spanish-Panama) | Spagnolo (Regione: Panama) valore LanguageId |
+| [Spanish_Paraguay](#Spanish-Paraguay) | Spagnolo (Regione: Paraguay) valore LanguageId |
+| [Spanish_Peru](#Spanish-Peru) | Spagnolo (Regione: Perù) valore LanguageId |
+| [Spanish_Puerto_Rico](#Spanish-Puerto-Rico) | Spagnolo (Regione: Porto Rico) valore LanguageId |
+| [Spanish_Traditional_Sort](#Spanish-Traditional-Sort) | Spagnolo (ordinamento tradizionale, Regione: Spagna, ESP) valore LanguageId |
+| [Spanish_United_States](#Spanish-United-States) | Spagnolo (Regione: Stati Uniti) valore LanguageId |
+| [Spanish_Uruguay](#Spanish-Uruguay) | Spagnolo (Regione: Uruguay) valore LanguageId |
+| [Spanish_Venezuela](#Spanish-Venezuela) | Spagnolo (Regione: Venezuela) valore LanguageId |
+| [Swedish_Finland](#Swedish-Finland) | Svedese (Regione: Finlandia) valore LanguageId |
+| [Swedish_Sweden](#Swedish-Sweden) | Svedese (Regione: Svezia, SVE) valore LanguageId |
+| [Syriac](#Syriac) | Siriano (Regione: Siria) valore LanguageId |
+| [Tajik](#Tajik) | Tagico (Cirillico, Regione: Tagikistan) valore LanguageId |
+| [Tamazight](#Tamazight) | Tamazight (Latino, Regione: Algeria) valore LanguageId |
+| [Tamil](#Tamil) | Tamil (Regione: India) valore LanguageId |
+| [Tatar](#Tatar) | Tatar (Regione: Russia) valore LanguageId |
+| [Telugu](#Telugu) | Telugu (Regione: India) valore LanguageId |
+| [Thai](#Thai) | Thai (Regione: Thailandia) valore LanguageId |
+| [Tibetan](#Tibetan) | Tibetano (Regione: RPC) valore LanguageId |
+| [Turkish](#Turkish) | Turco (Regione: Turchia, TRK) valore LanguageId |
+| [Turkmen](#Turkmen) | Turkmeno (Regione: Turkmenistan) valore LanguageId |
+| [Uighur](#Uighur) | Uiguro (Regione: RPC) valore LanguageId |
+| [Ukrainian](#Ukrainian) | Ucraino (Regione: Ucraina, UKR) valore LanguageId |
+| [Upper_Sorbian](#Upper-Sorbian) | Sorabo Superiore (Regione: Germania) valore LanguageId |
+| [Urdu](#Urdu) | Urdu (Regione: Repubblica Islamica del Pakistan) valore LanguageId |
+| [Uzbek_Cyrillic](#Uzbek-Cyrillic) | Uzbeko (Cirillico, Regione: Uzbekistan) valore LanguageId |
+| [Uzbek_Latin](#Uzbek-Latin) | Uzbeko (Latino, Regione: Uzbekistan) valore LanguageId |
+| [Vietnamese](#Vietnamese) | Vietnamita (Regione: Vietnam) valore LanguageId |
+| [Welsh](#Welsh) | Gallese (Regione: Regno Unito) valore LanguageId |
+| [Wolof](#Wolof) | Wolof (Regione: Senegal) valore LanguageId |
+| [Yakut](#Yakut) | Yakut (Regione: Russia) valore LanguageId |
+| [Yi](#Yi) | Yi (Regione: RPC) valore LanguageId |
+| [Yoruba](#Yoruba) | Yoruba (Regione: Nigeria) valore LanguageId |
+| [isiXhosa](#isiXhosa) | isiXhosa (Regione: Sudafrica, SA) valore LanguageId |
+| [isiZulu](#isiZulu) | isiZulu (Regione: Sudafrica, SA) valore LanguageId |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getId()](#getId--) | Ottieni il valore intero. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Afrikaans {#Afrikaans}
+```
+public static final MSLanguageId Afrikaans
+```
+
+
+Afrikaans (Regione: Sud Africa, SA) valore LanguageId
+
+### Albanian {#Albanian}
+```
+public static final MSLanguageId Albanian
+```
+
+
+Albanese (Regione: Albania, SQI) valore LanguageId
+
+### Alsatian {#Alsatian}
+```
+public static final MSLanguageId Alsatian
+```
+
+
+Alsaziano (Regione: Francia) valore LanguageId
+
+### Amharic {#Amharic}
+```
+public static final MSLanguageId Amharic
+```
+
+
+Amarico (Regione: Etiopia) valore LanguageId
+
+### Arabic_Algeria {#Arabic-Algeria}
+```
+public static final MSLanguageId Arabic_Algeria
+```
+
+
+Arabo (Regione: Algeria) valore LanguageId
+
+### Arabic_Bahrain {#Arabic-Bahrain}
+```
+public static final MSLanguageId Arabic_Bahrain
+```
+
+
+Arabo (Regione: Bahrain) valore LanguageId
+
+### Arabic_Egypt {#Arabic-Egypt}
+```
+public static final MSLanguageId Arabic_Egypt
+```
+
+
+Arabo (Regione: Egitto) valore LanguageId
+
+### Arabic_Iraq {#Arabic-Iraq}
+```
+public static final MSLanguageId Arabic_Iraq
+```
+
+
+Arabo (Regione: Iraq) valore LanguageId
+
+### Arabic_Jordan {#Arabic-Jordan}
+```
+public static final MSLanguageId Arabic_Jordan
+```
+
+
+Arabo (Regione: Giordania) valore LanguageId
+
+### Arabic_Kuwait {#Arabic-Kuwait}
+```
+public static final MSLanguageId Arabic_Kuwait
+```
+
+
+Arabo (Regione: Kuwait) valore LanguageId
+
+### Arabic_Lebanon {#Arabic-Lebanon}
+```
+public static final MSLanguageId Arabic_Lebanon
+```
+
+
+Arabo (Regione: Libano) valore LanguageId
+
+### Arabic_Libya {#Arabic-Libya}
+```
+public static final MSLanguageId Arabic_Libya
+```
+
+
+Arabo (Regione: Libia) valore LanguageId
+
+### Arabic_Morocco {#Arabic-Morocco}
+```
+public static final MSLanguageId Arabic_Morocco
+```
+
+
+Arabo (Regione: Marocco) valore LanguageId
+
+### Arabic_Oman {#Arabic-Oman}
+```
+public static final MSLanguageId Arabic_Oman
+```
+
+
+Arabo (Regione: Oman) valore LanguageId
+
+### Arabic_Qatar {#Arabic-Qatar}
+```
+public static final MSLanguageId Arabic_Qatar
+```
+
+
+Arabo (Regione: Qatar) valore LanguageId
+
+### Arabic_Saudi_Arabia {#Arabic-Saudi-Arabia}
+```
+public static final MSLanguageId Arabic_Saudi_Arabia
+```
+
+
+Arabo (Regione: Arabia Saudita) valore LanguageId
+
+### Arabic_Syria {#Arabic-Syria}
+```
+public static final MSLanguageId Arabic_Syria
+```
+
+
+Arabo (Regione: Siria) valore LanguageId
+
+### Arabic_Tunisia {#Arabic-Tunisia}
+```
+public static final MSLanguageId Arabic_Tunisia
+```
+
+
+Arabo (Regione: Tunisia) valore LanguageId
+
+### Arabic_U_A_E {#Arabic-U-A-E}
+```
+public static final MSLanguageId Arabic_U_A_E
+```
+
+
+Arabo (Regione: U.A.E.) valore LanguageId
+
+### Arabic_Yemen {#Arabic-Yemen}
+```
+public static final MSLanguageId Arabic_Yemen
+```
+
+
+Arabo (Regione: Yemen) valore LanguageId
+
+### Armenian {#Armenian}
+```
+public static final MSLanguageId Armenian
+```
+
+
+Armeno (Regione: Armenia) valore LanguageId
+
+### Assamese {#Assamese}
+```
+public static final MSLanguageId Assamese
+```
+
+
+Assamese (Regione: India) valore LanguageId
+
+### Azeri_Cyrillic {#Azeri-Cyrillic}
+```
+public static final MSLanguageId Azeri_Cyrillic
+```
+
+
+Azero (Cirillico, Regione: Azerbaigian) valore LanguageId
+
+### Azeri_Latin {#Azeri-Latin}
+```
+public static final MSLanguageId Azeri_Latin
+```
+
+
+Azero (Latino, Regione: Azerbaigian) valore LanguageId
+
+### Bashkir {#Bashkir}
+```
+public static final MSLanguageId Bashkir
+```
+
+
+Bashkir (Regione: Russia) valore LanguageId
+
+### Basque {#Basque}
+```
+public static final MSLanguageId Basque
+```
+
+
+Basco (Regione: Paesi Baschi, EUQ) valore LanguageId
+
+### Belarusian {#Belarusian}
+```
+public static final MSLanguageId Belarusian
+```
+
+
+Bielorusso (Regione: Belarus, BEL) valore LanguageId
+
+### Bengali_Bangladesh {#Bengali-Bangladesh}
+```
+public static final MSLanguageId Bengali_Bangladesh
+```
+
+
+Bengalese (Regione: Bangladesh) valore LanguageId
+
+### Bengali_India {#Bengali-India}
+```
+public static final MSLanguageId Bengali_India
+```
+
+
+Bengalese (Regione: India) valore LanguageId
+
+### Bosnian_Cyrillic {#Bosnian-Cyrillic}
+```
+public static final MSLanguageId Bosnian_Cyrillic
+```
+
+
+Bosniaco (Cirillico, Regione: Bosnia ed Erzegovina) valore LanguageId
+
+### Bosnian_Latin {#Bosnian-Latin}
+```
+public static final MSLanguageId Bosnian_Latin
+```
+
+
+Bosniaco (Latino, Regione: Bosnia ed Erzegovina) valore LanguageId
+
+### Breton {#Breton}
+```
+public static final MSLanguageId Breton
+```
+
+
+Bretone (Regione: Francia) valore LanguageId
+
+### Bulgarian {#Bulgarian}
+```
+public static final MSLanguageId Bulgarian
+```
+
+
+Bulgaro (Regione: Bulgaria, BGR) valore LanguageId
+
+### Catalan {#Catalan}
+```
+public static final MSLanguageId Catalan
+```
+
+
+Catalano (Regione: Catalan, CAT) valore LanguageId
+
+### Chinese_Hong_Kong {#Chinese-Hong-Kong}
+```
+public static final MSLanguageId Chinese_Hong_Kong
+```
+
+
+Cinese (Regione: Hong Kong S.A.R.) valore LanguageId
+
+### Chinese_Macao {#Chinese-Macao}
+```
+public static final MSLanguageId Chinese_Macao
+```
+
+
+Cinese (Regione: Macao S.A.R.) valore LanguageId
+
+### Chinese_PRC {#Chinese-PRC}
+```
+public static final MSLanguageId Chinese_PRC
+```
+
+
+Cinese (Regione: Repubblica Popolare Cinese) valore LanguageId
+
+### Chinese_Singapore {#Chinese-Singapore}
+```
+public static final MSLanguageId Chinese_Singapore
+```
+
+
+Cinese (Regione: Singapore) valore LanguageId
+
+### Chinese_Taiwan {#Chinese-Taiwan}
+```
+public static final MSLanguageId Chinese_Taiwan
+```
+
+
+Cinese (Regione: Taiwan) valore LanguageId
+
+### Corsican {#Corsican}
+```
+public static final MSLanguageId Corsican
+```
+
+
+Corso (Regione: Francia) valore LanguageId
+
+### Croatian {#Croatian}
+```
+public static final MSLanguageId Croatian
+```
+
+
+Croato (Regione: Croazia, SHL) valore LanguageId
+
+### Croatian_Latin {#Croatian-Latin}
+```
+public static final MSLanguageId Croatian_Latin
+```
+
+
+Croato (Latino, Regione: Bosnia ed Erzegovina) valore LanguageId
+
+### Czech {#Czech}
+```
+public static final MSLanguageId Czech
+```
+
+
+Ceco (Regione: Repubblica Ceca, CSY) valore LanguageId
+
+### Danish {#Danish}
+```
+public static final MSLanguageId Danish
+```
+
+
+Danese (Regione: Danimarca, DAN) valore LanguageId
+
+### Dari {#Dari}
+```
+public static final MSLanguageId Dari
+```
+
+
+Dari (Regione: Afghanistan) valore LanguageId
+
+### Divehi {#Divehi}
+```
+public static final MSLanguageId Divehi
+```
+
+
+Divehi (Regione: Maldive) valore LanguageId
+
+### Dutch_Belgium {#Dutch-Belgium}
+```
+public static final MSLanguageId Dutch_Belgium
+```
+
+
+Olandese (Fiammingo, Regione: Belgio, NLB) valore LanguageId
+
+### Dutch_Netherlands {#Dutch-Netherlands}
+```
+public static final MSLanguageId Dutch_Netherlands
+```
+
+
+Olandese (Standard, Regione: Paesi Bassi, NLD) valore LanguageId
+
+### English_Australia {#English-Australia}
+```
+public static final MSLanguageId English_Australia
+```
+
+
+Inglese (Australiano, Regione: Australia, ENA) valore LanguageId
+
+### English_Belize {#English-Belize}
+```
+public static final MSLanguageId English_Belize
+```
+
+
+Inglese (Regione: Belize) valore LanguageId
+
+### English_Canada {#English-Canada}
+```
+public static final MSLanguageId English_Canada
+```
+
+
+Inglese (Canadese, Regione: Canada, ENC) valore LanguageId
+
+### English_Caribbean {#English-Caribbean}
+```
+public static final MSLanguageId English_Caribbean
+```
+
+
+Inglese (Regione: Caribbean) valore LanguageId
+
+### English_India {#English-India}
+```
+public static final MSLanguageId English_India
+```
+
+
+Inglese (Regione: India) valore LanguageId
+
+### English_Ireland {#English-Ireland}
+```
+public static final MSLanguageId English_Ireland
+```
+
+
+Inglese (Regione: Irlanda, ENI) valore LanguageId
+
+### English_Jamaica {#English-Jamaica}
+```
+public static final MSLanguageId English_Jamaica
+```
+
+
+Inglese (Regione: Giamaica) valore LanguageId
+
+### English_Malaysia {#English-Malaysia}
+```
+public static final MSLanguageId English_Malaysia
+```
+
+
+Inglese (Regione: Malesia) valore LanguageId
+
+### English_New_Zealand {#English-New-Zealand}
+```
+public static final MSLanguageId English_New_Zealand
+```
+
+
+Inglese (Regione: Nuova Zelanda, ENZ) valore LanguageId
+
+### English_ROP {#English-ROP}
+```
+public static final MSLanguageId English_ROP
+```
+
+
+Inglese (Regione: Repubblica delle Filippine, ROP) valore LanguageId
+
+### English_Singapore {#English-Singapore}
+```
+public static final MSLanguageId English_Singapore
+```
+
+
+Inglese (Regione: Singapore) valore LanguageId
+
+### English_South_Africa {#English-South-Africa}
+```
+public static final MSLanguageId English_South_Africa
+```
+
+
+Inglese (Regione: Sudafrica, SA) valore LanguageId
+
+### English_TT {#English-TT}
+```
+public static final MSLanguageId English_TT
+```
+
+
+Inglese (Regione: Trinidad e Tobago, TT) valore LanguageId
+
+### English_United_Kingdom {#English-United-Kingdom}
+```
+public static final MSLanguageId English_United_Kingdom
+```
+
+
+Inglese (Britannico, Regione: Regno Unito, ENG) valore LanguageId
+
+### English_United_States {#English-United-States}
+```
+public static final MSLanguageId English_United_States
+```
+
+
+Inglese (Americano, Regione: Stati Uniti, ENU) valore LanguageId
+
+### English_Zimbabwe {#English-Zimbabwe}
+```
+public static final MSLanguageId English_Zimbabwe
+```
+
+
+Inglese (Regione: Zimbabwe) valore LanguageId
+
+### Estonian {#Estonian}
+```
+public static final MSLanguageId Estonian
+```
+
+
+Estone (Regione: Estonia, ETI) valore LanguageId
+
+### Faroese {#Faroese}
+```
+public static final MSLanguageId Faroese
+```
+
+
+Faroese (Regione: Isole Faroe) valore LanguageId
+
+### Filipino {#Filipino}
+```
+public static final MSLanguageId Filipino
+```
+
+
+Filippino (Regione: Filippine) valore LanguageId
+
+### Finnish {#Finnish}
+```
+public static final MSLanguageId Finnish
+```
+
+
+Finlandese (Regione: Finlandia, FIN) valore LanguageId
+
+### French_Belgium {#French-Belgium}
+```
+public static final MSLanguageId French_Belgium
+```
+
+
+Francese (Belga, Regione: Belgio, FRB) valore LanguageId
+
+### French_Canada {#French-Canada}
+```
+public static final MSLanguageId French_Canada
+```
+
+
+Francese (Canadese, Regione: Canada, FRC) valore LanguageId
+
+### French_France {#French-France}
+```
+public static final MSLanguageId French_France
+```
+
+
+Francese (Standard, Regione: Francia, FRA) valore LanguageId
+
+### French_Luxembourg {#French-Luxembourg}
+```
+public static final MSLanguageId French_Luxembourg
+```
+
+
+Francese (Regione: Lussemburgo, FRL) valore LanguageId
+
+### French_MC {#French-MC}
+```
+public static final MSLanguageId French_MC
+```
+
+
+Francese (Regione: Principato di Monaco, MC) valore LanguageId
+
+### French_Switzerland {#French-Switzerland}
+```
+public static final MSLanguageId French_Switzerland
+```
+
+
+Francese (Svizzero, Regione: Svizzera, FRS) valore LanguageId
+
+### Frisian {#Frisian}
+```
+public static final MSLanguageId Frisian
+```
+
+
+Frisone (Regione: Paesi Bassi, NLD) valore LanguageId
+
+### Galician {#Galician}
+```
+public static final MSLanguageId Galician
+```
+
+
+Galiziano (Regione: Galizia) valore LanguageId
+
+### Georgian {#Georgian}
+```
+public static final MSLanguageId Georgian
+```
+
+
+Georgiano (Regione: Georgia) LanguageId value
+
+### German_Austria {#German-Austria}
+```
+public static final MSLanguageId German_Austria
+```
+
+
+Tedesco (Austriaco, Regione: Austria, DEA) LanguageId value
+
+### German_Germany {#German-Germany}
+```
+public static final MSLanguageId German_Germany
+```
+
+
+Tedesco (Standard, Regione: Germania, DEU) LanguageId value
+
+### German_Liechtenstein {#German-Liechtenstein}
+```
+public static final MSLanguageId German_Liechtenstein
+```
+
+
+Tedesco (Regione: Liechtenstein, DEC) LanguageId value
+
+### German_Luxembourg {#German-Luxembourg}
+```
+public static final MSLanguageId German_Luxembourg
+```
+
+
+Tedesco (Regione: Lussemburgo, DEL) LanguageId value
+
+### German_Switzerland {#German-Switzerland}
+```
+public static final MSLanguageId German_Switzerland
+```
+
+
+Tedesco (Svizzero, Regione: Svizzera, DES) LanguageId value
+
+### Greek {#Greek}
+```
+public static final MSLanguageId Greek
+```
+
+
+Greco (Regione: Grecia, ELL) LanguageId value
+
+### Greenlandic {#Greenlandic}
+```
+public static final MSLanguageId Greenlandic
+```
+
+
+Groenlandese (Regione: Groenlandia) LanguageId value
+
+### Gujarati {#Gujarati}
+```
+public static final MSLanguageId Gujarati
+```
+
+
+Gujarati (Regione: India) LanguageId value
+
+### Hausa {#Hausa}
+```
+public static final MSLanguageId Hausa
+```
+
+
+Hausa (Latino, Regione: Nigeria) LanguageId value
+
+### Hebrew {#Hebrew}
+```
+public static final MSLanguageId Hebrew
+```
+
+
+Ebraico (Regione: Israele) LanguageId value
+
+### Hindi {#Hindi}
+```
+public static final MSLanguageId Hindi
+```
+
+
+Hindi (Regione: India) LanguageId value
+
+### Hungarian {#Hungarian}
+```
+public static final MSLanguageId Hungarian
+```
+
+
+Ungherese (Regione: Ungheria, HUN) LanguageId value
+
+### Icelandic {#Icelandic}
+```
+public static final MSLanguageId Icelandic
+```
+
+
+Islandese (Regione: Islanda, ISL) LanguageId value
+
+### Igbo {#Igbo}
+```
+public static final MSLanguageId Igbo
+```
+
+
+Igbo (Regione: Nigeria) LanguageId value
+
+### Indonesian {#Indonesian}
+```
+public static final MSLanguageId Indonesian
+```
+
+
+Indonesiano (Regione: Indonesia) LanguageId value
+
+### Inuktitut {#Inuktitut}
+```
+public static final MSLanguageId Inuktitut
+```
+
+
+Inuktitut (Regione: Canada) LanguageId value
+
+### Inuktitut_Latin {#Inuktitut-Latin}
+```
+public static final MSLanguageId Inuktitut_Latin
+```
+
+
+Inuktitut (Latino, Regione: Canada) LanguageId value
+
+### Irish {#Irish}
+```
+public static final MSLanguageId Irish
+```
+
+
+Irlandese (Regione: Irlanda) LanguageId value
+
+### Italian_Italy {#Italian-Italy}
+```
+public static final MSLanguageId Italian_Italy
+```
+
+
+Italiano (Standard, Regione: Italia, ITA) LanguageId value
+
+### Italian_Switzerland {#Italian-Switzerland}
+```
+public static final MSLanguageId Italian_Switzerland
+```
+
+
+Italiano (Svizzero, Regione: Svizzera, ITS) LanguageId value
+
+### Japanese {#Japanese}
+```
+public static final MSLanguageId Japanese
+```
+
+
+Giapponese (Regione: Giappone) LanguageId value
+
+### Kannada {#Kannada}
+```
+public static final MSLanguageId Kannada
+```
+
+
+Kannada (Regione: India) LanguageId value
+
+### Kazakh {#Kazakh}
+```
+public static final MSLanguageId Kazakh
+```
+
+
+Kazako (Regione: Kazakistan) LanguageId value
+
+### Khmer {#Khmer}
+```
+public static final MSLanguageId Khmer
+```
+
+
+Khmer (Regione: Cambogia) LanguageId value
+
+### Kiche {#Kiche}
+```
+public static final MSLanguageId Kiche
+```
+
+
+K\u2019iche (Regione: Guatemala) valore LanguageId
+
+### Kinyarwanda {#Kinyarwanda}
+```
+public static final MSLanguageId Kinyarwanda
+```
+
+
+Kinyarwanda (Regione: Rwanda) valore LanguageId
+
+### Kiswahili {#Kiswahili}
+```
+public static final MSLanguageId Kiswahili
+```
+
+
+Kiswahili (Regione: Kenya) valore LanguageId
+
+### Konkani {#Konkani}
+```
+public static final MSLanguageId Konkani
+```
+
+
+Konkani (Regione: India) valore LanguageId
+
+### Korean {#Korean}
+```
+public static final MSLanguageId Korean
+```
+
+
+Korean (Regione: Corea) valore LanguageId
+
+### Kyrgyz {#Kyrgyz}
+```
+public static final MSLanguageId Kyrgyz
+```
+
+
+Kyrgyz (Regione: Kirghizistan) valore LanguageId
+
+### Lao {#Lao}
+```
+public static final MSLanguageId Lao
+```
+
+
+Lao (Regione: Lao P.D.R.) valore LanguageId
+
+### Latvian {#Latvian}
+```
+public static final MSLanguageId Latvian
+```
+
+
+Latvian (Regione: Lettonia, LVI) valore LanguageId
+
+### Lithuanian {#Lithuanian}
+```
+public static final MSLanguageId Lithuanian
+```
+
+
+Lithuanian (Regione: Lituania, LTH) valore LanguageId
+
+### Lower_Sorbian {#Lower-Sorbian}
+```
+public static final MSLanguageId Lower_Sorbian
+```
+
+
+Lower Sorbian (Regione: Germania) valore LanguageId
+
+### Luxembourgish {#Luxembourgish}
+```
+public static final MSLanguageId Luxembourgish
+```
+
+
+Luxembourgish (Regione: Lussemburgo) valore LanguageId
+
+### Macedonian {#Macedonian}
+```
+public static final MSLanguageId Macedonian
+```
+
+
+Macedonian (Regione: Macedonia del Nord) valore LanguageId
+
+### Malay_Brunei_Darussalam {#Malay-Brunei-Darussalam}
+```
+public static final MSLanguageId Malay_Brunei_Darussalam
+```
+
+
+Malay (Regione: Brunei Darussalam) valore LanguageId
+
+### Malay_Malaysia {#Malay-Malaysia}
+```
+public static final MSLanguageId Malay_Malaysia
+```
+
+
+Malay (Regione: Malesia) valore LanguageId
+
+### Malayalam {#Malayalam}
+```
+public static final MSLanguageId Malayalam
+```
+
+
+Malayalam (Regione: India) valore LanguageId
+
+### Maltese {#Maltese}
+```
+public static final MSLanguageId Maltese
+```
+
+
+Maltese (Regione: Malta) valore LanguageId
+
+### Maori {#Maori}
+```
+public static final MSLanguageId Maori
+```
+
+
+Maori (Regione: Nuova Zelanda) valore LanguageId
+
+### Mapudungun {#Mapudungun}
+```
+public static final MSLanguageId Mapudungun
+```
+
+
+Mapudungun (Regione: Cile) valore LanguageId
+
+### Marathi {#Marathi}
+```
+public static final MSLanguageId Marathi
+```
+
+
+Marathi (Regione: India) valore LanguageId
+
+### Mohawk {#Mohawk}
+```
+public static final MSLanguageId Mohawk
+```
+
+
+Mohawk (Regione: Mohawk) valore LanguageId
+
+### Mongolian_Cyrillic {#Mongolian-Cyrillic}
+```
+public static final MSLanguageId Mongolian_Cyrillic
+```
+
+
+Mongolian (Cirillico, Regione: Mongolia) valore LanguageId
+
+### Mongolian_Traditional {#Mongolian-Traditional}
+```
+public static final MSLanguageId Mongolian_Traditional
+```
+
+
+Mongolian (Tradizionale, Regione: People\u2019s Republic of China) valore LanguageId
+
+### Nepali {#Nepali}
+```
+public static final MSLanguageId Nepali
+```
+
+
+Nepali (Regione: Nepal) valore LanguageId
+
+### Norwegian_Bokmal {#Norwegian-Bokmal}
+```
+public static final MSLanguageId Norwegian_Bokmal
+```
+
+
+Norwegian (Bokmal, Regione: Norvegia, NOR) valore LanguageId
+
+### Norwegian_Nynorsk {#Norwegian-Nynorsk}
+```
+public static final MSLanguageId Norwegian_Nynorsk
+```
+
+
+Norwegian (Nynorsk, Regione: Norvegia, NON) valore LanguageId
+
+### Occitan {#Occitan}
+```
+public static final MSLanguageId Occitan
+```
+
+
+Occitano (Regione: Francia) valore LanguageId
+
+### Odia {#Odia}
+```
+public static final MSLanguageId Odia
+```
+
+
+Odia (precedentemente Oriya, Regione: India) valore LanguageId
+
+### Pashto {#Pashto}
+```
+public static final MSLanguageId Pashto
+```
+
+
+Pashto (Regione: Afghanistan) valore LanguageId
+
+### Polish {#Polish}
+```
+public static final MSLanguageId Polish
+```
+
+
+Polacco (Regione: Polonia, PLK) valore LanguageId
+
+### Portuguese_Brazil {#Portuguese-Brazil}
+```
+public static final MSLanguageId Portuguese_Brazil
+```
+
+
+Portoghese (Brasiliano, Regione: Brasile, PTB) valore LanguageId
+
+### Portuguese_Portugal {#Portuguese-Portugal}
+```
+public static final MSLanguageId Portuguese_Portugal
+```
+
+
+Portoghese (Standard, Regione: Portogallo, PTG) valore LanguageId
+
+### Punjabi {#Punjabi}
+```
+public static final MSLanguageId Punjabi
+```
+
+
+Punjabi (Regione: India) valore LanguageId
+
+### Quechua_Bolivia {#Quechua-Bolivia}
+```
+public static final MSLanguageId Quechua_Bolivia
+```
+
+
+Quechua (Regione: Bolivia) valore LanguageId
+
+### Quechua_Ecuador {#Quechua-Ecuador}
+```
+public static final MSLanguageId Quechua_Ecuador
+```
+
+
+Quechua (Regione: Ecuador) valore LanguageId
+
+### Quechua_Peru {#Quechua-Peru}
+```
+public static final MSLanguageId Quechua_Peru
+```
+
+
+Quechua (Regione: Perù) valore LanguageId
+
+### Romanian {#Romanian}
+```
+public static final MSLanguageId Romanian
+```
+
+
+Rumeno (Regione: Romania, ROM) valore LanguageId
+
+### Romansh {#Romansh}
+```
+public static final MSLanguageId Romansh
+```
+
+
+Romancio (Regione: Svizzera) valore LanguageId
+
+### Russian {#Russian}
+```
+public static final MSLanguageId Russian
+```
+
+
+Russo (Regione: Russia, RUS) valore LanguageId
+
+### Sami_Inari {#Sami-Inari}
+```
+public static final MSLanguageId Sami_Inari
+```
+
+
+Sami (Inari, Regione: Finlandia) valore LanguageId
+
+### Sami_Lule_Norway {#Sami-Lule-Norway}
+```
+public static final MSLanguageId Sami_Lule_Norway
+```
+
+
+Sami (Lule, Regione: Norvegia) valore LanguageId
+
+### Sami_Lule_Sweden {#Sami-Lule-Sweden}
+```
+public static final MSLanguageId Sami_Lule_Sweden
+```
+
+
+Sami (Lule, Regione: Svezia) valore LanguageId
+
+### Sami_Northern_Finland {#Sami-Northern-Finland}
+```
+public static final MSLanguageId Sami_Northern_Finland
+```
+
+
+Sami (Settentrionale, Regione: Finlandia) valore LanguageId
+
+### Sami_Northern_Norway {#Sami-Northern-Norway}
+```
+public static final MSLanguageId Sami_Northern_Norway
+```
+
+
+Sami (Settentrionale, Regione: Norvegia) valore LanguageId
+
+### Sami_Northern_Sweden {#Sami-Northern-Sweden}
+```
+public static final MSLanguageId Sami_Northern_Sweden
+```
+
+
+Sami (Settentrionale, Regione: Svezia) valore LanguageId
+
+### Sami_Skolt {#Sami-Skolt}
+```
+public static final MSLanguageId Sami_Skolt
+```
+
+
+Sami (Skolt, Regione: Finlandia) valore LanguageId
+
+### Sami_Southern_Norway {#Sami-Southern-Norway}
+```
+public static final MSLanguageId Sami_Southern_Norway
+```
+
+
+Sami (Meridionale, Regione: Norvegia) valore LanguageId
+
+### Sami_Southern_Sweden {#Sami-Southern-Sweden}
+```
+public static final MSLanguageId Sami_Southern_Sweden
+```
+
+
+Sami (Meridionale, Regione: Svezia) valore LanguageId
+
+### Sanskrit {#Sanskrit}
+```
+public static final MSLanguageId Sanskrit
+```
+
+
+Sanskrit (Regione: India) valore LanguageId
+
+### Serbian_Cyrillic_BIH {#Serbian-Cyrillic-BIH}
+```
+public static final MSLanguageId Serbian_Cyrillic_BIH
+```
+
+
+Serbo (Cirillico, Regione: Bosnia ed Erzegovina) valore LanguageId
+
+### Serbian_Cyrillic_Serbia {#Serbian-Cyrillic-Serbia}
+```
+public static final MSLanguageId Serbian_Cyrillic_Serbia
+```
+
+
+Serbo (Cirillico, Regione: Serbia) valore LanguageId
+
+### Serbian_Latin_BIH {#Serbian-Latin-BIH}
+```
+public static final MSLanguageId Serbian_Latin_BIH
+```
+
+
+Serbo (latino, Regione: Bosnia ed Erzegovina) valore LanguageId
+
+### Serbian_Latin_Serbia {#Serbian-Latin-Serbia}
+```
+public static final MSLanguageId Serbian_Latin_Serbia
+```
+
+
+Serbo (latino, Regione: Serbia) valore LanguageId
+
+### Sesotho_Sa_Leboa {#Sesotho-Sa-Leboa}
+```
+public static final MSLanguageId Sesotho_Sa_Leboa
+```
+
+
+Sesotho sa Leboa (Sotho del Nord, Regione: Sudafrica, SA) valore LanguageId
+
+### Setswana {#Setswana}
+```
+public static final MSLanguageId Setswana
+```
+
+
+Setswana (Regione: Sudafrica, SA) valore LanguageId
+
+### Sinhala {#Sinhala}
+```
+public static final MSLanguageId Sinhala
+```
+
+
+Singalese (Regione: Sri Lanka) valore LanguageId
+
+### Slovak {#Slovak}
+```
+public static final MSLanguageId Slovak
+```
+
+
+Slovacco (Regione: Slovacchia, SKY) valore LanguageId
+
+### Slovenian {#Slovenian}
+```
+public static final MSLanguageId Slovenian
+```
+
+
+Sloveno (Regione: Slovenia, SLV) valore LanguageId
+
+### Spanish_Argentina {#Spanish-Argentina}
+```
+public static final MSLanguageId Spanish_Argentina
+```
+
+
+Spagnolo (Regione: Argentina) valore LanguageId
+
+### Spanish_Bolivia {#Spanish-Bolivia}
+```
+public static final MSLanguageId Spanish_Bolivia
+```
+
+
+Spagnolo (Regione: Bolivia) valore LanguageId
+
+### Spanish_Chile {#Spanish-Chile}
+```
+public static final MSLanguageId Spanish_Chile
+```
+
+
+Spagnolo (Regione: Cile) valore LanguageId
+
+### Spanish_Colombia {#Spanish-Colombia}
+```
+public static final MSLanguageId Spanish_Colombia
+```
+
+
+Spagnolo (Regione: Colombia) valore LanguageId
+
+### Spanish_Costa_Rica {#Spanish-Costa-Rica}
+```
+public static final MSLanguageId Spanish_Costa_Rica
+```
+
+
+Spagnolo (Regione: Costa Rica) valore LanguageId
+
+### Spanish_Dominican_Republic {#Spanish-Dominican-Republic}
+```
+public static final MSLanguageId Spanish_Dominican_Republic
+```
+
+
+Spagnolo (Regione: Repubblica Dominicana) valore LanguageId
+
+### Spanish_Ecuador {#Spanish-Ecuador}
+```
+public static final MSLanguageId Spanish_Ecuador
+```
+
+
+Spagnolo (Regione: Ecuador) valore LanguageId
+
+### Spanish_El_Salvador {#Spanish-El-Salvador}
+```
+public static final MSLanguageId Spanish_El_Salvador
+```
+
+
+Spagnolo (Regione: El Salvador) valore LanguageId
+
+### Spanish_Guatemala {#Spanish-Guatemala}
+```
+public static final MSLanguageId Spanish_Guatemala
+```
+
+
+Spagnolo (Regione: Guatemala) valore LanguageId
+
+### Spanish_Honduras {#Spanish-Honduras}
+```
+public static final MSLanguageId Spanish_Honduras
+```
+
+
+Spagnolo (Regione: Honduras) valore LanguageId
+
+### Spanish_Mexico {#Spanish-Mexico}
+```
+public static final MSLanguageId Spanish_Mexico
+```
+
+
+Spagnolo (messicano, Regione: Messico, ESM) valore LanguageId
+
+### Spanish_Modern_Sort {#Spanish-Modern-Sort}
+```
+public static final MSLanguageId Spanish_Modern_Sort
+```
+
+
+Spagnolo (ordinamento moderno, Regione: Spagna, ESN) valore LanguageId
+
+### Spanish_Nicaragua {#Spanish-Nicaragua}
+```
+public static final MSLanguageId Spanish_Nicaragua
+```
+
+
+Spagnolo (Regione: Nicaragua) valore LanguageId
+
+### Spanish_Panama {#Spanish-Panama}
+```
+public static final MSLanguageId Spanish_Panama
+```
+
+
+Spagnolo (Regione: Panama) valore LanguageId
+
+### Spanish_Paraguay {#Spanish-Paraguay}
+```
+public static final MSLanguageId Spanish_Paraguay
+```
+
+
+Spagnolo (Regione: Paraguay) valore LanguageId
+
+### Spanish_Peru {#Spanish-Peru}
+```
+public static final MSLanguageId Spanish_Peru
+```
+
+
+Spagnolo (Regione: Perù) valore LanguageId
+
+### Spanish_Puerto_Rico {#Spanish-Puerto-Rico}
+```
+public static final MSLanguageId Spanish_Puerto_Rico
+```
+
+
+Spagnolo (Regione: Porto Rico) valore LanguageId
+
+### Spanish_Traditional_Sort {#Spanish-Traditional-Sort}
+```
+public static final MSLanguageId Spanish_Traditional_Sort
+```
+
+
+Spagnolo (ordinamento tradizionale, Regione: Spagna, ESP) valore LanguageId
+
+### Spanish_United_States {#Spanish-United-States}
+```
+public static final MSLanguageId Spanish_United_States
+```
+
+
+Spagnolo (Regione: Stati Uniti) valore LanguageId
+
+### Spanish_Uruguay {#Spanish-Uruguay}
+```
+public static final MSLanguageId Spanish_Uruguay
+```
+
+
+Spagnolo (Regione: Uruguay) valore LanguageId
+
+### Spanish_Venezuela {#Spanish-Venezuela}
+```
+public static final MSLanguageId Spanish_Venezuela
+```
+
+
+Spagnolo (Regione: Venezuela) valore LanguageId
+
+### Swedish_Finland {#Swedish-Finland}
+```
+public static final MSLanguageId Swedish_Finland
+```
+
+
+Svedese (Regione: Finlandia) valore LanguageId
+
+### Swedish_Sweden {#Swedish-Sweden}
+```
+public static final MSLanguageId Swedish_Sweden
+```
+
+
+Svedese (Regione: Svezia, SVE) valore LanguageId
+
+### Syriac {#Syriac}
+```
+public static final MSLanguageId Syriac
+```
+
+
+Siriano (Regione: Siria) valore LanguageId
+
+### Tajik {#Tajik}
+```
+public static final MSLanguageId Tajik
+```
+
+
+Tagico (Cirillico, Regione: Tagikistan) valore LanguageId
+
+### Tamazight {#Tamazight}
+```
+public static final MSLanguageId Tamazight
+```
+
+
+Tamazight (Latino, Regione: Algeria) valore LanguageId
+
+### Tamil {#Tamil}
+```
+public static final MSLanguageId Tamil
+```
+
+
+Tamil (Regione: India) valore LanguageId
+
+### Tatar {#Tatar}
+```
+public static final MSLanguageId Tatar
+```
+
+
+Tatar (Regione: Russia) valore LanguageId
+
+### Telugu {#Telugu}
+```
+public static final MSLanguageId Telugu
+```
+
+
+Telugu (Regione: India) valore LanguageId
+
+### Thai {#Thai}
+```
+public static final MSLanguageId Thai
+```
+
+
+Thai (Regione: Thailandia) valore LanguageId
+
+### Tibetan {#Tibetan}
+```
+public static final MSLanguageId Tibetan
+```
+
+
+Tibetano (Regione: RPC) valore LanguageId
+
+### Turkish {#Turkish}
+```
+public static final MSLanguageId Turkish
+```
+
+
+Turco (Regione: Turchia, TRK) valore LanguageId
+
+### Turkmen {#Turkmen}
+```
+public static final MSLanguageId Turkmen
+```
+
+
+Turkmeno (Regione: Turkmenistan) valore LanguageId
+
+### Uighur {#Uighur}
+```
+public static final MSLanguageId Uighur
+```
+
+
+Uiguro (Regione: RPC) valore LanguageId
+
+### Ukrainian {#Ukrainian}
+```
+public static final MSLanguageId Ukrainian
+```
+
+
+Ucraino (Regione: Ucraina, UKR) valore LanguageId
+
+### Upper_Sorbian {#Upper-Sorbian}
+```
+public static final MSLanguageId Upper_Sorbian
+```
+
+
+Sorabo Superiore (Regione: Germania) valore LanguageId
+
+### Urdu {#Urdu}
+```
+public static final MSLanguageId Urdu
+```
+
+
+Urdu (Regione: Repubblica Islamica del Pakistan) valore LanguageId
+
+### Uzbek_Cyrillic {#Uzbek-Cyrillic}
+```
+public static final MSLanguageId Uzbek_Cyrillic
+```
+
+
+Uzbeko (Cirillico, Regione: Uzbekistan) valore LanguageId
+
+### Uzbek_Latin {#Uzbek-Latin}
+```
+public static final MSLanguageId Uzbek_Latin
+```
+
+
+Uzbeko (Latino, Regione: Uzbekistan) valore LanguageId
+
+### Vietnamese {#Vietnamese}
+```
+public static final MSLanguageId Vietnamese
+```
+
+
+Vietnamita (Regione: Vietnam) valore LanguageId
+
+### Welsh {#Welsh}
+```
+public static final MSLanguageId Welsh
+```
+
+
+Gallese (Regione: Regno Unito) valore LanguageId
+
+### Wolof {#Wolof}
+```
+public static final MSLanguageId Wolof
+```
+
+
+Wolof (Regione: Senegal) valore LanguageId
+
+### Yakut {#Yakut}
+```
+public static final MSLanguageId Yakut
+```
+
+
+Yakut (Regione: Russia) valore LanguageId
+
+### Yi {#Yi}
+```
+public static final MSLanguageId Yi
+```
+
+
+Yi (Regione: RPC) valore LanguageId
+
+### Yoruba {#Yoruba}
+```
+public static final MSLanguageId Yoruba
+```
+
+
+Yoruba (Regione: Nigeria) valore LanguageId
+
+### isiXhosa {#isiXhosa}
+```
+public static final MSLanguageId isiXhosa
+```
+
+
+isiXhosa (Regione: Sudafrica, SA) valore LanguageId
+
+### isiZulu {#isiZulu}
+```
+public static final MSLanguageId isiZulu
+```
+
+
+isiZulu (Regione: Sudafrica, SA) valore LanguageId
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getId() {#getId--}
+```
+public int getId()
+```
+
+
+Ottieni il valore intero.
+
+**Returns:**
+int - Il valore intero.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/msplatformspecificid/_index.md
+++ b/italian/java/com.aspose.font/msplatformspecificid/_index.md
@@ -1,0 +1,331 @@
+---
+title: "MSPlatformSpecificId"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'enumerazione PlatformSpecificId della piattaforma Microsoft."
+type: docs
+weight: 139
+url: /it/java/com.aspose.font/msplatformspecificid/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum MSPlatformSpecificId extends Enum<MSPlatformSpecificId>
+```
+
+Rappresenta l'enumerazione PlatformSpecificId della piattaforma Microsoft.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [Big5](#Big5) | Big5 MS MSPlatformSpecificId. |
+| [Johab](#Johab) | Johab MS MSPlatformSpecificId. |
+| [PRC](#PRC) | PRC MS MSPlatformSpecificId. |
+| [Reserved1](#Reserved1) | Reserved1 MS MSPlatformSpecificId. |
+| [Reserved2](#Reserved2) | Reserved2 MS MSPlatformSpecificId. |
+| [Reserved3](#Reserved3) | Reserved3 MS MSPlatformSpecificId. |
+| [ShiftJIS](#ShiftJIS) | ShiftJIS MS MSPlatformSpecificId. |
+| [Symbol](#Symbol) | Symbol MS MSPlatformSpecificId. |
+| [Unicode_BMP_UCS2](#Unicode-BMP-UCS2) | Unicode BMP (UCS2) MS PlatformSpecificId. |
+| [Unicode_UCS4](#Unicode-UCS4) | Unicode\_UCS4 MS MSPlatformSpecificId. |
+| [Wansung](#Wansung) | Wansung MS MSPlatformSpecificId. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Big5 {#Big5}
+```
+public static final MSPlatformSpecificId Big5
+```
+
+
+Big5 MS MSPlatformSpecificId.
+
+### Johab {#Johab}
+```
+public static final MSPlatformSpecificId Johab
+```
+
+
+Johab MS MSPlatformSpecificId.
+
+### PRC {#PRC}
+```
+public static final MSPlatformSpecificId PRC
+```
+
+
+PRC MS MSPlatformSpecificId.
+
+### Reserved1 {#Reserved1}
+```
+public static final MSPlatformSpecificId Reserved1
+```
+
+
+Reserved1 MS MSPlatformSpecificId.
+
+### Reserved2 {#Reserved2}
+```
+public static final MSPlatformSpecificId Reserved2
+```
+
+
+Reserved2 MS MSPlatformSpecificId.
+
+### Reserved3 {#Reserved3}
+```
+public static final MSPlatformSpecificId Reserved3
+```
+
+
+Reserved3 MS MSPlatformSpecificId.
+
+### ShiftJIS {#ShiftJIS}
+```
+public static final MSPlatformSpecificId ShiftJIS
+```
+
+
+ShiftJIS MS MSPlatformSpecificId.
+
+### Symbol {#Symbol}
+```
+public static final MSPlatformSpecificId Symbol
+```
+
+
+Symbol MS MSPlatformSpecificId.
+
+### Unicode_BMP_UCS2 {#Unicode-BMP-UCS2}
+```
+public static final MSPlatformSpecificId Unicode_BMP_UCS2
+```
+
+
+Unicode BMP (UCS2) MS PlatformSpecificId.
+
+### Unicode_UCS4 {#Unicode-UCS4}
+```
+public static final MSPlatformSpecificId Unicode_UCS4
+```
+
+
+Unicode\_UCS4 MS MSPlatformSpecificId.
+
+### Wansung {#Wansung}
+```
+public static final MSPlatformSpecificId Wansung
+```
+
+
+Wansung MS MSPlatformSpecificId.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static MSPlatformSpecificId valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[MSPlatformSpecificId](../../com.aspose.font/msplatformspecificid)
+### values() {#values--}
+```
+public static MSPlatformSpecificId[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.MSPlatformSpecificId[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/multilanguagestring/_index.md
+++ b/italian/java/com.aspose.font/multilanguagestring/_index.md
@@ -1,0 +1,296 @@
+---
+title: "MultiLanguageString"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta una stringa multilingua."
+type: docs
+weight: 66
+url: /it/java/com.aspose.font/multilanguagestring/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class MultiLanguageString
+```
+
+Rappresenta una stringa multilingua.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [MultiLanguageString()](#MultiLanguageString--) | Crea una stringa multilingue vuota. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addLanguageString(String str, int languageId)](#addLanguageString-java.lang.String-int-) | Aggiunge una stringa di una lingua specifica |
+| [containsString(String str)](#containsString-java.lang.String-) | Restituisce true se la stringa è presente in tutte le stringhe delle lingue. |
+| [equals(Object objToCompare)](#equals-java.lang.Object-) | Restituisce true se gli oggetti sono considerati uguali. |
+| [getAllLanguageIds()](#getAllLanguageIds--) | Ottiene gli identificatori di lingua per tutte le stringhe o un array vuoto se non sono presenti stringhe. |
+| [getAllStrings()](#getAllStrings--) | Restituisce tutte le stringhe di tutte le lingue. |
+| [getClass()](#getClass--) |  |
+| [getEnglishString()](#getEnglishString--) | Restituisce la stringa inglese se trovata. |
+| [getStringForLanguageId(int languageId)](#getStringForLanguageId-int-) | Restituisce la stringa relativa all'identificatore di lingua fornito, se trovata. |
+| [hashCode()](#hashCode--) | Implementazione di GetHashCode. |
+| [isEmpty()](#isEmpty--) | True, se MultiLanguageString non ha stringhe di lingue. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(MultiLanguageString obj1, String obj2)](#op-Equality-com.aspose.font.MultiLanguageString-java.lang.String-) | Implementazione dell'operatore di uguaglianza. |
+| [op_Equality(String obj1, MultiLanguageString obj2)](#op-Equality-java.lang.String-com.aspose.font.MultiLanguageString-) | Implementazione dell'operatore di uguaglianza. |
+| [op_Inequality(MultiLanguageString obj1, String obj2)](#op-Inequality-com.aspose.font.MultiLanguageString-java.lang.String-) | Implementazione dell'operatore di disuguaglianza. |
+| [op_Inequality(String obj1, MultiLanguageString obj2)](#op-Inequality-java.lang.String-com.aspose.font.MultiLanguageString-) | Implementazione dell'operatore di disuguaglianza. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MultiLanguageString() {#MultiLanguageString--}
+```
+public MultiLanguageString()
+```
+
+
+Crea una stringa multilingue vuota.
+
+### addLanguageString(String str, int languageId) {#addLanguageString-java.lang.String-int-}
+```
+public void addLanguageString(String str, int languageId)
+```
+
+
+Aggiunge una stringa di una lingua specifica
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| str | java.lang.String | Stringa da aggiungere |
+| languageId | int | Identificatore della lingua |
+
+### containsString(String str) {#containsString-java.lang.String-}
+```
+public boolean containsString(String str)
+```
+
+
+Restituisce true se la stringa è presente in tutte le stringhe delle lingue.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| str | java.lang.String | Stringa da verificare. |
+
+**Returns:**
+boolean - True se la stringa è presente in tutte le stringhe delle lingue.
+### equals(Object objToCompare) {#equals-java.lang.Object-}
+```
+public boolean equals(Object objToCompare)
+```
+
+
+Restituisce true se gli oggetti sono considerati uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| objToCompare | java.lang.Object | oggetto da confrontare con |
+
+**Returns:**
+boolean - risultato del confronto
+### getAllLanguageIds() {#getAllLanguageIds--}
+```
+public int[] getAllLanguageIds()
+```
+
+
+Ottiene gli identificatori di lingua per tutte le stringhe o un array vuoto se non sono presenti stringhe.
+
+**Returns:**
+int[] - Array con identificatori di lingua o array vuoto se non sono presenti stringhe.
+### getAllStrings() {#getAllStrings--}
+```
+public String[] getAllStrings()
+```
+
+
+Restituisce tutte le stringhe di tutte le lingue.
+
+**Returns:**
+java.lang.String[] - Array di tutte le stringhe di tutte le lingue.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEnglishString() {#getEnglishString--}
+```
+public String getEnglishString()
+```
+
+
+Restituisce la stringa inglese se trovata. Altrimenti restituisce la prima stringa non inglese.
+
+**Returns:**
+java.lang.String - Stringa inglese se trovata, altrimenti la prima stringa non inglese.
+### getStringForLanguageId(int languageId) {#getStringForLanguageId-int-}
+```
+public String getStringForLanguageId(int languageId)
+```
+
+
+Restituisce la stringa relativa all'identificatore di lingua fornito, se trovata. Stringa vuota altrimenti.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| languageId | int | Identificatore di lingua. |
+
+**Returns:**
+java.lang.String - Stringa relativa all'identificatore di lingua fornito, se trovata. Stringa vuota altrimenti.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Implementazione di GetHashCode.
+
+**Returns:**
+int - codice hash dell'oggetto
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+True, se MultiLanguageString non ha stringhe di lingue.
+
+**Returns:**
+boolean - True, se MultiLanguageString non ha stringhe di lingue.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(MultiLanguageString obj1, String obj2) {#op-Equality-com.aspose.font.MultiLanguageString-java.lang.String-}
+```
+public static boolean op_Equality(MultiLanguageString obj1, String obj2)
+```
+
+
+Implementazione dell'operatore di uguaglianza.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj1 | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | primo oggetto da confrontare |
+| obj2 | java.lang.String | secondo oggetto da confrontare |
+
+**Returns:**
+boolean - risultato del confronto
+### op_Equality(String obj1, MultiLanguageString obj2) {#op-Equality-java.lang.String-com.aspose.font.MultiLanguageString-}
+```
+public static boolean op_Equality(String obj1, MultiLanguageString obj2)
+```
+
+
+Implementazione dell'operatore di uguaglianza.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj1 | java.lang.String | stringa da confrontare |
+| obj2 | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | stringa multilingua da confrontare |
+
+**Returns:**
+boolean - risultato del confronto
+### op_Inequality(MultiLanguageString obj1, String obj2) {#op-Inequality-com.aspose.font.MultiLanguageString-java.lang.String-}
+```
+public static boolean op_Inequality(MultiLanguageString obj1, String obj2)
+```
+
+
+Implementazione dell'operatore di disuguaglianza.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj1 | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | stringa da confrontare |
+| obj2 | java.lang.String | stringa multilingua da confrontare |
+
+**Returns:**
+boolean - risultato del confronto
+### op_Inequality(String obj1, MultiLanguageString obj2) {#op-Inequality-java.lang.String-com.aspose.font.MultiLanguageString-}
+```
+public static boolean op_Inequality(String obj1, MultiLanguageString obj2)
+```
+
+
+Implementazione dell'operatore di disuguaglianza.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj1 | java.lang.String | stringa da confrontare |
+| obj2 | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | stringa multilingua da confrontare |
+
+**Returns:**
+boolean - risultato del confronto
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/nameid/_index.md
+++ b/italian/java/com.aspose.font/nameid/_index.md
@@ -1,0 +1,380 @@
+---
+title: "NameId"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'enumerazione NameId."
+type: docs
+weight: 67
+url: /it/java/com.aspose.font/nameid/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class NameId
+```
+
+Rappresenta l'enumerazione NameId.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CompatibleFull](#CompatibleFull) | 18 Compatibile Full (solo Macintosh); su Macintosh, il nome del menu è costruito utilizzando la risorsa Font. |
+| [CopyrightNotice](#CopyrightNotice) | 0 Avviso di copyright. |
+| [DarkBackground](#DarkBackground) | Questo ID, se usato nell'Array di Etichette della Palette della tabella CPAL\\u2019s, specifica che la palette di colori corrispondente nella tabella CPAL è appropriata per l'uso con il font quando lo si visualizza su uno sfondo scuro come il nero. |
+| [Description](#Description) | 10 Descrizione; descrizione del carattere tipografico. |
+| [DesignerName](#DesignerName) | 9 Designer; nome del designer del carattere. |
+| [FontFamily](#FontFamily) | 1 Famiglia di caratteri. |
+| [FontSubfamily](#FontSubfamily) | 2 Sottofamiglia di caratteri. |
+| [FullName](#FullName) | 4 Nome completo del carattere. |
+| [LicenseDescription](#LicenseDescription) | 13 Descrizione della licenza; descrizione di come il carattere può essere utilizzato legalmente, o diversi scenari di esempio per l'uso con licenza. |
+| [LicenseInfoUrl](#LicenseInfoUrl) | 14 URL delle informazioni sulla licenza, dove è possibile trovare ulteriori informazioni sulla licenza. |
+| [LightBackground](#LightBackground) | Questo ID, se usato nell'array Palette Labels della tabella CPAL\\u2019s, specifica che la palette di colori corrispondente nella tabella CPAL è appropriata per l'uso con il carattere quando viene visualizzato su uno sfondo chiaro come il bianco. |
+| [ManufacturerName](#ManufacturerName) | 8 Nome del produttore. |
+| [PostScriptCID](#PostScriptCID) | La sua presenza in un carattere significa che il nameID 6 contiene un nome di carattere PostScript destinato ad essere usato con l'invocazione \\u201ccomposefont\\u201d per richiamare il carattere in un interprete PostScript. |
+| [PostScriptName](#PostScriptName) | 6 Nome PostScript del carattere. |
+| [PreferredFamily](#PreferredFamily) | 15 Riservato 16 Famiglia Preferita (solo Windows); In Windows, il nome della Famiglia è visualizzato nel menu Carattere; il nome della Sottofamiglia è presentato come nome dello Stile. |
+| [PreferredSubfamily](#PreferredSubfamily) | 17 Sottofamiglia Preferita (solo Windows); In Windows, il nome della Famiglia è visualizzato nel menu Carattere; il nome della Sottofamiglia è presentato come nome dello Stile. |
+| [SampleText](#SampleText) | 19 Testo di esempio. |
+| [TrademarkNotice](#TrademarkNotice) | 7 Avviso di marchio. |
+| [UniqueFontId](#UniqueFontId) | 3 Specifica Apple: identificazione unica della sottofamiglia. 3 Specifica MS: identificatore unico del carattere. |
+| [UrlDesigner](#UrlDesigner) | 12 URL del designer del carattere (con protocollo, ad es., http://, ftp://) |
+| [UrlVendor](#UrlVendor) | 11 URL del fornitore del carattere (con protocollo, ad es., http://, ftp://). |
+| [VariationsPostScriptNamePrefix](#VariationsPostScriptNamePrefix) | Se presente in un carattere variabile, può essere usato come prefisso di famiglia nell'algoritmo di Generazione del Nome PostScript per i Font a Variazione. |
+| [Version](#Version) | 5 Versione della tabella dei nomi. |
+| [WwsFamilyName](#WwsFamilyName) | Usato per fornire un nome di famiglia conforme a WWS nel caso in cui le voci per gli ID 16 e 17 non siano conformi al modello WWS. |
+| [WwsSubfamilyName](#WwsSubfamilyName) | Usato in combinazione con l'ID 21, questo ID fornisce un nome di sottofamiglia conforme a WWS (che riflette solo gli attributi di peso, larghezza e inclinazione) nel caso in cui le voci per gli ID 16 e 17 non siano conformi al modello WWS. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fromId(int id)](#fromId-int-) | Crea un ID nome a partire da un valore intero. |
+| [getClass()](#getClass--) |  |
+| [getId()](#getId--) | Ottieni il valore intero. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CompatibleFull {#CompatibleFull}
+```
+public static final NameId CompatibleFull
+```
+
+
+18 Compatibile Completo (solo Macintosh); Su Macintosh, il nome del menu è costruito usando la risorsa Font. Questo di solito corrisponde al Nome Completo. Se vuoi che il nome del carattere appaia diversamente dal Nome Completo, puoi inserire il Nome Compatibile Completo nell'ID 18. Questo nome non è usato dal Mac OS stesso, ma può essere usato dagli sviluppatori di applicazioni (ad es., Adobe).
+
+### CopyrightNotice {#CopyrightNotice}
+```
+public static final NameId CopyrightNotice
+```
+
+
+0 Avviso di copyright.
+
+### DarkBackground {#DarkBackground}
+```
+public static final NameId DarkBackground
+```
+
+
+Questo ID, se usato nell'Array di Etichette della Palette della tabella CPAL\\u2019s, specifica che la palette di colori corrispondente nella tabella CPAL è appropriata per l'uso con il font quando lo si visualizza su uno sfondo scuro come il nero.
+
+### Description {#Description}
+```
+public static final NameId Description
+```
+
+
+10 Descrizione; descrizione del carattere. Può contenere informazioni di revisione, raccomandazioni d'uso, storia, funzionalità, ecc.
+
+### DesignerName {#DesignerName}
+```
+public static final NameId DesignerName
+```
+
+
+9 Designer; nome del designer del carattere.
+
+### FontFamily {#FontFamily}
+```
+public static final NameId FontFamily
+```
+
+
+1 Famiglia di caratteri. Questa stringa è il nome della famiglia di caratteri che l'utente vede sulle piattaforme Macintosh.
+
+### FontSubfamily {#FontSubfamily}
+```
+public static final NameId FontSubfamily
+```
+
+
+2 Sottoclasse del Font. Questa stringa è la famiglia del Font che l'utente vede sulle piattaforme Macintosh.
+
+### FullName {#FullName}
+```
+public static final NameId FullName
+```
+
+
+4 Nome completo del carattere.
+
+### LicenseDescription {#LicenseDescription}
+```
+public static final NameId LicenseDescription
+```
+
+
+13 Descrizione della licenza; descrizione di come il Font può essere utilizzato legalmente, o diversi scenari di esempio per l'uso con licenza. Questo campo dovrebbe essere scritto in linguaggio semplice, non in gergo legale.
+
+### LicenseInfoUrl {#LicenseInfoUrl}
+```
+public static final NameId LicenseInfoUrl
+```
+
+
+14 URL delle informazioni sulla licenza, dove è possibile trovare ulteriori informazioni sulla licenza.
+
+### LightBackground {#LightBackground}
+```
+public static final NameId LightBackground
+```
+
+
+Questo ID, se usato nell'array Palette Labels della tabella CPAL\\u2019s, specifica che la palette di colori corrispondente nella tabella CPAL è appropriata per l'uso con il carattere quando viene visualizzato su uno sfondo chiaro come il bianco.
+
+### ManufacturerName {#ManufacturerName}
+```
+public static final NameId ManufacturerName
+```
+
+
+8 Nome del produttore.
+
+### PostScriptCID {#PostScriptCID}
+```
+public static final NameId PostScriptCID
+```
+
+
+La sua presenza in un carattere significa che il nameID 6 contiene un nome di carattere PostScript destinato ad essere usato con l'invocazione \\u201ccomposefont\\u201d per richiamare il carattere in un interprete PostScript.
+
+### PostScriptName {#PostScriptName}
+```
+public static final NameId PostScriptName
+```
+
+
+6 Nome PostScript del Font. Nota: un Font può avere un solo nome PostScript e quel nome deve essere ASCII.
+
+### PreferredFamily {#PreferredFamily}
+```
+public static final NameId PreferredFamily
+```
+
+
+15 Riservato 16 Famiglia Preferita (solo Windows); in Windows, il nome della Famiglia viene visualizzato nel menu Font; il nome della Sottoclasse viene presentato come nome dello Stile. Per ragioni storiche, le famiglie di Font hanno contenuto un massimo di quattro stili, ma i designer di font possono raggruppare più di quattro font in un'unica famiglia. Gli ID di Famiglia Preferita e Sottoclasse Preferita consentono ai designer di font di includere i raggruppamenti di famiglia/sottoclasse preferiti. Questi ID sono presenti solo se sono diversi dagli ID 1 e 2.
+
+### PreferredSubfamily {#PreferredSubfamily}
+```
+public static final NameId PreferredSubfamily
+```
+
+
+17 Sottoclasse Preferita (solo Windows); in Windows, il nome della Famiglia viene visualizzato nel menu Font; il nome della Sottoclasse viene presentato come nome dello Stile. Per ragioni storiche, le famiglie di Font hanno contenuto un massimo di quattro stili, ma i designer di font possono raggruppare più di quattro font in un'unica famiglia. Gli ID di Famiglia Preferita e Sottoclasse Preferita consentono ai designer di font di includere i raggruppamenti di famiglia/sottoclasse preferiti. Questi ID sono presenti solo se sono diversi dagli ID 1 e 2.
+
+### SampleText {#SampleText}
+```
+public static final NameId SampleText
+```
+
+
+19 Testo di esempio. Può essere il nome del Font, o qualsiasi altro testo che il designer ritiene il migliore per mostrare l'aspetto del font.
+
+### TrademarkNotice {#TrademarkNotice}
+```
+public static final NameId TrademarkNotice
+```
+
+
+7 Avviso di marchio.
+
+### UniqueFontId {#UniqueFontId}
+```
+public static final NameId UniqueFontId
+```
+
+
+3 Specifica Apple: identificazione unica della sottofamiglia. 3 Specifica MS: identificatore unico del carattere.
+
+### UrlDesigner {#UrlDesigner}
+```
+public static final NameId UrlDesigner
+```
+
+
+12 URL del designer del carattere (con protocollo, ad es., http://, ftp://)
+
+### UrlVendor {#UrlVendor}
+```
+public static final NameId UrlVendor
+```
+
+
+11 URL del fornitore del Font (con protocollo, ad es., http://, ftp://). Se un numero di serie univoco è incorporato nell'URL, può essere usato per registrare il Font.
+
+### VariationsPostScriptNamePrefix {#VariationsPostScriptNamePrefix}
+```
+public static final NameId VariationsPostScriptNamePrefix
+```
+
+
+Se presente in un carattere variabile, può essere usato come prefisso di famiglia nell'algoritmo di Generazione del Nome PostScript per i Font a Variazione.
+
+### Version {#Version}
+```
+public static final NameId Version
+```
+
+
+5 Versione della tabella dei nomi.
+
+### WwsFamilyName {#WwsFamilyName}
+```
+public static final NameId WwsFamilyName
+```
+
+
+Usato per fornire un nome di famiglia conforme a WWS nel caso in cui le voci per gli ID 16 e 17 non siano conformi al modello WWS.
+
+### WwsSubfamilyName {#WwsSubfamilyName}
+```
+public static final NameId WwsSubfamilyName
+```
+
+
+Usato in combinazione con l'ID 21, questo ID fornisce un nome di sottofamiglia conforme a WWS (che riflette solo gli attributi di peso, larghezza e inclinazione) nel caso in cui le voci per gli ID 16 e 17 non siano conformi al modello WWS.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fromId(int id) {#fromId-int-}
+```
+public static NameId fromId(int id)
+```
+
+
+Crea un ID nome a partire da un valore intero.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| id | int | Un valore intero. |
+
+**Returns:**
+[NameId](../../com.aspose.font/nameid) - The name id.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getId() {#getId--}
+```
+public int getId()
+```
+
+
+Ottieni il valore intero.
+
+**Returns:**
+int - Il valore intero.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/nameindexdataprovider/_index.md
+++ b/italian/java/com.aspose.font/nameindexdataprovider/_index.md
@@ -1,0 +1,250 @@
+---
+title: "NameIndexDataProvider"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Fornisce impostazioni comuni ai font CFF."
+type: docs
+weight: 68
+url: /it/java/com.aspose.font/nameindexdataprovider/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.ICffIndexDataProvider](../../com.aspose.font/icffindexdataprovider)
+```
+public abstract class NameIndexDataProvider implements ICffIndexDataProvider
+```
+
+Fornisce impostazioni comuni ai font CFF.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [NameIndexDataProvider()](#NameIndexDataProvider--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addName(String name)](#addName-java.lang.String-) | Aggiunge un nome di carattere alla struttura Name INDEX. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene il nome del carattere all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di oggetti nella struttura CFF INDEX. |
+| [getName(int index)](#getName-int-) | Ottiene il nome del carattere all'indice specificato. |
+| [getRawBytes()](#getRawBytes--) | Ottiene tutti i byte della struttura CFF INDEX. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeName(int index)](#removeName-int-) | Rimuove il nome all'indice specificato. |
+| [set(int index, String name)](#set-int-java.lang.String-) | Specifica il nome del font all'indice specificato. |
+| [setName(String name, int index)](#setName-java.lang.String-int-) | Imposta il nome del font all'indice specificato. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NameIndexDataProvider() {#NameIndexDataProvider--}
+```
+public NameIndexDataProvider()
+```
+
+
+### addName(String name) {#addName-java.lang.String-}
+```
+public abstract void addName(String name)
+```
+
+
+Aggiunge un nome di font alla struttura Name INDEX. Utilizza questo metodo con cautela perché ogni nome di font nella struttura CFF Name INDEX deve avere una struttura DICT corrispondente nell'indice Top DICT secondo la specifica CFF.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public abstract String get(int index)
+```
+
+
+Ottiene il nome del carattere all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | Indice del font. |
+
+**Returns:**
+java.lang.String - Nome del font.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public abstract int getCount()
+```
+
+
+Ottiene il numero di oggetti nella struttura CFF INDEX.
+
+**Returns:**
+int
+### getName(int index) {#getName-int-}
+```
+public abstract String getName(int index)
+```
+
+
+Ottiene il nome del carattere all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | Indice del font. |
+
+**Returns:**
+java.lang.String - Il nome del font.
+### getRawBytes() {#getRawBytes--}
+```
+public abstract byte[] getRawBytes()
+```
+
+
+Ottiene tutti i byte della struttura CFF INDEX.
+
+**Returns:**
+byte[] - Byte della struttura CFF INDEX
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeName(int index) {#removeName-int-}
+```
+public abstract void removeName(int index)
+```
+
+
+Rimuove il nome all'indice specificato. Utilizza questo metodo con cautela perché ogni nome di font nella struttura CFF Name INDEX deve avere una struttura DICT corrispondente nell'indice Top DICT secondo la specifica CFF.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | Indice del font. |
+
+### set(int index, String name) {#set-int-java.lang.String-}
+```
+public abstract void set(int index, String name)
+```
+
+
+Specifica il nome del font all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | Indice del font. |
+| nome | java.lang.String | Nome del font. |
+
+### setName(String name, int index) {#setName-java.lang.String-int-}
+```
+public abstract void setName(String name, int index)
+```
+
+
+Imposta il nome del font all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String | Nome del font. |
+| indice | int | Indice del font. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/namerecord/_index.md
+++ b/italian/java/com.aspose.font/namerecord/_index.md
@@ -1,0 +1,190 @@
+---
+title: "NameRecord"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la struttura NameRecord della tabella dei nomi."
+type: docs
+weight: 69
+url: /it/java/com.aspose.font/namerecord/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class NameRecord
+```
+
+Rappresenta la struttura NameRecord della tabella 'name'
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [NameRecord()](#NameRecord--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getLanguageId()](#getLanguageId--) | Ottiene l'identificatore della lingua. |
+| [getNameId()](#getNameId--) | Ottiene l'identificatore del nome. |
+| [getPlatformId()](#getPlatformId--) | Ottiene il codice identificatore della piattaforma. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ottiene l'identificatore della codifica specifica della piattaforma. |
+| [getString()](#getString--) | Ottiene la stringa nella memoria delle stringhe relativa a questo record di nome. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NameRecord() {#NameRecord--}
+```
+public NameRecord()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLanguageId() {#getLanguageId--}
+```
+public int getLanguageId()
+```
+
+
+Ottiene l'identificatore della lingua.
+
+**Returns:**
+int - Identificatore della lingua.
+### getNameId() {#getNameId--}
+```
+public int getNameId()
+```
+
+
+Ottiene l'identificatore del nome.
+
+**Returns:**
+int - Identificatore del nome.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ottiene il codice identificatore della piattaforma.
+
+**Returns:**
+int - Codice identificatore della piattaforma.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ottiene l'identificatore della codifica specifica della piattaforma.
+
+**Returns:**
+int - Identificatore della codifica specifica della piattaforma.
+### getString() {#getString--}
+```
+public String getString()
+```
+
+
+Ottiene la stringa nella memoria delle stringhe relativa a questo record di nome.
+
+**Returns:**
+java.lang.String - Stringa nella memoria delle stringhe relativa a questo record di nome.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/nametocodemap/_index.md
+++ b/italian/java/com.aspose.font/nametocodemap/_index.md
@@ -1,0 +1,178 @@
+---
+title: "NameToCodeMap"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la mappa nome-codice."
+type: docs
+weight: 70
+url: /it/java/com.aspose.font/nametocodemap/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class NameToCodeMap
+```
+
+Rappresenta la mappa nome-codice.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [containsKey(String name)](#containsKey-java.lang.String-) | Restituisce true nel caso in cui la chiave sia già nella mappa. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(String name)](#get-java.lang.String-) | Ottiene il codice per nome. |
+| [getClass()](#getClass--) |  |
+| [getKeys()](#getKeys--) | Restituisce la collezione di nomi di stringa. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [size()](#size--) | Ottiene il conteggio delle coppie nome-codice nella mappa. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### containsKey(String name) {#containsKey-java.lang.String-}
+```
+public boolean containsKey(String name)
+```
+
+
+Restituisce true nel caso in cui la chiave sia già nella mappa.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String | Nome del glifo. |
+
+**Returns:**
+boolean - True o false.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(String name) {#get-java.lang.String-}
+```
+public int get(String name)
+```
+
+
+Ottiene il codice per nome.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String | Nome del glifo. |
+
+**Returns:**
+int - Codice glifo.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getKeys() {#getKeys--}
+```
+public Collection<String> getKeys()
+```
+
+
+Restituisce la collezione di nomi di stringa.
+
+**Returns:**
+java.util.Collection<java.lang.String> - Collezione di nomi stringa.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+Ottiene il conteggio delle coppie nome-codice nella mappa.
+
+**Returns:**
+int - Conteggio delle coppie nome-codice nella mappa.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/offsetslist/_index.md
+++ b/italian/java/com.aspose.font/offsetslist/_index.md
@@ -1,0 +1,151 @@
+---
+title: "TtfLocaTable.OffsetsList"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'elenco degli offset dei glifi."
+type: docs
+weight: 10
+url: /it/java/com.aspose.font/ttflocatable.offsetslist/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static class TtfLocaTable.OffsetsList
+```
+
+Rappresenta l'elenco degli offset dei glifi.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'offset per indice. |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [size()](#size--) | Ottiene il conteggio degli offset dei glifi. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public long get(int index)
+```
+
+
+Ottiene l'offset per indice.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | Indice offset. |
+
+**Returns:**
+long - Offset del glifo.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+Ottiene il conteggio degli offset dei glifi.
+
+**Returns:**
+int - Conteggio degli offset dei glifi.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/parsingstrictness/_index.md
+++ b/italian/java/com.aspose.font/parsingstrictness/_index.md
@@ -1,0 +1,248 @@
+---
+title: "FontEnvironment.ParsingStrictness"
+second_title: "Riferimento API Aspose.Font per Java"
+description: 
+type: docs
+weight: 10
+url: /it/java/com.aspose.font/fontenvironment.parsingstrictness/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum FontEnvironment.ParsingStrictness extends Enum<FontEnvironment.ParsingStrictness>
+```
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [Strict](#Strict) | Specifica il tipo strict. |
+| [Tolerant](#Tolerant) | Specifica il tipo tolerant. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Strict {#Strict}
+```
+public static final FontEnvironment.ParsingStrictness Strict
+```
+
+
+Specifica il tipo strict.
+
+### Tolerant {#Tolerant}
+```
+public static final FontEnvironment.ParsingStrictness Tolerant
+```
+
+
+Specifica il tipo tolerant.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static FontEnvironment.ParsingStrictness valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[ParsingStrictness](../../com.aspose.font/parsingstrictness)
+### values() {#values--}
+```
+public static FontEnvironment.ParsingStrictness[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.FontEnvironment.ParsingStrictness[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/pathsegmentcollection/_index.md
+++ b/italian/java/com.aspose.font/pathsegmentcollection/_index.md
@@ -1,0 +1,565 @@
+---
+title: "PathSegmentCollection"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta una collezione di segmenti di percorso."
+type: docs
+weight: 71
+url: /it/java/com.aspose.font/pathsegmentcollection/
+---
+**Inheritance:**
+java.lang.Object, java.util.AbstractCollection, java.util.AbstractList, java.util.ArrayList
+```
+public class PathSegmentCollection extends ArrayList<IPathSegment>
+```
+
+Rappresenta una collezione di segmenti di percorso.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>toArray(T[] arg0)](#-T-toArray-T---) |  |
+| [add(E arg0)](#add-E-) |  |
+| [add(int arg0, E arg1)](#add-int-E-) |  |
+| [addAll(int arg0, Collection<? extends E> arg1)](#addAll-int-java.util.Collection---extends-E--) |  |
+| [addAll(Collection<? extends E> arg0)](#addAll-java.util.Collection---extends-E--) |  |
+| [clear()](#clear--) |  |
+| [clone()](#clone--) |  |
+| [contains(Object arg0)](#contains-java.lang.Object-) |  |
+| [containsAll(Collection<?> arg0)](#containsAll-java.util.Collection----) |  |
+| [ensureCapacity(int arg0)](#ensureCapacity-int-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [forEach(Consumer<? super E> arg0)](#forEach-java.util.function.Consumer---super-E--) |  |
+| [get(int arg0)](#get-int-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object arg0)](#indexOf-java.lang.Object-) |  |
+| [isEmpty()](#isEmpty--) |  |
+| [iterator()](#iterator--) |  |
+| [lastIndexOf(Object arg0)](#lastIndexOf-java.lang.Object-) |  |
+| [listIterator()](#listIterator--) |  |
+| [listIterator(int arg0)](#listIterator-int-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(int arg0)](#remove-int-) |  |
+| [remove(Object arg0)](#remove-java.lang.Object-) |  |
+| [removeAll(Collection<?> arg0)](#removeAll-java.util.Collection----) |  |
+| [removeIf(Predicate<? super E> arg0)](#removeIf-java.util.function.Predicate---super-E--) |  |
+| [replaceAll(UnaryOperator<E> arg0)](#replaceAll-java.util.function.UnaryOperator-E--) |  |
+| [retainAll(Collection<?> arg0)](#retainAll-java.util.Collection----) |  |
+| [set(int arg0, E arg1)](#set-int-E-) |  |
+| [size()](#size--) |  |
+| [sort(Comparator<? super E> arg0)](#sort-java.util.Comparator---super-E--) |  |
+| [spliterator()](#spliterator--) |  |
+| [subList(int arg0, int arg1)](#subList-int-int-) |  |
+| [toArray()](#toArray--) |  |
+| [toString()](#toString--) |  |
+| [trimToSize()](#trimToSize--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>toArray(T[] arg0) {#-T-toArray-T---}
+```
+public T[] <T>toArray(T[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | T[] |  |
+
+**Returns:**
+T[]
+### add(E arg0) {#add-E-}
+```
+public boolean add(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+boolean
+### add(int arg0, E arg1) {#add-int-E-}
+```
+public void add(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+### addAll(int arg0, Collection<? extends E> arg1) {#addAll-int-java.util.Collection---extends-E--}
+```
+public boolean addAll(int arg0, Collection<? extends E> arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### addAll(Collection<? extends E> arg0) {#addAll-java.util.Collection---extends-E--}
+```
+public boolean addAll(Collection<? extends E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### contains(Object arg0) {#contains-java.lang.Object-}
+```
+public boolean contains(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### containsAll(Collection<?> arg0) {#containsAll-java.util.Collection----}
+```
+public boolean containsAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### ensureCapacity(int arg0) {#ensureCapacity-int-}
+```
+public void ensureCapacity(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### forEach(Consumer<? super E> arg0) {#forEach-java.util.function.Consumer---super-E--}
+```
+public void forEach(Consumer<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.function.Consumer<? super E> |  |
+
+### get(int arg0) {#get-int-}
+```
+public E get(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object arg0) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public Iterator<E> iterator()
+```
+
+
+
+
+**Returns:**
+java.util.Iterator<E>
+### lastIndexOf(Object arg0) {#lastIndexOf-java.lang.Object-}
+```
+public int lastIndexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### listIterator() {#listIterator--}
+```
+public ListIterator<E> listIterator()
+```
+
+
+
+
+**Returns:**
+java.util.ListIterator<E>
+### listIterator(int arg0) {#listIterator-int-}
+```
+public ListIterator<E> listIterator(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+java.util.ListIterator<E>
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(int arg0) {#remove-int-}
+```
+public E remove(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### remove(Object arg0) {#remove-java.lang.Object-}
+```
+public boolean remove(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### removeAll(Collection<?> arg0) {#removeAll-java.util.Collection----}
+```
+public boolean removeAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### removeIf(Predicate<? super E> arg0) {#removeIf-java.util.function.Predicate---super-E--}
+```
+public boolean removeIf(Predicate<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.function.Predicate<? super E> |  |
+
+**Returns:**
+boolean
+### replaceAll(UnaryOperator<E> arg0) {#replaceAll-java.util.function.UnaryOperator-E--}
+```
+public void replaceAll(UnaryOperator<E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.function.UnaryOperator<E> |  |
+
+### retainAll(Collection<?> arg0) {#retainAll-java.util.Collection----}
+```
+public boolean retainAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### set(int arg0, E arg1) {#set-int-E-}
+```
+public E set(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+**Returns:**
+E
+### size() {#size--}
+```
+public int size()
+```
+
+
+
+
+**Returns:**
+int
+### sort(Comparator<? super E> arg0) {#sort-java.util.Comparator---super-E--}
+```
+public void sort(Comparator<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.util.Comparator<? super E> |  |
+
+### spliterator() {#spliterator--}
+```
+public Spliterator<E> spliterator()
+```
+
+
+
+
+**Returns:**
+java.util.Spliterator<E>
+### subList(int arg0, int arg1) {#subList-int-int-}
+```
+public List<E> subList(int arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | int |  |
+
+**Returns:**
+java.util.List<E>
+### toArray() {#toArray--}
+```
+public Object[] toArray()
+```
+
+
+
+
+**Returns:**
+java.lang.Object[]
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### trimToSize() {#trimToSize--}
+```
+public void trimToSize()
+```
+
+
+
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/platformid/_index.md
+++ b/italian/java/com.aspose.font/platformid/_index.md
@@ -1,0 +1,268 @@
+---
+title: "PlatformId"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'enumerazione PlatformId."
+type: docs
+weight: 141
+url: /it/java/com.aspose.font/platformid/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum PlatformId extends Enum<PlatformId>
+```
+
+Rappresenta l'enumerazione PlatformId.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ISO](#ISO) | Value2 specifica Apple: (riservato; non utilizzare) specifica MS: codifica ISO. |
+| [Macintosh](#Macintosh) | Value 1 codice Macintosh Script Manager. |
+| [Microsoft](#Microsoft) | Value 3 codifica Microsoft. |
+| [Unicode](#Unicode) | Value 0 Unicode |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ISO {#ISO}
+```
+public static final PlatformId ISO
+```
+
+
+Value2 specifica Apple: (riservato; non utilizzare) specifica MS: codifica ISO. Nota che l'ID piattaforma 2 (ISO) è stato deprecato a partire dalla Specifica OpenType v1.3. Era destinato a rappresentare ISO/IEC 10646, in contrapposizione a Unicode; entrambi gli standard hanno assegnazioni di codici carattere identiche.
+
+### Macintosh {#Macintosh}
+```
+public static final PlatformId Macintosh
+```
+
+
+Value 1 codice Macintosh Script Manager.
+
+### Microsoft {#Microsoft}
+```
+public static final PlatformId Microsoft
+```
+
+
+Value 3 codifica Microsoft.
+
+### Unicode {#Unicode}
+```
+public static final PlatformId Unicode
+```
+
+
+Value 0 Unicode
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static PlatformId valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[PlatformId](../../com.aspose.font/platformid)
+### values() {#values--}
+```
+public static PlatformId[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.PlatformId[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/renderingutils/_index.md
+++ b/italian/java/com.aspose.font/renderingutils/_index.md
@@ -1,0 +1,202 @@
+---
+title: "RenderingUtils"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Fornisce metodi di utilità per il rendering."
+type: docs
+weight: 72
+url: /it/java/com.aspose.font/renderingutils/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class RenderingUtils
+```
+
+Fornisce metodi di utilità per il rendering.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [drawText(Font font, GlyphId[] glyphIds, double fontSize)](#drawText-com.aspose.font.Font-com.aspose.font.GlyphId---double-) | Rendering del testo in BitMap. |
+| [drawText(Font font, GlyphId[] glyphIds, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)](#drawText-com.aspose.font.Font-com.aspose.font.GlyphId---double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-) | Rendering del testo in BitMap. |
+| [drawText(Font font, String text, double fontSize)](#drawText-com.aspose.font.Font-java.lang.String-double-) | Rendering del testo in BitMap. |
+| [drawText(Font font, String text, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)](#drawText-com.aspose.font.Font-java.lang.String-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-) | Rendering del testo in BitMap. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### drawText(Font font, GlyphId[] glyphIds, double fontSize) {#drawText-com.aspose.font.Font-com.aspose.font.GlyphId---double-}
+```
+public static InputStream drawText(Font font, GlyphId[] glyphIds, double fontSize)
+```
+
+
+Rendering del testo in BitMap. Restituisce il risultato in formato PNG come flusso di byte.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.font/font) | Font |
+| glyphIds | [GlyphId\[\]](../../com.aspose.font/glyphid) | Testo rappresentato come array di identificatori di glifo |
+| fontSize | double | Dimensione del font |
+
+**Returns:**
+java.io.InputStream - Immagine in formato PNG come flusso di byte
+### drawText(Font font, GlyphId[] glyphIds, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth) {#drawText-com.aspose.font.Font-com.aspose.font.GlyphId---double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-}
+```
+public static InputStream drawText(Font font, GlyphId[] glyphIds, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)
+```
+
+
+Rendering del testo in BitMap. Restituisce il risultato in formato PNG come flusso di byte.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.font/font) | Font |
+| glyphIds | [GlyphId\[\]](../../com.aspose.font/glyphid) | Testo rappresentato come array di identificatori di glifo |
+| fontSize | double | Dimensione del font |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Tipo di interlinea. Numero di pixel o percentuale dell'altezza del font |
+| lineSpacingValue | int | Valore dell'interlinea |
+| maxWidth | int | Larghezza massima in pixel per l'immagine |
+
+**Returns:**
+java.io.InputStream - Immagine in formato PNG come flusso di byte
+### drawText(Font font, String text, double fontSize) {#drawText-com.aspose.font.Font-java.lang.String-double-}
+```
+public static InputStream drawText(Font font, String text, double fontSize)
+```
+
+
+Rendering del testo in BitMap.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.font/font) | Il carattere. |
+| text | java.lang.String | Il testo. |
+| fontSize | double | La dimensione del carattere. |
+
+**Returns:**
+java.io.InputStream - L'immagine PNG con il testo come flusso di byte.
+### drawText(Font font, String text, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth) {#drawText-com.aspose.font.Font-java.lang.String-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-}
+```
+public static InputStream drawText(Font font, String text, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)
+```
+
+
+Rendering del testo in BitMap.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.font/font) | Il carattere. |
+| text | java.lang.String | Il testo. |
+| fontSize | double | La dimensione del carattere. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Il tipo di interlinea. Numero di pixel o percentuale dell'altezza del carattere. |
+| lineSpacingValue | int | Il valore dell'interlinea. |
+| maxWidth | int | La larghezza massima in pixel per l'immagine risultante. |
+
+**Returns:**
+java.io.InputStream - L'immagine PNG con il testo come flusso di byte.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/segmentpath/_index.md
+++ b/italian/java/com.aspose.font/segmentpath/_index.md
@@ -1,0 +1,149 @@
+---
+title: "SegmentPath"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta il percorso di rendering."
+type: docs
+weight: 73
+url: /it/java/com.aspose.font/segmentpath/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Cloneable
+```
+public class SegmentPath implements Cloneable
+```
+
+Rappresenta il percorso di rendering.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clone()](#clone--) | Clona il Path. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getSegments()](#getSegments--) | Ottiene i segmenti del percorso. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Clona il Path.
+
+**Returns:**
+java.lang.Object - Copia del percorso.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSegments() {#getSegments--}
+```
+public PathSegmentCollection getSegments()
+```
+
+
+Ottiene i segmenti del percorso.
+
+**Returns:**
+[PathSegmentCollection](../../com.aspose.font/pathsegmentcollection) - Path segments.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/streamsource/_index.md
+++ b/italian/java/com.aspose.font/streamsource/_index.md
@@ -1,0 +1,195 @@
+---
+title: "StreamSource"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Definisce un modo per ottenere un flusso di file quando è necessario."
+type: docs
+weight: 74
+url: /it/java/com.aspose.font/streamsource/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class StreamSource
+```
+
+Definisce un modo per ottenere un flusso di file quando è necessario.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [StreamSource()](#StreamSource--) | Inizializza l'istanza della sorgente di stream. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Clona l'oggetto della sorgente di stream. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontStream()](#getFontStream--) | Restituisce lo stream del Font. |
+| [getOffset()](#getOffset--) | Ottiene l'offset all'interno della sorgente. |
+| [hashCode()](#hashCode--) |  |
+| [mustCloseAfterUse()](#mustCloseAfterUse--) | Gli eredi possono impedire la chiusura del stream. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOffset(long value)](#setOffset-long-) | Imposta l'offset all'interno della sorgente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StreamSource() {#StreamSource--}
+```
+public StreamSource()
+```
+
+
+Inizializza l'istanza della sorgente di stream.
+
+### deepClone() {#deepClone--}
+```
+public abstract Object deepClone()
+```
+
+
+Clona l'oggetto della sorgente di stream.
+
+**Returns:**
+java.lang.Object - Copia dell'oggetto della sorgente di stream.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontStream() {#getFontStream--}
+```
+public abstract InputStream getFontStream()
+```
+
+
+Restituisce lo stream del Font.
+
+**Returns:**
+java.io.InputStream - Stream del Font.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset all'interno della sorgente.
+
+**Returns:**
+long - Offset all'interno della sorgente.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### mustCloseAfterUse() {#mustCloseAfterUse--}
+```
+public boolean mustCloseAfterUse()
+```
+
+
+Gli eredi possono impedire la chiusura del stream. Restituisce true se la sorgente di stream desidera che il stream venga chiuso dopo l'uso. Altrimenti restituisce false.
+
+**Returns:**
+boolean - True se la sorgente di stream desidera che il stream venga chiuso dopo l'uso, altrimenti false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOffset(long value) {#setOffset-long-}
+```
+public void setOffset(long value)
+```
+
+
+Imposta l'offset all'interno della sorgente.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long | Offset all'interno della sorgente. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/stringindexdataprovider/_index.md
+++ b/italian/java/com.aspose.font/stringindexdataprovider/_index.md
@@ -1,0 +1,250 @@
+---
+title: "StringIndexDataProvider"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Dichiara la funzionalità per accedere alla struttura CFF String INDEX."
+type: docs
+weight: 75
+url: /it/java/com.aspose.font/stringindexdataprovider/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.ICffIndexDataProvider](../../com.aspose.font/icffindexdataprovider)
+```
+public abstract class StringIndexDataProvider implements ICffIndexDataProvider
+```
+
+Dichiara la funzionalità per accedere alla struttura CFF String INDEX.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [StringIndexDataProvider()](#StringIndexDataProvider--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addString(String value)](#addString-java.lang.String-) | Aggiunge la stringa nella struttura CFF String INDEX. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene/imposta la stringa all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Il numero di oggetti nella struttura CFF INDEX. |
+| [getRawBytes()](#getRawBytes--) | Ottiene tutti i byte della struttura CFF INDEX. |
+| [getString(int index)](#getString-int-) | Ottiene la stringa all'indice specificato dalla struttura CFF String INDEX. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeString(int index)](#removeString-int-) | Rimuove la stringa dalla struttura CFF String Index all'indice specificato. |
+| [set(int index, String value)](#set-int-java.lang.String-) |  |
+| [setString(String value, int index)](#setString-java.lang.String-int-) | Imposta la stringa nella struttura CFF String Index all'indice specificato. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StringIndexDataProvider() {#StringIndexDataProvider--}
+```
+public StringIndexDataProvider()
+```
+
+
+### addString(String value) {#addString-java.lang.String-}
+```
+public abstract void addString(String value)
+```
+
+
+Aggiunge la stringa nella struttura CFF String INDEX.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Valore stringa |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public abstract String get(int index)
+```
+
+
+Ottiene/imposta la stringa all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | Indice della stringa, l'indice indica un numero ordinale nella struttura CFF INDEX, non SID |
+
+**Returns:**
+java.lang.String - String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public abstract int getCount()
+```
+
+
+Il numero di oggetti nella struttura CFF INDEX.
+
+**Returns:**
+int
+### getRawBytes() {#getRawBytes--}
+```
+public abstract byte[] getRawBytes()
+```
+
+
+Ottiene tutti i byte della struttura CFF INDEX.
+
+**Returns:**
+byte[] - Byte della struttura CFF INDEX
+### getString(int index) {#getString-int-}
+```
+public abstract String getString(int index)
+```
+
+
+Ottiene la stringa all'indice specificato dalla struttura CFF String INDEX.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | Indice della stringa, l'indice indica un numero ordinale nella struttura CFF INDEX, non SID |
+
+**Returns:**
+java.lang.String - String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeString(int index) {#removeString-int-}
+```
+public abstract void removeString(int index)
+```
+
+
+Rimuove la stringa dalla struttura CFF String Index all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | Indice della stringa, l'indice indica un numero ordinale nella struttura CFF INDEX, non SID |
+
+### set(int index, String value) {#set-int-java.lang.String-}
+```
+public abstract void set(int index, String value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+| valore | java.lang.String |  |
+
+### setString(String value, int index) {#setString-java.lang.String-int-}
+```
+public abstract void setString(String value, int index)
+```
+
+
+Imposta la stringa nella struttura CFF String Index all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Valore stringa |
+| indice | int | Indice della stringa, l'indice indica un numero ordinale nella struttura CFF INDEX, non SID |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/svgconversionexception/_index.md
+++ b/italian/java/com.aspose.font/svgconversionexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "SvgConversionException"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'eccezione di conversione del Font per il formato SVG."
+type: docs
+weight: 76
+url: /it/java/com.aspose.font/svgconversionexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class SvgConversionException extends FontException
+```
+
+Rappresenta un'eccezione di conversione del font per il formato SVG. L'eccezione può essere sollevata in caso di errori durante il processo di conversione del font.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [SvgConversionException()](#SvgConversionException--) | Inizializza un nuovo  SvgConversionException  oggetto. |
+| [SvgConversionException(String message)](#SvgConversionException-java.lang.String-) | Inizializza un nuovo  SvgConversionException  oggetto. |
+| [SvgConversionException(String message, RuntimeException innerException)](#SvgConversionException-java.lang.String-java.lang.RuntimeException-) | Inizializza un nuovo  SvgConversionException  oggetto. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SvgConversionException() {#SvgConversionException--}
+```
+public SvgConversionException()
+```
+
+
+Inizializza un nuovo  SvgConversionException  oggetto.
+
+### SvgConversionException(String message) {#SvgConversionException-java.lang.String-}
+```
+public SvgConversionException(String message)
+```
+
+
+Inizializza un nuovo  SvgConversionException  oggetto.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+
+### SvgConversionException(String message, RuntimeException innerException) {#SvgConversionException-java.lang.String-java.lang.RuntimeException-}
+```
+public SvgConversionException(String message, RuntimeException innerException)
+```
+
+
+Inizializza un nuovo  SvgConversionException  oggetto.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+| innerException | java.lang.RuntimeException | L'eccezione che è la causa dell'eccezione corrente. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/topdictdataprovider/_index.md
+++ b/italian/java/com.aspose.font/topdictdataprovider/_index.md
@@ -1,0 +1,968 @@
+---
+title: "TopDictDataProvider"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Dichiara la funzionalità per leggere/aggiornare la struttura CFF Top DICT."
+type: docs
+weight: 77
+url: /it/java/com.aspose.font/topdictdataprovider/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class TopDictDataProvider
+```
+
+Dichiara la funzionalità per leggere/aggiornare la struttura CFF Top DICT.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBaseFontName()](#getBaseFontName--) |  |
+| [getCidCount()](#getCidCount--) |  |
+| [getCidFontRevision()](#getCidFontRevision--) |  |
+| [getCidFontType()](#getCidFontType--) |  |
+| [getCidFontVersion()](#getCidFontVersion--) |  |
+| [getClass()](#getClass--) |  |
+| [getCopyright()](#getCopyright--) |  |
+| [getFamilyName()](#getFamilyName--) |  |
+| [getFontBBox()](#getFontBBox--) |  |
+| [getFontMatrix()](#getFontMatrix--) |  |
+| [getFontName()](#getFontName--) |  |
+| [getFullName()](#getFullName--) |  |
+| [getItalicAngle()](#getItalicAngle--) |  |
+| [getNotice()](#getNotice--) |  |
+| [getPaintType()](#getPaintType--) |  |
+| [getPostScript()](#getPostScript--) |  |
+| [getPrivateDictProvider()](#getPrivateDictProvider--) |  |
+| [getRos(int[] registrySid, int[] orderingSid, int[] supplement)](#getRos-int---int---int---) |  |
+| [getRos(String[] registry, String[] ordering, int[] supplement)](#getRos-java.lang.String---java.lang.String---int---) |  |
+| [getStrokeWidth()](#getStrokeWidth--) |  |
+| [getSyntheticBase()](#getSyntheticBase--) |  |
+| [getUidBase()](#getUidBase--) |  |
+| [getUnderlinePosition()](#getUnderlinePosition--) |  |
+| [getUnderlineThickness()](#getUnderlineThickness--) |  |
+| [getUniqueId()](#getUniqueId--) |  |
+| [getVersion()](#getVersion--) |  |
+| [getWeight()](#getWeight--) |  |
+| [getXuid()](#getXuid--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBaseFontName(String value)](#setBaseFontName-java.lang.String-) |  |
+| [setBaseFontNameSid(int sid)](#setBaseFontNameSid-int-) |  |
+| [setCidCount(int value)](#setCidCount-int-) |  |
+| [setCidFontRevision(int value)](#setCidFontRevision-int-) |  |
+| [setCidFontType(int value)](#setCidFontType-int-) |  |
+| [setCidFontVersion(int value)](#setCidFontVersion-int-) |  |
+| [setCopyright(String value)](#setCopyright-java.lang.String-) |  |
+| [setCopyrightSid(int sid)](#setCopyrightSid-int-) |  |
+| [setFamilyName(String value)](#setFamilyName-java.lang.String-) |  |
+| [setFamilyNameSid(int sid)](#setFamilyNameSid-int-) |  |
+| [setFixedPitch(boolean value)](#setFixedPitch-boolean-) |  |
+| [setFontBBox(FontBBox value)](#setFontBBox-com.aspose.font.FontBBox-) |  |
+| [setFontMatrix(TransformationMatrix value)](#setFontMatrix-com.aspose.font.TransformationMatrix-) |  |
+| [setFontName(String value)](#setFontName-java.lang.String-) |  |
+| [setFontNameSid(int sid)](#setFontNameSid-int-) |  |
+| [setFullName(String value)](#setFullName-java.lang.String-) |  |
+| [setFullNameSid(int sid)](#setFullNameSid-int-) |  |
+| [setItalicAngle(int value)](#setItalicAngle-int-) |  |
+| [setNotice(String value)](#setNotice-java.lang.String-) |  |
+| [setNoticeSid(int sid)](#setNoticeSid-int-) |  |
+| [setPaintType(int value)](#setPaintType-int-) |  |
+| [setPostScript(String value)](#setPostScript-java.lang.String-) |  |
+| [setPostScriptSid(int sid)](#setPostScriptSid-int-) |  |
+| [setRos(int registry, int ordering, int supplement)](#setRos-int-int-int-) |  |
+| [setRos(String registry, String ordering, int supplement)](#setRos-java.lang.String-java.lang.String-int-) |  |
+| [setStrokeWidth(int value)](#setStrokeWidth-int-) |  |
+| [setSyntheticBase(int value)](#setSyntheticBase-int-) |  |
+| [setUidBase(int value)](#setUidBase-int-) |  |
+| [setUnderlinePosition(int value)](#setUnderlinePosition-int-) |  |
+| [setUnderlineThickness(int value)](#setUnderlineThickness-int-) |  |
+| [setUniqueId(int value)](#setUniqueId-int-) |  |
+| [setVersion(String value)](#setVersion-java.lang.String-) |  |
+| [setVersionSid(int sid)](#setVersionSid-int-) |  |
+| [setWeight(String value)](#setWeight-java.lang.String-) |  |
+| [setWeightSid(int sid)](#setWeightSid-int-) |  |
+| [setXuid(double[] value)](#setXuid-double---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBaseFontName() {#getBaseFontName--}
+```
+public String getBaseFontName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getCidCount() {#getCidCount--}
+```
+public int getCidCount()
+```
+
+
+
+
+**Returns:**
+int
+### getCidFontRevision() {#getCidFontRevision--}
+```
+public int getCidFontRevision()
+```
+
+
+
+
+**Returns:**
+int
+### getCidFontType() {#getCidFontType--}
+```
+public int getCidFontType()
+```
+
+
+
+
+**Returns:**
+int
+### getCidFontVersion() {#getCidFontVersion--}
+```
+public int getCidFontVersion()
+```
+
+
+
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCopyright() {#getCopyright--}
+```
+public String getCopyright()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getFamilyName() {#getFamilyName--}
+```
+public String getFamilyName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox)
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix)
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getFullName() {#getFullName--}
+```
+public String getFullName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getItalicAngle() {#getItalicAngle--}
+```
+public int getItalicAngle()
+```
+
+
+
+
+**Returns:**
+int
+### getNotice() {#getNotice--}
+```
+public String getNotice()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getPaintType() {#getPaintType--}
+```
+public int getPaintType()
+```
+
+
+
+
+**Returns:**
+int
+### getPostScript() {#getPostScript--}
+```
+public String getPostScript()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getPrivateDictProvider() {#getPrivateDictProvider--}
+```
+public PrivateDictDataProvider getPrivateDictProvider()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.PrivateDictDataProvider
+### getRos(int[] registrySid, int[] orderingSid, int[] supplement) {#getRos-int---int---int---}
+```
+public void getRos(int[] registrySid, int[] orderingSid, int[] supplement)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| registrySid | int[] |  |
+| orderingSid | int[] |  |
+| supplement | int[] |  |
+
+### getRos(String[] registry, String[] ordering, int[] supplement) {#getRos-java.lang.String---java.lang.String---int---}
+```
+public void getRos(String[] registry, String[] ordering, int[] supplement)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| registry | java.lang.String[] |  |
+| ordering | java.lang.String[] |  |
+| supplement | int[] |  |
+
+### getStrokeWidth() {#getStrokeWidth--}
+```
+public int getStrokeWidth()
+```
+
+
+
+
+**Returns:**
+int
+### getSyntheticBase() {#getSyntheticBase--}
+```
+public int getSyntheticBase()
+```
+
+
+
+
+**Returns:**
+int
+### getUidBase() {#getUidBase--}
+```
+public int getUidBase()
+```
+
+
+
+
+**Returns:**
+int
+### getUnderlinePosition() {#getUnderlinePosition--}
+```
+public int getUnderlinePosition()
+```
+
+
+
+
+**Returns:**
+int
+### getUnderlineThickness() {#getUnderlineThickness--}
+```
+public int getUnderlineThickness()
+```
+
+
+
+
+**Returns:**
+int
+### getUniqueId() {#getUniqueId--}
+```
+public int getUniqueId()
+```
+
+
+
+
+**Returns:**
+int
+### getVersion() {#getVersion--}
+```
+public String getVersion()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getWeight() {#getWeight--}
+```
+public String getWeight()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getXuid() {#getXuid--}
+```
+public double[] getXuid()
+```
+
+
+
+
+**Returns:**
+double[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBaseFontName(String value) {#setBaseFontName-java.lang.String-}
+```
+public int setBaseFontName(String value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+**Returns:**
+int
+### setBaseFontNameSid(int sid) {#setBaseFontNameSid-int-}
+```
+public void setBaseFontNameSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| sid | int |  |
+
+### setCidCount(int value) {#setCidCount-int-}
+```
+public void setCidCount(int value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setCidFontRevision(int value) {#setCidFontRevision-int-}
+```
+public void setCidFontRevision(int value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setCidFontType(int value) {#setCidFontType-int-}
+```
+public void setCidFontType(int value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setCidFontVersion(int value) {#setCidFontVersion-int-}
+```
+public void setCidFontVersion(int value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setCopyright(String value) {#setCopyright-java.lang.String-}
+```
+public int setCopyright(String value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+**Returns:**
+int
+### setCopyrightSid(int sid) {#setCopyrightSid-int-}
+```
+public void setCopyrightSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| sid | int |  |
+
+### setFamilyName(String value) {#setFamilyName-java.lang.String-}
+```
+public int setFamilyName(String value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+**Returns:**
+int
+### setFamilyNameSid(int sid) {#setFamilyNameSid-int-}
+```
+public void setFamilyNameSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| sid | int |  |
+
+### setFixedPitch(boolean value) {#setFixedPitch-boolean-}
+```
+public void setFixedPitch(boolean value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setFontBBox(FontBBox value) {#setFontBBox-com.aspose.font.FontBBox-}
+```
+public void setFontBBox(FontBBox value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [FontBBox](../../com.aspose.font/fontbbox) |  |
+
+### setFontMatrix(TransformationMatrix value) {#setFontMatrix-com.aspose.font.TransformationMatrix-}
+```
+public void setFontMatrix(TransformationMatrix value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [TransformationMatrix](../../com.aspose.font/transformationmatrix) |  |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public int setFontName(String value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+**Returns:**
+int
+### setFontNameSid(int sid) {#setFontNameSid-int-}
+```
+public void setFontNameSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| sid | int |  |
+
+### setFullName(String value) {#setFullName-java.lang.String-}
+```
+public int setFullName(String value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+**Returns:**
+int
+### setFullNameSid(int sid) {#setFullNameSid-int-}
+```
+public void setFullNameSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| sid | int |  |
+
+### setItalicAngle(int value) {#setItalicAngle-int-}
+```
+public void setItalicAngle(int value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setNotice(String value) {#setNotice-java.lang.String-}
+```
+public int setNotice(String value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+**Returns:**
+int
+### setNoticeSid(int sid) {#setNoticeSid-int-}
+```
+public void setNoticeSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| sid | int |  |
+
+### setPaintType(int value) {#setPaintType-int-}
+```
+public void setPaintType(int value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPostScript(String value) {#setPostScript-java.lang.String-}
+```
+public int setPostScript(String value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+**Returns:**
+int
+### setPostScriptSid(int sid) {#setPostScriptSid-int-}
+```
+public void setPostScriptSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| sid | int |  |
+
+### setRos(int registry, int ordering, int supplement) {#setRos-int-int-int-}
+```
+public void setRos(int registry, int ordering, int supplement)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| registry | int |  |
+| ordering | int |  |
+| supplement | int |  |
+
+### setRos(String registry, String ordering, int supplement) {#setRos-java.lang.String-java.lang.String-int-}
+```
+public void setRos(String registry, String ordering, int supplement)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| registry | java.lang.String |  |
+| ordering | java.lang.String |  |
+| supplement | int |  |
+
+### setStrokeWidth(int value) {#setStrokeWidth-int-}
+```
+public void setStrokeWidth(int value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSyntheticBase(int value) {#setSyntheticBase-int-}
+```
+public void setSyntheticBase(int value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setUidBase(int value) {#setUidBase-int-}
+```
+public void setUidBase(int value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setUnderlinePosition(int value) {#setUnderlinePosition-int-}
+```
+public void setUnderlinePosition(int value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setUnderlineThickness(int value) {#setUnderlineThickness-int-}
+```
+public void setUnderlineThickness(int value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setUniqueId(int value) {#setUniqueId-int-}
+```
+public void setUniqueId(int value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setVersion(String value) {#setVersion-java.lang.String-}
+```
+public int setVersion(String value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+**Returns:**
+int
+### setVersionSid(int sid) {#setVersionSid-int-}
+```
+public void setVersionSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| sid | int |  |
+
+### setWeight(String value) {#setWeight-java.lang.String-}
+```
+public int setWeight(String value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+**Returns:**
+int
+### setWeightSid(int sid) {#setWeightSid-int-}
+```
+public void setWeightSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| sid | int |  |
+
+### setXuid(double[] value) {#setXuid-double---}
+```
+public void setXuid(double[] value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/transformationmatrix/_index.md
+++ b/italian/java/com.aspose.font/transformationmatrix/_index.md
@@ -1,0 +1,412 @@
+---
+title: "Matrice di trasformazione"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta una matrice 3x3  A   B   0   C   D   0   TX  TY  1 ."
+type: docs
+weight: 78
+url: /it/java/com.aspose.font/transformationmatrix/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TransformationMatrix
+```
+
+Rappresenta una matrice 3x3 | A B 0 | | C D 0 | | TX TY 1 |. Trasforma le coordinate nel modo seguente: x1 = A\*x + C\*y + TX y1 = B\*x + D\*y + TY.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [TransformationMatrix()](#TransformationMatrix--) | Crea una matrice standard 1 a 1: [ A B C D TX TY ] = [ 1, 0, 0, 1, 0, 0] |
+| [TransformationMatrix(double[] matrixArray)](#TransformationMatrix-double---) | Accetta una matrice di trasformazione con la seguente rappresentazione di array: [ A B C D TX TY ] |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Fornisce l'accesso all'array sottostante. |
+| [getA()](#getA--) | Ottiene il valore A della matrice di trasformazione. |
+| [getB()](#getB--) | Ottiene il valore B della matrice di trasformazione. |
+| [getC()](#getC--) | Ottiene il valore C della matrice di trasformazione. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Ottiene il valore D della matrice di trasformazione. |
+| [getTX()](#getTX--) | Ottiene il valore TX della matrice di trasformazione. |
+| [getTY()](#getTY--) | Ottiene il valore TY della matrice di trasformazione. |
+| [hashCode()](#hashCode--) |  |
+| [multiply(TransformationMatrix matrix)](#multiply-com.aspose.font.TransformationMatrix-) | Moltiplica con un'altra matrice di trasformazione. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [scale(double x, double y, double[] x1, double[] y1)](#scale-double-double-double---double---) | Scala x e y con la matrice di trasformazione: x1 = A\*x + C\*y; y1 = B\*x + D\*y. |
+| [setA(double value)](#setA-double-) | Imposta il valore A della matrice di trasformazione. |
+| [setB(double value)](#setB-double-) | Imposta il valore B della matrice di trasformazione. |
+| [setC(double value)](#setC-double-) | Imposta il valore C della matrice di trasformazione. |
+| [setD(double value)](#setD-double-) | Imposta il valore D della matrice di trasformazione. |
+| [setTX(double value)](#setTX-double-) | Imposta il valore TX della matrice di trasformazione. |
+| [setTY(double value)](#setTY-double-) | Imposta il valore TY della matrice di trasformazione. |
+| [toArray()](#toArray--) | Alloca un nuovo array, copia la matrice di trasformazione e la restituisce. |
+| [toString()](#toString--) |  |
+| [transform(double x, double y, double[] x1, double[] y1)](#transform-double-double-double---double---) | Trasforma x e y con la matrice di trasformazione: x1 = A\*x + C\*y + TX; y1 = B\*x + D\*y + TY. |
+| [unScale(double x1, double y1, double[] x, double[] y)](#unScale-double-double-double---double---) | Scala indietro x1 e y1 e restituisce x e y prima della matrice di trasformazione. |
+| [unTransform(double x1, double y1, double[] x, double[] y)](#unTransform-double-double-double---double---) | Trasforma indietro x1 e y1 e restituisce x e y prima della matrice di trasformazione. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TransformationMatrix() {#TransformationMatrix--}
+```
+public TransformationMatrix()
+```
+
+
+Crea una matrice standard 1 a 1: [ A B C D TX TY ] = [ 1, 0, 0, 1, 0, 0]
+
+### TransformationMatrix(double[] matrixArray) {#TransformationMatrix-double---}
+```
+public TransformationMatrix(double[] matrixArray)
+```
+
+
+Accetta una matrice di trasformazione con la seguente rappresentazione di array: [ A B C D TX TY ]
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| matrixArray | double[] | Array con i valori della matrice di trasformazione, deve contenere 6 elementi. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public double get(int index)
+```
+
+
+Fornisce l'accesso all'array sottostante.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | Indice nell'array della matrice di trasformazione. |
+
+**Returns:**
+double - L'elemento dell'array sottostante per indice.
+### getA() {#getA--}
+```
+public double getA()
+```
+
+
+Ottiene il valore A della matrice di trasformazione.
+
+**Returns:**
+double - Un valore della matrice di trasformazione.
+### getB() {#getB--}
+```
+public double getB()
+```
+
+
+Ottiene il valore B della matrice di trasformazione.
+
+**Returns:**
+double - Valore B della matrice di trasformazione.
+### getC() {#getC--}
+```
+public double getC()
+```
+
+
+Ottiene il valore C della matrice di trasformazione.
+
+**Returns:**
+double - Valore C della matrice di trasformazione.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public double getD()
+```
+
+
+Ottiene il valore D della matrice di trasformazione.
+
+**Returns:**
+double - Valore D della matrice di trasformazione.
+### getTX() {#getTX--}
+```
+public double getTX()
+```
+
+
+Ottiene il valore TX della matrice di trasformazione.
+
+**Returns:**
+double - Valore TX della matrice di trasformazione.
+### getTY() {#getTY--}
+```
+public double getTY()
+```
+
+
+Ottiene il valore TY della matrice di trasformazione.
+
+**Returns:**
+double - Valore TY della matrice di trasformazione.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### multiply(TransformationMatrix matrix) {#multiply-com.aspose.font.TransformationMatrix-}
+```
+public TransformationMatrix multiply(TransformationMatrix matrix)
+```
+
+
+Moltiplica con un'altra matrice di trasformazione. Non modifica la matrice di trasformazione originale, restituisce un nuovo oggetto TransformationMatrix.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrice di trasformazione con cui moltiplicare. |
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - New TransformationMatrix object.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### scale(double x, double y, double[] x1, double[] y1) {#scale-double-double-double---double---}
+```
+public void scale(double x, double y, double[] x1, double[] y1)
+```
+
+
+Scala x e y con la matrice di trasformazione: x1 = A\*x + C\*y; y1 = B\*x + D\*y.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| x | double | Coordinata x originale |
+| y | double | Coordinata y originale. |
+| x1 | double[] | Coordinata x scalata. |
+| y1 | double[] | Coordinata y scalata. |
+
+### setA(double value) {#setA-double-}
+```
+public void setA(double value)
+```
+
+
+Imposta il valore A della matrice di trasformazione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore A della matrice di trasformazione. |
+
+### setB(double value) {#setB-double-}
+```
+public void setB(double value)
+```
+
+
+Imposta il valore B della matrice di trasformazione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore B della matrice di trasformazione. |
+
+### setC(double value) {#setC-double-}
+```
+public void setC(double value)
+```
+
+
+Imposta il valore C della matrice di trasformazione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore C della matrice di trasformazione. |
+
+### setD(double value) {#setD-double-}
+```
+public void setD(double value)
+```
+
+
+Imposta il valore D della matrice di trasformazione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore D della matrice di trasformazione. |
+
+### setTX(double value) {#setTX-double-}
+```
+public void setTX(double value)
+```
+
+
+Imposta il valore TX della matrice di trasformazione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore della matrice di trasformazione TX. |
+
+### setTY(double value) {#setTY-double-}
+```
+public void setTY(double value)
+```
+
+
+Imposta il valore TY della matrice di trasformazione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore della matrice di trasformazione TY. |
+
+### toArray() {#toArray--}
+```
+public double[] toArray()
+```
+
+
+Alloca un nuovo array, copia la matrice di trasformazione e la restituisce.
+
+**Returns:**
+double[] - TransformationMatrix in forma di array.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(double x, double y, double[] x1, double[] y1) {#transform-double-double-double---double---}
+```
+public void transform(double x, double y, double[] x1, double[] y1)
+```
+
+
+Trasforma x e y con la matrice di trasformazione: x1 = A\*x + C\*y + TX; y1 = B\*x + D\*y + TY.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| x | double | Coordinata x originale. |
+| y | double | Coordinata y originale. |
+| x1 | double[] | Coordinata x trasformata. |
+| y1 | double[] | Coordinata y trasformata. |
+
+### unScale(double x1, double y1, double[] x, double[] y) {#unScale-double-double-double---double---}
+```
+public void unScale(double x1, double y1, double[] x, double[] y)
+```
+
+
+Scala indietro x1 e y1 e restituisce x e y prima della matrice di trasformazione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| x1 | double | Coordinata x1 |
+| y1 | double | Coordinata y1 |
+| x | double[] | Coordinata x riportata. |
+| y | double[] | Coordinata y riportata. |
+
+### unTransform(double x1, double y1, double[] x, double[] y) {#unTransform-double-double-double---double---}
+```
+public void unTransform(double x1, double y1, double[] x, double[] y)
+```
+
+
+Trasforma indietro x1 e y1 e restituisce x e y prima della matrice di trasformazione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| x1 | double | Coordinata x1. |
+| y1 | double | Coordinata y1. |
+| x | double[] | Coordinata x trasformata indietro. |
+| y | double[] | Coordinata y trasformata indietro. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttcfontfiledefinition/_index.md
+++ b/italian/java/com.aspose.font/ttcfontfiledefinition/_index.md
@@ -1,0 +1,200 @@
+---
+title: "TtcFontFileDefinition"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la definizione del file per il Font TTC."
+type: docs
+weight: 79
+url: /it/java/com.aspose.font/ttcfontfiledefinition/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.FontFileDefinition](../../com.aspose.font/fontfiledefinition)
+```
+public class TtcFontFileDefinition extends FontFileDefinition
+```
+
+Rappresenta la definizione del file per il Font TTC.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [TtcFontFileDefinition(int fontIndex, String fileExtension, StreamSource streamSource, long offset)](#TtcFontFileDefinition-int-java.lang.String-com.aspose.font.StreamSource-long-) | Crea una definizione di file utilizzando solo il contenuto del file. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileExtension()](#getFileExtension--) | Ottiene l'estensione del file. |
+| [getFileName()](#getFileName--) | Ottiene il nome del file. |
+| [getFontIndex()](#getFontIndex--) | Ottiene l'indice del font all'interno del font TTC. |
+| [getOffset()](#getOffset--) | Ottiene l'offset all'interno dello stream. |
+| [getStreamSource()](#getStreamSource--) | Ottiene la sorgente dello stream. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TtcFontFileDefinition(int fontIndex, String fileExtension, StreamSource streamSource, long offset) {#TtcFontFileDefinition-int-java.lang.String-com.aspose.font.StreamSource-long-}
+```
+public TtcFontFileDefinition(int fontIndex, String fileExtension, StreamSource streamSource, long offset)
+```
+
+
+Crea una definizione di file utilizzando solo il contenuto del file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontIndex | int | Indice del font nella collezione di font TTC. |
+| fileExtension | java.lang.String | Estensione della raccolta di file di font. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Origine della raccolta di file di font. |
+| offset | long | Offset ai dati del font nella raccolta di file di font, vedere l'intestazione TTC, la tabella Offset nella specifica del file OpenType Font. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileExtension() {#getFileExtension--}
+```
+public String getFileExtension()
+```
+
+
+Ottiene l'estensione del file.
+
+**Returns:**
+java.lang.String - Estensione del file.
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Ottiene il nome del file.
+
+**Returns:**
+java.lang.String - Nome del file.
+### getFontIndex() {#getFontIndex--}
+```
+public long getFontIndex()
+```
+
+
+Ottiene l'indice del font all'interno del font TTC.
+
+**Returns:**
+long - Indice del font all'interno del TTC Font.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset all'interno dello stream.
+
+**Returns:**
+long - Offset all'interno del flusso.
+### getStreamSource() {#getStreamSource--}
+```
+public StreamSource getStreamSource()
+```
+
+
+Ottiene la sorgente dello stream.
+
+**Returns:**
+[StreamSource](../../com.aspose.font/streamsource) - The stream source.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttcfontsource/_index.md
+++ b/italian/java/com.aspose.font/ttcfontsource/_index.md
@@ -1,0 +1,170 @@
+---
+title: "TtcFontSource"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la sorgente del Font TTC."
+type: docs
+weight: 80
+url: /it/java/com.aspose.font/ttcfontsource/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+com.aspose.font.IFontSource
+```
+public class TtcFontSource implements IFontSource
+```
+
+Rappresenta la sorgente del Font TTC.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [TtcFontSource(StreamSource source)](#TtcFontSource-com.aspose.font.StreamSource-) | Crea la sorgente del font TTC basata sull'oggetto stream fornito da IStreamSource. |
+| [TtcFontSource(String filePath)](#TtcFontSource-java.lang.String-) | Crea la sorgente del font TTC basata sul percorso del file di raccolta dei font ttc. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontDefinitions()](#getFontDefinitions--) | Restituisce l'array di definizioni dei font della sorgente del font TTC. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TtcFontSource(StreamSource source) {#TtcFontSource-com.aspose.font.StreamSource-}
+```
+public TtcFontSource(StreamSource source)
+```
+
+
+Crea la sorgente del font TTC basata sull'oggetto stream fornito da IStreamSource.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| source | [StreamSource](../../com.aspose.font/streamsource) | Stream di origine da cui estrarre i dati della raccolta di font TTC. |
+
+### TtcFontSource(String filePath) {#TtcFontSource-java.lang.String-}
+```
+public TtcFontSource(String filePath)
+```
+
+
+Crea la sorgente del font TTC basata sul percorso del file di raccolta dei font ttc.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| filePath | java.lang.String | File di raccolta dei font. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontDefinitions() {#getFontDefinitions--}
+```
+public FontDefinition[] getFontDefinitions()
+```
+
+
+Restituisce l'array di definizioni dei font della sorgente del font TTC.
+
+**Returns:**
+com.aspose.font.FontDefinition[] - Tutte le definizioni di carattere dalla sorgente del font TTC.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfcfftable/_index.md
+++ b/italian/java/com.aspose.font/ttfcfftable/_index.md
@@ -1,0 +1,182 @@
+---
+title: "TtfCffTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella cff del file di font TTF."
+type: docs
+weight: 90
+url: /it/java/com.aspose.font/ttfcfftable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfCffTable extends TtfTableBase
+```
+
+Rappresenta la tabella "cff" del file TTF Font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCffSource()](#getCffSource--) | Byte grezzi per i contorni nella rappresentazione Compact Font Format. |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCffSource(StreamSource streamSource)](#setCffSource-com.aspose.font.StreamSource-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCffSource() {#getCffSource--}
+```
+public StreamSource getCffSource()
+```
+
+
+Byte grezzi per i contorni nella rappresentazione Compact Font Format.
+
+**Returns:**
+[StreamSource](../../com.aspose.font/streamsource) - Raw bytes for outlines in Compact Font Format representation.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - Etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCffSource(StreamSource streamSource) {#setCffSource-com.aspose.font.StreamSource-}
+```
+public void setCffSource(StreamSource streamSource)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfcmapformat0table/_index.md
+++ b/italian/java/com.aspose.font/ttfcmapformat0table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat0Table"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la sottotabella Format0 CMap del file TTF Font."
+type: docs
+weight: 81
+url: /it/java/com.aspose.font/ttfcmapformat0table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat0Table extends TtfCMapFormatBaseTable
+```
+
+Rappresenta la sottotabella Format0 CMap del file TTF Font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Ottiene tutti i codici dalla sottotabella CMap corrente. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Ottiene l'indice del glifo per un dato codice di carattere. |
+| [getPlatformId()](#getPlatformId--) | Ottiene PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ottiene PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Ottiene tutti i codici dalla sottotabella CMap corrente.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Tutti i codici dalla sottotabella CMap corrente.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Ottiene l'indice del glifo per un dato codice di carattere.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| charCode | long | Codice carattere. |
+
+**Returns:**
+long - indice Glyph.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ottiene PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ottiene PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfcmapformat10table/_index.md
+++ b/italian/java/com.aspose.font/ttfcmapformat10table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat10Table"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la sottotabella Format10 CMap del file TTF Font."
+type: docs
+weight: 82
+url: /it/java/com.aspose.font/ttfcmapformat10table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat10Table extends TtfCMapFormatBaseTable
+```
+
+Rappresenta la sottotabella Format10 CMap del file TTF Font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Ottiene tutti i codici dalla sottotabella CMap corrente. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Ottiene l'indice del glifo per un dato codice di carattere. |
+| [getPlatformId()](#getPlatformId--) | Ottiene PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ottiene PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Ottiene tutti i codici dalla sottotabella CMap corrente.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Tutti i codici dalla sottotabella CMap corrente.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Ottiene l'indice del glifo per un dato codice di carattere.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| charCode | long | Codice carattere. |
+
+**Returns:**
+long - indice Glyph.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ottiene PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ottiene PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfcmapformat12table/_index.md
+++ b/italian/java/com.aspose.font/ttfcmapformat12table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat12Table"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la sottotabella Format8 CMap del file TTF Font."
+type: docs
+weight: 83
+url: /it/java/com.aspose.font/ttfcmapformat12table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat12Table extends TtfCMapFormatBaseTable
+```
+
+Rappresenta la sottotabella Format8 CMap del file TTF Font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Ottiene tutti i codici dalla sottotabella CMap corrente. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Ottiene l'indice del glifo per un dato codice di carattere. |
+| [getPlatformId()](#getPlatformId--) | Ottiene PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ottiene PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Ottiene tutti i codici dalla sottotabella CMap corrente.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Tutti i codici dalla sottotabella CMap corrente.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Ottiene l'indice del glifo per un dato codice di carattere.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| charCode | long | Codice carattere |
+
+**Returns:**
+long - indice Glyph.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ottiene PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ottiene PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfcmapformat2table/_index.md
+++ b/italian/java/com.aspose.font/ttfcmapformat2table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat2Table"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la sottotabella Format2 CMap del file TTF Font."
+type: docs
+weight: 84
+url: /it/java/com.aspose.font/ttfcmapformat2table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat2Table extends TtfCMapFormatBaseTable
+```
+
+Rappresenta la sottotabella Format2 CMap del file TTF Font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Ottiene tutti i codici dalla sottotabella CMap corrente. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Ottiene l'indice del glifo per un dato codice di carattere. |
+| [getPlatformId()](#getPlatformId--) | Ottiene PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ottiene PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Ottiene tutti i codici dalla sottotabella CMap corrente.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Tutti i codici dalla sottotabella CMap corrente.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Ottiene l'indice del glifo per un dato codice di carattere.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| charCode | long | Codice carattere. |
+
+**Returns:**
+long - indice Glyph.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ottiene PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ottiene PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfcmapformat4table/_index.md
+++ b/italian/java/com.aspose.font/ttfcmapformat4table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat4Table"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la sottotabella Format4 CMap del file TTF Font."
+type: docs
+weight: 85
+url: /it/java/com.aspose.font/ttfcmapformat4table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat4Table extends TtfCMapFormatBaseTable
+```
+
+Rappresenta la sottotabella Format4 CMap del file TTF Font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Ottiene tutti i codici dalla sottotabella CMap corrente. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Ottiene l'indice del glifo per un dato codice di carattere. |
+| [getPlatformId()](#getPlatformId--) | Ottiene PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ottiene PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Ottiene tutti i codici dalla sottotabella CMap corrente.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Tutti i codici dalla sottotabella CMap corrente.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Ottiene l'indice del glifo per un dato codice di carattere.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| charCode | long | Codice carattere. |
+
+**Returns:**
+long - indice Glyph.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ottiene PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ottiene PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfcmapformat6table/_index.md
+++ b/italian/java/com.aspose.font/ttfcmapformat6table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat6Table"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la sottotabella Format6 CMap del file TTF Font."
+type: docs
+weight: 86
+url: /it/java/com.aspose.font/ttfcmapformat6table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat6Table extends TtfCMapFormatBaseTable
+```
+
+Rappresenta la sottotabella Format6 CMap del file TTF Font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Ottiene tutti i codici dalla sottotabella CMap corrente. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Ottiene l'indice del glifo per un dato codice di carattere. |
+| [getPlatformId()](#getPlatformId--) | Ottiene PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ottiene PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Ottiene tutti i codici dalla sottotabella CMap corrente.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Tutti i codici dalla sottotabella CMap corrente.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Ottiene l'indice del glifo per un dato codice di carattere.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| charCode | long | Codice carattere. |
+
+**Returns:**
+long - indice Glyph.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ottiene PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ottiene PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfcmapformat8table/_index.md
+++ b/italian/java/com.aspose.font/ttfcmapformat8table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat8Table"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la sottotabella Format8 CMap del file TTF Font."
+type: docs
+weight: 87
+url: /it/java/com.aspose.font/ttfcmapformat8table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat8Table extends TtfCMapFormatBaseTable
+```
+
+Rappresenta la sottotabella Format8 CMap del file TTF Font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Ottiene tutti i codici dalla sottotabella CMap corrente. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Ottiene l'indice del glifo per un dato codice di carattere. |
+| [getPlatformId()](#getPlatformId--) | Ottiene PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ottiene PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Ottiene tutti i codici dalla sottotabella CMap corrente.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Tutti i codici dalla sottotabella CMap corrente.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Ottiene l'indice del glifo per un dato codice di carattere.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| charCode | long | Codice carattere. |
+
+**Returns:**
+long - indice Glyph.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ottiene PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ottiene PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfcmapformatbasetable/_index.md
+++ b/italian/java/com.aspose.font/ttfcmapformatbasetable/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormatBaseTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la classe base della sottotabella CMap."
+type: docs
+weight: 88
+url: /it/java/com.aspose.font/ttfcmapformatbasetable/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TtfCMapFormatBaseTable
+```
+
+Rappresenta la classe base della sottotabella CMap.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Ottiene tutti i codici dalla sottotabella CMap corrente. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Ottiene un indice di glifo per un dato codice carattere |
+| [getPlatformId()](#getPlatformId--) | Ottiene PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ottiene PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Ottiene tutti i codici dalla sottotabella CMap corrente.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Tutti i codici dalla sottotabella CMap corrente.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Ottiene un indice di glifo per un dato codice carattere
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| charCode | long | codice carattere |
+
+**Returns:**
+long - indice Glyph.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ottiene PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ottiene PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfcmapsubtabledescription/_index.md
+++ b/italian/java/com.aspose.font/ttfcmapsubtabledescription/_index.md
@@ -1,0 +1,157 @@
+---
+title: "TtfCMapTable.TtfCMapSubtableDescription"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Fornisce brevi informazioni sulla sottotabella CMap."
+type: docs
+weight: 10
+url: /it/java/com.aspose.font/ttfcmaptable.ttfcmapsubtabledescription/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract static class TtfCMapTable.TtfCMapSubtableDescription
+```
+
+Fornisce brevi informazioni sulla sottotabella CMap.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFormat()](#getFormat--) | Ottiene il formato della sottotabella. |
+| [getPlatformId()](#getPlatformId--) | Ottiene l'ID della piattaforma. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ottiene l'ID della codifica specifica della piattaforma. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Ottiene il formato della sottotabella.
+
+**Returns:**
+int - formato della sottotabella.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ottiene l'ID della piattaforma.
+
+**Returns:**
+int - ID della piattaforma.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ottiene l'ID della codifica specifica della piattaforma.
+
+**Returns:**
+int - ID della codifica specifica della piattaforma.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfcmaptable/_index.md
+++ b/italian/java/com.aspose.font/ttfcmaptable/_index.md
@@ -1,0 +1,196 @@
+---
+title: "TtfCMapTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella cmap del file di font TTF."
+type: docs
+weight: 89
+url: /it/java/com.aspose.font/ttfcmaptable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfCMapTable extends TtfTableBase
+```
+
+Rappresenta la tabella "cmap" del file TTF Font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [findUnicodeTable()](#findUnicodeTable--) | Cerca e restituisce la CMap Unicode. |
+| [getAllSubtables()](#getAllSubtables--) | Restituisce tutte le sotto-tabelle dalla tabella CMap. |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getPlatformTables(int platformId, int platformSpecificId)](#getPlatformTables-int-int-) | Restituisce le sotto-tabelle CMap per planformId e platformSpecificId. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### findUnicodeTable() {#findUnicodeTable--}
+```
+public TtfCMapFormatBaseTable findUnicodeTable()
+```
+
+
+Cerca e restituisce la CMap Unicode. Se esiste una CMap ucs-4 - la restituisce per prima; altrimenti - restituisce qualsiasi CMap Unicode che riesce a trovare.
+
+**Returns:**
+[TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable) - Unicode subtable.
+### getAllSubtables() {#getAllSubtables--}
+```
+public TtfCMapTable.TtfCMapSubtableDescription[] getAllSubtables()
+```
+
+
+Restituisce tutte le sotto-tabelle dalla tabella CMap.
+
+**Returns:**
+com.aspose.font.TtfCMapTable.TtfCMapSubtableDescription[] - array di oggetti TtfCmapSubtableDescription
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getPlatformTables(int platformId, int platformSpecificId) {#getPlatformTables-int-int-}
+```
+public TtfCMapFormatBaseTable[] getPlatformTables(int platformId, int platformSpecificId)
+```
+
+
+Restituisce le sotto-tabelle CMap per planformId e platformSpecificId.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| platformId | int | ID piattaforma. |
+| platformSpecificId | int | ID di codifica specifica della piattaforma. |
+
+**Returns:**
+com.aspose.font.TtfCMapFormatBaseTable[] - sotto-tabelle CMap.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - Etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfcvttable/_index.md
+++ b/italian/java/com.aspose.font/ttfcvttable/_index.md
@@ -1,0 +1,168 @@
+---
+title: "TtfCvtTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la Control Value Table CVT del file Font TTF."
+type: docs
+weight: 91
+url: /it/java/com.aspose.font/ttfcvttable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfCvtTable extends TtfTableBase
+```
+
+Rappresenta la Control Value Table (CVT) del file TTF Font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getControlValues()](#getControlValues--) | Ottiene l'elenco dei valori referenziabili dalle istruzioni. |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getControlValues() {#getControlValues--}
+```
+public short[] getControlValues()
+```
+
+
+Ottiene l'elenco dei valori referenziabili dalle istruzioni.
+
+**Returns:**
+short[] - Elenco dei valori referenziabili dalle istruzioni.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - Etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfencoding/_index.md
+++ b/italian/java/com.aspose.font/ttfencoding/_index.md
@@ -1,0 +1,207 @@
+---
+title: "TtfEncoding"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la codifica del Font TTF."
+type: docs
+weight: 92
+url: /it/java/com.aspose.font/ttfencoding/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFontEncoding](../../com.aspose.font/ifontencoding)
+```
+public class TtfEncoding implements IFontEncoding
+```
+
+Rappresenta la codifica del Font TTF.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [decodeToGid(long unicode)](#decodeToGid-long-) | L'implementazione DecodeToGlyphId del font TTF trova la tabella Unicode e restituisce l'ID del glifo per il carattere Unicode. |
+| [decodeToGidParameterized(IEncodingParameters parameters, long charCode)](#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-) | La versione parametrizzata consente di utilizzare una tabella CMap specifica (non Unicode). |
+| [encode(long gid, long charCode)](#encode-long-long-) | Codifica il glifo. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [gidToUnicode(GlyphId glyphId)](#gidToUnicode-com.aspose.font.GlyphId-) | Decodifica l'ID del glifo in Unicode. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [unicodeToGid(long unicode)](#unicodeToGid-long-) | Decodifica un Unicode e restituisce l'ID del glifo. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### decodeToGid(long unicode) {#decodeToGid-long-}
+```
+public GlyphId decodeToGid(long unicode)
+```
+
+
+L'implementazione DecodeToGlyphId del font TTF trova la tabella Unicode e restituisce l'ID del glifo per il carattere Unicode. L'ID del glifo è un numero unico per un glifo, dipendente dal tipo di font. Per esempio: l'ID di Type1 è un nome di glifo, istanza della classe ( GlyphStringId ). L'ID di TTF è un indice intero, istanza della classe ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| unicode | long | Codice carattere per cui ottenere l'identificatore del glifo. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to character code passed.
+### decodeToGidParameterized(IEncodingParameters parameters, long charCode) {#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-}
+```
+public GlyphId decodeToGidParameterized(IEncodingParameters parameters, long charCode)
+```
+
+
+La versione parametrizzata consente di utilizzare una tabella CMap specifica (non Unicode).
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| parameters | [IEncodingParameters](../../com.aspose.font/iencodingparameters) | Implementazione dell'interfaccia IEncodingParameters. |
+| charCode | long | codice carattere per ottenere l'identificatore del glifo. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to character code passed.
+### encode(long gid, long charCode) {#encode-long-long-}
+```
+public void encode(long gid, long charCode)
+```
+
+
+Codifica il glifo. Per i font TTF il codice carattere è Unicode.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| gid | long | Identificatore del glifo. |
+| charCode | long | Codice carattere. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### gidToUnicode(GlyphId glyphId) {#gidToUnicode-com.aspose.font.GlyphId-}
+```
+public long gidToUnicode(GlyphId glyphId)
+```
+
+
+Decodifica l'ID del glifo in Unicode. L'ID del glifo è un numero unico per un glifo, dipendente dal tipo di font. Per esempio: l'ID di Type1 è un nome di glifo, istanza della classe ( GlyphStringId ). L'ID di TTF è un indice intero, istanza della classe ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificatore del glifo del simbolo da decodificare. |
+
+**Returns:**
+long - Valore Unicode relativo all'id del glifo passato.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unicodeToGid(long unicode) {#unicodeToGid-long-}
+```
+public GlyphId unicodeToGid(long unicode)
+```
+
+
+Decodifica un Unicode e restituisce l'ID del glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| unicode | long | Unicode per cui ottenere l'identificatore del glifo. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to unicode passed.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfencodingparameters/_index.md
+++ b/italian/java/com.aspose.font/ttfencodingparameters/_index.md
@@ -1,0 +1,196 @@
+---
+title: "TtfEncodingParameters"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta i parametri di codifica TTF."
+type: docs
+weight: 93
+url: /it/java/com.aspose.font/ttfencodingparameters/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IEncodingParameters](../../com.aspose.font/iencodingparameters)
+```
+public class TtfEncodingParameters implements IEncodingParameters
+```
+
+Rappresenta i parametri di codifica TTF. Dovrebbe essere usato per richiedere una codifica specifica dal font TTF.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [TtfEncodingParameters(int platformId, int platformSpecificId)](#TtfEncodingParameters-int-int-) | Inizializza una nuova istanza della classe TtfEncodingParameters. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPlatformId()](#getPlatformId--) | Ottieni il valore PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Ottiene il valore PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setPlatformId(int value)](#setPlatformId-int-) | Imposta il valore PlatformId. |
+| [setPlatformSpecificId(int value)](#setPlatformSpecificId-int-) | Imposta il valore PlatformSpecificId. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TtfEncodingParameters(int platformId, int platformSpecificId) {#TtfEncodingParameters-int-int-}
+```
+public TtfEncodingParameters(int platformId, int platformSpecificId)
+```
+
+
+Inizializza una nuova istanza della classe TtfEncodingParameters. Accetta Platform Id e Platform-specific encoding id come parametri. Questi parametri sono usati per richiedere una sottotabella CMap speciale dalla tabella CMap principale del font, vedere la tabella 'CMap', 'name' nella specifica del file OpenType Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| platformId | int | ID piattaforma. |
+| platformSpecificId | int | ID di codifica specifica della piattaforma. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Ottieni il valore PlatformId.
+
+**Returns:**
+int - valore PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Ottiene il valore PlatformSpecificId.
+
+**Returns:**
+int - valore PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setPlatformId(int value) {#setPlatformId-int-}
+```
+public void setPlatformId(int value)
+```
+
+
+Imposta il valore PlatformId.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int | Valore PlatformId. |
+
+### setPlatformSpecificId(int value) {#setPlatformSpecificId-int-}
+```
+public void setPlatformSpecificId(int value)
+```
+
+
+Imposta il valore PlatformSpecificId.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int | Valore PlatformSpecificId. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttffont/_index.md
+++ b/italian/java/com.aspose.font/ttffont/_index.md
@@ -1,0 +1,648 @@
+---
+title: "TtfFont"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta il font TrueType TTF."
+type: docs
+weight: 94
+url: /it/java/com.aspose.font/ttffont/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Font](../../com.aspose.font/font)
+```
+public class TtfFont extends Font
+```
+
+Rappresenta il TrueType Font (TTF).
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Converte il Font in un altro formato. |
+| [convert(FontType fontType, Collection<Integer> limitingCharacterSet)](#convert-com.aspose.font.FontType-java.util.Collection-java.lang.Integer--) | Converte il Font in un altro formato con set di caratteri limitato  *Nota: il tipo di Font TTF è ora supportato solo.* |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Restituisce un array di tutti gli ID glifo, disponibili nel Font. |
+| [getCffFont()](#getCffFont--) | Ottiene il Font CFF se presente. |
+| [getClass()](#getClass--) |  |
+| [getEncoding()](#getEncoding--) | Ottiene la codifica del Font. |
+| [getFontDefinition()](#getFontDefinition--) | Ottiene la definizione del Font. |
+| [getFontFamily()](#getFontFamily--) | Ottiene la famiglia del Font. |
+| [getFontName()](#getFontName--) | Ottiene il nome del Font face. |
+| [getFontNames()](#getFontNames--) | Ottiene i nomi del Font. |
+| [getFontSaver()](#getFontSaver--) | Ottiene la funzionalità di salvataggio del Font. |
+| [getFontStyle()](#getFontStyle--) | Ottiene lo stile del Font. |
+| [getFontType()](#getFontType--) | Ottiene il tipo di Font. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Accessor dei glifi del Font. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Restituisce il glifo per ID glifo. |
+| [getGlyphById(String glyphName)](#getGlyphById-java.lang.String-) | Restituisce il glifo per nome glifo. |
+| [getGlyphById(long id)](#getGlyphById-long-) | Restituisce il glifo per ID glifo. |
+| [getGlyphComponentsById(GlyphId id, GlyphIdList componentsToPopulate)](#getGlyphComponentsById-com.aspose.font.GlyphId-com.aspose.font.GlyphIdList-) | Ottiene un glifo tramite l'identificatore di glifo fornito e riempie la lista di identificatori di glifo fornita con i componenti di questo glifo. |
+| [getGlyphComponentsById(String glyphName, GlyphIdList componentsToPopulate)](#getGlyphComponentsById-java.lang.String-com.aspose.font.GlyphIdList-) | Ottiene un glifo tramite il nome di glifo fornito e riempie la lista di identificatori di glifo fornita con i componenti di questo glifo. |
+| [getGlyphComponentsById(long id, GlyphIdList componentsToPopulate)](#getGlyphComponentsById-long-com.aspose.font.GlyphIdList-) | Ottiene un glifo tramite l'indice di glifo fornito e riempie la lista di identificatori di glifo fornita con i componenti di questo glifo. |
+| [getGlyphIdType()](#getGlyphIdType--) | Ottiene la specifica del tipo di ID glifo. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Ottieni la rappresentazione dei glifi per il testo. |
+| [getMetrics()](#getMetrics--) | Ottiene le metriche del Font. |
+| [getNumGlyphs()](#getNumGlyphs--) | Ottiene il numero di glifi nel Font. |
+| [getPostscriptNames()](#getPostscriptNames--) | Ottiene i nomi dei font Postscript. |
+| [getStyle()](#getStyle--) | Ottiene lo stile del Font. |
+| [getTtfTables()](#getTtfTables--) | Ottiene le tabelle TTF. |
+| [hashCode()](#hashCode--) |  |
+| [isSymbolic()](#isSymbolic--) | Restituisce true nel caso in cui il Font sia simbolico. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Apre un font, utilizzando l'oggetto FontDefinition. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Apre un font, utilizzando il tipo di font e l'array di byte dei dati del font. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Apre un font, utilizzando il tipo di font e la sorgente stream. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Apre un font, utilizzando il tipo di font e il nome del file del font. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Salva il Font nel formato originale. |
+| [save(String fileName)](#save-java.lang.String-) | Salva il Font nel formato originale. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Salva il Font nel formato specificato. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Imposta la famiglia del Font. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Imposta il nome del Font face. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Imposta lo stile del Font. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public Font convert(FontType fontType)
+```
+
+
+Converte il Font in un altro formato. Nota: il tipo di Font TTF è ora supportato solo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di formato del Font in cui convertire. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### convert(FontType fontType, Collection<Integer> limitingCharacterSet) {#convert-com.aspose.font.FontType-java.util.Collection-java.lang.Integer--}
+```
+public Font convert(FontType fontType, Collection<Integer> limitingCharacterSet)
+```
+
+
+Converte il Font in un altro formato con set di caratteri limitato  *Nota: il tipo di Font TTF è ora supportato solo.*
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di formato del Font in cui convertire. |
+| limitingCharacterSet | java.util.Collection<java.lang.Integer> | Set di caratteri limitante. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public GlyphId[] getAllGlyphIds()
+```
+
+
+Restituisce un array di tutti gli ID dei glifi, disponibili nel Font. L'ID del glifo è un numero unico per un glifo, dipendente dal tipo di font. L'ID del glifo del Font TTF può essere un'istanza della classe ( GlyphStringId ) o della classe ( GlyphUInt32Id ). L'indirizzamento dei glifi per nome (stringa) è supportato per i Font TTF tramite la mappatura della tabella Post. Nel caso di un Font CFF, le strutture CFF sono utilizzate per indirizzare i glifi per nome.
+
+**Returns:**
+com.aspose.font.GlyphId[] - Identificatori dei glifi.
+### getCffFont() {#getCffFont--}
+```
+public Font getCffFont()
+```
+
+
+Ottiene il Font CFF se presente.
+
+**Returns:**
+[Font](../../com.aspose.font/font) - CFF Font.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncoding() {#getEncoding--}
+```
+public IFontEncoding getEncoding()
+```
+
+
+Ottiene la codifica del Font.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public FontDefinition getFontDefinition()
+```
+
+
+Ottiene la definizione del Font.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public String getFontFamily()
+```
+
+
+Ottiene la famiglia del Font.
+
+**Returns:**
+java.lang.String - Famiglia del Font.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Ottiene il nome del Font face.
+
+**Returns:**
+java.lang.String - Nome del Font face.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Ottiene i nomi del Font.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Ottiene la funzionalità di salvataggio del Font.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public int getFontStyle()
+```
+
+
+Ottiene lo stile del Font. Questo è un valore calcolato e rappresentato in tipo generalizzato.
+
+**Returns:**
+int - Stile del Font. Di solito, una combinazione di valori di flag costanti della classe FontStyle o 0.
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Ottiene il tipo di Font. Restituisce il valore FontType.TTF.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Accessor dei glifi del font. Recupera i glifi e gli identificatori dei glifi.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public Glyph getGlyphById(GlyphId id)
+```
+
+
+Restituisce il glifo per ID glifo. L'ID glifo è un numero unico per un glifo, dipendente dal tipo di font. L'ID glifo del font TTF può essere un'istanza della classe ( GlyphStringId ) o della classe ( GlyphUInt32Id ). L'indirizzamento dei glifi per nome (stringa) è supportato per i font TTF tramite la mappatura della tabella Post. Nel caso di un font CFF, le strutture CFF sono usate per indirizzare i glifi per nome.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) |  |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph)
+### getGlyphById(String glyphName) {#getGlyphById-java.lang.String-}
+```
+public Glyph getGlyphById(String glyphName)
+```
+
+
+Restituisce il glifo per nome glifo. L'indirizzamento dei glifi per nome (stringa) è supportato per i font TTF tramite la mappatura della tabella Post. Nel caso di un font CFF, le strutture CFF sono usate per indirizzare i glifi per nome.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphName | java.lang.String | Identificatore di stringa del glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(long id) {#getGlyphById-long-}
+```
+public Glyph getGlyphById(long id)
+```
+
+
+Restituisce il glifo per ID glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| id | long | Indice del glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphComponentsById(GlyphId id, GlyphIdList componentsToPopulate) {#getGlyphComponentsById-com.aspose.font.GlyphId-com.aspose.font.GlyphIdList-}
+```
+public void getGlyphComponentsById(GlyphId id, GlyphIdList componentsToPopulate)
+```
+
+
+Ottiene un glifo tramite l'identificatore del glifo fornito e riempie la lista di identificatori di glifi fornita con i componenti di questo glifo. L'ID glifo è un numero unico per un glifo, dipendente dal tipo di font. L'ID glifo del font TTF può essere un'istanza della classe ( GlyphStringId ) o della classe ( GlyphUInt32Id ). L'indirizzamento dei glifi per nome (stringa) è supportato per i font TTF tramite la mappatura della tabella Post. Nel caso di un font CFF, le strutture CFF sono usate per indirizzare i glifi per nome.
+
+--------------------
+
+Deve essere passata una collezione vuota componentsToPopulate che conterrà l'elenco degli ID dei componenti del glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | ID glifo. |
+| componentsToPopulate | [GlyphIdList](../../com.aspose.font/glyphidlist) | Elenco di identificatori di glifi da riempire. |
+
+### getGlyphComponentsById(String glyphName, GlyphIdList componentsToPopulate) {#getGlyphComponentsById-java.lang.String-com.aspose.font.GlyphIdList-}
+```
+public void getGlyphComponentsById(String glyphName, GlyphIdList componentsToPopulate)
+```
+
+
+Ottiene un glifo tramite il nome di glifo fornito e riempie la lista di identificatori di glifo fornita con i componenti di questo glifo.
+
+--------------------
+
+Deve essere passata una collezione vuota componentsToPopulate che conterrà l'elenco degli ID dei componenti del glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphName | java.lang.String | Nome del glifo. |
+| componentsToPopulate | [GlyphIdList](../../com.aspose.font/glyphidlist) | Elenco di identificatori di glifi da riempire. |
+
+### getGlyphComponentsById(long id, GlyphIdList componentsToPopulate) {#getGlyphComponentsById-long-com.aspose.font.GlyphIdList-}
+```
+public void getGlyphComponentsById(long id, GlyphIdList componentsToPopulate)
+```
+
+
+Ottiene un glifo tramite l'indice di glifo fornito e riempie la lista di identificatori di glifo fornita con i componenti di questo glifo.
+
+--------------------
+
+Deve essere passata una collezione vuota componentsToPopulate che conterrà l'elenco degli ID dei componenti del glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| id | long | Indice del glifo. |
+| componentsToPopulate | [GlyphIdList](../../com.aspose.font/glyphidlist) | Elenco di identificatori di glifi da riempire. |
+
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public GlyphIdType getGlyphIdType()
+```
+
+
+Ottiene la specifica del tipo di ID glifo.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype) - Glyph id type specification.
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Ottieni la rappresentazione dei glifi per il testo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| text | java.lang.String | Testo di input. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - array di GlyphId.
+### getMetrics() {#getMetrics--}
+```
+public IFontMetrics getMetrics()
+```
+
+
+Ottiene le metriche del Font.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Ottiene il numero di glifi nel Font.
+
+**Returns:**
+int - Numero di glifi nel Font.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Ottiene i nomi dei font Postscript.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript font names.
+### getStyle() {#getStyle--}
+```
+public String getStyle()
+```
+
+
+Ottiene lo stile del Font. Questo è un valore stringa grezzo fornito dal file Font.
+
+**Returns:**
+java.lang.String - Stile del Font.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Ottiene le tabelle TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - TTF tables.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isSymbolic() {#isSymbolic--}
+```
+public boolean isSymbolic()
+```
+
+
+Restituisce true nel caso in cui il Font sia simbolico.
+
+**Returns:**
+boolean - True nel caso in cui il Font sia simbolico.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Apre un font, utilizzando l'oggetto FontDefinition.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Oggetto definizione del Font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Apre un font, utilizzando il tipo di font e l'array di byte dei dati del font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fontData | byte[] | Array di byte da cui caricare il font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Apre un font, utilizzando il tipo di font e la sorgente stream.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Sorgente stream per il font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Apre un font, utilizzando il tipo di font e il nome del file del font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fileName | java.lang.String | Nome file del font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Salva il Font nel formato originale.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Stream per salvare il font. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Salva il Font nel formato originale.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fileName | java.lang.String | File per salvare il font. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Salva il Font nel formato specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| stream | java.io.OutputStream | stream per salvare il font |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | formato desiderato |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public void setFontFamily(String value)
+```
+
+
+Imposta la famiglia del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Nuova famiglia di Font. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public void setFontName(String value)
+```
+
+
+Imposta il nome del Font face.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Nuovo nome faccia del Font. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public void setStyle(String value)
+```
+
+
+Imposta lo stile del Font. Questo è un valore stringa grezzo fornito dal file Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Nuovo stile del Font. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttffontmetrics/_index.md
+++ b/italian/java/com.aspose.font/ttffontmetrics/_index.md
@@ -1,0 +1,484 @@
+---
+title: "TtfFontMetrics"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta le metriche del Font TTF."
+type: docs
+weight: 95
+url: /it/java/com.aspose.font/ttffontmetrics/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.FontMetrics](../../com.aspose.font/fontmetrics)
+```
+public class TtfFontMetrics extends FontMetrics
+```
+
+Rappresenta le metriche del Font TTF.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAscender()](#getAscender--) | Ottiene il valore dell'ascendente. |
+| [getAscender(double fontSize)](#getAscender-double-) | Restituisce l'ascender per una dimensione specifica del Font. |
+| [getClass()](#getClass--) |  |
+| [getDescender()](#getDescender--) | Ottiene il valore del discendente. |
+| [getDescender(double fontSize)](#getDescender-double-) | Restituisce il descender per una dimensione specifica del Font. |
+| [getFontBBox()](#getFontBBox--) | Restituisce il valore FontBBox. |
+| [getFontMatrix()](#getFontMatrix--) | Restituisce il valore FontBBox. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Restituisce il Bbox del glifo. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Restituisce la larghezza dei glifi per ID glifo. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Restituisce il valore di kerning per la coppia di glifi. |
+| [getLineGap()](#getLineGap--) | Ottiene il valore LineGap. |
+| [getTypoAscender()](#getTypoAscender--) | Ottiene il valore TypoAscender. |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Restituisce l'ascendente tipografico per una dimensione specifica del Font. |
+| [getTypoDescender()](#getTypoDescender--) | Ottiene il valore TypoDescender. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Restituisce il discendente tipografico per una dimensione specifica del font. |
+| [getTypoLineGap()](#getTypoLineGap--) | Ottiene il valore TypoLineGap. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Restituisce il gap di linea per una dimensione specifica del Font. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Ottiene il valore UnitsPerEM. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Ottiene il valore IsFixedPitch. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Misura la stringa e restituisce la larghezza della stringa. |
+| [measureString(long[] charCodes, double fontSize)](#measureString-long---double-) | Misura il testo rappresentato come array di codici carattere e restituisce la larghezza della stringa. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAscender(double value)](#setAscender-double-) | Imposta il valore dell'ascendente. |
+| [setDescender(double value)](#setDescender-double-) | Imposta il valore del discendente. |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) | Imposta la larghezza del glifo. |
+| [setTypoAscender(double value)](#setTypoAscender-double-) | Imposta il valore TypoAscender. |
+| [setTypoDescender(double value)](#setTypoDescender-double-) | Imposta il valore TypoDescender. |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAscender() {#getAscender--}
+```
+public double getAscender()
+```
+
+
+Ottiene il valore dell'ascendente.
+
+**Returns:**
+double - valore Ascender.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public double getAscender(double fontSize)
+```
+
+
+Restituisce l'ascender per una dimensione specifica del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - valore Ascender.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescender() {#getDescender--}
+```
+public double getDescender()
+```
+
+
+Ottiene il valore del discendente.
+
+**Returns:**
+double - valore Descender.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public double getDescender(double fontSize)
+```
+
+
+Restituisce il descender per una dimensione specifica del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - valore Descender.
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+Restituisce il valore FontBBox.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox)
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+Restituisce il valore FontBBox.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix)
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Restituisce il Bbox del glifo. Restituisce FontBBox se il BBox non era definito per il glifo. Può essere sovrascritto da eredi di codifica del font specifici.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificatore del glifo. |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox.
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Restituisce la larghezza dei glifi per ID glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificatore del glifo. |
+
+**Returns:**
+double - Larghezza del glyph.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Restituisce il valore di kerning per la coppia di glifi.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Primo glyph nella coppia. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Dimensione del Font. |
+
+**Returns:**
+double - Valore del kerning
+### getLineGap() {#getLineGap--}
+```
+public double getLineGap()
+```
+
+
+Ottiene il valore LineGap.
+
+**Returns:**
+double - Valore del LineGap.
+### getTypoAscender() {#getTypoAscender--}
+```
+public double getTypoAscender()
+```
+
+
+Ottiene il valore TypoAscender.
+
+**Returns:**
+double - Valore del TypoAscender.
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public double getTypoAscender(double fontSize)
+```
+
+
+Restituisce l'ascendente tipografico per una dimensione specifica del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - Valore del Typographic ascender.
+### getTypoDescender() {#getTypoDescender--}
+```
+public double getTypoDescender()
+```
+
+
+Ottiene il valore TypoDescender.
+
+**Returns:**
+double - Valore del TypoDescender.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public double getTypoDescender(double fontSize)
+```
+
+
+Restituisce il discendente tipografico per una dimensione specifica del font.
+
+param fontSize Dimensione del font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double |  |
+
+**Returns:**
+double - Valore del Typographic descender.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public double getTypoLineGap()
+```
+
+
+Ottiene il valore TypoLineGap.
+
+**Returns:**
+double - Valore del TypoLineGap.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public double getTypoLineGap(double fontSize)
+```
+
+
+Restituisce il gap di linea per una dimensione specifica del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - Valore del Line gap.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Ottiene il valore UnitsPerEM.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+Ottiene il valore IsFixedPitch.
+
+**Returns:**
+boolean - Valore del IsFixedPitch.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public double measureString(String unicode, double fontSize)
+```
+
+
+Misura la stringa e restituisce la larghezza della stringa.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| unicode | java.lang.String | Stringa Unicode. |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - Larghezza del String.
+### measureString(long[] charCodes, double fontSize) {#measureString-long---double-}
+```
+public double measureString(long[] charCodes, double fontSize)
+```
+
+
+Misura il testo rappresentato come array di codici carattere e restituisce la larghezza della stringa.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| charCodes | long[] | Stringa di testo rappresentata come array di codici carattere. |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - Larghezza del String.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAscender(double value) {#setAscender-double-}
+```
+public void setAscender(double value)
+```
+
+
+Imposta il valore dell'ascendente.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore del Ascender. |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public void setDescender(double value)
+```
+
+
+Imposta il valore del discendente.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore del Descender. |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Imposta la larghezza del glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificatore del glifo. |
+| valore | double | Nuova larghezza. |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public void setTypoAscender(double value)
+```
+
+
+Imposta il valore TypoAscender.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore del TypoAscender. |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public void setTypoDescender(double value)
+```
+
+
+Imposta il valore TypoDescender.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore del TypoDescender. |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public void setUnitsPerEM(long value)
+```
+
+
+Imposta il valore UnitsPerEM.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttffpgmtable/_index.md
+++ b/italian/java/com.aspose.font/ttffpgmtable/_index.md
@@ -1,0 +1,168 @@
+---
+title: "TtfFpgmTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella fpgm del file Font TTF."
+type: docs
+weight: 96
+url: /it/java/com.aspose.font/ttffpgmtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfFpgmTable extends TtfTableBase
+```
+
+Rappresenta la tabella "fpgm" del file TTF Font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getProgram()](#getProgram--) | Ottiene il programma fpgm. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getProgram() {#getProgram--}
+```
+public byte[] getProgram()
+```
+
+
+Ottiene il programma fpgm.
+
+**Returns:**
+byte[] - Programma fpgm.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - Etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfgasptable/_index.md
+++ b/italian/java/com.aspose.font/ttfgasptable/_index.md
@@ -1,0 +1,190 @@
+---
+title: "TtfGaspTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella gasp del file Font TTF."
+type: docs
+weight: 97
+url: /it/java/com.aspose.font/ttfgasptable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfGaspTable extends TtfTableBase
+```
+
+Rappresenta la tabella "gasp" del file TTF Font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGaspRanges()](#getGaspRanges--) | Ottiene l'elenco dei record GaspRange che fornisce comportamenti consigliati per varie dimensioni ppem. |
+| [getNumRanges()](#getNumRanges--) | Ottiene i record GaspRange. |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getTag()](#getTag--) | Ottiene il tag della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [getVersion()](#getVersion--) | Ottiene la versione della tabella. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGaspRanges() {#getGaspRanges--}
+```
+public List<GaspRange> getGaspRanges()
+```
+
+
+Ottiene l'elenco dei record GaspRange che fornisce comportamenti consigliati per varie dimensioni ppem.
+
+**Returns:**
+java.util.List<com.aspose.font.GaspRange> - L'elenco dei GaspRange.
+### getNumRanges() {#getNumRanges--}
+```
+public int getNumRanges()
+```
+
+
+Ottiene i record GaspRange.
+
+**Returns:**
+int - record GaspRange.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene il tag della tabella.
+
+**Returns:**
+java.lang.String - L'etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public int getVersion()
+```
+
+
+Ottiene la versione della tabella.
+
+**Returns:**
+int - La versione della tabella.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfglyftable/_index.md
+++ b/italian/java/com.aspose.font/ttfglyftable/_index.md
@@ -1,0 +1,189 @@
+---
+title: "TtfGlyfTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella glyf del file di carattere TTF."
+type: docs
+weight: 98
+url: /it/java/com.aspose.font/ttfglyftable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfGlyfTable extends TtfTableBase
+```
+
+Rappresenta la tabella "glyf" del file TTF font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [containsGlyph(int glyphIndex)](#containsGlyph-int-) | Restituisce true se la tabella contiene il glifo con glyphIndex. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGlyph(long glyphIndex)](#getGlyph-long-) | Restituisce un glifo per indice di glifo. |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### containsGlyph(int glyphIndex) {#containsGlyph-int-}
+```
+public boolean containsGlyph(int glyphIndex)
+```
+
+
+Restituisce true se la tabella contiene il glifo con glyphIndex.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphIndex | int | Indice del glifo. |
+
+**Returns:**
+boolean - True se la tabella contiene il glifo per l'indice specificato, false altrimenti.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyph(long glyphIndex) {#getGlyph-long-}
+```
+public Glyph getGlyph(long glyphIndex)
+```
+
+
+Restituisce un glifo per indice di glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphIndex | long | Indice del glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph Glyph related to index specified.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - Etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfheadtable/_index.md
+++ b/italian/java/com.aspose.font/ttfheadtable/_index.md
@@ -1,0 +1,344 @@
+---
+title: "TtfHeadTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella head del file di font TTF."
+type: docs
+weight: 99
+url: /it/java/com.aspose.font/ttfheadtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfHeadTable extends TtfTableBase
+```
+
+Rappresenta la tabella "head" del file TTF Font.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCheckSumAdjustment()](#getCheckSumAdjustment--) | Ottiene uint32 checkSumAdjustment. |
+| [getClass()](#getClass--) |  |
+| [getCreated()](#getCreated--) | Ottiene longDateTime data internazionale di creazione. |
+| [getFlags()](#getFlags--) | Ottiene uint16 flags. |
+| [getFontDirectionHint()](#getFontDirectionHint--) | Ottiene int16 fontDirectionHint. 0 Glifi direzionali misti; 1 Solo glifi fortemente da sinistra a destra; 2 Come 1 ma contiene anche neutrali; -1 Solo glifi fortemente da destra a sinistra; -2 Come -1 ma contiene anche neutrali. |
+| [getFontRevision()](#getFontRevision--) | Ottieni fontRevision fixed impostato dal produttore del font. |
+| [getGlyphDataFormat()](#getGlyphDataFormat--) | Ottiene int16 glyphDataFormat 0 per il formato corrente. |
+| [getIndexToLocFormat()](#getIndexToLocFormat--) | Ottiene int16 indexToLocFormat 0 per offset brevi, 1 per lunghi. |
+| [getLowestRecPPEM()](#getLowestRecPPEM--) | Ottiene uint16 lowestRecPPEM dimensione leggibile più piccola in pixel. |
+| [getMacStyle()](#getMacStyle--) | Ottiene uint16 macStyle. |
+| [getMagicNumber()](#getMagicNumber--) | Ottiene uint32 magicNumber impostato a 0x5F0F3CF5. |
+| [getModified()](#getModified--) | Ottiene longDateTime data internazionale di modifica. |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Ottiene uint16 unitsPerEM intervallo da 64 a 16384. |
+| [getVersion()](#getVersion--) | Versione fixed 0x00010000 se (versione 1.0). |
+| [getXMax()](#getXMax--) | Ottiene FWord xMax per tutti i riquadri di delimitazione dei glifi. |
+| [getXMin()](#getXMin--) | Ottiene FWord xMin per tutti i riquadri di delimitazione dei glifi. |
+| [getYMax()](#getYMax--) | Ottiene FWord yMax per tutti i riquadri di delimitazione dei glifi. |
+| [getYMin()](#getYMin--) | Ottiene FWord yMin per tutti i riquadri di delimitazione dei glifi. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCheckSumAdjustment() {#getCheckSumAdjustment--}
+```
+public long getCheckSumAdjustment()
+```
+
+
+Ottiene uint32 checkSumAdjustment. Per calcolarlo: impostalo a 0, calcola il checksum per la tabella 'head' e inseriscilo nella directory della tabella, somma l'intero font come uint32, quindi memorizza B1B0AFBA - somma. Il checksum per la tabella 'head' non sarà errato. Va bene.
+
+**Returns:**
+long - Uint32 checkSumAdjustment.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCreated() {#getCreated--}
+```
+public Date getCreated()
+```
+
+
+Ottiene longDateTime data internazionale di creazione.
+
+**Returns:**
+java.util.Date - LongDateTime data internazionale di creazione.
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Ottiene uint16 flags.
+
+**Returns:**
+int - UInt16 flags.
+### getFontDirectionHint() {#getFontDirectionHint--}
+```
+public short getFontDirectionHint()
+```
+
+
+Ottiene int16 fontDirectionHint. 0 Glifi direzionali misti; 1 Solo glifi fortemente da sinistra a destra; 2 Come 1 ma contiene anche neutrali; -1 Solo glifi fortemente da destra a sinistra; -2 Come -1 ma contiene anche neutrali.
+
+**Returns:**
+short - Int16 fontDirectionHint.
+### getFontRevision() {#getFontRevision--}
+```
+public float getFontRevision()
+```
+
+
+Ottieni fontRevision fixed impostato dal produttore del font.
+
+**Returns:**
+float - Fixed fontRevision impostato dal produttore del font.
+### getGlyphDataFormat() {#getGlyphDataFormat--}
+```
+public short getGlyphDataFormat()
+```
+
+
+Ottiene int16 glyphDataFormat 0 per il formato corrente.
+
+**Returns:**
+short - Int16 glyphDataFormat 0 per il formato corrente.
+### getIndexToLocFormat() {#getIndexToLocFormat--}
+```
+public short getIndexToLocFormat()
+```
+
+
+Ottiene int16 indexToLocFormat 0 per offset brevi, 1 per lunghi.
+
+**Returns:**
+short - Int16 indexToLocFormat 0 per offset brevi, 1 per lunghi.
+### getLowestRecPPEM() {#getLowestRecPPEM--}
+```
+public int getLowestRecPPEM()
+```
+
+
+Ottiene uint16 lowestRecPPEM dimensione leggibile più piccola in pixel.
+
+**Returns:**
+int - UInt16 lowestRecPPEM dimensione leggibile più piccola in pixel.
+### getMacStyle() {#getMacStyle--}
+```
+public int getMacStyle()
+```
+
+
+Ottiene uint16 macStyle.
+
+**Returns:**
+int - UInt16 macStyle.
+### getMagicNumber() {#getMagicNumber--}
+```
+public long getMagicNumber()
+```
+
+
+Ottiene uint32 magicNumber impostato a 0x5F0F3CF5.
+
+**Returns:**
+long - UInt32 magicNumber impostato a 0x5F0F3CF5.
+### getModified() {#getModified--}
+```
+public Date getModified()
+```
+
+
+Ottiene longDateTime data internazionale di modifica.
+
+**Returns:**
+java.util.Date - LongDateTime data internazionale modificata.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - Etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Ottiene uint16 unitsPerEM intervallo da 64 a 16384.
+
+**Returns:**
+long - UInt16 unitsPerEM intervallo da 64 a 16384.
+### getVersion() {#getVersion--}
+```
+public float getVersion()
+```
+
+
+Versione fixed 0x00010000 se (versione 1.0).
+
+**Returns:**
+float - Versione fissa 0x00010000 se (versione 1.0).
+### getXMax() {#getXMax--}
+```
+public short getXMax()
+```
+
+
+Ottiene FWord xMax per tutti i riquadri di delimitazione dei glifi.
+
+**Returns:**
+short - FWord xMax per tutti i riquadri di delimitazione dei glifi.
+### getXMin() {#getXMin--}
+```
+public short getXMin()
+```
+
+
+Ottiene FWord xMin per tutti i riquadri di delimitazione dei glifi.
+
+**Returns:**
+short - FWord xMin per tutti i riquadri di delimitazione dei glifi.
+### getYMax() {#getYMax--}
+```
+public short getYMax()
+```
+
+
+Ottiene FWord yMax per tutti i riquadri di delimitazione dei glifi.
+
+**Returns:**
+short - FWord yMax per tutti i riquadri di delimitazione dei glifi.
+### getYMin() {#getYMin--}
+```
+public short getYMin()
+```
+
+
+Ottiene FWord yMin per tutti i riquadri di delimitazione dei glifi.
+
+**Returns:**
+short - FWord yMin per tutti i riquadri di delimitazione dei glifi.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfhheatable/_index.md
+++ b/italian/java/com.aspose.font/ttfhheatable/_index.md
@@ -1,0 +1,300 @@
+---
+title: "TtfHheaTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella hhea del file di carattere TTF."
+type: docs
+weight: 100
+url: /it/java/com.aspose.font/ttfhheatable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfHheaTable extends TtfTableBase
+```
+
+Rappresenta la tabella "hhea" del file di font TTF.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdvanceWidthMax()](#getAdvanceWidthMax--) | Ottiene uFWord advanceWidthMax deve essere coerente con le metriche orizzontali. |
+| [getAscent()](#getAscent--) | Ottiene l'ascesa. |
+| [getCaretOffset()](#getCaretOffset--) | Ottiene l'offset del caret. |
+| [getCaretSlopeRise()](#getCaretSlopeRise--) | Ottiene caret slop rise. |
+| [getCaretSlopeRun()](#getCaretSlopeRun--) | Ottiene caret slop run. |
+| [getClass()](#getClass--) |  |
+| [getDescent()](#getDescent--) | Ottiene la discesa. |
+| [getLineGap()](#getLineGap--) | Ottiene il lineGap. |
+| [getMetricDataFormat()](#getMetricDataFormat--) | Ottiene il formato dei dati metrici. |
+| [getMinLeftSideBearing()](#getMinLeftSideBearing--) | Ottiene il valore MinLeftSideBearing. |
+| [getMinRightSideBearing()](#getMinRightSideBearing--) | Ottiene il valore MinRightSideBearing. |
+| [getNumOfLongHorMetrics()](#getNumOfLongHorMetrics--) | Ottiene uint16 numOfLongHorMetrics numero di larghezze di avanzamento nella tabella metriche. |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [getVersion()](#getVersion--) | Ottiene la versione. |
+| [getXMaxExtent()](#getXMaxExtent--) | Ottiene il valore XMaxExtent. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdvanceWidthMax() {#getAdvanceWidthMax--}
+```
+public int getAdvanceWidthMax()
+```
+
+
+Ottiene uFWord advanceWidthMax deve essere coerente con le metriche orizzontali.
+
+**Returns:**
+int - uFWord advanceWidthMax deve essere coerente con le metriche orizzontali.
+### getAscent() {#getAscent--}
+```
+public short getAscent()
+```
+
+
+Ottiene l'ascesa.
+
+**Returns:**
+short - L'ascesa.
+### getCaretOffset() {#getCaretOffset--}
+```
+public short getCaretOffset()
+```
+
+
+Ottiene l'offset del caret.
+
+**Returns:**
+short - L'offset del caret.
+### getCaretSlopeRise() {#getCaretSlopeRise--}
+```
+public short getCaretSlopeRise()
+```
+
+
+Ottiene caret slop rise.
+
+**Returns:**
+short - Il caret slop rise.
+### getCaretSlopeRun() {#getCaretSlopeRun--}
+```
+public short getCaretSlopeRun()
+```
+
+
+Ottiene caret slop run.
+
+**Returns:**
+short - Il caret slop run.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescent() {#getDescent--}
+```
+public short getDescent()
+```
+
+
+Ottiene la discesa.
+
+**Returns:**
+short - La discesa.
+### getLineGap() {#getLineGap--}
+```
+public short getLineGap()
+```
+
+
+Ottiene il lineGap.
+
+**Returns:**
+short - Il lineGap.
+### getMetricDataFormat() {#getMetricDataFormat--}
+```
+public short getMetricDataFormat()
+```
+
+
+Ottiene il formato dei dati metrici.
+
+**Returns:**
+short - Il formato dei dati metrici.
+### getMinLeftSideBearing() {#getMinLeftSideBearing--}
+```
+public short getMinLeftSideBearing()
+```
+
+
+Ottiene il valore MinLeftSideBearing.
+
+**Returns:**
+short - Il valore MinLeftSideBearing.
+### getMinRightSideBearing() {#getMinRightSideBearing--}
+```
+public short getMinRightSideBearing()
+```
+
+
+Ottiene il valore MinRightSideBearing.
+
+**Returns:**
+short - Il valore MinRightSideBearing.
+### getNumOfLongHorMetrics() {#getNumOfLongHorMetrics--}
+```
+public int getNumOfLongHorMetrics()
+```
+
+
+Ottiene uint16 numOfLongHorMetrics numero di larghezze di avanzamento nella tabella metriche.
+
+**Returns:**
+int - UInt16 numOfLongHorMetrics numero di larghezze di avanzamento nella tabella delle metriche.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - Etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public float getVersion()
+```
+
+
+Ottiene la versione.
+
+**Returns:**
+float - Versione del formato della tabella.
+### getXMaxExtent() {#getXMaxExtent--}
+```
+public short getXMaxExtent()
+```
+
+
+Ottiene il valore XMaxExtent.
+
+**Returns:**
+short - Il valore XMaxExtent.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfhmtxtable/_index.md
+++ b/italian/java/com.aspose.font/ttfhmtxtable/_index.md
@@ -1,0 +1,190 @@
+---
+title: "TtfHmtxTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella hmtx del file di font TTF."
+type: docs
+weight: 101
+url: /it/java/com.aspose.font/ttfhmtxtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfHmtxTable extends TtfTableBase
+```
+
+Rappresenta la tabella "hmtx" del file di font TTF.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalAdvanceWidth()](#getAdditionalAdvanceWidth--) | Nella tabella hmtx potrebbero esserci casi in cui il numero totale di glifi non è uguale a hhea.numberOfHMetrics. |
+| [getClass()](#getClass--) |  |
+| [getHMetrics()](#getHMetrics--) | Ottiene le metriche orizzontali. |
+| [getLeftSidebearings()](#getLeftSidebearings--) | Ottiene i left side bearings. |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalAdvanceWidth() {#getAdditionalAdvanceWidth--}
+```
+public int getAdditionalAdvanceWidth()
+```
+
+
+Nella tabella hmtx potrebbero esserci casi in cui il numero totale di glifi non è uguale a hhea.numberOfHMetrics. Per questi casi la tabella hmtx contiene un array aggiuntivo 'leftSideBearing' che corrisponde alla proprietà LeftSidebearings. Tuttavia i glifi con indici da hhea.numOfLongHorMetrics a maxp.numGlyphs hanno anche larghezze. E queste larghezze, in conformità alla specifica per la tabella hmtx, hanno i seguenti valori: "Here the advanceWidth is assumed to be the same as the advanceWidth for the last entry above".
+
+**Returns:**
+int - Larghezza di avanzamento aggiuntiva.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHMetrics() {#getHMetrics--}
+```
+public TtfHmtxTable.MetricList getHMetrics()
+```
+
+
+Ottiene le metriche orizzontali.
+
+**Returns:**
+[MetricList](../../com.aspose.font/metriclist) - Horizontal metrics.
+### getLeftSidebearings() {#getLeftSidebearings--}
+```
+public short[] getLeftSidebearings()
+```
+
+
+Ottiene i left side bearings.
+
+**Returns:**
+short[] - Left side bearings.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - Etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttflocatable/_index.md
+++ b/italian/java/com.aspose.font/ttflocatable/_index.md
@@ -1,0 +1,157 @@
+---
+title: "TtfLocaTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella loca del file di font TTF."
+type: docs
+weight: 102
+url: /it/java/com.aspose.font/ttflocatable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfLocaTable extends TtfTableBase
+```
+
+Rappresenta la tabella "loca" del file di font TTF.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - Etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfltshtable/_index.md
+++ b/italian/java/com.aspose.font/ttfltshtable/_index.md
@@ -1,0 +1,195 @@
+---
+title: "TtfLtshTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella Linear Threshold del file di font TTF."
+type: docs
+weight: 103
+url: /it/java/com.aspose.font/ttfltshtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfLtshTable extends TtfTableBase
+```
+
+Rappresenta la tabella Linear Threshold del file di font TTF.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getNumGlyphs()](#getNumGlyphs--) | Ottiene il numero di glifi (da "numGlyphs" nella tabella 'maxp'). |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getTag()](#getTag--) | Ottiene il tag della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [getVersion()](#getVersion--) | Ottiene la versione della tabella. |
+| [getYPel(int glyphNum)](#getYPel-int-) | Restituisce l'altezza verticale del pel per il glifo/zero se il numero del glifo è errato. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Ottiene il numero di glifi (da "numGlyphs" nella tabella 'maxp').
+
+**Returns:**
+int - Il numero di glifi (da "numGlyphs" nella tabella 'maxp').
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene il tag della tabella.
+
+**Returns:**
+java.lang.String - L'etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public int getVersion()
+```
+
+
+Ottiene la versione della tabella.
+
+**Returns:**
+int - La versione della tabella.
+### getYPel(int glyphNum) {#getYPel-int-}
+```
+public byte getYPel(int glyphNum)
+```
+
+
+Restituisce l'altezza verticale del pel per il glifo/zero se il numero del glifo è errato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphNum | int | Un numero di glifo (indice). |
+
+**Returns:**
+byte - L'altezza verticale del pel per il glifo/zero se il numero del glifo è errato.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfmaxptable/_index.md
+++ b/italian/java/com.aspose.font/ttfmaxptable/_index.md
@@ -1,0 +1,333 @@
+---
+title: "TtfMaxpTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella maxp del file font TTF"
+type: docs
+weight: 104
+url: /it/java/com.aspose.font/ttfmaxptable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfMaxpTable extends TtfTableBase
+```
+
+Rappresenta la tabella "maxp" del file di font TTF
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxComponentContours()](#getMaxComponentContours--) | Ottiene uint16 maxComponentContours contorni in glifo composto. |
+| [getMaxComponentDepth()](#getMaxComponentDepth--) | Ottiene uint16 maxComponentDepth livelli di ricorsione, impostato a 0 se il font ha solo glifi semplici. |
+| [getMaxComponentElements()](#getMaxComponentElements--) | Ottiene uint16 maxComponentElements numero di glifi referenziati al livello superiore. |
+| [getMaxComponentPoints()](#getMaxComponentPoints--) | Ottiene uint16 maxComponentPoints punti in glifo composto. |
+| [getMaxContours()](#getMaxContours--) | Ottiene uint16 maxContours contorni in glifo non composto. |
+| [getMaxFunctionDefs()](#getMaxFunctionDefs--) | Ottiene uint16 maxFunctionDefs numero di FDEF. |
+| [getMaxInstructionDefs()](#getMaxInstructionDefs--) | Ottiene uint16 maxInstructionDefs numero di IDEF. |
+| [getMaxPoints()](#getMaxPoints--) | Ottieni uint16 maxPoints punti in glifo non composto. |
+| [getMaxSizeOfInstructions()](#getMaxSizeOfInstructions--) | Ottiene uint16 maxSizeOfInstructions conteggio byte per le istruzioni del glifo. |
+| [getMaxStackElements()](#getMaxStackElements--) | Ottiene uint16 maxStackElements profondità massima dello stack. |
+| [getMaxStorage()](#getMaxStorage--) | Ottiene uint16 maxStorage numero di posizioni dell'Area di Memorizzazione. |
+| [getMaxTwilightPoints()](#getMaxTwilightPoints--) | Ottiene uint16 maxTwilightPoints punti usati nella Twilight Zone (Z0). |
+| [getMaxZones()](#getMaxZones--) | Ottiene uint16 maxZones impostato a 2. |
+| [getNumGlyphs()](#getNumGlyphs--) | Ottiene uint16 numGlyphs il numero di glifi nel Font. |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getTableVersion()](#getTableVersion--) | Ottiene la versione del formato. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [getVersion()](#getVersion--) | Ottiene la versione fissa 0x00010000 se (versione 1.0). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxComponentContours() {#getMaxComponentContours--}
+```
+public int getMaxComponentContours()
+```
+
+
+Ottiene uint16 maxComponentContours contorni in glifo composto.
+
+**Returns:**
+int - UInt16 maxComponentContours contorni in glifo composto.
+### getMaxComponentDepth() {#getMaxComponentDepth--}
+```
+public int getMaxComponentDepth()
+```
+
+
+Ottiene uint16 maxComponentDepth livelli di ricorsione, impostato a 0 se il font ha solo glifi semplici.
+
+**Returns:**
+int - Uint16 maxComponentDepth livelli di ricorsione, impostati a 0 se il font contiene solo glifi semplici.
+### getMaxComponentElements() {#getMaxComponentElements--}
+```
+public int getMaxComponentElements()
+```
+
+
+Ottiene uint16 maxComponentElements numero di glifi referenziati al livello superiore.
+
+**Returns:**
+int - UInt16 maxComponentElements numero di glifi referenziati al livello superiore.
+### getMaxComponentPoints() {#getMaxComponentPoints--}
+```
+public int getMaxComponentPoints()
+```
+
+
+Ottiene uint16 maxComponentPoints punti in glifo composto.
+
+**Returns:**
+int - UInt16 maxComponentPoints punti in glifo composto.
+### getMaxContours() {#getMaxContours--}
+```
+public int getMaxContours()
+```
+
+
+Ottiene uint16 maxContours contorni in glifo non composto.
+
+**Returns:**
+int - UInt16 maxContours contorni in glifo non composto.
+### getMaxFunctionDefs() {#getMaxFunctionDefs--}
+```
+public int getMaxFunctionDefs()
+```
+
+
+Ottiene uint16 maxFunctionDefs numero di FDEF.
+
+**Returns:**
+int - UInt16 maxFunctionDefs numero di FDEFs.
+### getMaxInstructionDefs() {#getMaxInstructionDefs--}
+```
+public int getMaxInstructionDefs()
+```
+
+
+Ottiene uint16 maxInstructionDefs numero di IDEF.
+
+**Returns:**
+int - UInt16 maxInstructionDefs numero di IDEFs.
+### getMaxPoints() {#getMaxPoints--}
+```
+public int getMaxPoints()
+```
+
+
+Ottieni uint16 maxPoints punti in glifo non composto.
+
+**Returns:**
+int - UInt16 maxPoints punti in glifo non composto.
+### getMaxSizeOfInstructions() {#getMaxSizeOfInstructions--}
+```
+public int getMaxSizeOfInstructions()
+```
+
+
+Ottiene uint16 maxSizeOfInstructions conteggio byte per le istruzioni del glifo.
+
+**Returns:**
+int - UInt16 maxSizeOfInstructions conteggio dei byte per le istruzioni del glifo.
+### getMaxStackElements() {#getMaxStackElements--}
+```
+public int getMaxStackElements()
+```
+
+
+Ottiene uint16 maxStackElements profondità massima dello stack.
+
+**Returns:**
+int - UInt16 maxStackElements profondità massima dello stack.
+### getMaxStorage() {#getMaxStorage--}
+```
+public int getMaxStorage()
+```
+
+
+Ottiene uint16 maxStorage numero di posizioni dell'Area di Memorizzazione.
+
+**Returns:**
+int - UInt16 maxStorage numero di posizioni dell'Area di Memorizzazione.
+### getMaxTwilightPoints() {#getMaxTwilightPoints--}
+```
+public int getMaxTwilightPoints()
+```
+
+
+Ottiene uint16 maxTwilightPoints punti usati nella Twilight Zone (Z0).
+
+**Returns:**
+int - UInt16 maxTwilightPoints punti usati nella Twilight Zone (Z0).
+### getMaxZones() {#getMaxZones--}
+```
+public int getMaxZones()
+```
+
+
+Ottiene uint16 maxZones impostato a 2.
+
+**Returns:**
+int - Uint16 maxZones impostato a 2.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Ottiene uint16 numGlyphs il numero di glifi nel Font.
+
+**Returns:**
+int - UInt16 numGlyphs il numero di glifi nel Font.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getTableVersion() {#getTableVersion--}
+```
+public Version16Dot16 getTableVersion()
+```
+
+
+Ottiene la versione del formato. Usa le proprietà MajorNumber e MinorNUmber dell'oggetto Version16Dot16 in notazione esadecimale per rilevare la versione utilizzata.
+
+**Returns:**
+[Version16Dot16](../../com.aspose.font/version16dot16) - Format version.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - Etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public float getVersion()
+```
+
+
+Ottiene la versione fissa 0x00010000 se (versione 1.0). Obsoleta, usa la proprietà TableVersion invece.
+
+**Returns:**
+float - Versione fissa 0x00010000 se (versione 1.0).
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfnametable/_index.md
+++ b/italian/java/com.aspose.font/ttfnametable/_index.md
@@ -1,0 +1,381 @@
+---
+title: "TtfNameTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella dei nomi del file di font TTF."
+type: docs
+weight: 105
+url: /it/java/com.aspose.font/ttfnametable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfNameTable extends TtfTableBase
+```
+
+Rappresenta la tabella "name" del file di font TTF.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addMultiLanguageNames(MultiLanguageString mlNames, PlatformId platformId, int platformSpecificId, NameId nameId)](#addMultiLanguageNames-com.aspose.font.MultiLanguageString-com.aspose.font.PlatformId-int-com.aspose.font.NameId-) | Estrae tutte le stringhe multilingue dall'oggetto mlNames passato e crea la struttura NameRecord corrispondente per ogni stringa estratta utilizzando i parametri passati platformId, platformSpecificId e nameId. |
+| [addName(NameId nameId, PlatformId platformId, int platformSpecificId, int languageId, String name)](#addName-com.aspose.font.NameId-com.aspose.font.PlatformId-int-int-java.lang.String-) | Aggiunge una voce nella tabella. |
+| [deleteRecords(PlatformId platformId, int platformSpecificId)](#deleteRecords-com.aspose.font.PlatformId-int-) | Elimina tutti i record relativi alla piattaforma specificata |
+| [deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId)](#deleteRecords-com.aspose.font.PlatformId-int-com.aspose.font.NameId-) | Elimina tutti i record relativi ai parametri passati |
+| [deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId)](#deleteRecords-com.aspose.font.PlatformId-int-com.aspose.font.NameId-int-) | Elimina i record relativi ai parametri specificati |
+| [deleteRecordsByNameId(NameId nameId)](#deleteRecordsByNameId-com.aspose.font.NameId-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllNameRecords()](#getAllNameRecords--) | Restituisce tutte le strutture NameRecord dalla tabella. |
+| [getClass()](#getClass--) |  |
+| [getMultiLanguageNameById(NameId nameId)](#getMultiLanguageNameById-com.aspose.font.NameId-) | restituisce un nome per nameId |
+| [getMultiLanguageNameById(NameId nameId, PlatformId platformId)](#getMultiLanguageNameById-com.aspose.font.NameId-com.aspose.font.PlatformId-) | Restituisce un nome per nameId utilizzando l'identificatore di piattaforma passato. |
+| [getMultiLanguageNameById(NameId nameId, PlatformId platformId, int platformSpecificId)](#getMultiLanguageNameById-com.aspose.font.NameId-com.aspose.font.PlatformId-int-) | Restituisce un nome come oggetto di tipo MultiLanguageString. |
+| [getNameById(NameId nameId)](#getNameById-com.aspose.font.NameId-) | Restituisce un nome per nameId se trovato, null altrimenti. |
+| [getNameRecordsByNameId(NameId nameId)](#getNameRecordsByNameId-com.aspose.font.NameId-) | Restituisce tutte le strutture NameRecord il cui campo NameId è uguale al valore nameId passato. |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [updateName(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId, String newName)](#updateName-com.aspose.font.PlatformId-int-com.aspose.font.NameId-int-java.lang.String-) | Aggiorna il nome nei record relativi alla piattaforma specificata (combinazione di platformId e platformSpecificId), categoria (nameId) e lingua (languageId). |
+| [updateNamesByNameId(NameId nameId, String newName)](#updateNamesByNameId-com.aspose.font.NameId-java.lang.String-) | Seleziona tutti i record relativi alla categoria logica della stringa, specificata dal parametro nameId, e aggiorna il campo nome (dati della stringa) in questi record. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### addMultiLanguageNames(MultiLanguageString mlNames, PlatformId platformId, int platformSpecificId, NameId nameId) {#addMultiLanguageNames-com.aspose.font.MultiLanguageString-com.aspose.font.PlatformId-int-com.aspose.font.NameId-}
+```
+public void addMultiLanguageNames(MultiLanguageString mlNames, PlatformId platformId, int platformSpecificId, NameId nameId)
+```
+
+
+Estrae tutte le stringhe multilingue dall'oggetto mlNames passato e crea la struttura NameRecord corrispondente per ogni stringa estratta utilizzando i parametri passati platformId, platformSpecificId e nameId. Il valore per il campo languageID è estratto dall'oggetto mlNames. Il nuovo record appena creato viene aggiunto alla tabella. Se viene trovato un record che coincide con quello appena creato per i campi platformID, platformSpecificID, nameID e languageId, il nuovo record non verrà aggiunto e solo i dati della stringa verranno aggiornati per il record esistente.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| mlNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Stringa multilingue |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Identificatore di piattaforma |
+| platformSpecificId | int | Identificatore di codifica specifico per la piattaforma |
+| nameId | [NameId](../../com.aspose.font/nameid) | Identificatore di nome, categoria logica della stringa, specificato dall'enumerazione NameId |
+
+### addName(NameId nameId, PlatformId platformId, int platformSpecificId, int languageId, String name) {#addName-com.aspose.font.NameId-com.aspose.font.PlatformId-int-int-java.lang.String-}
+```
+public void addName(NameId nameId, PlatformId platformId, int platformSpecificId, int languageId, String name)
+```
+
+
+Aggiunge una voce nella tabella. La categoria dei dati stringa da aggiungere è specificata dal parametro  name .
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Identificatore del nome, categoria logica della stringa, specificata dall'enumerazione [NameId](../../com.aspose.font/nameid). |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Identificatore della piattaforma. |
+| platformSpecificId | int | Identificatore della codifica specifica della piattaforma. Per favore, utilizza un valore da una di queste enumerazioni -  UnicodePlatformSpecificId ,  MacPlatformSpecificId ,  MSPlatformSpecificId . L'enumerazione da utilizzare è definita dal contesto ( parametro  platformId ). |
+| languageId | int | Identificatore della lingua. Per favore, utilizza un valore dalle enumerazioni  MSLanguageId  o  MacLanguageId  a seconda del contesto, definito dal parametro  platformId . |
+| nome | java.lang.String | Dati stringa effettivi. |
+
+### deleteRecords(PlatformId platformId, int platformSpecificId) {#deleteRecords-com.aspose.font.PlatformId-int-}
+```
+public void deleteRecords(PlatformId platformId, int platformSpecificId)
+```
+
+
+Elimina tutti i record relativi alla piattaforma specificata
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Identificatore di piattaforma |
+| platformSpecificId | int | Identificatore di codifica specifico per la piattaforma |
+
+### deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId) {#deleteRecords-com.aspose.font.PlatformId-int-com.aspose.font.NameId-}
+```
+public void deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId)
+```
+
+
+Elimina tutti i record relativi ai parametri passati
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Identificatore di piattaforma |
+| platformSpecificId | int | Identificatore di codifica specifico per la piattaforma |
+| nameId | [NameId](../../com.aspose.font/nameid) | Identificatore di nome, categoria logica della stringa, specificato dall'enumerazione NameId |
+
+### deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId) {#deleteRecords-com.aspose.font.PlatformId-int-com.aspose.font.NameId-int-}
+```
+public void deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId)
+```
+
+
+Elimina i record relativi ai parametri specificati
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Identificatore di piattaforma |
+| platformSpecificId | int | Identificatore di codifica specifico per la piattaforma |
+| nameId | [NameId](../../com.aspose.font/nameid) | Identificatore di nome, categoria logica della stringa, specificato dall'enumerazione NameId |
+| languageId | int | Identificatore della lingua |
+
+### deleteRecordsByNameId(NameId nameId) {#deleteRecordsByNameId-com.aspose.font.NameId-}
+```
+public void deleteRecordsByNameId(NameId nameId)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllNameRecords() {#getAllNameRecords--}
+```
+public NameRecord[] getAllNameRecords()
+```
+
+
+Restituisce tutte le strutture NameRecord dalla tabella.
+
+**Returns:**
+com.aspose.font.NameRecord[] - Tutte le strutture  NameRecord  dalla tabella.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMultiLanguageNameById(NameId nameId) {#getMultiLanguageNameById-com.aspose.font.NameId-}
+```
+public MultiLanguageString getMultiLanguageNameById(NameId nameId)
+```
+
+
+restituisce un nome per nameId
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Id nome. |
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - name
+### getMultiLanguageNameById(NameId nameId, PlatformId platformId) {#getMultiLanguageNameById-com.aspose.font.NameId-com.aspose.font.PlatformId-}
+```
+public MultiLanguageString getMultiLanguageNameById(NameId nameId, PlatformId platformId)
+```
+
+
+Restituisce un nome per nameId utilizzando l'identificatore di piattaforma passato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Id Nome. |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | ID piattaforma. |
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Name.
+### getMultiLanguageNameById(NameId nameId, PlatformId platformId, int platformSpecificId) {#getMultiLanguageNameById-com.aspose.font.NameId-com.aspose.font.PlatformId-int-}
+```
+public MultiLanguageString getMultiLanguageNameById(NameId nameId, PlatformId platformId, int platformSpecificId)
+```
+
+
+Restituisce un nome come oggetto di tipo  MultiLanguageString . Il metodo raccoglie tutte le strutture NameRecord che coincidono con i parametri passati nameId, platformId e platformSpecificId e quindi costruisce l'oggetto risultante basandosi su questa lista di strutture.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Id Nome. |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | ID piattaforma. |
+| platformSpecificId | int | Id specifico della piattaforma. |
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Name.
+### getNameById(NameId nameId) {#getNameById-com.aspose.font.NameId-}
+```
+public String getNameById(NameId nameId)
+```
+
+
+Restituisce un nome per nameId se trovato, null altrimenti.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | identificatore del nome |
+
+**Returns:**
+java.lang.String - nome
+### getNameRecordsByNameId(NameId nameId) {#getNameRecordsByNameId-com.aspose.font.NameId-}
+```
+public NameRecord[] getNameRecordsByNameId(NameId nameId)
+```
+
+
+Restituisce tutte le strutture  NameRecord  il cui campo NameId è uguale al valore  nameId  passato. Se non vengono trovati record, verrà restituito un array vuoto.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | identificatore del nome |
+
+**Returns:**
+com.aspose.font.NameRecord[] - Array di strutture  NameRecord 
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - Etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### updateName(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId, String newName) {#updateName-com.aspose.font.PlatformId-int-com.aspose.font.NameId-int-java.lang.String-}
+```
+public void updateName(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId, String newName)
+```
+
+
+Aggiorna il nome nei record relativi alla piattaforma specificata (combinazione di platformId e platformSpecificId), categoria (nameId) e lingua (languageId).
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Identificatore di piattaforma |
+| platformSpecificId | int | Identificatore di codifica specifico per la piattaforma |
+| nameId | [NameId](../../com.aspose.font/nameid) | Identificatore di nome, categoria logica della stringa, specificato dall'enumerazione NameId |
+| languageId | int | Identificatore della lingua |
+| newName | java.lang.String | Nuovo nome o nuovi dati stringa |
+
+### updateNamesByNameId(NameId nameId, String newName) {#updateNamesByNameId-com.aspose.font.NameId-java.lang.String-}
+```
+public void updateNamesByNameId(NameId nameId, String newName)
+```
+
+
+Seleziona tutti i record relativi alla categoria logica della stringa, specificata dal parametro nameId, e aggiorna il campo name (dati stringa) in questi record. I campi relativi alla piattaforma (platformID, Platform-specific encoding ID) e alla lingua (Language ID) non sono influenzati da questo metodo. Solo i dati stringa del nome vengono sostituiti con un nuovo nome. Usa questo metodo con cautela, poiché sostituirà i nomi originali per tutte le piattaforme e lingue correlate a nameId. Può creare conflitti nei casi in cui i nomi originali avevano valori diversi, poiché l'operazione di sostituzione cambia tutti questi valori con un unico nuovo valore. E questo nuovo valore può presentare un'incoerenza logica con alcune piattaforme e lingue. Questo metodo è utile nei casi in cui il nome originale ha una rappresentazione unica per tutte le piattaforme e lingue, ad esempio quando i dati stringa del nome sono in lingua inglese.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Identificatore di nome, categoria logica della stringa, specificato dall'enumerazione NameId |
+| newName | java.lang.String | Nuovo nome o nuovi dati stringa |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfos2table/_index.md
+++ b/italian/java/com.aspose.font/ttfos2table/_index.md
@@ -1,0 +1,578 @@
+---
+title: "TtfOs2Table"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella OS/2 del file Font TTF."
+type: docs
+weight: 106
+url: /it/java/com.aspose.font/ttfos2table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfOs2Table extends TtfTableBase
+```
+
+Rappresenta la tabella "OS/2" del file di font TTF.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAchVendId()](#getAchVendId--) | Ottiene il valore AchVendId. |
+| [getClass()](#getClass--) |  |
+| [getFSSelection()](#getFSSelection--) | Contiene informazioni sulla natura dei pattern del font. |
+| [getFSType()](#getFSType--) | Ottiene il valore FSType. |
+| [getLicenseFlags()](#getLicenseFlags--) | Ottiene i flag incorporati (fsType) nella rappresentazione dell'oggetto. |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getPanose()](#getPanose--) | Questa serie di 10 byte di numeri è usata per descrivere le caratteristiche visive di un determinato tipo di carattere. |
+| [getSCapHeight()](#getSCapHeight--) | Ottiene il valore SCapHeight. |
+| [getSFamilyClass()](#getSFamilyClass--) | Questo parametro è una classificazione del design della famiglia di font. |
+| [getSTypoAscender()](#getSTypoAscender--) | Ottiene il valore STypoAscender. |
+| [getSTypoDescender()](#getSTypoDescender--) | Ottiene il valore STypoDescender. |
+| [getSTypoLineGap()](#getSTypoLineGap--) | Ottiene il valore STypoLineGap. |
+| [getSXHeight()](#getSXHeight--) | Ottiene il valore SXHeight. |
+| [getSupportedTableVersions()](#getSupportedTableVersions--) | Ottiene le versioni supportate della tabella OS/2. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [getULCodePageRange()](#getULCodePageRange--) | Ottiene il valore ULCodePageRange. |
+| [getULUnicodeRange()](#getULUnicodeRange--) | Ottiene il valore ULUnicodeRange. |
+| [getUSBreakChar()](#getUSBreakChar--) | Ottiene il valore USBreakChar. |
+| [getUSDefaultChar()](#getUSDefaultChar--) | Ottiene il valore USDefaultChar. |
+| [getUSFirstCharIndex()](#getUSFirstCharIndex--) | Ottiene il valore USFirstCharIndex. |
+| [getUSLastCharIndex()](#getUSLastCharIndex--) | Ottiene il valore USLastCharIndex. |
+| [getUSLowerOpticalPointSize()](#getUSLowerOpticalPointSize--) | Ottiene il valore USLowerOpticalPointSize. |
+| [getUSMaxContext()](#getUSMaxContext--) | Ottiene il valore USMaxContext. |
+| [getUSUpperOpticalPointSize()](#getUSUpperOpticalPointSize--) | Ottiene il valore USUpperOpticalPointSize. |
+| [getUSWeightClass()](#getUSWeightClass--) | Indica il peso visivo (grado di oscurità o spessore dei tratti) dei caratteri nel Font. |
+| [getUSWidthClass()](#getUSWidthClass--) | Indica una variazione relativa dal rapporto d'aspetto normale (rapporto larghezza/altezza) come specificato da un designer di font per i glifi in un Font. |
+| [getUSWinAscent()](#getUSWinAscent--) | Ottiene il valore USWinAscent. |
+| [getUSWinDescent()](#getUSWinDescent--) | Ottiene il valore USWinDescent. |
+| [getVersion()](#getVersion--) | Ottiene il valore Version. |
+| [getXAvgCharWidth()](#getXAvgCharWidth--) | Ottiene il parametro Average Character Width. |
+| [getYStrikeoutPosition()](#getYStrikeoutPosition--) | Ottiene il valore YStrikeoutPosition. |
+| [getYStrikeoutSize()](#getYStrikeoutSize--) | Ottiene il valore YStrikeoutSize. |
+| [getYSubscriptXOffset()](#getYSubscriptXOffset--) | Ottiene il valore YSubscriptXOffset. |
+| [getYSubscriptXSize()](#getYSubscriptXSize--) | Ottiene il valore YSubscriptXSize. |
+| [getYSubscriptYOffset()](#getYSubscriptYOffset--) | Ottiene il valore YSubscriptYOffset. |
+| [getYSubscriptYSize()](#getYSubscriptYSize--) | Ottiene il valore YSubscriptYSize. |
+| [getYSuperscriptXOffset()](#getYSuperscriptXOffset--) | Ottiene il valore YSuperscriptXOffset. |
+| [getYSuperscriptXSize()](#getYSuperscriptXSize--) | Ottiene il valore YSuperscriptXSize. |
+| [getYSuperscriptYOffset()](#getYSuperscriptYOffset--) | Ottiene il valore YSuperscriptYOffset. |
+| [getYSuperscriptYSize()](#getYSuperscriptYSize--) | Ottiene il valore YSuperscriptYSize. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAchVendId() {#getAchVendId--}
+```
+public byte[] getAchVendId()
+```
+
+
+Ottiene il valore AchVendId.
+
+**Returns:**
+byte[] - valore AchVendId.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFSSelection() {#getFSSelection--}
+```
+public int getFSSelection()
+```
+
+
+Contiene informazioni sulla natura dei pattern del font.
+
+> ```
+> 0	bit 1	ITALIC	Font contains Italic characters, otherwise they are upright.
+>  1	 	    UNDERSCORE	Characters are underscored.
+>  2	 	    NEGATIVE	Characters have their foreground and background reversed.
+>  3	 	    OUTLINED	Outline (hollow) characters, otherwise they are solid.
+>  4	 	    STRIKEOUT	Characters are overstruck.
+>  5	bit 0	BOLD	Characters are emboldened.
+>  6	 	    REGULAR	Characters are in the standard weight/style for the font.
+> ```
+
+**Returns:**
+int - L'informazione.
+### getFSType() {#getFSType--}
+```
+public int getFSType()
+```
+
+
+Ottiene il valore FSType.
+
+--------------------
+
+Indica i diritti di licenza per l'incorporamento del font per il Font.
+
+**Returns:**
+int - valore FSType.
+### getLicenseFlags() {#getLicenseFlags--}
+```
+public LicenseFlags getLicenseFlags()
+```
+
+
+Ottiene i flag incorporati (fsType) nella rappresentazione dell'oggetto.
+
+**Returns:**
+[LicenseFlags](../../com.aspose.font/licenseflags) - Embedded flags.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getPanose() {#getPanose--}
+```
+public byte[] getPanose()
+```
+
+
+Questa serie di 10 byte di numeri è usata per descrivere le caratteristiche visive di un determinato tipo di carattere. Queste caratteristiche sono poi utilizzate per associare il font ad altri font di aspetto simile con nomi diversi.
+
+**Returns:**
+byte[] - Le caratteristiche visive di un determinato tipo di carattere.
+### getSCapHeight() {#getSCapHeight--}
+```
+public short getSCapHeight()
+```
+
+
+Ottiene il valore SCapHeight.
+
+**Returns:**
+short - valore SCapHeight.
+### getSFamilyClass() {#getSFamilyClass--}
+```
+public short getSFamilyClass()
+```
+
+
+Questo parametro è una classificazione del design della famiglia di font. La classe di font e la sottoclasse di font sono valori registrati assegnati da IBM a ciascuna famiglia di font. Questo parametro è destinato all'uso per selezionare un font alternativo quando il font richiesto non è disponibile.
+
+**Returns:**
+short - Classificazione del design della famiglia di font.
+### getSTypoAscender() {#getSTypoAscender--}
+```
+public short getSTypoAscender()
+```
+
+
+Ottiene il valore STypoAscender.
+
+**Returns:**
+short - valore STypoAscender.
+### getSTypoDescender() {#getSTypoDescender--}
+```
+public short getSTypoDescender()
+```
+
+
+Ottiene il valore STypoDescender.
+
+**Returns:**
+short - valore STypoDescender.
+### getSTypoLineGap() {#getSTypoLineGap--}
+```
+public short getSTypoLineGap()
+```
+
+
+Ottiene il valore STypoLineGap.
+
+**Returns:**
+short - valore STypoLineGap.
+### getSXHeight() {#getSXHeight--}
+```
+public short getSXHeight()
+```
+
+
+Ottiene il valore SXHeight.
+
+**Returns:**
+short - valore SXHeight.
+### getSupportedTableVersions() {#getSupportedTableVersions--}
+```
+public int[] getSupportedTableVersions()
+```
+
+
+Ottiene le versioni supportate della tabella OS/2.
+
+**Returns:**
+int[] - Versioni supportate della tabella OS/2.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - Etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getULCodePageRange() {#getULCodePageRange--}
+```
+public long[] getULCodePageRange()
+```
+
+
+Ottiene il valore ULCodePageRange.
+
+**Returns:**
+long[] - Valore ULCodePageRange.
+### getULUnicodeRange() {#getULUnicodeRange--}
+```
+public long[] getULUnicodeRange()
+```
+
+
+Ottiene il valore ULUnicodeRange.
+
+**Returns:**
+long[] - Valore ULUnicodeRange.
+### getUSBreakChar() {#getUSBreakChar--}
+```
+public int getUSBreakChar()
+```
+
+
+Ottiene il valore USBreakChar.
+
+**Returns:**
+int - Valore USBreakChar.
+### getUSDefaultChar() {#getUSDefaultChar--}
+```
+public int getUSDefaultChar()
+```
+
+
+Ottiene il valore USDefaultChar.
+
+**Returns:**
+int - Valore USDefaultChar.
+### getUSFirstCharIndex() {#getUSFirstCharIndex--}
+```
+public int getUSFirstCharIndex()
+```
+
+
+Ottiene il valore USFirstCharIndex.
+
+**Returns:**
+int - Valore USFirstCharIndex.
+### getUSLastCharIndex() {#getUSLastCharIndex--}
+```
+public int getUSLastCharIndex()
+```
+
+
+Ottiene il valore USLastCharIndex.
+
+**Returns:**
+int - Valore USLastCharIndex.
+### getUSLowerOpticalPointSize() {#getUSLowerOpticalPointSize--}
+```
+public int getUSLowerOpticalPointSize()
+```
+
+
+Ottiene il valore USLowerOpticalPointSize.
+
+**Returns:**
+int - Il valore USLowerOpticalPointSize.
+### getUSMaxContext() {#getUSMaxContext--}
+```
+public int getUSMaxContext()
+```
+
+
+Ottiene il valore USMaxContext.
+
+**Returns:**
+int - Valore UsMaxContext.
+### getUSUpperOpticalPointSize() {#getUSUpperOpticalPointSize--}
+```
+public int getUSUpperOpticalPointSize()
+```
+
+
+Ottiene il valore USUpperOpticalPointSize.
+
+**Returns:**
+int - Il valore USUpperOpticalPointSize.
+### getUSWeightClass() {#getUSWeightClass--}
+```
+public int getUSWeightClass()
+```
+
+
+Indica il peso visivo (grado di oscurità o spessore dei tratti) dei caratteri nel Font.
+
+**Returns:**
+int - Il peso visivo (grado di oscurità o spessore dei tratti) dei caratteri nel Font.
+### getUSWidthClass() {#getUSWidthClass--}
+```
+public int getUSWidthClass()
+```
+
+
+Indica una variazione relativa dal rapporto d'aspetto normale (rapporto larghezza/altezza) come specificato da un designer di font per i glifi in un Font.
+
+**Returns:**
+int - Una variazione relativa dal rapporto d'aspetto normale (rapporto larghezza/altezza) come specificato da un designer di font per i glifi in un Font.
+### getUSWinAscent() {#getUSWinAscent--}
+```
+public int getUSWinAscent()
+```
+
+
+Ottiene il valore USWinAscent.
+
+**Returns:**
+int - Valore USWinAscent.
+### getUSWinDescent() {#getUSWinDescent--}
+```
+public int getUSWinDescent()
+```
+
+
+Ottiene il valore USWinDescent.
+
+**Returns:**
+int - Valore USWinDescent.
+### getVersion() {#getVersion--}
+```
+public int getVersion()
+```
+
+
+Ottiene il valore Version.
+
+**Returns:**
+int - Valore Versione.
+### getXAvgCharWidth() {#getXAvgCharWidth--}
+```
+public short getXAvgCharWidth()
+```
+
+
+Ottiene il parametro Average Character Width.
+
+**Returns:**
+short - Il parametro Larghezza Media Carattere.
+### getYStrikeoutPosition() {#getYStrikeoutPosition--}
+```
+public short getYStrikeoutPosition()
+```
+
+
+Ottiene il valore YStrikeoutPosition.
+
+**Returns:**
+short - Valore YStrikeoutPosition.
+### getYStrikeoutSize() {#getYStrikeoutSize--}
+```
+public short getYStrikeoutSize()
+```
+
+
+Ottiene il valore YStrikeoutSize.
+
+**Returns:**
+short - Valore YStrikeoutSize.
+### getYSubscriptXOffset() {#getYSubscriptXOffset--}
+```
+public short getYSubscriptXOffset()
+```
+
+
+Ottiene il valore YSubscriptXOffset.
+
+**Returns:**
+short - Valore YSubscriptXOffset.
+### getYSubscriptXSize() {#getYSubscriptXSize--}
+```
+public short getYSubscriptXSize()
+```
+
+
+Ottiene il valore YSubscriptXSize.
+
+**Returns:**
+short - Valore YSubscriptXSize.
+### getYSubscriptYOffset() {#getYSubscriptYOffset--}
+```
+public short getYSubscriptYOffset()
+```
+
+
+Ottiene il valore YSubscriptYOffset.
+
+**Returns:**
+short - Valore YSubscriptYOffset.
+### getYSubscriptYSize() {#getYSubscriptYSize--}
+```
+public short getYSubscriptYSize()
+```
+
+
+Ottiene il valore YSubscriptYSize.
+
+**Returns:**
+short - Valore YSubscriptYSize.
+### getYSuperscriptXOffset() {#getYSuperscriptXOffset--}
+```
+public short getYSuperscriptXOffset()
+```
+
+
+Ottiene il valore YSuperscriptXOffset.
+
+**Returns:**
+short - Valore YSuperscriptXOffset.
+### getYSuperscriptXSize() {#getYSuperscriptXSize--}
+```
+public short getYSuperscriptXSize()
+```
+
+
+Ottiene il valore YSuperscriptXSize.
+
+**Returns:**
+short - Valore YSuperscriptXSize.
+### getYSuperscriptYOffset() {#getYSuperscriptYOffset--}
+```
+public short getYSuperscriptYOffset()
+```
+
+
+Ottiene il valore YSuperscriptYOffset.
+
+**Returns:**
+short - Valore YSuperscriptYOffset.
+### getYSuperscriptYSize() {#getYSuperscriptYSize--}
+```
+public short getYSuperscriptYSize()
+```
+
+
+Ottiene il valore YSuperscriptYSize.
+
+**Returns:**
+short - valore YSuperscriptYSize.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfposttable/_index.md
+++ b/italian/java/com.aspose.font/ttfposttable/_index.md
@@ -1,0 +1,326 @@
+---
+title: "TtfPostTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella post del file di font TTF."
+type: docs
+weight: 107
+url: /it/java/com.aspose.font/ttfposttable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfPostTable extends TtfTableBase
+```
+
+Rappresenta la tabella "post" del file di font TTF
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIndexesForGlyphName(String glyphName)](#getAllGlyphIndexesForGlyphName-java.lang.String-) | Ottiene l'array di indici dei glifi per nome del glifo |
+| [getClass()](#getClass--) |  |
+| [getFormat()](#getFormat--) | Ottiene il formato fisso (versione) di questa tabella. |
+| [getGlyphIndex(String glyphName)](#getGlyphIndex-java.lang.String-) | Ottiene l'indice del glifo per nome del glifo. |
+| [getGlyphName(long glyphIndex)](#getGlyphName-long-) | Ottiene il nome del glifo per indice del glifo. |
+| [getItalicAngle()](#getItalicAngle--) | Restituisce fixed italicAngle Angolo italic in gradi. |
+| [getMaxMemType1()](#getMaxMemType1--) | Restituisce uint32 maxMemType1 Memoria massima utilizzata quando un TrueType Font viene scaricato come Type 1 Font. |
+| [getMaxMemType42()](#getMaxMemType42--) | Restituisce uint32 maxMemType42 Memoria massima utilizzata quando un TrueType font viene scaricato come Type 42 Font. |
+| [getMinMemType1()](#getMinMemType1--) | Restituisce uint32 minMemType1 Memoria minima utilizzata quando un TrueType Font viene scaricato come Type 1 Font. |
+| [getMinMemType42()](#getMinMemType42--) | Restituisce uint32 minMemType42 Memoria minima utilizzata quando un TrueType font viene scaricato come Type 42 Font. |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getTableFormat()](#getTableFormat--) | Restituisce fixed format (versione) di questa tabella. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [getUnderlinePosition()](#getUnderlinePosition--) | Restituisce FWord underlinePosition Posizione della sottolineatura. |
+| [getUnderlineThickness()](#getUnderlineThickness--) | Restituisce FWord underlineThickness Spessore della sottolineatura. |
+| [hasNoPostScriptNames()](#hasNoPostScriptNames--) | Indica che nessuna informazione sul nome PostScript è fornita per i glifi in questo file di font. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Restituisce uint32 isFixedPitch. 0 se il font è a spaziatura proporzionale, diverso da zero se il Font non è a spaziatura proporzionale (cioè monospazio). |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIndexesForGlyphName(String glyphName) {#getAllGlyphIndexesForGlyphName-java.lang.String-}
+```
+public long[] getAllGlyphIndexesForGlyphName(String glyphName)
+```
+
+
+Ottiene l'array di indici dei glifi per nome del glifo
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphName | java.lang.String | Nome glifo |
+
+**Returns:**
+long[] - array di indici dei glifi
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFormat() {#getFormat--}
+```
+public float getFormat()
+```
+
+
+Ottiene il formato fisso (versione) di questa tabella.
+
+**Returns:**
+float - Fixed format(versione) di questa tabella.
+### getGlyphIndex(String glyphName) {#getGlyphIndex-java.lang.String-}
+```
+public long getGlyphIndex(String glyphName)
+```
+
+
+Ottiene l'indice del glifo per nome del glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphName | java.lang.String | Nome del glifo. |
+
+**Returns:**
+long - Indice del glifo. Quando nessuna informazione sul nome PostScript è fornita per i glifi in questo file di font, restituisce l'indice 0, che è il glifo non definito o il glifo \".notdef\".
+### getGlyphName(long glyphIndex) {#getGlyphName-long-}
+```
+public String getGlyphName(long glyphIndex)
+```
+
+
+Ottiene il nome del glifo per indice del glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphIndex | long | Indice del glifo. |
+
+**Returns:**
+java.lang.String - Nome del glifo. Quando nessuna informazione sul nome PostScript è fornita per i glifi in questo file di font, restituisce null.
+### getItalicAngle() {#getItalicAngle--}
+```
+public float getItalicAngle()
+```
+
+
+Restituisce fixed italicAngle Angolo italic in gradi.
+
+**Returns:**
+float - Fixed italicAngle Angolo italic in gradi.
+### getMaxMemType1() {#getMaxMemType1--}
+```
+public long getMaxMemType1()
+```
+
+
+Restituisce uint32 maxMemType1 Memoria massima utilizzata quando un TrueType Font viene scaricato come Type 1 Font.
+
+**Returns:**
+long - UInt32 maxMemType1 Memoria massima utilizzata quando un TrueType Font viene scaricato come Type 1 Font.
+### getMaxMemType42() {#getMaxMemType42--}
+```
+public long getMaxMemType42()
+```
+
+
+Restituisce uint32 maxMemType42 Memoria massima utilizzata quando un TrueType font viene scaricato come Type 42 Font.
+
+**Returns:**
+long - UInt32 maxMemType42 Memoria massima utilizzata quando un TrueType font viene scaricato come Type 42 Font.
+### getMinMemType1() {#getMinMemType1--}
+```
+public long getMinMemType1()
+```
+
+
+Restituisce uint32 minMemType1 Memoria minima utilizzata quando un TrueType Font viene scaricato come Type 1 Font.
+
+**Returns:**
+long - UInt32 minMemType1 Memoria minima utilizzata quando un TrueType Font viene scaricato come Type 1 Font.
+### getMinMemType42() {#getMinMemType42--}
+```
+public long getMinMemType42()
+```
+
+
+Restituisce uint32 minMemType42 Memoria minima utilizzata quando un TrueType font viene scaricato come Type 42 Font.
+
+**Returns:**
+long - UInt32 minMemType42 Memoria minima utilizzata quando un TrueType font viene scaricato come Type 42 Font.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getTableFormat() {#getTableFormat--}
+```
+public Version16Dot16 getTableFormat()
+```
+
+
+Restituisce fixed format (versione) di questa tabella. Usa le proprietà MajorNumber e MinorNUmber dell'oggetto Version16Dot16 in notazione esadecimale per rilevare la versione utilizzata.
+
+**Returns:**
+[Version16Dot16](../../com.aspose.font/version16dot16) - Fixed format (version) of this table.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - Etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getUnderlinePosition() {#getUnderlinePosition--}
+```
+public short getUnderlinePosition()
+```
+
+
+Restituisce FWord underlinePosition Posizione della sottolineatura.
+
+**Returns:**
+short - FWord underlinePosition Posizione della sottolineatura.
+### getUnderlineThickness() {#getUnderlineThickness--}
+```
+public short getUnderlineThickness()
+```
+
+
+Restituisce FWord underlineThickness Spessore della sottolineatura.
+
+**Returns:**
+short - FWord underlineThickness Spessore della sottolineatura.
+### hasNoPostScriptNames() {#hasNoPostScriptNames--}
+```
+public boolean hasNoPostScriptNames()
+```
+
+
+Indica che nessuna informazione sul nome PostScript è fornita per i glifi in questo file di font.
+
+**Returns:**
+boolean - True, se nessuna informazione sul nome PostScript è fornita per i glifi in questo file di font. False, altrimenti.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public long isFixedPitch()
+```
+
+
+Restituisce uint32 isFixedPitch. 0 se il font è a spaziatura proporzionale, diverso da zero se il Font non è a spaziatura proporzionale (cioè monospazio).
+
+**Returns:**
+long - UInt32 isFixedPitch. 0 se il font è a spaziatura proporzionale, diverso da zero se il Font non è a spaziatura proporzionale (cioè monospazio).
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfpreptable/_index.md
+++ b/italian/java/com.aspose.font/ttfpreptable/_index.md
@@ -1,0 +1,168 @@
+---
+title: "TtfPrepTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella prep del file di carattere TTF."
+type: docs
+weight: 108
+url: /it/java/com.aspose.font/ttfpreptable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfPrepTable extends TtfTableBase
+```
+
+Rappresenta la tabella "prep" del file di font TTF.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getProgram()](#getProgram--) | Set di istruzioni. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getProgram() {#getProgram--}
+```
+public byte[] getProgram()
+```
+
+
+Set di istruzioni.
+
+**Returns:**
+byte[] - Set di istruzioni.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - Etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfstattable/_index.md
+++ b/italian/java/com.aspose.font/ttfstattable/_index.md
@@ -1,0 +1,267 @@
+---
+title: "TtfStatTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: 
+type: docs
+weight: 109
+url: /it/java/com.aspose.font/ttfstattable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfStatTable extends TtfTableBase
+```
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addAxisRecord(AxisRecord axisRecord)](#addAxisRecord-com.aspose.font.AxisRecord-) | Aggiunge una struttura Axis Record alla tabella. |
+| [addAxisValueTable(AxisValueTableBase axisValueTable)](#addAxisValueTable-com.aspose.font.AxisValueTableBase-) | Aggiunge una struttura Axis Value Table alla tabella. |
+| [clearAxisRecords()](#clearAxisRecords--) | Rimuove tutti i record degli assi dalla tabella. |
+| [clearAxisValueTables()](#clearAxisValueTables--) | Rimuove tutte le tabelle dei valori degli assi dalla tabella. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisRecords()](#getAxisRecords--) | Restituisce l'array degli assi di design. |
+| [getAxisValueCount()](#getAxisValueCount--) | Restituisce il numero di tabelle dei valori degli assi. |
+| [getAxisValueTables()](#getAxisValueTables--) | Restituisce l'array di Axis Value Tables. |
+| [getClass()](#getClass--) |  |
+| [getDesignAxisCount()](#getDesignAxisCount--) | Restituisce il numero di record degli assi. |
+| [getElidedFallbackName()](#getElidedFallbackName--) | Spec: Nome usato come fallback quando la proiezione dei nomi in un modello di font particolare produce un nome di sottoclasse contenente solo elementi elidibili. |
+| [getElidedFallbackNameId()](#getElidedFallbackNameId--) | Spec: ID nome usato come fallback quando la proiezione dei nomi in un modello di font particolare produce un nome di sottoclasse contenente solo elementi elidibili. |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### addAxisRecord(AxisRecord axisRecord) {#addAxisRecord-com.aspose.font.AxisRecord-}
+```
+public void addAxisRecord(AxisRecord axisRecord)
+```
+
+
+Aggiunge una struttura Axis Record alla tabella.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| axisRecord | [AxisRecord](../../com.aspose.font/axisrecord) | Struttura AxisRecord |
+
+### addAxisValueTable(AxisValueTableBase axisValueTable) {#addAxisValueTable-com.aspose.font.AxisValueTableBase-}
+```
+public void addAxisValueTable(AxisValueTableBase axisValueTable)
+```
+
+
+Aggiunge una struttura Axis Value Table alla tabella.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| axisValueTable | [AxisValueTableBase](../../com.aspose.font/axisvaluetablebase) | Struttura della tabella dei valori dell'asse |
+
+### clearAxisRecords() {#clearAxisRecords--}
+```
+public void clearAxisRecords()
+```
+
+
+Rimuove tutti i record degli assi dalla tabella.
+
+### clearAxisValueTables() {#clearAxisValueTables--}
+```
+public void clearAxisValueTables()
+```
+
+
+Rimuove tutte le tabelle dei valori degli assi dalla tabella.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisRecords() {#getAxisRecords--}
+```
+public AxisRecord[] getAxisRecords()
+```
+
+
+Restituisce l'array degli assi di design. L'array degli assi è un array di strutture di tipo Axis Record. Spec: il record dell'asse fornisce informazioni su un singolo asse di design.
+
+**Returns:**
+com.aspose.font.AxisRecord[] - L'array degli assi di design.
+### getAxisValueCount() {#getAxisValueCount--}
+```
+public int getAxisValueCount()
+```
+
+
+Restituisce il numero di tabelle dei valori degli assi.
+
+**Returns:**
+int - Il numero di tabelle dei valori degli assi.
+### getAxisValueTables() {#getAxisValueTables--}
+```
+public AxisValueTableBase[] getAxisValueTables()
+```
+
+
+Restituisce l'array di Axis Value Tables. Spec: le Axis Value Tables forniscono dettagli riguardo a un valore di attributo di stile specifico su un asse specifico di variazione di design, o una combinazione di valori di assi di variazione di design, e la relazione di tali valori con le etichette usate come elementi nei nomi di sottoclasse.
+
+**Returns:**
+com.aspose.font.AxisValueTableBase[] - L'array di tabelle dei valori dell'asse.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDesignAxisCount() {#getDesignAxisCount--}
+```
+public int getDesignAxisCount()
+```
+
+
+Restituisce il numero di record dell'asse. Specifica: in un font con una tabella 'fvar', questo valore deve essere maggiore o uguale al valore axisCount nella tabella 'fvar'. In tutti i font, deve essere maggiore di zero se axisValueCount è maggiore di zero.
+
+**Returns:**
+int - Il numero di record dell'asse.
+### getElidedFallbackName() {#getElidedFallbackName--}
+```
+public String getElidedFallbackName()
+```
+
+
+Spec: Nome usato come fallback quando la proiezione dei nomi in un modello di font particolare produce un nome di sottoclasse contenente solo elementi elidibili.
+
+**Returns:**
+java.lang.String - Il nome usato come fallback quando la proiezione dei nomi in un modello di font particolare produce un nome di sottogruppo contenente solo elementi elidibili.
+### getElidedFallbackNameId() {#getElidedFallbackNameId--}
+```
+public int getElidedFallbackNameId()
+```
+
+
+Spec: ID nome usato come fallback quando la proiezione dei nomi in un modello di font particolare produce un nome di sottoclasse contenente solo elementi elidibili.
+
+**Returns:**
+int - L'ID del nome.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - Etichetta della tabella.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttftablebase/_index.md
+++ b/italian/java/com.aspose.font/ttftablebase/_index.md
@@ -1,0 +1,146 @@
+---
+title: "TtfTableBase"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la definizione della tabella TTF."
+type: docs
+weight: 110
+url: /it/java/com.aspose.font/ttftablebase/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TtfTableBase
+```
+
+Rappresenta la definizione della tabella TTF.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttftablerepository/_index.md
+++ b/italian/java/com.aspose.font/ttftablerepository/_index.md
@@ -1,0 +1,333 @@
+---
+title: "TtfTableRepository"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "repository delle tabelle TTF"
+type: docs
+weight: 111
+url: /it/java/com.aspose.font/ttftablerepository/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TtfTableRepository
+```
+
+repository delle tabelle TTF
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCMapTable()](#getCMapTable--) | Ottiene la tabella cmap. |
+| [getCffTable()](#getCffTable--) | Ottiene la tabella cff. |
+| [getClass()](#getClass--) |  |
+| [getCvtTable()](#getCvtTable--) | Ottiene la tabella cvt. |
+| [getFpgmTable()](#getFpgmTable--) | Ottiene la tabella fpgm. |
+| [getGaspTable()](#getGaspTable--) | Ottiene la tabella GASP. |
+| [getGlyfTable()](#getGlyfTable--) | Ottiene la tabella glyf. |
+| [getHeadTable()](#getHeadTable--) | Ottiene la tabella head. |
+| [getHheaTable()](#getHheaTable--) | Ottiene la tabella hhea. |
+| [getHmtxTable()](#getHmtxTable--) | Ottiene la tabella hmtx. |
+| [getLocaTable()](#getLocaTable--) | Ottiene la tabella loca. |
+| [getLtshTable()](#getLtshTable--) | Ottiene la tabella LTSH. |
+| [getMaxpTable()](#getMaxpTable--) | Ottiene la tabella maxp. |
+| [getNameTable()](#getNameTable--) | Ottiene la tabella name. |
+| [getOs2Table()](#getOs2Table--) | Ottiene la tabella OS/2. |
+| [getPostTable()](#getPostTable--) | Ottiene la tabella post. |
+| [getPrepTable()](#getPrepTable--) | Ottiene la tabella prep. |
+| [getStatTable()](#getStatTable--) | Ottiene la tabella STAT. |
+| [getVheaTable()](#getVheaTable--) | Ottiene la tabella vhea. |
+| [getVmtxTable()](#getVmtxTable--) | Ottiene la tabella vmtx. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCMapTable() {#getCMapTable--}
+```
+public TtfCMapTable getCMapTable()
+```
+
+
+Ottiene la tabella cmap.
+
+**Returns:**
+[TtfCMapTable](../../com.aspose.font/ttfcmaptable) - Cmap table.
+### getCffTable() {#getCffTable--}
+```
+public TtfCffTable getCffTable()
+```
+
+
+Ottiene la tabella cff.
+
+**Returns:**
+[TtfCffTable](../../com.aspose.font/ttfcfftable) - Cff table.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCvtTable() {#getCvtTable--}
+```
+public TtfCvtTable getCvtTable()
+```
+
+
+Ottiene la tabella cvt.
+
+**Returns:**
+[TtfCvtTable](../../com.aspose.font/ttfcvttable) - Cvt table.
+### getFpgmTable() {#getFpgmTable--}
+```
+public TtfFpgmTable getFpgmTable()
+```
+
+
+Ottiene la tabella fpgm.
+
+**Returns:**
+[TtfFpgmTable](../../com.aspose.font/ttffpgmtable) - Fpgm table.
+### getGaspTable() {#getGaspTable--}
+```
+public TtfGaspTable getGaspTable()
+```
+
+
+Ottiene la tabella GASP.
+
+**Returns:**
+[TtfGaspTable](../../com.aspose.font/ttfgasptable) - The GASP table.
+### getGlyfTable() {#getGlyfTable--}
+```
+public TtfGlyfTable getGlyfTable()
+```
+
+
+Ottiene la tabella glyf.
+
+**Returns:**
+[TtfGlyfTable](../../com.aspose.font/ttfglyftable) - Glyf table.
+### getHeadTable() {#getHeadTable--}
+```
+public TtfHeadTable getHeadTable()
+```
+
+
+Ottiene la tabella head.
+
+**Returns:**
+[TtfHeadTable](../../com.aspose.font/ttfheadtable) - Head table.
+### getHheaTable() {#getHheaTable--}
+```
+public TtfHheaTable getHheaTable()
+```
+
+
+Ottiene la tabella hhea.
+
+**Returns:**
+[TtfHheaTable](../../com.aspose.font/ttfhheatable) - Hhea table.
+### getHmtxTable() {#getHmtxTable--}
+```
+public TtfHmtxTable getHmtxTable()
+```
+
+
+Ottiene la tabella hmtx.
+
+**Returns:**
+[TtfHmtxTable](../../com.aspose.font/ttfhmtxtable) - Hmtx table.
+### getLocaTable() {#getLocaTable--}
+```
+public TtfLocaTable getLocaTable()
+```
+
+
+Ottiene la tabella loca.
+
+**Returns:**
+[TtfLocaTable](../../com.aspose.font/ttflocatable) - Loca table.
+### getLtshTable() {#getLtshTable--}
+```
+public TtfLtshTable getLtshTable()
+```
+
+
+Ottiene la tabella LTSH.
+
+**Returns:**
+[TtfLtshTable](../../com.aspose.font/ttfltshtable) - The LTSH table.
+### getMaxpTable() {#getMaxpTable--}
+```
+public TtfMaxpTable getMaxpTable()
+```
+
+
+Ottiene la tabella maxp.
+
+**Returns:**
+[TtfMaxpTable](../../com.aspose.font/ttfmaxptable) - Maxp table.
+### getNameTable() {#getNameTable--}
+```
+public TtfNameTable getNameTable()
+```
+
+
+Ottiene la tabella name.
+
+**Returns:**
+[TtfNameTable](../../com.aspose.font/ttfnametable) - Name table.
+### getOs2Table() {#getOs2Table--}
+```
+public TtfOs2Table getOs2Table()
+```
+
+
+Ottiene la tabella OS/2.
+
+**Returns:**
+[TtfOs2Table](../../com.aspose.font/ttfos2table) - OS/2 table.
+### getPostTable() {#getPostTable--}
+```
+public TtfPostTable getPostTable()
+```
+
+
+Ottiene la tabella post.
+
+**Returns:**
+[TtfPostTable](../../com.aspose.font/ttfposttable) - Post table.
+### getPrepTable() {#getPrepTable--}
+```
+public TtfPrepTable getPrepTable()
+```
+
+
+Ottiene la tabella prep.
+
+**Returns:**
+[TtfPrepTable](../../com.aspose.font/ttfpreptable) - Prep table.
+### getStatTable() {#getStatTable--}
+```
+public TtfStatTable getStatTable()
+```
+
+
+Ottiene la tabella STAT.
+
+**Returns:**
+[TtfStatTable](../../com.aspose.font/ttfstattable) - The STAT table.
+### getVheaTable() {#getVheaTable--}
+```
+public TtfVheaTable getVheaTable()
+```
+
+
+Ottiene la tabella vhea.
+
+**Returns:**
+[TtfVheaTable](../../com.aspose.font/ttfvheatable) - Vhea table.
+### getVmtxTable() {#getVmtxTable--}
+```
+public TtfVmtxTable getVmtxTable()
+```
+
+
+Ottiene la tabella vmtx.
+
+**Returns:**
+[TtfVmtxTable](../../com.aspose.font/ttfvmtxtable) - Vmtx table.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfvheatable/_index.md
+++ b/italian/java/com.aspose.font/ttfvheatable/_index.md
@@ -1,0 +1,300 @@
+---
+title: "TtfVheaTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella hhea del file di carattere TTF."
+type: docs
+weight: 112
+url: /it/java/com.aspose.font/ttfvheatable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfVheaTable extends TtfTableBase
+```
+
+Rappresenta la tabella "hhea" del file di font TTF.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdvanceHeightMax()](#getAdvanceHeightMax--) | Ottiene AdvanceHeightMax. |
+| [getAscent()](#getAscent--) | Ottiene Ascent. |
+| [getCaretOffset()](#getCaretOffset--) | Ottiene CaretOffset. |
+| [getCaretSlopeRise()](#getCaretSlopeRise--) | Ottiene CaretSlopeRise. |
+| [getCaretSlopeRun()](#getCaretSlopeRun--) | Ottiene CaretSlopeRun. |
+| [getClass()](#getClass--) |  |
+| [getDescent()](#getDescent--) | Ottiene Descent. |
+| [getLineGap()](#getLineGap--) | Ottiene LineGap. |
+| [getMetricDataFormat()](#getMetricDataFormat--) | Ottiene MetricDataFormat. |
+| [getMinBottomSideBearing()](#getMinBottomSideBearing--) | Ottiene MinBottomSideBearing. |
+| [getMinTopSideBearing()](#getMinTopSideBearing--) | Ottiene MinTopSideBearing. |
+| [getNumOfLongVerMetrics()](#getNumOfLongVerMetrics--) | Ottiene MetricDataFormat. |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [getVersion()](#getVersion--) | Ottiene il numero di versione della tabella di intestazione verticale. |
+| [getYMaxExtent()](#getYMaxExtent--) | Ottiene \_yMaxExtent. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdvanceHeightMax() {#getAdvanceHeightMax--}
+```
+public short getAdvanceHeightMax()
+```
+
+
+Ottiene AdvanceHeightMax. La massima misura dell'altezza di avanzamento in FUnits trovata nel font.
+
+**Returns:**
+short - L'AdvanceHeightMax.
+### getAscent() {#getAscent--}
+```
+public short getAscent()
+```
+
+
+Ottiene Ascent. Distanza in FUnits dalla linea centrale al \_descent della riga precedente.
+
+**Returns:**
+short - L'Ascent.
+### getCaretOffset() {#getCaretOffset--}
+```
+public short getCaretOffset()
+```
+
+
+Ottiene CaretOffset.
+
+**Returns:**
+short - Il CaretOffset.
+### getCaretSlopeRise() {#getCaretSlopeRise--}
+```
+public short getCaretSlopeRise()
+```
+
+
+Ottiene CaretSlopeRise.
+
+**Returns:**
+short - Il CaretSlopeRise.
+### getCaretSlopeRun() {#getCaretSlopeRun--}
+```
+public short getCaretSlopeRun()
+```
+
+
+Ottiene CaretSlopeRun.
+
+**Returns:**
+short - Il CaretSlopeRun.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescent() {#getDescent--}
+```
+public short getDescent()
+```
+
+
+Ottiene Descent. Distanza in FUnits dalla linea centrale al \_ascent della riga successiva.
+
+**Returns:**
+short - Il Descent.
+### getLineGap() {#getLineGap--}
+```
+public short getLineGap()
+```
+
+
+Ottiene LineGap. Lo spazio tipografico verticale per questo font.
+
+**Returns:**
+short - Il LineGap.
+### getMetricDataFormat() {#getMetricDataFormat--}
+```
+public short getMetricDataFormat()
+```
+
+
+Ottiene MetricDataFormat.
+
+**Returns:**
+short - Il MetricDataFormat.
+### getMinBottomSideBearing() {#getMinBottomSideBearing--}
+```
+public short getMinBottomSideBearing()
+```
+
+
+Ottiene MinBottomSideBearing. La minima misura del sidebearing inferiore trovata nel font, in FUnits.
+
+**Returns:**
+short - Il MinBottomSideBearing.
+### getMinTopSideBearing() {#getMinTopSideBearing--}
+```
+public short getMinTopSideBearing()
+```
+
+
+Ottiene MinTopSideBearing. La misura minima del sidebearing superiore trovata nel font, in FUnits.
+
+**Returns:**
+short - Il MinTopSideBearing.
+### getNumOfLongVerMetrics() {#getNumOfLongVerMetrics--}
+```
+public int getNumOfLongVerMetrics()
+```
+
+
+Ottiene MetricDataFormat. Numero di altezze di avanzamento nella tabella metriche verticali.
+
+**Returns:**
+int - Il MetricDataFormat.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - Il tag.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public Version16Dot16 getVersion()
+```
+
+
+Ottiene il numero di versione della tabella di intestazione verticale.
+
+**Returns:**
+[Version16Dot16](../../com.aspose.font/version16dot16) - The Version number of the vertical header table.
+### getYMaxExtent() {#getYMaxExtent--}
+```
+public short getYMaxExtent()
+```
+
+
+Ottiene \_yMaxExtent.
+
+**Returns:**
+short - Il \_yMaxExtent.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/ttfvmtxtable/_index.md
+++ b/italian/java/com.aspose.font/ttfvmtxtable/_index.md
@@ -1,0 +1,179 @@
+---
+title: "TtfVmtxTable"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la tabella vmtx del file di font TTF."
+type: docs
+weight: 113
+url: /it/java/com.aspose.font/ttfvmtxtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfVmtxTable extends TtfTableBase
+```
+
+Rappresenta la tabella "vmtx" del file di font TTF.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Ottiene l'offset dall'inizio di sfnt. |
+| [getTag()](#getTag--) | Ottiene l'etichetta della tabella. |
+| [getTopSideBearings()](#getTopSideBearings--) | Ottiene i Top Side Bearings. |
+| [getTtfTables()](#getTtfTables--) | Riferimento al repository della tabella TTF. |
+| [getVMetrics()](#getVMetrics--) | Ottiene le metriche verticali. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Ottiene l'offset dall'inizio di sfnt.
+
+**Returns:**
+long - Offset dall'inizio di sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Ottiene l'etichetta della tabella.
+
+**Returns:**
+java.lang.String - L'etichetta della tabella.
+### getTopSideBearings() {#getTopSideBearings--}
+```
+public short[] getTopSideBearings()
+```
+
+
+Ottiene i Top Side Bearings. Array di top side bearings del glifo.
+
+**Returns:**
+short[] - I cuscinetti superiori laterali.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Riferimento al repository della tabella TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVMetrics() {#getVMetrics--}
+```
+public TtfVmtxTable.LongVerMetric[] getVMetrics()
+```
+
+
+Ottiene le metriche verticali.
+
+**Returns:**
+com.aspose.font.TtfVmtxTable.LongVerMetric[] - Le metriche verticali.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/type1encoding/_index.md
+++ b/italian/java/com.aspose.font/type1encoding/_index.md
@@ -1,0 +1,218 @@
+---
+title: "Type1Encoding"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta la codifica del Font Type1."
+type: docs
+weight: 114
+url: /it/java/com.aspose.font/type1encoding/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFontEncoding](../../com.aspose.font/ifontencoding), [com.aspose.font.ISupportsNameAddressing](../../com.aspose.font/isupportsnameaddressing)
+```
+public class Type1Encoding implements IFontEncoding, ISupportsNameAddressing
+```
+
+Rappresenta la codifica del Font Type1.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [decodeToGid(long charCode)](#decodeToGid-long-) | Decodifica Gid in unicode. |
+| [decodeToGidParameterized(IEncodingParameters parameters, long charCode)](#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-) | Metodo di decodifica parametrizzato. |
+| [encode(long gid, long charCode)](#encode-long-long-) | Codifica il glifo. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getNameToCharCodeIndex()](#getNameToCharCodeIndex--) | Restituisce la mappa di codifica nome a codice carattere. |
+| [gidToUnicode(GlyphId gid)](#gidToUnicode-com.aspose.font.GlyphId-) | Decodifica Gid in Unicode. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [unicodeToGid(long unicode)](#unicodeToGid-long-) | Restituisce GlyphId per unicode. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### decodeToGid(long charCode) {#decodeToGid-long-}
+```
+public GlyphId decodeToGid(long charCode)
+```
+
+
+Decodifica Gid in unicode. Glyph id è un numero unico per un glifo, dipendente dal tipo di font. Per esempio: l'id di Type1 è un nome di glifo, istanza della classe ( GlyphStringId ). L'id di TTF è un indice intero, istanza della classe ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| charCode | long | Codice carattere per cui ottenere l'identificatore del glifo. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to character code passed.
+### decodeToGidParameterized(IEncodingParameters parameters, long charCode) {#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-}
+```
+public GlyphId decodeToGidParameterized(IEncodingParameters parameters, long charCode)
+```
+
+
+Metodo di decodifica parametrizzato. Non supportato per il tipo di Font Type1.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| parameters | [IEncodingParameters](../../com.aspose.font/iencodingparameters) | Non supportato per il tipo di Font Type1. |
+| charCode | long | Non supportato per il tipo di Font Type1. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Not supported for Type1 Font type.
+### encode(long gid, long charCode) {#encode-long-long-}
+```
+public void encode(long gid, long charCode)
+```
+
+
+Codifica il glifo. Per i Font TTF il codice carattere è unicode. Non supportato per i tipi di Font Type1.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| gid | long | ID glifo. |
+| charCode | long | Codice carattere associato all'id del glifo. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNameToCharCodeIndex() {#getNameToCharCodeIndex--}
+```
+public NameToCodeMap getNameToCharCodeIndex()
+```
+
+
+Restituisce la mappa di codifica nome a codice carattere. Nota: il codice carattere non è un unicode. Il codice carattere è un indice di carattere nella \"tabella\" di codifica del Font.
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - Name to character code encoding map.
+### gidToUnicode(GlyphId gid) {#gidToUnicode-com.aspose.font.GlyphId-}
+```
+public long gidToUnicode(GlyphId gid)
+```
+
+
+Decodifica Gid in Unicode. Glyph id è un numero unico per un glifo, dipendente dal tipo di font. Per esempio: l'id di Type1 è un nome di glifo, istanza della classe ( GlyphStringId ). L'id di TTF è un indice intero, istanza della classe ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| gid | [GlyphId](../../com.aspose.font/glyphid) | Identificatore del glifo del simbolo da decodificare. |
+
+**Returns:**
+long - Valore Unicode relativo all'id del glifo passato.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unicodeToGid(long unicode) {#unicodeToGid-long-}
+```
+public GlyphId unicodeToGid(long unicode)
+```
+
+
+Restituisce GlyphId per unicode. O notdef se il font non contiene un glifo per l'unicode. Glyph id è un numero unico per un glifo, dipendente dal tipo di font. Per esempio: l'id di Type1 è un nome di glifo, istanza della classe ( GlyphStringId ). L'id di TTF è un indice intero, istanza della classe ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| unicode | long | Unicode per cui ottenere l'identificatore del glifo. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to unicode passed.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/type1font/_index.md
+++ b/italian/java/com.aspose.font/type1font/_index.md
@@ -1,0 +1,545 @@
+---
+title: "Type1Font"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta il Font Type1."
+type: docs
+weight: 115
+url: /it/java/com.aspose.font/type1font/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Font](../../com.aspose.font/font)
+```
+public class Type1Font extends Font
+```
+
+Rappresenta il Font Type1.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Converte il Font in un altro formato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Restituisce un array di tutti gli ID glifo, disponibili nel Font. |
+| [getClass()](#getClass--) |  |
+| [getEncoding()](#getEncoding--) | Ottiene la codifica del Font. |
+| [getFontDefinition()](#getFontDefinition--) | Ottiene la definizione del Font. |
+| [getFontFamily()](#getFontFamily--) | Ottiene la famiglia del Font. |
+| [getFontName()](#getFontName--) | Ottiene il nome del Font face. |
+| [getFontNames()](#getFontNames--) | Ottiene i nomi del Font. |
+| [getFontSaver()](#getFontSaver--) | Ottiene la funzionalità di salvataggio del Font. |
+| [getFontStyle()](#getFontStyle--) | Ottiene lo stile del Font. |
+| [getFontType()](#getFontType--) | Ottiene il tipo di Font. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Accessor dei glifi del Font. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Restituisce il glifo per ID glifo. |
+| [getGlyphById(String id)](#getGlyphById-java.lang.String-) | Restituisce il glifo per ID glifo. |
+| [getGlyphById(long id)](#getGlyphById-long-) | Restituisce il glifo per ID glifo. |
+| [getGlyphIdType()](#getGlyphIdType--) | Specificazione del tipo di ID glifo. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Ottiene la rappresentazione dei glifi per il testo. |
+| [getMetrics()](#getMetrics--) | Ottiene le metriche del Font. |
+| [getNumGlyphs()](#getNumGlyphs--) | Ottiene il numero di glifi nel Font. |
+| [getPostscriptNames()](#getPostscriptNames--) | Ottiene i nomi del font Postscript. |
+| [getStyle()](#getStyle--) | Ottiene lo stile del Font. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Apre un font, utilizzando l'oggetto FontDefinition. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Apre un font, utilizzando il tipo di font e l'array di byte dei dati del font. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Apre un font, utilizzando il tipo di font e la sorgente stream. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Apre un font, utilizzando il tipo di font e il nome del file del font. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Salva il Font nel formato originale. |
+| [save(String fileName)](#save-java.lang.String-) | Salva il Font nel formato originale. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Salva il Font nel formato specificato. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Il setter della famiglia del font non è ancora implementato. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Il setter del nome del font non è ancora implementato. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Il setter dello stile non è ancora implementato. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public Font convert(FontType fontType)
+```
+
+
+Converte il Font in un altro formato.
+
+> ```
+> Note: TTF Font type is now supported only.
+> ```
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di formato del Font in cui convertire. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public GlyphId[] getAllGlyphIds()
+```
+
+
+Restituisce un array di tutti gli ID glifo, disponibili nel Font. L'ID glifo è un numero univoco per un glifo, dipendente dal tipo di font. L'ID glifo del Font Type1 può essere un'istanza della classe ( GlyphStringId ) o della classe ( GlyphUInt32Id ).
+
+**Returns:**
+com.aspose.font.GlyphId[]
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncoding() {#getEncoding--}
+```
+public IFontEncoding getEncoding()
+```
+
+
+Ottiene la codifica del Font.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public FontDefinition getFontDefinition()
+```
+
+
+Ottiene la definizione del Font.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public String getFontFamily()
+```
+
+
+Ottiene la famiglia del Font.
+
+**Returns:**
+java.lang.String - Famiglia del Font.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Ottiene il nome del Font face.
+
+**Returns:**
+java.lang.String - Nome del Font face.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Ottiene i nomi del Font.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Ottiene la funzionalità di salvataggio del Font.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public int getFontStyle()
+```
+
+
+Ottiene lo stile del Font. Questo è un valore calcolato e rappresentato in tipo generalizzato.
+
+**Returns:**
+int - Stile del Font. Di solito, una combinazione di valori di flag costanti della classe FontStyle o 0.
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Ottiene il tipo di Font. Restituisce il valore FontType.Type1.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Accessor dei glifi del font. Recupera i glifi e gli identificatori dei glifi.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public Glyph getGlyphById(GlyphId id)
+```
+
+
+Restituisce il glifo per ID glifo. L'ID glifo è un numero univoco per un glifo, dipendente dal tipo di font. L'ID glifo del Font Type1 può essere un'istanza della classe ( GlyphStringId ) o della classe ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) |  |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph)
+### getGlyphById(String id) {#getGlyphById-java.lang.String-}
+```
+public Glyph getGlyphById(String id)
+```
+
+
+Restituisce il glifo per ID glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| id | java.lang.String | ID glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(long id) {#getGlyphById-long-}
+```
+public Glyph getGlyphById(long id)
+```
+
+
+Restituisce il glifo per ID glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| id | long | ID glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public GlyphIdType getGlyphIdType()
+```
+
+
+Specificazione del tipo di ID glifo.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype)
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Ottiene la rappresentazione dei glifi per il testo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| text | java.lang.String | Testo di input. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - array di GlyphId.
+### getMetrics() {#getMetrics--}
+```
+public IFontMetrics getMetrics()
+```
+
+
+Ottiene le metriche del Font.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Ottiene il numero di glifi nel Font.
+
+**Returns:**
+int - Numero di glifi nel Font.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Ottiene i nomi del font Postscript.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names
+### getStyle() {#getStyle--}
+```
+public String getStyle()
+```
+
+
+Ottiene lo stile del Font. Questo è un valore stringa grezzo fornito dal file Font.
+
+**Returns:**
+java.lang.String - Stile del Font.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Apre un font, utilizzando l'oggetto FontDefinition.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Oggetto definizione del Font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Apre un font, utilizzando il tipo di font e l'array di byte dei dati del font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fontData | byte[] | Array di byte da cui caricare il font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Apre un font, utilizzando il tipo di font e la sorgente stream.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Sorgente stream per il font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Apre un font, utilizzando il tipo di font e il nome del file del font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fileName | java.lang.String | Nome file del font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Salva il Font nel formato originale.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Stream per salvare il font. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Salva il Font nel formato originale.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fileName | java.lang.String | File per salvare il font. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Salva il Font nel formato specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| stream | java.io.OutputStream | stream per salvare il font |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | formato desiderato |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public void setFontFamily(String value)
+```
+
+
+Il setter della famiglia del font non è ancora implementato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Nuova famiglia di Font. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public void setFontName(String value)
+```
+
+
+Il setter del nome del font non è ancora implementato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Nuovo nome faccia del Font. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public void setStyle(String value)
+```
+
+
+Il setter Style non è ancora implementato. Questo è un valore stringa grezzo fornito dal file Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Nuovo stile del Font. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/type1fontmetrics/_index.md
+++ b/italian/java/com.aspose.font/type1fontmetrics/_index.md
@@ -1,0 +1,555 @@
+---
+title: "Type1FontMetrics"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta le metriche del Font Type1."
+type: docs
+weight: 116
+url: /it/java/com.aspose.font/type1fontmetrics/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.FontMetrics](../../com.aspose.font/fontmetrics)
+```
+public class Type1FontMetrics extends FontMetrics
+```
+
+Rappresenta le metriche del Font Type1.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAscender()](#getAscender--) | Ottiene il valore dell'ascendente. |
+| [getAscender(double fontSize)](#getAscender-double-) | Restituisce l'ascender per una dimensione specifica del Font. |
+| [getCapHeight()](#getCapHeight--) | Ottiene il valore dell'altezza delle maiuscole. |
+| [getClass()](#getClass--) |  |
+| [getDescender()](#getDescender--) | Ottiene il valore del discendente. |
+| [getDescender(double fontSize)](#getDescender-double-) | Restituisce il descender per una dimensione specifica del Font. |
+| [getFontBBox()](#getFontBBox--) | Restituisce il valore FontBBox. |
+| [getFontMatrix()](#getFontMatrix--) | Ottiene la matrice di trasformazione del Font. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Restituisce il Bbox del glifo. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Restituisce la larghezza del glifo. |
+| [getItalicAngle()](#getItalicAngle--) | Ottiene il valore dell'angolo italic. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Restituisce il valore di kerning per la coppia di glifi. |
+| [getLineGap()](#getLineGap--) | Ottiene il valore LineGap. |
+| [getStdHW()](#getStdHW--) | Ottiene il valore StdHW. |
+| [getStdVW()](#getStdVW--) | Ottiene il valore StdVW. |
+| [getTypoAscender()](#getTypoAscender--) | Ottiene il valore TypoAscender. |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Restituisce l'ascendente tipografico per una dimensione specifica del Font. |
+| [getTypoDescender()](#getTypoDescender--) | Ottiene il valore TypoDescender. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Restituisce il discendente tipografico per una dimensione specifica del font. |
+| [getTypoLineGap()](#getTypoLineGap--) | Ottiene il valore TypoLineGap. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Restituisce il gap di linea per una dimensione specifica del Font. |
+| [getUnderlinePosition()](#getUnderlinePosition--) | Ottiene il valore della posizione di sottolineatura. |
+| [getUnderlineThickness()](#getUnderlineThickness--) | Ottiene il valore dello spessore della sottolineatura. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Ottiene il valore UnitsPerEM della sottolineatura. |
+| [getWeight()](#getWeight--) | Ottiene il peso. |
+| [getXHeight()](#getXHeight--) | Ottiene il valore XHeight. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Ottiene il valore IsFixedPitch. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Misura la stringa e restituisce la larghezza della stringa. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAscender(double value)](#setAscender-double-) | Imposta il valore Ascender. |
+| [setDescender(double value)](#setDescender-double-) | Imposta il valore Descender. |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) | Imposta la larghezza del glifo. |
+| [setTypoAscender(double value)](#setTypoAscender-double-) | Imposta il valore TypoAscender. |
+| [setTypoDescender(double value)](#setTypoDescender-double-) | Imposta il valore TypoDescender. |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAscender() {#getAscender--}
+```
+public double getAscender()
+```
+
+
+Ottiene il valore dell'ascendente.
+
+**Returns:**
+double - valore Ascender.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public double getAscender(double fontSize)
+```
+
+
+Restituisce l'ascender per una dimensione specifica del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - valore Ascender.
+### getCapHeight() {#getCapHeight--}
+```
+public double getCapHeight()
+```
+
+
+Ottiene il valore dell'altezza delle maiuscole.
+
+**Returns:**
+double - valore dell'altezza Cap.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescender() {#getDescender--}
+```
+public double getDescender()
+```
+
+
+Ottiene il valore del discendente.
+
+**Returns:**
+double - valore Descender.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public double getDescender(double fontSize)
+```
+
+
+Restituisce il descender per una dimensione specifica del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - valore Descender.
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+Restituisce il valore FontBBox.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - FontBBox value.
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+Ottiene la matrice di trasformazione del Font.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - Font transformation matrix.
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Restituisce il Bbox del glifo. Restituisce FontBBox se il BBox non era definito per il glifo. Può essere sovrascritto da eredi di codifica del font specifici.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificatore del glifo. |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox.
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Restituisce la larghezza del glyph. Può essere sovrascritto da eredi di codifica del font specifici.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificatore del glifo. |
+
+**Returns:**
+double - Larghezza del glyph.
+### getItalicAngle() {#getItalicAngle--}
+```
+public double getItalicAngle()
+```
+
+
+Ottiene il valore dell'angolo italic.
+
+**Returns:**
+double - valore dell'angolo Italic.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Restituisce il valore di kerning per la coppia di glifi.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Primo glyph nella coppia. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Dimensione del Font. |
+
+**Returns:**
+double - Valore del kerning.
+### getLineGap() {#getLineGap--}
+```
+public double getLineGap()
+```
+
+
+Ottiene il valore LineGap.
+
+**Returns:**
+double - Valore del LineGap.
+### getStdHW() {#getStdHW--}
+```
+public double getStdHW()
+```
+
+
+Ottiene il valore StdHW.
+
+**Returns:**
+double - valore StdHW.
+### getStdVW() {#getStdVW--}
+```
+public double getStdVW()
+```
+
+
+Ottiene il valore StdVW.
+
+**Returns:**
+double - valore StdVW.
+### getTypoAscender() {#getTypoAscender--}
+```
+public double getTypoAscender()
+```
+
+
+Ottiene il valore TypoAscender.
+
+**Returns:**
+double - Valore del TypoAscender.
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public double getTypoAscender(double fontSize)
+```
+
+
+Restituisce l'ascendente tipografico per una dimensione specifica del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - Valore del Typographic ascender.
+### getTypoDescender() {#getTypoDescender--}
+```
+public double getTypoDescender()
+```
+
+
+Ottiene il valore TypoDescender.
+
+**Returns:**
+double - Valore del TypoDescender.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public double getTypoDescender(double fontSize)
+```
+
+
+Restituisce il discendente tipografico per una dimensione specifica del font.
+
+param fontSize Dimensione del font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double |  |
+
+**Returns:**
+double - Valore del Typographic descender.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public double getTypoLineGap()
+```
+
+
+Ottiene il valore TypoLineGap.
+
+**Returns:**
+double - Valore del TypoLineGap.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public double getTypoLineGap(double fontSize)
+```
+
+
+Restituisce il gap di linea per una dimensione specifica del Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - Valore del Line gap.
+### getUnderlinePosition() {#getUnderlinePosition--}
+```
+public double getUnderlinePosition()
+```
+
+
+Ottiene il valore della posizione di sottolineatura.
+
+**Returns:**
+double - valore della posizione di sottolineatura.
+### getUnderlineThickness() {#getUnderlineThickness--}
+```
+public double getUnderlineThickness()
+```
+
+
+Ottiene il valore dello spessore della sottolineatura.
+
+**Returns:**
+double - valore dello spessore della sottolineatura.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Ottiene il valore UnitsPerEM della sottolineatura.
+
+**Returns:**
+long - valore UnitsPerEM della sottolineatura.
+### getWeight() {#getWeight--}
+```
+public String getWeight()
+```
+
+
+Ottiene il peso.
+
+**Returns:**
+java.lang.String - Peso.
+### getXHeight() {#getXHeight--}
+```
+public double getXHeight()
+```
+
+
+Ottiene il valore XHeight.
+
+**Returns:**
+double - valore XHeight.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+Ottiene il valore IsFixedPitch.
+
+**Returns:**
+boolean - Valore del IsFixedPitch.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public double measureString(String unicode, double fontSize)
+```
+
+
+Misura la stringa e restituisce la larghezza della stringa.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| unicode | java.lang.String | Stringa Unicode. |
+| fontSize | double | Dimensione del Font. |
+
+**Returns:**
+double - Larghezza del String.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAscender(double value) {#setAscender-double-}
+```
+public void setAscender(double value)
+```
+
+
+Imposta il valore Ascender.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore del Ascender. |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public void setDescender(double value)
+```
+
+
+Imposta il valore Descender.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore del Descender. |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Imposta la larghezza del glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificatore del glifo. |
+| valore | double | Nuova larghezza. |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public void setTypoAscender(double value)
+```
+
+
+Imposta il valore TypoAscender.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore del TypoAscender. |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public void setTypoDescender(double value)
+```
+
+
+Imposta il valore TypoDescender.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Valore del TypoDescender. |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public void setUnitsPerEM(long value)
+```
+
+
+Imposta il valore UnitsPerEM.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/type1metricfont/_index.md
+++ b/italian/java/com.aspose.font/type1metricfont/_index.md
@@ -1,0 +1,574 @@
+---
+title: "Type1MetricFont"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Implementazione del font metric Type1."
+type: docs
+weight: 117
+url: /it/java/com.aspose.font/type1metricfont/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Font](../../com.aspose.font/font), [com.aspose.font.Type1Font](../../com.aspose.font/type1font)
+```
+public class Type1MetricFont extends Type1Font
+```
+
+Implementazione di font metrici Type1. Questo font type1 è creato utilizzando solo le metriche. Le funzioni di recupero dei glifi e altre che richiedono un font reale non sono consentite; le funzioni non consentite generano l'eccezione Type1NotSupportedException. Altre proprietà (FontName, Weight, Metrics e Encoding) sono prelevate dal file di metriche.
+
+--------------------
+
+> ```
+> Note: If metrics file defines Encoding as "FontSpecific", user should provide the specific encoding with following way:
+>      string[] zapfDingbatsEncoding = new string[256] {null, null, ... , "space", "a1", ...};
+>      FontEnvironment.Current.FontSpecificEncodings.RegisterEncoding("ZapfDingbats", zapfDingbatsEncoding);
+>  ```
+> 
+>      System::ArrayPtr<System::String> zapfDingbatsEncoding = System::MakeArray<System::String>({nullptr, nullptr, ..., u"space", u"a1", ...});
+>      FontEnvironment::get_Current()->get_FontSpecificEncodings()->RegisterEncoding(u"ZapfDingbats", zapfDingbatsEncoding);
+>  
+> ```
+> ```
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Converte il Font in un altro formato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Restituisce tutti gli ID glifo, disponibili nel Font. |
+| [getClass()](#getClass--) |  |
+| [getEncoding()](#getEncoding--) | La codifica è definita nel file di metriche. |
+| [getFontDefinition()](#getFontDefinition--) | Ottiene la definizione del Font. |
+| [getFontFamily()](#getFontFamily--) | Ottiene la famiglia del Font. |
+| [getFontName()](#getFontName--) | Ottiene il nome del Font. |
+| [getFontNames()](#getFontNames--) | Ottiene i nomi del Font. |
+| [getFontSaver()](#getFontSaver--) | Ottiene la funzionalità di salvataggio del Font. |
+| [getFontStyle()](#getFontStyle--) | Ottiene lo stile del Font. |
+| [getFontType()](#getFontType--) | Ottiene il tipo di Font. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Accessor dei glifi del Font. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Restituisce il glifo per ID glifo. |
+| [getGlyphById(String id)](#getGlyphById-java.lang.String-) | Restituisce il glifo per ID glifo. |
+| [getGlyphById(long id)](#getGlyphById-long-) | Restituisce il glifo per ID glifo. |
+| [getGlyphIdType()](#getGlyphIdType--) | Specificazione del tipo di ID glifo. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Ottiene la rappresentazione dei glifi per il testo. |
+| [getMetrics()](#getMetrics--) | Ottiene le metriche del Font. |
+| [getNumGlyphs()](#getNumGlyphs--) | Ottiene il numero di glifi nel Font. |
+| [getPostscriptNames()](#getPostscriptNames--) | Ottiene i nomi del font Postscript. |
+| [getStyle()](#getStyle--) | Ottiene lo stile del Font. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Apre un font, utilizzando l'oggetto FontDefinition. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Apre un font, utilizzando il tipo di font e l'array di byte dei dati del font. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Apre un font, utilizzando il tipo di font e la sorgente stream. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Apre un font, utilizzando il tipo di font e il nome del file del font. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Salva il Font nel formato originale. |
+| [save(String fileName)](#save-java.lang.String-) | Salva il Font nel formato originale. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Salva il Font nel formato specificato. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Il setter della famiglia del font non è ancora implementato. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Il setter del nome del font non è ancora implementato. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Il setter dello stile non è ancora implementato. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public Font convert(FontType fontType)
+```
+
+
+Converte il Font in un altro formato.
+
+> ```
+> Note: TTF Font type is now supported only.
+> ```
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di formato del Font in cui convertire. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public GlyphId[] getAllGlyphIds()
+```
+
+
+Restituisce tutti gli ID glifo, disponibili nel Font. Non supportato per il tipo Type1MetricFont.
+
+**Returns:**
+com.aspose.font.GlyphId[] - Tutti gli identificatori di glifo, disponibili nel Font.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncoding() {#getEncoding--}
+```
+public IFontEncoding getEncoding()
+```
+
+
+La codifica è definita nel file di metriche. StandardAdobeEncoding: la codifica è popolata automaticamente
+
+--------------------
+
+> ```
+> FontSpecific:
+>         user should provide the specific encoding with following way:
+>      string[] zapfDingbatsEncoding = new string[256] {null, null, ... , "space", "a1", ...};
+>      FontEnvironment.Current.FontSpecificEncodings.RegisterEncoding("ZapfDingbats", zapfDingbatsEncoding);
+>  ```
+> 
+>      System::ArrayPtr<System::String> zapfDingbatsEncoding = System::MakeArray<System::String>({nullptr, nullptr, ..., u"space", u"a1", ...});
+>      FontEnvironment::get_Current()->get_FontSpecificEncodings()->RegisterEncoding(u"ZapfDingbats", zapfDingbatsEncoding);
+>  
+> ```
+> ```
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding)
+### getFontDefinition() {#getFontDefinition--}
+```
+public FontDefinition getFontDefinition()
+```
+
+
+Ottiene la definizione del Font.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public String getFontFamily()
+```
+
+
+Ottiene la famiglia del Font.
+
+**Returns:**
+java.lang.String - Famiglia del Font.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Ottiene il nome del Font.
+
+**Returns:**
+java.lang.String - Nome del font.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Ottiene i nomi del Font.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Ottiene la funzionalità di salvataggio del Font.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public int getFontStyle()
+```
+
+
+Ottiene lo stile del Font. Questo è un valore calcolato e rappresentato in tipo generalizzato.
+
+**Returns:**
+int - Ottiene lo stile del Font. Di solito, una combinazione di valori di flag costanti della classe FontStyle o 0.
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Ottiene il tipo di Font. Restituisce il valore FontType.Type1.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Accessor dei glifi del font. Recupera i glifi e gli identificatori dei glifi.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public Glyph getGlyphById(GlyphId id)
+```
+
+
+Restituisce il glifo per ID glifo. Non supportato per il tipo (@code Type1MetricFont\} type.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | Identificatore del glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(String id) {#getGlyphById-java.lang.String-}
+```
+public Glyph getGlyphById(String id)
+```
+
+
+Restituisce il glifo per ID glifo. Non supportato per il tipo (@code Type1MetricFont\} type.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| id | java.lang.String | Identificatore del glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(long id) {#getGlyphById-long-}
+```
+public Glyph getGlyphById(long id)
+```
+
+
+Restituisce il glifo per ID glifo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| id | long | ID glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public GlyphIdType getGlyphIdType()
+```
+
+
+Specificazione del tipo di ID glifo.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype)
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Ottiene la rappresentazione dei glifi per il testo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| text | java.lang.String | Testo di input. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - array di GlyphId.
+### getMetrics() {#getMetrics--}
+```
+public IFontMetrics getMetrics()
+```
+
+
+Ottiene le metriche del Font.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Ottiene il numero di glifi nel Font.
+
+**Returns:**
+int - Numero di glifi nel Font.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Ottiene i nomi del font Postscript.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names
+### getStyle() {#getStyle--}
+```
+public String getStyle()
+```
+
+
+Ottiene lo stile del Font.
+
+**Returns:**
+java.lang.String - Stile del Font.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Apre un font, utilizzando l'oggetto FontDefinition.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Oggetto definizione del Font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Apre un font, utilizzando il tipo di font e l'array di byte dei dati del font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fontData | byte[] | Array di byte da cui caricare il font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Apre un font, utilizzando il tipo di font e la sorgente stream.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Sorgente stream per il font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Apre un font, utilizzando il tipo di font e il nome del file del font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo di Font. |
+| fileName | java.lang.String | Nome file del font. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Salva il Font nel formato originale.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Stream per salvare il font. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Salva il Font nel formato originale.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fileName | java.lang.String | File per salvare il font. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Salva il Font nel formato specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| stream | java.io.OutputStream | stream per salvare il font |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | formato desiderato |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public void setFontFamily(String value)
+```
+
+
+Il setter della famiglia del font non è ancora implementato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Nuova famiglia di Font. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public void setFontName(String value)
+```
+
+
+Il setter del nome del font non è ancora implementato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Nuovo nome faccia del Font. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public void setStyle(String value)
+```
+
+
+Il setter Style non è ancora implementato. Questo è un valore stringa grezzo fornito dal file Font.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Nuovo stile del Font. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/unicodeplatformspecificid/_index.md
+++ b/italian/java/com.aspose.font/unicodeplatformspecificid/_index.md
@@ -1,0 +1,277 @@
+---
+title: "UnicodePlatformSpecificId"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'enumerazione specifica della piattaforma Unicode."
+type: docs
+weight: 143
+url: /it/java/com.aspose.font/unicodeplatformspecificid/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum UnicodePlatformSpecificId extends Enum<UnicodePlatformSpecificId>
+```
+
+Rappresenta l'enumerazione specifica della piattaforma Unicode.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [Default](#Default) | Valore 0 Semantica predefinita (Unicode 1.0). |
+| [ISO10646_1993](#ISO10646-1993) | Valore 2 Semantica ISO 10646 1993 (deprecata). |
+| [Unicode1_1](#Unicode1-1) | Valore 1 Semantica Unicode 1.1. |
+| [Unicode2_0](#Unicode2-0) | Valore 3 Semantica Unicode 2.0 o successive. |
+| [Unicode2_0_Full](#Unicode2-0-Full) | Valore 4 Semantica Unicode 2.0 e successive (caratteri non BMP consentiti), repertorio Unicode completo. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Default {#Default}
+```
+public static final UnicodePlatformSpecificId Default
+```
+
+
+Valore 0 Semantica predefinita (Unicode 1.0).
+
+### ISO10646_1993 {#ISO10646-1993}
+```
+public static final UnicodePlatformSpecificId ISO10646_1993
+```
+
+
+Valore 2 Semantica ISO 10646 1993 (deprecata).
+
+### Unicode1_1 {#Unicode1-1}
+```
+public static final UnicodePlatformSpecificId Unicode1_1
+```
+
+
+Valore 1 Semantica Unicode 1.1.
+
+### Unicode2_0 {#Unicode2-0}
+```
+public static final UnicodePlatformSpecificId Unicode2_0
+```
+
+
+Valore 3 Semantica Unicode 2.0 o successive. Solo BMP Unicode.
+
+### Unicode2_0_Full {#Unicode2-0-Full}
+```
+public static final UnicodePlatformSpecificId Unicode2_0_Full
+```
+
+
+Valore 4 Semantica Unicode 2.0 e successive (caratteri non BMP consentiti), repertorio Unicode completo.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static UnicodePlatformSpecificId valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[UnicodePlatformSpecificId](../../com.aspose.font/unicodeplatformspecificid)
+### values() {#values--}
+```
+public static UnicodePlatformSpecificId[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.UnicodePlatformSpecificId[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/version16dot16/_index.md
+++ b/italian/java/com.aspose.font/version16dot16/_index.md
@@ -1,0 +1,227 @@
+---
+title: "Version16Dot16"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta il tipo di dato Version16Dot16"
+type: docs
+weight: 118
+url: /it/java/com.aspose.font/version16dot16/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Cloneable
+```
+public class Version16Dot16 implements Cloneable
+```
+
+Rappresenta il tipo di dato Version16Dot16
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Version16Dot16()](#Version16Dot16--) | Costruttore |
+| [Version16Dot16(int majorNumber, int minorNumber)](#Version16Dot16-int-int-) | Costruttore |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clone()](#clone--) | Crea una copia dell'oggetto Version16Dot16. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMajorNumber()](#getMajorNumber--) | Ottiene il numero di versione maggiore. |
+| [getMinorNumber()](#getMinorNumber--) | Ottiene il numero di versione minore. |
+| [getRawBytes()](#getRawBytes--) | Ottiene tutti i bit grezzi per il numero di versione Version16Dot16 come array di byte di dimensione 4 byte. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setMajorNumber(int value)](#setMajorNumber-int-) | Imposta il numero di versione maggiore. |
+| [setMinorNumber(int value)](#setMinorNumber-int-) | Imposta il numero di versione minore. |
+| [toString()](#toString--) | Restituisce il valore della versione come stringa formattata. Ad esempio "0.5", "1.1", "3.0" ecc. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Version16Dot16() {#Version16Dot16--}
+```
+public Version16Dot16()
+```
+
+
+Costruttore
+
+### Version16Dot16(int majorNumber, int minorNumber) {#Version16Dot16-int-int-}
+```
+public Version16Dot16(int majorNumber, int minorNumber)
+```
+
+
+Costruttore
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| majorNumber | int | Numero di versione maggiore |
+| minorNumber | int | Numero di versione minore |
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Crea una copia dell'oggetto Version16Dot16.
+
+**Returns:**
+java.lang.Object - Oggetto di tipo Version16Dot16
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMajorNumber() {#getMajorNumber--}
+```
+public int getMajorNumber()
+```
+
+
+Ottiene il numero di versione maggiore. Il valore ha senso solo in notazione esadecimale, per esempio la versione 0.5 per 'maxp' nei file di font reali è di 4 byte: \{0, 0, 80, 0\}, che ha la rappresentazione esadecimale 0x00005000. Dopo aver letto questa versione dal file di font, i numeri maggiore e minore per l'oggetto Version16Dot16 saranno 0 e 20480 rispettivamente. E questi valori in forma esadecimale sono 0x0000 e 0x5000.
+
+**Returns:**
+int - Numero di versione maggiore.
+### getMinorNumber() {#getMinorNumber--}
+```
+public int getMinorNumber()
+```
+
+
+Ottiene il numero di versione minore. Il valore ha senso solo in notazione esadecimale, per esempio la versione 0.5 per 'maxp' nei file di font reali è di 4 byte: \{0, 0, 80, 0\}, che ha la rappresentazione esadecimale 0x00005000. Dopo aver letto questa versione dal file di font, i numeri maggiore e minore per l'oggetto Version16Dot16 saranno 0 e 20480 rispettivamente. E questi valori in forma esadecimale sono 0x0000 e 0x5000.
+
+**Returns:**
+int - Numero di versione minore.
+### getRawBytes() {#getRawBytes--}
+```
+public byte[] getRawBytes()
+```
+
+
+Ottiene tutti i bit grezzi per il numero di versione Version16Dot16 come array di byte di dimensione 4 byte.
+
+**Returns:**
+byte[] - Tutti i bit grezzi per il numero di versione Version16Dot16 come array di byte di dimensione 4 byte.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setMajorNumber(int value) {#setMajorNumber-int-}
+```
+public void setMajorNumber(int value)
+```
+
+
+Imposta il numero di versione maggiore. Il valore ha senso solo in notazione esadecimale, per esempio la versione 0.5 per 'maxp' nei file di font reali è di 4 byte: \{0, 0, 80, 0\}, che ha la rappresentazione esadecimale 0x00005000. Dopo aver letto questa versione dal file di font, i numeri maggiore e minore per l'oggetto Version16Dot16 saranno 0 e 20480 rispettivamente. E questi valori in forma esadecimale sono 0x0000 e 0x5000.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int | Numero di versione maggiore. |
+
+### setMinorNumber(int value) {#setMinorNumber-int-}
+```
+public void setMinorNumber(int value)
+```
+
+
+Imposta il numero di versione minore. Il valore ha senso solo in notazione esadecimale, per esempio la versione 0.5 per 'maxp' nei file di font reali è di 4 byte: \{0, 0, 80, 0\}, che ha la rappresentazione esadecimale 0x00005000. Dopo aver letto questa versione dal file di font, i numeri maggiore e minore per l'oggetto Version16Dot16 saranno 0 e 20480 rispettivamente. E questi valori in forma esadecimale sono 0x0000 e 0x5000.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int | Numero di versione minore. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+Restituisce il valore della versione come stringa formattata. Ad esempio "0.5", "1.1", "3.0" ecc.
+
+**Returns:**
+java.lang.String - Oggetto di tipo String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.font/woffformatexception/_index.md
+++ b/italian/java/com.aspose.font/woffformatexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "WoffFormatException"
+second_title: "Riferimento API Aspose.Font per Java"
+description: "Rappresenta l'eccezione relativa all'elaborazione dei font WOFF."
+type: docs
+weight: 119
+url: /it/java/com.aspose.font/woffformatexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException
+```
+public class WoffFormatException extends IllegalStateException
+```
+
+Rappresenta l'eccezione relativa all'elaborazione dei font WOFF.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [WoffFormatException()](#WoffFormatException--) | Inizializza un nuovo oggetto WoffFormatException. |
+| [WoffFormatException(String message)](#WoffFormatException-java.lang.String-) | Inizializza un nuovo oggetto WoffFormatException. |
+| [WoffFormatException(String message, RuntimeException innerException)](#WoffFormatException-java.lang.String-java.lang.RuntimeException-) | Inizializza un nuovo oggetto WoffFormatException. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### WoffFormatException() {#WoffFormatException--}
+```
+public WoffFormatException()
+```
+
+
+Inizializza un nuovo oggetto WoffFormatException.
+
+### WoffFormatException(String message) {#WoffFormatException-java.lang.String-}
+```
+public WoffFormatException(String message)
+```
+
+
+Inizializza un nuovo oggetto WoffFormatException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+
+### WoffFormatException(String message, RuntimeException innerException) {#WoffFormatException-java.lang.String-java.lang.RuntimeException-}
+```
+public WoffFormatException(String message, RuntimeException innerException)
+```
+
+
+Inizializza un nuovo oggetto WoffFormatException.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| messaggio | java.lang.String | Un messaggio che descrive l'errore. |
+| innerException | java.lang.RuntimeException | L'eccezione che è la causa dell'eccezione corrente. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **Italian** (`it`) generated by RDA.

- Pages translated: 151/151
- Errors: 0
- Source: `english/java`
- Output: `italian/java`

🤖 Generated by RDA