### PR TITLE
[auto] Translate JAVA API Reference to Spanish

### DIFF
--- a/spanish/java/_index.md
+++ b/spanish/java/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Aspose.Font para Java"
+type: docs
+weight: 11
+url: /es/java/
+description: "Las referencias de API de Aspose.Font para Java contienen ejemplos, fragmentos de código y documentación de API. Proporciona paquetes, clases, interfaces y otros detalles de la API."
+is_root: true
+---
+## Packages
+| Paquete | Descripción |
+| --- | --- |
+| [com.aspose.font](./com.aspose.font) | El **com.aspose.font** es un paquete raíz para todas las clases que manejan fuentes. |
+| [com.aspose.font.textutils](./com.aspose.font.textutils) | El paquete **com.aspose.font.text.utils** proporciona clases e interfaces para el procesamiento de texto. |

--- a/spanish/java/com.aspose.font.textutils/_index.md
+++ b/spanish/java/com.aspose.font.textutils/_index.md
@@ -1,0 +1,32 @@
+---
+title: "com.aspose.font.textutils"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "El paquete com.aspose.font.text.utils proporciona clases e interfaces para el procesamiento de texto."
+type: docs
+weight: 11
+url: /es/java/com.aspose.font.textutils/
+---
+
+El paquete **com.aspose.font.text.utils** proporciona clases e interfaces para el procesamiento de texto.
+
+
+## Clases
+
+| Clase | Descripción |
+| --- | --- |
+| [TextUtilsFactory](../com.aspose.font.textutils/textutilsfactory) | Proporciona funcionalidad para recuperar los creadores de objetos de servicio de texto |
+
+## Interfaces
+
+| Interfaz | Descripción |
+| --- | --- |
+| [IFontMorseDecoder](../com.aspose.font.textutils/ifontmorsedecoder) | Declara funcionalidad para decodificar código Morse en glifos de la fuente especificada. |
+| [IFontMorseEncoder](../com.aspose.font.textutils/ifontmorseencoder) | Declara funcionalidad para codificar texto mediante código Morse y obtener el resultado como glifos de fuente. |
+| [IMorseDecoder](../com.aspose.font.textutils/imorsedecoder) | Declara funcionalidad para descifrar código Morse. |
+| [IMorseEncoder](../com.aspose.font.textutils/imorseencoder) | Declara funcionalidad para codificar texto mediante código Morse. |
+
+## Enumeraciones
+
+| Enumeración | Descripción |
+| --- | --- |
+| [MorseAlphabets](../com.aspose.font.textutils/morsealphabets) | Representa el conjunto de alfabetos compatibles con código Morse |

--- a/spanish/java/com.aspose.font.textutils/ifontmorsedecoder/_index.md
+++ b/spanish/java/com.aspose.font.textutils/ifontmorsedecoder/_index.md
@@ -1,0 +1,180 @@
+---
+title: "IFontMorseDecoder"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Declara funcionalidad para decodificar código Morse en glifos de la fuente especificada."
+type: docs
+weight: 11
+url: /es/java/com.aspose.font.textutils/ifontmorsedecoder/
+---```
+public interface IFontMorseDecoder
+```
+
+Declares functionality to decode Morse code into glyphs of the specified font.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [decode(String morseText, IFont font)](#decode-java.lang.String-com.aspose.font.IFont-) | Deciphers Morse code into glyphs of the specified font. |
+| [decode(String morseText, IFont font, MorseAlphabets alphabet)](#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-) | Deciphers Morse code into glyphs of the specified font. |
+| [decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator)](#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-) | Deciphers Morse code into glyphs of the specified font. |
+| [decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-char-) | Deciphers Morse code into glyphs of the specified font. |
+| [decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)](#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-) | Deciphers Morse code and draws result in PNG-format. |
+| [decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet)](#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-) | Deciphers Morse code and draws result in PNG-format. |
+| [decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator)](#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-) | Deciphers Morse code and draws result in PNG-format. |
+| [decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-char-) | Deciphers Morse code and draws result in PNG-format. |
+### decode(String morseText, IFont font) {#decode-java.lang.String-com.aspose.font.IFont-}
+```
+public abstract GlyphId[] decode(String morseText, IFont font)
+```
+
+
+Deciphers Morse code into glyphs of the specified font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs (glyph identifiers) related to decoded text.
+### decode(String morseText, IFont font, MorseAlphabets alphabet) {#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract GlyphId[] decode(String morseText, IFont font, MorseAlphabets alphabet)
+```
+
+
+Deciphers Morse code into glyphs of the specified font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs (glyph identifiers) related to decoded text.
+### decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator) {#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract GlyphId[] decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Deciphers Morse code into glyphs of the specified font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs (glyph identifiers) related to decoded text.
+### decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract GlyphId[] decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Deciphers Morse code into glyphs of the specified font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+| outputSeparator | char | Symbol used to separate words in decoded text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs (glyph identifiers) related to decoded text.
+### decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth) {#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-}
+```
+public abstract InputStream decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)
+```
+
+
+Deciphers Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+
+**Returns:**
+java.io.InputStream - Decoded text in PNG-format as stream of bytes.
+### decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet) {#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract InputStream decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet)
+```
+
+
+Deciphers Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+java.io.InputStream - Decoded text in PNG-format as stream of bytes.
+### decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator) {#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract InputStream decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Deciphers Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.io.InputStream - Decoded text in PNG-format as stream of bytes.
+### decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract InputStream decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Deciphers Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+| outputSeparator | char | Symbol used to separate words in decoded text. |
+
+**Returns:**
+java.io.InputStream - Decoded text in PNG-format as stream of bytes.

--- a/spanish/java/com.aspose.font.textutils/ifontmorseencoder/_index.md
+++ b/spanish/java/com.aspose.font.textutils/ifontmorseencoder/_index.md
@@ -1,0 +1,262 @@
+---
+title: "IFontMorseEncoder"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Declara funcionalidad para codificar texto mediante código Morse y obtener el resultado como glifos de fuente."
+type: docs
+weight: 12
+url: /es/java/com.aspose.font.textutils/ifontmorseencoder/
+---```
+public interface IFontMorseEncoder
+```
+
+Declares functionality to encode text by Morse code and get result as font glyphs.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [encode(String text, IFont font)](#encode-java.lang.String-com.aspose.font.IFont-) | Encodes text in Morse code and returns result as set of glyphs(glyphId). |
+| [encode(String text, IFont font, char inputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-char-) | Encodes text in Morse code and returns result as set of glyphs(glyphId). |
+| [encode(String text, IFont font, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-char-char-) | Encodes text in Morse code and returns result as set of glyphs(glyphId). |
+| [encode(String text, IFont font, MorseAlphabets alphabet)](#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-) | Encodes text by Morse code and returns result as set of glyphs(glyph identifiers). |
+| [encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-) | Encodes text by Morse code and returns result as set of glyphs(glyph identifiers). |
+| [encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-char-) | Encodes text by Morse code and returns result as set of glyphs(glyph identifiers). |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-) | Encodes text in Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-char-) | Encodes text in Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-char-char-) | Encodes text in Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-) | Encodes text by Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-) | Encodes text by Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-char-) | Encodes text by Morse code and draws result in PNG-format. |
+### encode(String text, IFont font) {#encode-java.lang.String-com.aspose.font.IFont-}
+```
+public abstract GlyphId[] encode(String text, IFont font)
+```
+
+
+Encodes text in Morse code and returns result as set of glyphs(glyphId). Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, char inputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-char-}
+```
+public abstract GlyphId[] encode(String text, IFont font, char inputSeparator)
+```
+
+
+Encodes text in Morse code and returns result as set of glyphs(glyphId). Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-char-char-}
+```
+public abstract GlyphId[] encode(String text, IFont font, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text in Morse code and returns result as set of glyphs(glyphId). Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, MorseAlphabets alphabet) {#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract GlyphId[] encode(String text, IFont font, MorseAlphabets alphabet)
+```
+
+
+Encodes text by Morse code and returns result as set of glyphs(glyph identifiers).
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract GlyphId[] encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Encodes text by Morse code and returns result as set of glyphs(glyph identifiers).
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract GlyphId[] encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text by Morse code and returns result as set of glyphs(glyph identifiers).
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)
+```
+
+
+Encodes text in Morse code and draws result in PNG-format. Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-char-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator)
+```
+
+
+Encodes text in Morse code and draws result in PNG-format. Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-char-char-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text in Morse code and draws result in PNG-format. Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet)
+```
+
+
+Encodes text by Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Encodes text by Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text by Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.

--- a/spanish/java/com.aspose.font.textutils/imorsedecoder/_index.md
+++ b/spanish/java/com.aspose.font.textutils/imorsedecoder/_index.md
@@ -1,0 +1,86 @@
+---
+title: "IMorseDecoder"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Declara funcionalidad para descifrar código Morse."
+type: docs
+weight: 13
+url: /es/java/com.aspose.font.textutils/imorsedecoder/
+---```
+public interface IMorseDecoder
+```
+
+Declares functionality to decipher Morse code.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [decode(String morseText)](#decode-java.lang.String-) | Deciphers Morse code. |
+| [decode(String morseText, MorseAlphabets alphabet)](#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-) | Deciphers Morse code. |
+| [decode(String morseText, MorseAlphabets alphabet, char inputSeparator)](#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-) | Deciphers Morse code. |
+| [decode(String morseText, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-char-) | Deciphers Morse code. |
+### decode(String morseText) {#decode-java.lang.String-}
+```
+public abstract String decode(String morseText)
+```
+
+
+Deciphers Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+
+**Returns:**
+java.lang.String - Decoded text.
+### decode(String morseText, MorseAlphabets alphabet) {#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract String decode(String morseText, MorseAlphabets alphabet)
+```
+
+
+Deciphers Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+java.lang.String - Decoded text.
+### decode(String morseText, MorseAlphabets alphabet, char inputSeparator) {#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract String decode(String morseText, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Deciphers Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.lang.String - Decoded text.
+### decode(String morseText, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract String decode(String morseText, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Deciphers Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+| outputSeparator | char | Symbol used to separate words in decoded text. |
+
+**Returns:**
+java.lang.String - Decoded text.

--- a/spanish/java/com.aspose.font.textutils/imorseencoder/_index.md
+++ b/spanish/java/com.aspose.font.textutils/imorseencoder/_index.md
@@ -1,0 +1,121 @@
+---
+title: "IMorseEncoder"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Declara funcionalidad para codificar texto mediante código Morse."
+type: docs
+weight: 14
+url: /es/java/com.aspose.font.textutils/imorseencoder/
+---```
+public interface IMorseEncoder
+```
+
+Declares functionality to encode text by Morse code.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [encode(String text)](#encode-java.lang.String-) | Encodes text by Morse code. |
+| [encode(String text, char inputSeparator)](#encode-java.lang.String-char-) | Encodes text by Morse code. |
+| [encode(String text, char inputSeparator, char outputSeparator)](#encode-java.lang.String-char-char-) | Encodes text by Morse code. |
+| [encode(String text, MorseAlphabets alphabet)](#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-) | Encodes text by Morse code. |
+| [encode(String text, MorseAlphabets alphabet, char inputSeparator)](#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-) | Encodes text by Morse code. |
+| [encode(String text, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-char-) | Encodes text by Morse code. |
+### encode(String text) {#encode-java.lang.String-}
+```
+public abstract String encode(String text)
+```
+
+
+Encodes text by Morse code. Heuristic analysis is used to calculate the alphabet of the input text. The alphabet is selected by the first word.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+
+**Returns:**
+java.lang.String - Encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, char inputSeparator) {#encode-java.lang.String-char-}
+```
+public abstract String encode(String text, char inputSeparator)
+```
+
+
+Encodes text by Morse code. Heuristic analysis is used to calculate the alphabet of the input text. The alphabet is selected by the first word.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+java.lang.String - Encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, char inputSeparator, char outputSeparator) {#encode-java.lang.String-char-char-}
+```
+public abstract String encode(String text, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text by Morse code. Heuristic analysis is used to calculate the alphabet of the input text. The alphabet is selected by the first word.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.lang.String - Encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, MorseAlphabets alphabet) {#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract String encode(String text, MorseAlphabets alphabet)
+```
+
+
+Encodes text by Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+java.lang.String - Encoded text, ie "... --- ..." for the input text "SOS".
+### encode(String text, MorseAlphabets alphabet, char inputSeparator) {#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract String encode(String text, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Encodes text by Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+java.lang.String - Encoded text, ie "... --- ..." for the input text "SOS".
+### encode(String text, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract String encode(String text, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text by Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.lang.String - Encoded text, ie "... --- ..." for the input text "SOS".

--- a/spanish/java/com.aspose.font.textutils/morsealphabets/_index.md
+++ b/spanish/java/com.aspose.font.textutils/morsealphabets/_index.md
@@ -1,0 +1,304 @@
+---
+title: "MorseAlphabets"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa el conjunto de alfabetos compatibles con código Morse"
+type: docs
+weight: 15
+url: /es/java/com.aspose.font.textutils/morsealphabets/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum MorseAlphabets extends Enum<MorseAlphabets>
+```
+
+Representa el conjunto de alfabetos compatibles con código Morse
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [Arabic](#Arabic) | El alfabeto de código árabe. |
+| [Cyrillic](#Cyrillic) | El alfabeto de código cirílico. |
+| [Greek](#Greek) | El alfabeto de código Morse griego. |
+| [Hebrew](#Hebrew) | El alfabeto de código hebreo. |
+| [Kurdish](#Kurdish) | El alfabeto de código kurdo. |
+| [Latin](#Latin) | El alfabeto de código Morse latino. |
+| [Persian](#Persian) | El alfabeto de código persa (Farsi). |
+| [Portuguese](#Portuguese) | El alfabeto de código portugués. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Arabic {#Arabic}
+```
+public static final MorseAlphabets Arabic
+```
+
+
+El alfabeto de código árabe.
+
+### Cyrillic {#Cyrillic}
+```
+public static final MorseAlphabets Cyrillic
+```
+
+
+El alfabeto de código cirílico.
+
+### Greek {#Greek}
+```
+public static final MorseAlphabets Greek
+```
+
+
+El alfabeto de código Morse griego.
+
+### Hebrew {#Hebrew}
+```
+public static final MorseAlphabets Hebrew
+```
+
+
+El alfabeto de código hebreo.
+
+### Kurdish {#Kurdish}
+```
+public static final MorseAlphabets Kurdish
+```
+
+
+El alfabeto de código kurdo.
+
+### Latin {#Latin}
+```
+public static final MorseAlphabets Latin
+```
+
+
+El alfabeto de código Morse latino.
+
+### Persian {#Persian}
+```
+public static final MorseAlphabets Persian
+```
+
+
+El alfabeto de código persa (Farsi).
+
+### Portuguese {#Portuguese}
+```
+public static final MorseAlphabets Portuguese
+```
+
+
+El alfabeto de código portugués.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static MorseAlphabets valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[MorseAlphabets](../../com.aspose.font.textutils/morsealphabets)
+### values() {#values--}
+```
+public static MorseAlphabets[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.textutils.MorseAlphabets[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font.textutils/textutilsfactory/_index.md
+++ b/spanish/java/com.aspose.font.textutils/textutilsfactory/_index.md
@@ -1,0 +1,215 @@
+---
+title: "TextUtilsFactory"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Proporciona funcionalidad para recuperar los creadores de objetos de servicio de texto"
+type: docs
+weight: 10
+url: /es/java/com.aspose.font.textutils/textutilsfactory/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TextUtilsFactory
+```
+
+Proporciona funcionalidad para recuperar los creadores de objetos de servicio de texto
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [TextUtilsFactory()](#TextUtilsFactory--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontCharactersMerger(Font primaryFont, Font secondaryFont, FontType outType)](#getFontCharactersMerger-com.aspose.font.Font-com.aspose.font.Font-com.aspose.font.FontType-) |  |
+| [getFontMorseDecoder()](#getFontMorseDecoder--) | Obtiene la instancia de IFontMorseDecoder. |
+| [getFontMorseEncoder()](#getFontMorseEncoder--) | Obtiene la instancia de IFontMorseEncoder. |
+| [getMorseDecoder()](#getMorseDecoder--) | Obtiene la instancia de IMorseDecoder. |
+| [getMorseEncoder()](#getMorseEncoder--) | Obtiene la instancia de IMorseEncoder. |
+| [hashCode()](#hashCode--) |  |
+| [isCffSimpleFontMerging(Font primaryFont, Font secondaryFont, FontType outType)](#isCffSimpleFontMerging-com.aspose.font.Font-com.aspose.font.Font-com.aspose.font.FontType-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TextUtilsFactory() {#TextUtilsFactory--}
+```
+public TextUtilsFactory()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontCharactersMerger(Font primaryFont, Font secondaryFont, FontType outType) {#getFontCharactersMerger-com.aspose.font.Font-com.aspose.font.Font-com.aspose.font.FontType-}
+```
+public FontCharactersMerger getFontCharactersMerger(Font primaryFont, Font secondaryFont, FontType outType)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| primaryFont | [Font](../../com.aspose.font/font) |  |
+| secondaryFont | [Font](../../com.aspose.font/font) |  |
+| outType | [FontType](../../com.aspose.font/fonttype) |  |
+
+**Returns:**
+[FontCharactersMerger](../../com.aspose.font/fontcharactersmerger)
+### getFontMorseDecoder() {#getFontMorseDecoder--}
+```
+public IFontMorseDecoder getFontMorseDecoder()
+```
+
+
+Obtiene la instancia de IFontMorseDecoder.
+
+**Returns:**
+[IFontMorseDecoder](../../com.aspose.font.textutils/ifontmorsedecoder) - The  IFontMorseDecoder  instance.
+### getFontMorseEncoder() {#getFontMorseEncoder--}
+```
+public IFontMorseEncoder getFontMorseEncoder()
+```
+
+
+Obtiene la instancia de IFontMorseEncoder.
+
+**Returns:**
+[IFontMorseEncoder](../../com.aspose.font.textutils/ifontmorseencoder) - The  IFontMorseEncoder  instance.
+### getMorseDecoder() {#getMorseDecoder--}
+```
+public IMorseDecoder getMorseDecoder()
+```
+
+
+Obtiene la instancia de IMorseDecoder.
+
+**Returns:**
+[IMorseDecoder](../../com.aspose.font.textutils/imorsedecoder) - The  IMorseDecoder  instance.
+### getMorseEncoder() {#getMorseEncoder--}
+```
+public IMorseEncoder getMorseEncoder()
+```
+
+
+Obtiene la instancia de IMorseEncoder.
+
+**Returns:**
+[IMorseEncoder](../../com.aspose.font.textutils/imorseencoder) - The  IMorseEncoder  instance.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isCffSimpleFontMerging(Font primaryFont, Font secondaryFont, FontType outType) {#isCffSimpleFontMerging-com.aspose.font.Font-com.aspose.font.Font-com.aspose.font.FontType-}
+```
+public static boolean isCffSimpleFontMerging(Font primaryFont, Font secondaryFont, FontType outType)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| primaryFont | [Font](../../com.aspose.font/font) |  |
+| secondaryFont | [Font](../../com.aspose.font/font) |  |
+| outType | [FontType](../../com.aspose.font/fonttype) |  |
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/_index.md
+++ b/spanish/java/com.aspose.font/_index.md
@@ -1,0 +1,165 @@
+---
+title: "com.aspose.font"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "El com.aspose.font es un paquete raíz para todas las clases que manejan fuentes."
+type: docs
+weight: 10
+url: /es/java/com.aspose.font/
+---
+
+El **com.aspose.font** es un paquete raíz para todas las clases que manejan fuentes.
+
+
+## Clases
+
+| Clase | Descripción |
+| --- | --- |
+| [AxisRecord](../com.aspose.font/axisrecord) | Representa la estructura de registro de eje. |
+| [AxisValue](../com.aspose.font/axisvalue) | Representa el registro AxisValue. |
+| [AxisValueTableBase](../com.aspose.font/axisvaluetablebase) | Clase base para la estructura de tabla de valores de eje. |
+| [AxisValueTableFormat1](../com.aspose.font/axisvaluetableformat1) | Representa el formato 1 de la tabla de valores de eje |
+| [AxisValueTableFormat2](../com.aspose.font/axisvaluetableformat2) | Representa el formato 2 de la tabla de valores de eje |
+| [AxisValueTableFormat3](../com.aspose.font/axisvaluetableformat3) | Representa el formato 3 de la tabla de valores de eje |
+| [AxisValueTableFormat4](../com.aspose.font/axisvaluetableformat4) | Representa el formato 4 de la tabla de valores de eje |
+| [ByteContentStreamSource](../com.aspose.font/bytecontentstreamsource) | Representa una fuente de flujo basada en el flujo \_content. |
+| [CffEncoding](../com.aspose.font/cffencoding) | Representa la codificación \_font de CFF. |
+| [CffFont](../com.aspose.font/cfffont) | Representa Compact Font Format (CFF). |
+| [CffFontException](../com.aspose.font/cfffontexception) | Representa una excepción común de procesamiento relacionada con fuentes del formato CFF. |
+| [CffFontMetrics](../com.aspose.font/cfffontmetrics) | Implementación de métricas de fuentes CFF |
+| [CffFontsSettings](../com.aspose.font/cfffontssettings) | Proporciona configuraciones comunes a fuentes CFF. |
+| [CffParsingException](../com.aspose.font/cffparsingexception) | Representa una excepción de análisis para fuentes del formato cff. |
+| [ClosePath](../com.aspose.font/closepath) | Representa la operación ClosePath. |
+| [CompositeGlyph](../com.aspose.font/compositeglyph) | Representa un glifo compuesto de fuente. |
+| [CompositeGlyphComponent](../com.aspose.font/compositeglyphcomponent) | Representa el componente de glifo compuesto (glifo con matriz de colocación). |
+| [CompositeGlyphComponentList](../com.aspose.font/compositeglyphcomponentlist) | Representa la lista de componentes de glifos compuestos. |
+| [CompressionUtils](../com.aspose.font/compressionutils) | Proporciona métodos utilitarios para compresión y descompresión. |
+| [CurveTo](../com.aspose.font/curveto) | Representa la operación CurveTo. |
+| [EncodingException](../com.aspose.font/encodingexception) | Representa una excepción de codificación. |
+| [FileSystemStreamSource](../com.aspose.font/filesystemstreamsource) | Representa una fuente de flujo basada en el sistema de archivos. |
+| [Font](../com.aspose.font/font) | Representa la clase base Font. |
+| [FontAgrumentException](../com.aspose.font/fontagrumentexception) | Representa una excepción de argumento de Font. |
+| [FontBBox](../com.aspose.font/fontbbox) | Representa el cuadro delimitador de la fuente. |
+| [FontCharactersMerger](../com.aspose.font/fontcharactersmerger) | Declara la funcionalidad para combinar fuentes de diferentes tipos. |
+| [FontConversionException](../com.aspose.font/fontconversionexception) | Representa una excepción de conversión de Font. |
+| [FontCreationException](../com.aspose.font/fontcreationexception) | Representa una excepción de creación de Font. |
+| [FontDefinition](../com.aspose.font/fontdefinition) | Representa la definición del conjunto de archivos de Font. |
+| [FontEnvironment](../com.aspose.font/fontenvironment) | Proporciona información sobre el entorno y la plataforma actuales. |
+| [FontException](../com.aspose.font/fontexception) | Representa una excepción común relacionada con el procesamiento de Font. |
+| [FontFactory](../com.aspose.font/fontfactory) | Contiene funcionalidad para abrir fuentes de diferentes tipos y otros métodos para crear varios objetos. |
+| [FontFileDefinition](../com.aspose.font/fontfiledefinition) | Representa la definición del archivo Font. |
+| [FontMergeException](../com.aspose.font/fontmergeexception) | Representa una excepción de combinación de Font. |
+| [FontMetrics](../com.aspose.font/fontmetrics) | Representa métricas de fuente. |
+| [FontNotSupportedOperationException](../com.aspose.font/fontnotsupportedoperationexception) | Representa una excepción de operación no soportada. |
+| [FontSpecificEncodings](../com.aspose.font/fontspecificencodings) | Representa codificaciones específicas para fuentes conscientes del consumidor. |
+| [FontStyle](../com.aspose.font/fontstyle) | Enumeración de estilo de fuente |
+| [GaspRange](../com.aspose.font/gasprange) | La matriz de registros GaspRange proporciona comportamientos recomendados para varios tamaños ppem. |
+| [Glyph](../com.aspose.font/glyph) | Representa un glifo de fuente. |
+| [GlyphId](../com.aspose.font/glyphid) | Representa los IDs de glifos, disponibles en la fuente. |
+| [GlyphIdList](../com.aspose.font/glyphidlist) | Representa una lista de IDs de glifos. |
+| [GlyphOutlineRenderer](../com.aspose.font/glyphoutlinerenderer) | Representa el renderizador de contorno de glifos. |
+| [GlyphRendererBase](../com.aspose.font/glyphrendererbase) | Representa la clase base para renderizadores de glifos. |
+| [GlyphStringId](../com.aspose.font/glyphstringid) | Representa el ID de glifo de cadena. |
+| [GlyphUInt32Id](../com.aspose.font/glyphuint32id) | Representa el ID de glifo entero. |
+| [HelpersFactory](../com.aspose.font/helpersfactory) | Crea objetos relacionados con el espacio de nombres TtfHelpers |
+| [IncorrectFontDataException](../com.aspose.font/incorrectfontdataexception) | Representa excepciones para casos en los que algunos valores del objeto Fuente son inválidos. |
+| [License](../com.aspose.font/license) | Proporciona métodos para licenciar el componente. |
+| [LicenseFlags](../com.aspose.font/licenseflags) | Representa un contenedor auxiliar para las banderas de incrustación de la tabla 'OS/2' (campo fsType). |
+| [LicenseRestrictionException](../com.aspose.font/licenserestrictionexception) | Representa una excepción que se puede lanzar al intentar ejecutar una funcionalidad que está restringida en modo de evaluación. |
+| [LineTo](../com.aspose.font/lineto) | Representa la operación LineTo. |
+| [MSLanguageId](../com.aspose.font/mslanguageid) | Enumeración de ID de idioma de la plataforma Microsoft. |
+| [MacLanguageId](../com.aspose.font/maclanguageid) | Enumeración de ID de idioma de la plataforma Macintosh. |
+| [Metered](../com.aspose.font/metered) | Proporciona métodos para establecer la clave medida. |
+| [MoveTo](../com.aspose.font/moveto) | Representa la operación MoveTo. |
+| [MultiLanguageString](../com.aspose.font/multilanguagestring) | Representa una cadena multilingüe. |
+| [NameId](../com.aspose.font/nameid) | Representa la enumeración NameId. |
+| [NameIndexDataProvider](../com.aspose.font/nameindexdataprovider) | Proporciona configuraciones comunes a fuentes CFF. |
+| [NameRecord](../com.aspose.font/namerecord) | Representa la estructura NameRecord de la tabla 'name' |
+| [NameToCodeMap](../com.aspose.font/nametocodemap) | Representa el mapa de nombre a código. |
+| [PathSegmentCollection](../com.aspose.font/pathsegmentcollection) | Representa una colección de segmentos de ruta. |
+| [RenderingUtils](../com.aspose.font/renderingutils) | Proporciona métodos utilitarios para el renderizado. |
+| [SegmentPath](../com.aspose.font/segmentpath) | Representa la ruta de renderizado. |
+| [StreamSource](../com.aspose.font/streamsource) | Define una forma de obtener un flujo de archivo cuando se necesita. |
+| [StringIndexDataProvider](../com.aspose.font/stringindexdataprovider) | Declara la funcionalidad para acceder a la estructura CFF String INDEX. |
+| [SvgConversionException](../com.aspose.font/svgconversionexception) | Representa la excepción de conversión de fuentes para el formato SVG. |
+| [TopDictDataProvider](../com.aspose.font/topdictdataprovider) | Declara la funcionalidad para leer/actualizar la estructura CFF Top DICT. |
+| [TransformationMatrix](../com.aspose.font/transformationmatrix) | Represents 3x3 matrix | A B 0 |  | C D 0 |  | TX TY 1 | . |
+| [TtcFontFileDefinition](../com.aspose.font/ttcfontfiledefinition) | Representa la definición de archivo para la fuente TTC. |
+| [TtcFontSource](../com.aspose.font/ttcfontsource) | Representa la fuente TTC. |
+| [TtfCMapFormat0Table](../com.aspose.font/ttfcmapformat0table) | Representa la subtabla Format0 CMap del archivo de fuente TTF. |
+| [TtfCMapFormat10Table](../com.aspose.font/ttfcmapformat10table) | Representa la subtabla Format10 CMap del archivo de fuente TTF. |
+| [TtfCMapFormat12Table](../com.aspose.font/ttfcmapformat12table) | Representa la subtabla Format8 CMap del archivo de fuente TTF. |
+| [TtfCMapFormat2Table](../com.aspose.font/ttfcmapformat2table) | Representa la subtabla Format2 CMap del archivo de fuente TTF. |
+| [TtfCMapFormat4Table](../com.aspose.font/ttfcmapformat4table) | Representa la subtabla Format4 CMap del archivo de fuente TTF. |
+| [TtfCMapFormat6Table](../com.aspose.font/ttfcmapformat6table) | Representa la subtabla Format6 CMap del archivo de fuente TTF. |
+| [TtfCMapFormat8Table](../com.aspose.font/ttfcmapformat8table) | Representa la subtabla Format8 CMap del archivo de fuente TTF. |
+| [TtfCMapFormatBaseTable](../com.aspose.font/ttfcmapformatbasetable) | Representa la clase base de la subtabla CMap. |
+| [TtfCMapTable](../com.aspose.font/ttfcmaptable) | Representa la tabla "cmap" del archivo de fuente TTF. |
+| [TtfCMapTable.TtfCMapSubtableDescription](../com.aspose.font/ttfcmaptable.ttfcmapsubtabledescription) | Proporciona información breve sobre la subtabla CMap. |
+| [TtfCffTable](../com.aspose.font/ttfcfftable) | Representa la tabla "cff" del archivo de fuente TTF. |
+| [TtfCvtTable](../com.aspose.font/ttfcvttable) | Representa la tabla de valores de control (CVT) del archivo de fuente TTF. |
+| [TtfEncoding](../com.aspose.font/ttfencoding) | Representa la codificación de la fuente TTF. |
+| [TtfEncodingParameters](../com.aspose.font/ttfencodingparameters) | Representa los parámetros de codificación TTF. |
+| [TtfFont](../com.aspose.font/ttffont) | Representa la fuente TrueType (TTF). |
+| [TtfFontMetrics](../com.aspose.font/ttffontmetrics) | Representa las métricas de la fuente TTF. |
+| [TtfFpgmTable](../com.aspose.font/ttffpgmtable) | Representa la tabla "fpgm" del archivo de fuente TTF. |
+| [TtfGaspTable](../com.aspose.font/ttfgasptable) | Representa la tabla "gasp" del archivo de fuente TTF. |
+| [TtfGlyfTable](../com.aspose.font/ttfglyftable) | Representa la tabla "glyf" del archivo de fuente TTF. |
+| [TtfHeadTable](../com.aspose.font/ttfheadtable) | Representa la tabla "head" del archivo de fuente TTF. |
+| [TtfHheaTable](../com.aspose.font/ttfhheatable) | Representa la tabla "hhea" del archivo de fuente TTF. |
+| [TtfHmtxTable](../com.aspose.font/ttfhmtxtable) | Representa la tabla "hmtx" del archivo de fuente TTF. |
+| [TtfHmtxTable.LongHorMetric](../com.aspose.font/ttfhmtxtable.longhormetric) | Representa el registro de métricas. |
+| [TtfHmtxTable.MetricList](../com.aspose.font/ttfhmtxtable.metriclist) | Representa la lista de métricas |
+| [TtfLocaTable](../com.aspose.font/ttflocatable) | Representa la tabla "loca" del archivo de fuente TTF. |
+| [TtfLocaTable.OffsetsList](../com.aspose.font/ttflocatable.offsetslist) | Representa la lista de desplazamientos de glifos. |
+| [TtfLtshTable](../com.aspose.font/ttfltshtable) | Representa la tabla Linear Threshold del archivo de fuente TTF. |
+| [TtfMaxpTable](../com.aspose.font/ttfmaxptable) | Representa la tabla "maxp" del archivo de fuente TTF |
+| [TtfNameTable](../com.aspose.font/ttfnametable) | Representa la tabla "name" del archivo de fuente TTF. |
+| [TtfOs2Table](../com.aspose.font/ttfos2table) | Representa la tabla "OS/2" del archivo de fuente TTF. |
+| [TtfPostTable](../com.aspose.font/ttfposttable) | Representa la tabla "post" del archivo de fuente TTF |
+| [TtfPrepTable](../com.aspose.font/ttfpreptable) | Representa la tabla "prep" del archivo de fuente TTF. |
+| [TtfStatTable](../com.aspose.font/ttfstattable) |  |
+| [TtfTableBase](../com.aspose.font/ttftablebase) | Representa la definición de tabla TTF. |
+| [TtfTableRepository](../com.aspose.font/ttftablerepository) | repositorio de tablas TTF |
+| [TtfVheaTable](../com.aspose.font/ttfvheatable) | Representa la tabla "hhea" del archivo de fuente TTF. |
+| [TtfVmtxTable](../com.aspose.font/ttfvmtxtable) | Representa la tabla "vmtx" del archivo de fuente TTF. |
+| [TtfVmtxTable.LongVerMetric](../com.aspose.font/ttfvmtxtable.longvermetric) | Representa el registro de métricas verticales. |
+| [Type1Encoding](../com.aspose.font/type1encoding) | Representa la codificación de fuente Type1. |
+| [Type1Font](../com.aspose.font/type1font) | Representa la fuente Type1. |
+| [Type1FontMetrics](../com.aspose.font/type1fontmetrics) | Representa las métricas de la fuente Type1. |
+| [Type1MetricFont](../com.aspose.font/type1metricfont) | Implementación de fuente métrica Type1. |
+| [Version16Dot16](../com.aspose.font/version16dot16) | Representa el tipo de dato Version16Dot16 |
+| [WoffFormatException](../com.aspose.font/woffformatexception) | Representa la excepción relacionada con el procesamiento de fuentes WOFF. |
+
+## Interfaces
+
+| Interfaz | Descripción |
+| --- | --- |
+| [ICffIndexDataProvider](../com.aspose.font/icffindexdataprovider) | Interfaz básica para acceder a las estructuras INDEX de fuentes CFF. |
+| [IEncodingParameters](../com.aspose.font/iencodingparameters) | Interfaz común para admitir parámetros de codificación. |
+| [IFont](../com.aspose.font/ifont) | Declara la funcionalidad común para todos los formatos de fuente. |
+| [IFontCharactersMerger](../com.aspose.font/ifontcharactersmerger) | Declara la funcionalidad de ayuda para combinar fuentes TrueType. |
+| [IFontEncoding](../com.aspose.font/ifontencoding) | Define una interfaz para la codificación de fuentes. |
+| [IFontMetrics](../com.aspose.font/ifontmetrics) | Define una interfaz para herramientas de métricas de fuentes. |
+| [IFontSaver](../com.aspose.font/ifontsaver) | Define una interfaz para la funcionalidad de guardado de fuentes. |
+| [IGlyphAccessor](../com.aspose.font/iglyphaccessor) | Define la funcionalidad para recuperar identificadores de glifos especificados y glifos. |
+| [IGlyphOutlinePainter](../com.aspose.font/iglyphoutlinepainter) | Define una forma esquemática de dibujar glifos. |
+| [IGlyphPainter](../com.aspose.font/iglyphpainter) | Define una forma de dibujar glifos. |
+| [IGlyphRenderer](../com.aspose.font/iglyphrenderer) | Interfaz utilizada para renderizar glifos. |
+| [IPathSegment](../com.aspose.font/ipathsegment) | Representa la interfaz de cualquier segmento de ruta. |
+| [ISupportsNameAddressing](../com.aspose.font/isupportsnameaddressing) | Define miembros que son específicos de codificaciones que admiten direccionamiento por nombre de glifo |
+
+## Enumeraciones
+
+| Enumeración | Descripción |
+| --- | --- |
+| [CffIndexProviderType](../com.aspose.font/cffindexprovidertype) | Especifica las estructuras INDEX compatibles con la familia de interfaces del proveedor de índices. |
+| [CffUpdateStringIndexStrategy](../com.aspose.font/cffupdatestringindexstrategy) | Especifica cómo agregar cadenas al almacenamiento CFF String INDEX. |
+| [FontSavingFormats](../com.aspose.font/fontsavingformats) | Especifica el tipo de fuente. |
+| [FontType](../com.aspose.font/fonttype) | Especifica el tipo de fuente. |
+| [GlyphIdType](../com.aspose.font/glyphidtype) | Especifica los tipos de identificador de glifo. |
+| [GlyphState](../com.aspose.font/glyphstate) | Especifica el estado del glifo. |
+| [MSPlatformSpecificId](../com.aspose.font/msplatformspecificid) | Representa la enumeración PlatformSpecificId de la plataforma Microsoft. |
+| [MacPlatformSpecificId](../com.aspose.font/macplatformspecificid) | Representa la enumeración PlatformSpecificId de la plataforma Macintosh. |
+| [PlatformId](../com.aspose.font/platformid) | Representa la enumeración PlatformId. |
+| [RangeGaspBehaviorFlags](../com.aspose.font/rangegaspbehaviorflags) | Indicadores que describen el comportamiento deseado del rasterizador. |
+| [UnicodePlatformSpecificId](../com.aspose.font/unicodeplatformspecificid) | Representa la enumeración específica de la plataforma Unicode. |

--- a/spanish/java/com.aspose.font/axisrecord/_index.md
+++ b/spanish/java/com.aspose.font/axisrecord/_index.md
@@ -1,0 +1,177 @@
+---
+title: "AxisRecord"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la estructura de registro de eje."
+type: docs
+weight: 10
+url: /es/java/com.aspose.font/axisrecord/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class AxisRecord
+```
+
+Representa la estructura Axis Record. Spec: el registro de eje proporciona información sobre un solo eje de diseño.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [AxisRecord(String tag, int axisNameId, int axisOrdering)](#AxisRecord-java.lang.String-int-int-) | Constructor |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisNameId()](#getAxisNameId--) | Devuelve el campo axisNameID. |
+| [getAxisOrdering()](#getAxisOrdering--) | Devuelve el campo axisOrdering. |
+| [getClass()](#getClass--) |  |
+| [getTag()](#getTag--) | Devuelve una etiqueta que identifica el eje de variación de diseño. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisRecord(String tag, int axisNameId, int axisOrdering) {#AxisRecord-java.lang.String-int-int-}
+```
+public AxisRecord(String tag, int axisNameId, int axisOrdering)
+```
+
+
+Constructor
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| tag | java.lang.String | Etiqueta, spec: una etiqueta que identifica el eje de variación de diseño |
+| axisNameId | int | El ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este eje |
+| axisOrdering | int | El valor que las aplicaciones pueden usar para determinar la ordenación primaria de los nombres de fuentes, o para ordenar etiquetas al componer nombres de familia o de fuente. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisNameId() {#getAxisNameId--}
+```
+public int getAxisNameId()
+```
+
+
+Devuelve el campo axisNameID. Spec: el campo axisNameID proporciona un ID de nombre que puede usarse para obtener cadenas de la tabla 'name' que pueden usarse para referirse al eje en las interfaces de usuario de la aplicación.
+
+**Returns:**
+int - El campo axisNameID.
+### getAxisOrdering() {#getAxisOrdering--}
+```
+public int getAxisOrdering()
+```
+
+
+Devuelve el campo axisOrdering. Spec: un valor que las aplicaciones pueden usar para determinar la ordenación primaria de los nombres de fuentes, o para ordenar etiquetas al componer nombres de familia o de fuente.
+
+**Returns:**
+int - El campo axisOrdering.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getTag() {#getTag--}
+```
+public String getTag()
+```
+
+
+Devuelve una etiqueta que identifica el eje de variación de diseño. Spec: cada registro de eje tiene una etiqueta que designa el eje. Los valores de etiqueta deben seguir las reglas para etiquetas de eje descritas en el Registro de Etiquetas de Eje de Variación de Diseño OpenType.
+
+**Returns:**
+java.lang.String - Una etiqueta que identifica el eje de variación de diseño.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/axisvalue/_index.md
+++ b/spanish/java/com.aspose.font/axisvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: "AxisValue"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa el registro AxisValue."
+type: docs
+weight: 11
+url: /es/java/com.aspose.font/axisvalue/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class AxisValue
+```
+
+Representa el registro AxisValue.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [AxisValue(int axisIndex, float value)](#AxisValue-int-float-) | Constructor |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisIndex()](#getAxisIndex--) | Obtiene el campo axisIndex. |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Obtiene un valor numérico para este valor de atributo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValue(int axisIndex, float value) {#AxisValue-int-float-}
+```
+public AxisValue(int axisIndex, float value)
+```
+
+
+Constructor
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| axisIndex | int | Índice base cero en la matriz de registros de ejes que identifica el eje al que se aplica este valor. Debe ser menor que designAxisCount. |
+| valor | float | El valor numérico para este valor de atributo. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisIndex() {#getAxisIndex--}
+```
+public int getAxisIndex()
+```
+
+
+Obtiene el campo axisIndex. Especificación: Índice base cero en la matriz de registros de ejes que identifica el eje al que se aplica este valor. Debe ser menor que designAxisCount.
+
+**Returns:**
+int - El campo axisIndex.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public float getValue()
+```
+
+
+Obtiene un valor numérico para este valor de atributo.
+
+**Returns:**
+float - Un valor numérico para este valor de atributo.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/axisvaluetablebase/_index.md
+++ b/spanish/java/com.aspose.font/axisvaluetablebase/_index.md
@@ -1,0 +1,168 @@
+---
+title: "AxisValueTableBase"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Clase base para la estructura de tabla de valores de eje."
+type: docs
+weight: 12
+url: /es/java/com.aspose.font/axisvaluetablebase/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class AxisValueTableBase
+```
+
+Clase base para la estructura de Axis Value Table. Especificación: Axis Value Tables proporcionan detalles respecto a un valor de atributo de estilo específico en algún eje de variación de diseño, o una combinación de valores de ejes de variación de diseño, y la relación de esos valores con las etiquetas usadas como elementos en los nombres de subfamilia.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Obtiene el campo de indicadores de la tabla de valores del eje. |
+| [getFormat()](#getFormat--) | Obtiene el identificador de formato (número de versión). |
+| [getValueName()](#getValueName--) | Obtiene el nombre de la tabla 'name' que proporciona una cadena de visualización para este valor de atributo. |
+| [getValueNameId()](#getValueNameId--) | Obtiene el ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Obtiene el campo de indicadores de la tabla de valores del eje.
+
+**Returns:**
+int - El campo de indicadores de la tabla de valores del eje.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Obtiene el identificador de formato (número de versión).
+
+**Returns:**
+int - El identificador de formato (número de versión).
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Obtiene el nombre de la tabla 'name' que proporciona una cadena de visualización para este valor de atributo.
+
+**Returns:**
+java.lang.String - El nombre de la tabla 'name' que proporciona una cadena de visualización para este valor de atributo.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Obtiene el ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo.
+
+**Returns:**
+int - El ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/axisvaluetableflags/_index.md
+++ b/spanish/java/com.aspose.font/axisvaluetableflags/_index.md
@@ -1,0 +1,259 @@
+---
+title: "TtfStatTable.AxisValueTableFlags"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Especifica los indicadores de la tabla de valores del eje."
+type: docs
+weight: 10
+url: /es/java/com.aspose.font/ttfstattable.axisvaluetableflags/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum TtfStatTable.AxisValueTableFlags extends Enum<TtfStatTable.AxisValueTableFlags>
+```
+
+Especifica los indicadores de la tabla de valores del eje.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ElidableAxisValueName](#ElidableAxisValueName) | Si está establecido, indica que el valor del eje representa el valor \"normal\" del eje y puede omitirse al componer cadenas de nombre. |
+| [OlderSiblingFontAttribute](#OlderSiblingFontAttribute) | Si está establecido, esta tabla de valores del eje proporciona información de valores del eje que es aplicable a otras fuentes dentro de la misma familia de fuentes. |
+| [Reserved](#Reserved) | Reservado para uso futuro |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ElidableAxisValueName {#ElidableAxisValueName}
+```
+public static final TtfStatTable.AxisValueTableFlags ElidableAxisValueName
+```
+
+
+Si está establecido, indica que el valor del eje representa el valor \"normal\" del eje y puede omitirse al componer cadenas de nombre.
+
+### OlderSiblingFontAttribute {#OlderSiblingFontAttribute}
+```
+public static final TtfStatTable.AxisValueTableFlags OlderSiblingFontAttribute
+```
+
+
+Si está establecido, esta tabla de valores del eje proporciona información de valores del eje que es aplicable a otras fuentes dentro de la misma familia de fuentes. Esto se utiliza si las otras fuentes se lanzaron antes y no incluían información sobre los valores de algunos ejes. Si versiones más recientes de las otras fuentes incluyen la información por sí mismas y están presentes, entonces esta tabla se ignora.
+
+### Reserved {#Reserved}
+```
+public static final TtfStatTable.AxisValueTableFlags Reserved
+```
+
+
+Reservado para uso futuro
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static TtfStatTable.AxisValueTableFlags valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[AxisValueTableFlags](../../com.aspose.font/axisvaluetableflags)
+### values() {#values--}
+```
+public static TtfStatTable.AxisValueTableFlags[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.TtfStatTable.AxisValueTableFlags[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/axisvaluetableformat1/_index.md
+++ b/spanish/java/com.aspose.font/axisvaluetableformat1/_index.md
@@ -1,0 +1,211 @@
+---
+title: "AxisValueTableFormat1"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa el formato 1 de la tabla de valores de eje"
+type: docs
+weight: 13
+url: /es/java/com.aspose.font/axisvaluetableformat1/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.AxisValueTableBase](../../com.aspose.font/axisvaluetablebase)
+```
+public class AxisValueTableFormat1 extends AxisValueTableBase
+```
+
+Representa el formato 1 de la tabla de valores de eje
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [AxisValueTableFormat1(int flags, int valueNameId, int axisIndex, float value)](#AxisValueTableFormat1-int-int-int-float-) | Constructor |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisIndex()](#getAxisIndex--) | Obtiene el índice base cero en la matriz de registros de ejes que identifica el eje de variación de diseño al que se aplica la tabla de valores del eje. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Obtiene el campo de indicadores de la tabla de valores del eje. |
+| [getFormat()](#getFormat--) | Obtiene el identificador de formato (número de versión). |
+| [getValue()](#getValue--) | El valor numérico para este valor de atributo. |
+| [getValueName()](#getValueName--) | Obtiene el nombre de la tabla 'name' que proporciona una cadena de visualización para este valor de atributo. |
+| [getValueNameId()](#getValueNameId--) | Obtiene el ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValueTableFormat1(int flags, int valueNameId, int axisIndex, float value) {#AxisValueTableFormat1-int-int-int-float-}
+```
+public AxisValueTableFormat1(int flags, int valueNameId, int axisIndex, float value)
+```
+
+
+Constructor
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| indicadores | int | Indicadores |
+| valueNameId | int | El ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo |
+| axisIndex | int | Especificación: Índice base cero en la matriz de registros de ejes que identifica el eje de variación de diseño al que se aplica la tabla de valores del eje. Debe ser menor que designAxisCount. |
+| valor | float | El valor numérico para este valor de atributo. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisIndex() {#getAxisIndex--}
+```
+public int getAxisIndex()
+```
+
+
+Obtiene el índice base cero en la matriz de registros de ejes que identifica el eje de variación de diseño al que se aplica la tabla de valores del eje.
+
+**Returns:**
+int - Índice base cero en la matriz de registros de ejes que identifica el eje de variación de diseño al que se aplica la tabla de valores del eje.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Obtiene el campo de indicadores de la tabla de valores del eje.
+
+**Returns:**
+int - El campo de indicadores de la tabla de valores del eje.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Obtiene el identificador de formato (número de versión).
+
+**Returns:**
+int - El identificador de formato (número de versión).
+### getValue() {#getValue--}
+```
+public float getValue()
+```
+
+
+El valor numérico para este valor de atributo.
+
+**Returns:**
+float - El valor numérico para este valor de atributo.
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Obtiene el nombre de la tabla 'name' que proporciona una cadena de visualización para este valor de atributo.
+
+**Returns:**
+java.lang.String - El nombre de la tabla 'name' que proporciona una cadena de visualización para este valor de atributo.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Obtiene el ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo.
+
+**Returns:**
+int - El ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/axisvaluetableformat2/_index.md
+++ b/spanish/java/com.aspose.font/axisvaluetableformat2/_index.md
@@ -1,0 +1,235 @@
+---
+title: "AxisValueTableFormat2"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa el formato 2 de la tabla de valores de eje"
+type: docs
+weight: 14
+url: /es/java/com.aspose.font/axisvaluetableformat2/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.AxisValueTableBase](../../com.aspose.font/axisvaluetablebase)
+```
+public class AxisValueTableFormat2 extends AxisValueTableBase
+```
+
+Representa el formato 2 de la tabla de valores de eje
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [AxisValueTableFormat2(int flags, int valueNameId, int axisIndex, float nominalValue, float rangeMinValue, float rangeMaxValue)](#AxisValueTableFormat2-int-int-int-float-float-float-) | Constructor |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisIndex()](#getAxisIndex--) | Obtiene el índice base cero en la matriz de registros de ejes que identifica el eje de variación de diseño al que se aplica la tabla de valores del eje. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Obtiene el campo de indicadores de la tabla de valores del eje. |
+| [getFormat()](#getFormat--) | Obtiene el identificador de formato (número de versión). |
+| [getNominalValue()](#getNominalValue--) | Un valor numérico nominal |
+| [getRangeMaxValue()](#getRangeMaxValue--) | El valor máximo para un rango asociado con el ID de nombre especificado. |
+| [getRangeMinValue()](#getRangeMinValue--) | El valor mínimo para un rango asociado con el ID de nombre especificado. |
+| [getValueName()](#getValueName--) | Obtiene el nombre de la tabla 'name' que proporciona una cadena de visualización para este valor de atributo. |
+| [getValueNameId()](#getValueNameId--) | Obtiene el ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValueTableFormat2(int flags, int valueNameId, int axisIndex, float nominalValue, float rangeMinValue, float rangeMaxValue) {#AxisValueTableFormat2-int-int-int-float-float-float-}
+```
+public AxisValueTableFormat2(int flags, int valueNameId, int axisIndex, float nominalValue, float rangeMinValue, float rangeMaxValue)
+```
+
+
+Constructor
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| indicadores | int | Indicadores |
+| valueNameId | int | El ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo |
+| axisIndex | int | Especificación: Índice base cero en la matriz de registros de ejes que identifica el eje de variación de diseño al que se aplica la tabla de valores del eje. Debe ser menor que designAxisCount. |
+| nominalValue | float | El valor numérico nominal para este valor de atributo. |
+| rangeMinValue | float | El valor mínimo para un rango asociado con el ID de nombre especificado. |
+| rangeMaxValue | float | El valor máximo para un rango asociado con el ID de nombre especificado. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisIndex() {#getAxisIndex--}
+```
+public int getAxisIndex()
+```
+
+
+Obtiene el índice base cero en la matriz de registros de ejes que identifica el eje de variación de diseño al que se aplica la tabla de valores del eje.
+
+**Returns:**
+int - El índice base cero en la matriz de registros de eje que identifica el eje de variación de diseño al que se aplica la tabla de valores del eje.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Obtiene el campo de indicadores de la tabla de valores del eje.
+
+**Returns:**
+int - El campo de indicadores de la tabla de valores del eje.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Obtiene el identificador de formato (número de versión).
+
+**Returns:**
+int - El identificador de formato (número de versión).
+### getNominalValue() {#getNominalValue--}
+```
+public float getNominalValue()
+```
+
+
+Un valor numérico nominal
+
+**Returns:**
+float - Un valor numérico nominal
+### getRangeMaxValue() {#getRangeMaxValue--}
+```
+public float getRangeMaxValue()
+```
+
+
+El valor máximo para un rango asociado con el ID de nombre especificado.
+
+**Returns:**
+float - El valor máximo para un rango asociado con el ID de nombre especificado.
+### getRangeMinValue() {#getRangeMinValue--}
+```
+public float getRangeMinValue()
+```
+
+
+El valor mínimo para un rango asociado con el ID de nombre especificado.
+
+**Returns:**
+float - El valor mínimo para un rango asociado con el ID de nombre especificado.
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Obtiene el nombre de la tabla 'name' que proporciona una cadena de visualización para este valor de atributo.
+
+**Returns:**
+java.lang.String - El nombre de la tabla 'name' que proporciona una cadena de visualización para este valor de atributo.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Obtiene el ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo.
+
+**Returns:**
+int - El ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/axisvaluetableformat3/_index.md
+++ b/spanish/java/com.aspose.font/axisvaluetableformat3/_index.md
@@ -1,0 +1,223 @@
+---
+title: "AxisValueTableFormat3"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa el formato 3 de la tabla de valores de eje"
+type: docs
+weight: 15
+url: /es/java/com.aspose.font/axisvaluetableformat3/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.AxisValueTableBase](../../com.aspose.font/axisvaluetablebase)
+```
+public class AxisValueTableFormat3 extends AxisValueTableBase
+```
+
+Representa el formato 3 de la tabla de valores de eje
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [AxisValueTableFormat3(int flags, int valueNameId, int axisIndex, float value, float linkedValue)](#AxisValueTableFormat3-int-int-int-float-float-) | Constructor |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisIndex()](#getAxisIndex--) | Obtiene el índice base cero en la matriz de registros de ejes que identifica el eje de variación de diseño al que se aplica la tabla de valores del eje. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Obtiene el campo de indicadores de la tabla de valores del eje. |
+| [getFormat()](#getFormat--) | Obtiene el identificador de formato (número de versión). |
+| [getLinkedValue()](#getLinkedValue--) | El valor numérico para un mapeo vinculado al estilo a partir de este valor. |
+| [getValue()](#getValue--) | El valor numérico para este valor de atributo. |
+| [getValueName()](#getValueName--) | Obtiene el nombre de la tabla 'name' que proporciona una cadena de visualización para este valor de atributo. |
+| [getValueNameId()](#getValueNameId--) | Obtiene el ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValueTableFormat3(int flags, int valueNameId, int axisIndex, float value, float linkedValue) {#AxisValueTableFormat3-int-int-int-float-float-}
+```
+public AxisValueTableFormat3(int flags, int valueNameId, int axisIndex, float value, float linkedValue)
+```
+
+
+Constructor
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| indicadores | int | Indicadores |
+| valueNameId | int | El ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo |
+| axisIndex | int | Especificación: Índice base cero en la matriz de registros de ejes que identifica el eje de variación de diseño al que se aplica la tabla de valores del eje. Debe ser menor que designAxisCount. |
+| valor | float | El valor numérico para este valor de atributo. |
+| linkedValue | float | El valor numérico para un mapeo vinculado al estilo a partir de este valor. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisIndex() {#getAxisIndex--}
+```
+public int getAxisIndex()
+```
+
+
+Obtiene el índice base cero en la matriz de registros de ejes que identifica el eje de variación de diseño al que se aplica la tabla de valores del eje.
+
+**Returns:**
+int - Índice base cero en la matriz de registros de ejes que identifica el eje de variación de diseño al que se aplica la tabla de valores del eje.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Obtiene el campo de indicadores de la tabla de valores del eje.
+
+**Returns:**
+int - El campo de indicadores de la tabla de valores del eje.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Obtiene el identificador de formato (número de versión).
+
+**Returns:**
+int - El identificador de formato (número de versión).
+### getLinkedValue() {#getLinkedValue--}
+```
+public float getLinkedValue()
+```
+
+
+El valor numérico para un mapeo vinculado al estilo a partir de este valor.
+
+**Returns:**
+float - El valor numérico para una asignación vinculada al estilo a partir de este valor.
+### getValue() {#getValue--}
+```
+public float getValue()
+```
+
+
+El valor numérico para este valor de atributo.
+
+**Returns:**
+float - El valor numérico para este valor de atributo.
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Obtiene el nombre de la tabla 'name' que proporciona una cadena de visualización para este valor de atributo.
+
+**Returns:**
+java.lang.String - El nombre de la tabla 'name' que proporciona una cadena de visualización para este valor de atributo.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Obtiene el ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo.
+
+**Returns:**
+int - El ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/axisvaluetableformat4/_index.md
+++ b/spanish/java/com.aspose.font/axisvaluetableformat4/_index.md
@@ -1,0 +1,199 @@
+---
+title: "AxisValueTableFormat4"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa el formato 4 de la tabla de valores de eje"
+type: docs
+weight: 16
+url: /es/java/com.aspose.font/axisvaluetableformat4/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.AxisValueTableBase](../../com.aspose.font/axisvaluetablebase)
+```
+public class AxisValueTableFormat4 extends AxisValueTableBase
+```
+
+Representa el formato 4 de la tabla de valores de eje
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [AxisValueTableFormat4(int flags, int valueNameId, AxisValue[] axisValues)](#AxisValueTableFormat4-int-int-com.aspose.font.AxisValue---) | Constructor |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisValues()](#getAxisValues--) | Matriz de registros AxisValue que proporcionan la combinación de valores de eje, uno para cada eje contribuyente. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Obtiene el campo de indicadores de la tabla de valores del eje. |
+| [getFormat()](#getFormat--) | Obtiene el identificador de formato (número de versión). |
+| [getValueName()](#getValueName--) | Obtiene el nombre de la tabla 'name' que proporciona una cadena de visualización para este valor de atributo. |
+| [getValueNameId()](#getValueNameId--) | Obtiene el ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValueTableFormat4(int flags, int valueNameId, AxisValue[] axisValues) {#AxisValueTableFormat4-int-int-com.aspose.font.AxisValue---}
+```
+public AxisValueTableFormat4(int flags, int valueNameId, AxisValue[] axisValues)
+```
+
+
+Constructor
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| indicadores | int | Indicadores |
+| valueNameId | int | El ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo |
+| axisValues | [AxisValue\[\]](../../com.aspose.font/axisvalue) | Matriz de registros AxisValue que proporcionan la combinación de valores de eje, uno para cada eje contribuyente. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisValues() {#getAxisValues--}
+```
+public AxisValue[] getAxisValues()
+```
+
+
+Matriz de registros AxisValue que proporcionan la combinación de valores de eje, uno para cada eje contribuyente.
+
+**Returns:**
+com.aspose.font.AxisValue[] - Matriz de registros AxisValue que proporcionan la combinación de valores de eje, uno para cada eje contribuyente.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Obtiene el campo de indicadores de la tabla de valores del eje.
+
+**Returns:**
+int - El campo de indicadores de la tabla de valores del eje.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Obtiene el identificador de formato (número de versión).
+
+**Returns:**
+int - El identificador de formato (número de versión).
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Obtiene el nombre de la tabla 'name' que proporciona una cadena de visualización para este valor de atributo.
+
+**Returns:**
+java.lang.String - El nombre de la tabla 'name' que proporciona una cadena de visualización para este valor de atributo.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Obtiene el ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo.
+
+**Returns:**
+int - El ID de nombre para las entradas en la tabla 'name' que proporcionan una cadena de visualización para este valor de atributo.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/bytecontentstreamsource/_index.md
+++ b/spanish/java/com.aspose.font/bytecontentstreamsource/_index.md
@@ -1,0 +1,200 @@
+---
+title: "ByteContentStreamSource"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa una fuente de flujo basada en _content stream."
+type: docs
+weight: 17
+url: /es/java/com.aspose.font/bytecontentstreamsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.StreamSource](../../com.aspose.font/streamsource)
+```
+public class ByteContentStreamSource extends StreamSource
+```
+
+Representa una fuente de flujo basada en el flujo \_content.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ByteContentStreamSource(byte[] fileContent)](#ByteContentStreamSource-byte---) | Inicializa un nuevo objeto ByteContentStreamSource. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Clona el objeto ByteContentStreamSource. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontStream()](#getFontStream--) | Devuelve el flujo del archivo de fuente. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento dentro de la fuente. |
+| [hashCode()](#hashCode--) |  |
+| [mustCloseAfterUse()](#mustCloseAfterUse--) | Los herederos pueden evitar que el flujo se cierre. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOffset(long value)](#setOffset-long-) | Establece el desplazamiento dentro de la fuente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ByteContentStreamSource(byte[] fileContent) {#ByteContentStreamSource-byte---}
+```
+public ByteContentStreamSource(byte[] fileContent)
+```
+
+
+Inicializa un nuevo objeto ByteContentStreamSource.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fileContent | byte[] | Bytes del archivo. |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Clona el objeto ByteContentStreamSource.
+
+**Returns:**
+java.lang.Object
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontStream() {#getFontStream--}
+```
+public InputStream getFontStream()
+```
+
+
+Devuelve el flujo del archivo de fuente. No olvides cerrar el flujo después de usarlo.
+
+**Returns:**
+java.io.InputStream - Flujo del archivo de fuente.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento dentro de la fuente.
+
+**Returns:**
+long - Desplazamiento dentro de la fuente.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### mustCloseAfterUse() {#mustCloseAfterUse--}
+```
+public boolean mustCloseAfterUse()
+```
+
+
+Los herederos pueden evitar que el flujo se cierre. Devuelve verdadero si la fuente de flujo desea que el flujo se cierre después de su uso. De lo contrario, devuelve falso.
+
+**Returns:**
+boolean - Verdadero si la fuente de flujo desea que el flujo se cierre después de su uso, de lo contrario falso.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOffset(long value) {#setOffset-long-}
+```
+public void setOffset(long value)
+```
+
+
+Establece el desplazamiento dentro de la fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long | Desplazamiento dentro de la fuente. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/cffencoding/_index.md
+++ b/spanish/java/com.aspose.font/cffencoding/_index.md
@@ -1,0 +1,256 @@
+---
+title: "CffEncoding"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la codificación _font CFF."
+type: docs
+weight: 18
+url: /es/java/com.aspose.font/cffencoding/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFontEncoding](../../com.aspose.font/ifontencoding), [com.aspose.font.ISupportsNameAddressing](../../com.aspose.font/isupportsnameaddressing)
+```
+public class CffEncoding implements IFontEncoding, ISupportsNameAddressing
+```
+
+Representa la codificación \_font de CFF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [decodeToGid(long charCode)](#decodeToGid-long-) | Obtiene Gid para el charCode proporcionado. |
+| [decodeToGidParameterized(IEncodingParameters parameters, long charCode)](#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-) | Método de decodificación parametrizado. |
+| [encode(long gid, long charCode)](#encode-long-long-) | Codifica el glifo. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getNameToCharCodeIndex()](#getNameToCharCodeIndex--) | Devuelve el mapa de codificación de nombre a código de carácter. |
+| [getNameToGidIndex()](#getNameToGidIndex--) | Devuelve el mapa de codificación de nombre a código de carácter. |
+| [getNameToSidIndex()](#getNameToSidIndex--) | Devuelve el mapa de codificación de nombre a código de carácter. |
+| [getSidName(int sid)](#getSidName-int-) | Obtiene el nombre para el SID especificado. |
+| [gidToUnicode(GlyphId gid)](#gidToUnicode-com.aspose.font.GlyphId-) | Decodifica Gid a unicode. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [unicodeToGid(long unicode)](#unicodeToGid-long-) | Decodifica un unicode y devuelve el id de glifo. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### decodeToGid(long charCode) {#decodeToGid-long-}
+```
+public GlyphId decodeToGid(long charCode)
+```
+
+
+Obtiene Gid para el charCode proporcionado. Este método está diseñado para CFF CIDFonts, donde charCode debe ser un valor CID válido. Glyph id es un número único para un glifo, que depende del tipo \_font. El glyph id de la fuente CFF puede ser una instancia de la clase ( GlyphStringId ) o de la clase ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| charCode | long | Código de carácter (CID) para obtener el identificador de glifo. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to CID passed.
+### decodeToGidParameterized(IEncodingParameters parameters, long charCode) {#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-}
+```
+public GlyphId decodeToGidParameterized(IEncodingParameters parameters, long charCode)
+```
+
+
+Método de decodificación parametrizado. No compatible con el tipo de fuente CFF.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| parameters | [IEncodingParameters](../../com.aspose.font/iencodingparameters) | Implementación de la interfaz IEncodingParameters. |
+| charCode | long | Código de carácter para obtener el identificador del glifo. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to charCode passed.
+### encode(long gid, long charCode) {#encode-long-long-}
+```
+public void encode(long gid, long charCode)
+```
+
+
+Codifica el glifo. No compatible con los tipos de fuente CFF.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| gid | long | ID de glifo |
+| charCode | long | CharCode asociado con el ID de glifo. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNameToCharCodeIndex() {#getNameToCharCodeIndex--}
+```
+public NameToCodeMap getNameToCharCodeIndex()
+```
+
+
+Devuelve el mapa de nombre a codificación de código de carácter. Nota: el código de carácter no es Unicode. El código de carácter es un índice de carácter en la "tabla" de codificación de la fuente.
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - Name to character code encoding map.
+### getNameToGidIndex() {#getNameToGidIndex--}
+```
+public NameToCodeMap getNameToGidIndex()
+```
+
+
+Devuelve el mapa de nombre a codificación de código de carácter. Nota: el código de carácter no es Unicode. El código de carácter es un índice de carácter en la "tabla" de codificación de la fuente.
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - Name to character code encoding map.
+### getNameToSidIndex() {#getNameToSidIndex--}
+```
+public NameToCodeMap getNameToSidIndex()
+```
+
+
+Devuelve el mapa de nombre a codificación de código de carácter. Nota: el código de carácter no es Unicode. El código de carácter es un índice de carácter en la "tabla" de codificación de la fuente.
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - Name to character code encoding map.
+### getSidName(int sid) {#getSidName-int-}
+```
+public String getSidName(int sid)
+```
+
+
+Obtiene el nombre para el SID especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| sid | int | Identificador de cadena. |
+
+**Returns:**
+java.lang.String - Nombre del String INDEX si se encuentra.
+### gidToUnicode(GlyphId gid) {#gidToUnicode-com.aspose.font.GlyphId-}
+```
+public long gidToUnicode(GlyphId gid)
+```
+
+
+Decodifica Gid a Unicode. Glyph id es un número único para un glifo, que depende del tipo \_font. El glyph id de la fuente CFF puede ser una instancia de la clase ( GlyphStringId ) o de la clase ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| gid | [GlyphId](../../com.aspose.font/glyphid) | Identificador de glifo del símbolo a decodificar. |
+
+**Returns:**
+long - Valor Unicode relacionado con el id de glifo pasado.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unicodeToGid(long unicode) {#unicodeToGid-long-}
+```
+public GlyphId unicodeToGid(long unicode)
+```
+
+
+Decodifica un Unicode y devuelve el ID de glifo. Glyph id es un número único para un glifo, que depende del tipo \_font. El glyph id de la fuente CFF puede ser una instancia de la clase ( GlyphStringId ) o de la clase ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| unicode | long | Unicode para obtener el identificador del glifo. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to unicode passed.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/cfffont/_index.md
+++ b/spanish/java/com.aspose.font/cfffont/_index.md
@@ -1,0 +1,604 @@
+---
+title: "CffFont"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa Compact Font Format CFF."
+type: docs
+weight: 19
+url: /es/java/com.aspose.font/cfffont/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Font](../../com.aspose.font/font)
+```
+public class CffFont extends Font
+```
+
+Representa Compact Font Format (CFF).
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Convierte la fuente a otro formato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Devuelve una matriz de todos los identificadores de glifos disponibles en la fuente. |
+| [getClass()](#getClass--) |  |
+| [getCommonFontsSettings()](#getCommonFontsSettings--) | Obtiene la configuración común a las fuentes CFF. |
+| [getEncoding()](#getEncoding--) | Obtiene la codificación de la fuente. |
+| [getFontDefinition()](#getFontDefinition--) | Obtiene la definición de la fuente. |
+| [getFontFamily()](#getFontFamily--) | Obtiene la familia de la fuente. |
+| [getFontName()](#getFontName--) | Obtiene el nombre del estilo de la fuente. |
+| [getFontNames()](#getFontNames--) | Obtiene los nombres de la fuente. |
+| [getFontSaver()](#getFontSaver--) | Obtiene la funcionalidad de guardado de la fuente. |
+| [getFontStyle()](#getFontStyle--) | Obtiene el estilo de la fuente. |
+| [getFontType()](#getFontType--) | Obtiene el tipo de la fuente. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Accesor de glifos de la fuente. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Devuelve el glifo por su identificador. |
+| [getGlyphById(String glyphName)](#getGlyphById-java.lang.String-) | Devuelve el glifo por su nombre. |
+| [getGlyphById(long id)](#getGlyphById-long-) | Devuelve el glifo por su identificador. |
+| [getGlyphIdType()](#getGlyphIdType--) | Obtiene la especificación del tipo de identificador de glifo. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Obtiene la representación de glifos para texto. |
+| [getIndexDataProvider(CffIndexProviderType indexType)](#getIndexDataProvider-com.aspose.font.CffIndexProviderType-) | Obtiene el proveedor para el tipo de estructura CFF INDEX especificado. |
+| [getMetrics()](#getMetrics--) | Obtiene las métricas de la fuente. |
+| [getNumGlyphs()](#getNumGlyphs--) | Obtiene el número de glifos en la Fuente. |
+| [getPostscriptNames()](#getPostscriptNames--) | Obtiene los nombres de fuente PostScript. |
+| [getStyle()](#getStyle--) | Obtiene el estilo de la fuente. |
+| [getTopDictDataProvider()](#getTopDictDataProvider--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isCidKeyedFont()](#isCidKeyedFont--) | Obtiene el valor que indica que la fuente está indexada por CID. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Abre una fuente, usando el objeto FontDefinition. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Abre una fuente, usando el tipo de fuente y la matriz de bytes de datos de fuente. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Abre una fuente, usando el tipo de fuente y la fuente de flujo. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Abre una fuente, usando el tipo de fuente y el nombre de archivo de fuente. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Guarda la Fuente en el formato original. |
+| [save(String fileName)](#save-java.lang.String-) | Guarda la Fuente en el formato original. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Guarda la Fuente en el formato especificado. |
+| [setCommonFontsSettings(CffFontsSettings value)](#setCommonFontsSettings-com.aspose.font.CffFontsSettings-) | Especifica la configuración común a las fuentes CFF. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | El setter de la familia de fuentes no está implementado aún. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | El setter del nombre de la cara de fuente no está implementado aún. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | El setter de estilo no está implementado aún. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public Font convert(FontType fontType)
+```
+
+
+Convierte la Fuente a otro formato. Nota: el tipo de Fuente TTF ahora solo es compatible.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de formato de fuente al que convertir. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public GlyphId[] getAllGlyphIds()
+```
+
+
+Devuelve una matriz de todos los ids de glifos disponibles en la fuente. El id de glifo es un número único para un glifo, que depende del tipo de fuente. El id de glifo de una fuente CFF puede ser una instancia de la clase ( GlyphStringId ) o de la clase ( GlyphUInt32Id ).
+
+**Returns:**
+com.aspose.font.GlyphId[]
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCommonFontsSettings() {#getCommonFontsSettings--}
+```
+public CffFontsSettings getCommonFontsSettings()
+```
+
+
+Obtiene la configuración común a las fuentes CFF. Estas configuraciones se utilizan en diferentes escenarios y pueden cambiarse para cada fuente individual.
+
+**Returns:**
+[CffFontsSettings](../../com.aspose.font/cfffontssettings) - Font definition.
+### getEncoding() {#getEncoding--}
+```
+public IFontEncoding getEncoding()
+```
+
+
+Obtiene la codificación de la fuente.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public FontDefinition getFontDefinition()
+```
+
+
+Obtiene la definición de la fuente.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public String getFontFamily()
+```
+
+
+Obtiene la familia de la fuente.
+
+**Returns:**
+java.lang.String - Familia de la Fuente.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Obtiene el nombre del estilo de la fuente.
+
+**Returns:**
+java.lang.String - Nombre de la cara de la Fuente.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Obtiene los nombres de la fuente.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Obtiene la funcionalidad de guardado de la fuente.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public int getFontStyle()
+```
+
+
+Obtiene el estilo de la Fuente. Este es un valor calculado y representado en tipo generalizado.
+
+**Returns:**
+int - Estilo de la Fuente. Normalmente, una combinación de valores de bandera constante de la clase FontStyle o 0.
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Obtiene el tipo de fuente. Devuelve el valor FontType.CFF.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Accesor de glifos de fuente. Recupera glifos e identificadores de glifos.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public Glyph getGlyphById(GlyphId id)
+```
+
+
+Devuelve el glifo por su id. El id de glifo es un número único para un glifo, que depende del tipo de fuente. El id de glifo de una fuente CFF puede ser una instancia de la clase ( GlyphStringId ) o de la clase ( GlyphInt32Id ).
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | Id de glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(String glyphName) {#getGlyphById-java.lang.String-}
+```
+public Glyph getGlyphById(String glyphName)
+```
+
+
+Devuelve el glifo por su nombre.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphName | java.lang.String | Nombre del glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(long id) {#getGlyphById-long-}
+```
+public Glyph getGlyphById(long id)
+```
+
+
+Devuelve el glifo por su identificador.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| id | long | Id de glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public GlyphIdType getGlyphIdType()
+```
+
+
+Obtiene la especificación del tipo de identificador de glifo.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype) - Glyph id type specification.
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Obtiene la representación de glifos para texto.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| text | java.lang.String | Texto de entrada. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - matriz de GlyphId.
+### getIndexDataProvider(CffIndexProviderType indexType) {#getIndexDataProvider-com.aspose.font.CffIndexProviderType-}
+```
+public ICffIndexDataProvider getIndexDataProvider(CffIndexProviderType indexType)
+```
+
+
+Obtiene el proveedor para el tipo de estructura CFF INDEX especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| indexType | [CffIndexProviderType](../../com.aspose.font/cffindexprovidertype) | Tipo de estructura INDEX. |
+
+**Returns:**
+[ICffIndexDataProvider](../../com.aspose.font/icffindexdataprovider) - Implementation of ( ICffIndexDataProvider ) interface.
+### getMetrics() {#getMetrics--}
+```
+public IFontMetrics getMetrics()
+```
+
+
+Obtiene las métricas de la fuente.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Obtiene el número de glifos en la Fuente.
+
+**Returns:**
+int - Número de glifos en la fuente.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Obtiene los nombres de fuente PostScript.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names.
+### getStyle() {#getStyle--}
+```
+public String getStyle()
+```
+
+
+Obtiene el estilo de la fuente. Este es un valor de cadena sin procesar proporcionado por el archivo de fuente.
+
+**Returns:**
+java.lang.String - Estilo de la fuente.
+### getTopDictDataProvider() {#getTopDictDataProvider--}
+```
+public TopDictDataProvider getTopDictDataProvider()
+```
+
+
+
+
+**Returns:**
+[TopDictDataProvider](../../com.aspose.font/topdictdataprovider)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isCidKeyedFont() {#isCidKeyedFont--}
+```
+public boolean isCidKeyedFont()
+```
+
+
+Obtiene el valor que indica que la fuente está indexada por CID.
+
+**Returns:**
+boolean - Valor que indica que la fuente está indexada por CID.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Abre una fuente, usando el objeto FontDefinition.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Objeto de definición de fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Abre una fuente, usando el tipo de fuente y la matriz de bytes de datos de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fontData | byte[] | Arreglo de bytes para cargar la fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Abre una fuente, usando el tipo de fuente y la fuente de flujo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Fuente de flujo para la fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Abre una fuente, usando el tipo de fuente y el nombre de archivo de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fileName | java.lang.String | Nombre del archivo de fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Guarda la Fuente en el formato original.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.OutputStream | Flujo para guardar la fuente. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Guarda la Fuente en el formato original.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | java.lang.String | Archivo para guardar la fuente. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Guarda la Fuente en el formato especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.OutputStream | flujo para guardar la fuente |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | formato deseado |
+
+### setCommonFontsSettings(CffFontsSettings value) {#setCommonFontsSettings-com.aspose.font.CffFontsSettings-}
+```
+public void setCommonFontsSettings(CffFontsSettings value)
+```
+
+
+Especifica la configuración común a las fuentes CFF.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [CffFontsSettings](../../com.aspose.font/cfffontssettings) | Definición de fuente. |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public void setFontFamily(String value)
+```
+
+
+El setter de la familia de fuentes no está implementado aún.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Nueva familia de fuente. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public void setFontName(String value)
+```
+
+
+El setter del nombre de la cara de fuente no está implementado aún.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Nuevo nombre de la cara de fuente. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public void setStyle(String value)
+```
+
+
+El setter de estilo no está implementado aún.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Nuevo estilo de fuente. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/cfffontexception/_index.md
+++ b/spanish/java/com.aspose.font/cfffontexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "CffFontException"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa una excepción común de procesamiento relacionada con fuentes del formato CFF."
+type: docs
+weight: 20
+url: /es/java/com.aspose.font/cfffontexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class CffFontException extends FontException
+```
+
+Representa una excepción común de procesamiento relacionada con fuentes del formato CFF.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [CffFontException()](#CffFontException--) | Inicializa un nuevo objeto CffFontException. |
+| [CffFontException(String message)](#CffFontException-java.lang.String-) | Inicializa un nuevo objeto CffFontException. |
+| [CffFontException(String message, RuntimeException innerException)](#CffFontException-java.lang.String-java.lang.RuntimeException-) | Inicializa un nuevo objeto CffFontException. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CffFontException() {#CffFontException--}
+```
+public CffFontException()
+```
+
+
+Inicializa un nuevo objeto CffFontException.
+
+### CffFontException(String message) {#CffFontException-java.lang.String-}
+```
+public CffFontException(String message)
+```
+
+
+Inicializa un nuevo objeto CffFontException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+
+### CffFontException(String message, RuntimeException innerException) {#CffFontException-java.lang.String-java.lang.RuntimeException-}
+```
+public CffFontException(String message, RuntimeException innerException)
+```
+
+
+Inicializa un nuevo objeto CffFontException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+| innerException | java.lang.RuntimeException | La excepción que es la causa de la excepción actual. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/cfffontmetrics/_index.md
+++ b/spanish/java/com.aspose.font/cfffontmetrics/_index.md
@@ -1,0 +1,483 @@
+---
+title: "CffFontMetrics"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Implementación de métricas de fuentes CFF"
+type: docs
+weight: 21
+url: /es/java/com.aspose.font/cfffontmetrics/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.FontMetrics](../../com.aspose.font/fontmetrics)
+```
+public class CffFontMetrics extends FontMetrics
+```
+
+Implementación de métricas de fuentes CFF
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAscender()](#getAscender--) | Obtiene el valor de Ascender. |
+| [getAscender(double fontSize)](#getAscender-double-) | Devuelve el ascender para un tamaño de fuente específico. |
+| [getClass()](#getClass--) |  |
+| [getDescender()](#getDescender--) | Obtiene el valor de Descender. |
+| [getDescender(double fontSize)](#getDescender-double-) | Devuelve el descender para un tamaño de fuente específico. |
+| [getFontBBox()](#getFontBBox--) | Obtiene el valor de FontBBox. |
+| [getFontMatrix()](#getFontMatrix--) | Obtiene el valor de FontMatrix. |
+| [getFontMatrixForGlyph(GlyphId glyphId)](#getFontMatrixForGlyph-com.aspose.font.GlyphId-) | Calcula la matriz de transformación para el glifo especificado por id. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Devuelve el Bbox del glifo. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Devuelve el ancho del glifo. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Devuelve el valor de kerning para el par de glifos. |
+| [getLineGap()](#getLineGap--) | Obtiene el valor de LineGap. |
+| [getTypoAscender()](#getTypoAscender--) | Obtiene el valor de TypoAscender. |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Devuelve el ascendente tipográfico para un tamaño de fuente específico. |
+| [getTypoDescender()](#getTypoDescender--) | Obtiene el valor de TypoDescender. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Devuelve el descendente tipográfico para un tamaño de fuente específico |
+| [getTypoLineGap()](#getTypoLineGap--) | Obtiene el valor de TypoLineGap. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Devuelve el espacio entre líneas para un tamaño de fuente específico. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Obtiene el valor de UnitsPerEM. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Obtiene el valor de IsFixedPitch. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Mide la cadena y devuelve el ancho de la cadena. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAscender(double value)](#setAscender-double-) | Establece el valor de Ascender. |
+| [setDescender(double value)](#setDescender-double-) | Establece el valor de Descender. |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) |  |
+| [setTypoAscender(double value)](#setTypoAscender-double-) | Establece el valor de TypoAscender. |
+| [setTypoDescender(double value)](#setTypoDescender-double-) | Establece el valor de TypoDescender. |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) | Establece el valor de UnitsPerEM. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAscender() {#getAscender--}
+```
+public double getAscender()
+```
+
+
+Obtiene el valor de Ascender.
+
+**Returns:**
+double - valor de Ascender.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public double getAscender(double fontSize)
+```
+
+
+Devuelve el ascender para un tamaño de fuente específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - valor de Ascender.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescender() {#getDescender--}
+```
+public double getDescender()
+```
+
+
+Obtiene el valor de Descender.
+
+**Returns:**
+double - valor de Descender.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public double getDescender(double fontSize)
+```
+
+
+Devuelve el descender para un tamaño de fuente específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - valor de Descender.
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+Obtiene el valor de FontBBox.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - FontBBox value.
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+Obtiene el valor de FontMatrix.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - FontMatrix value.
+### getFontMatrixForGlyph(GlyphId glyphId) {#getFontMatrixForGlyph-com.aspose.font.GlyphId-}
+```
+public TransformationMatrix getFontMatrixForGlyph(GlyphId glyphId)
+```
+
+
+Calcula la matriz de transformación para el glifo especificado por id.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificador de glifo. |
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - Glyph transformation matrix.
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Devuelve el Bbox del glifo. Devuelve FontBBox si el Bbox no estaba definido para el glifo. Puede ser sobrescrito por herederos de codificación de fuente específicos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificador de glifo. |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox.
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Devuelve el ancho del glifo. Puede ser sobrescrito por herederos de codificación de fuente específicos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificador de glifo. |
+
+**Returns:**
+double - Ancho del glifo.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Devuelve el valor de kerning para el par de glifos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Primer glifo en el par. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Tamaño de fuente. |
+
+**Returns:**
+double - Valor de interletraje.
+### getLineGap() {#getLineGap--}
+```
+public double getLineGap()
+```
+
+
+Obtiene el valor de LineGap.
+
+**Returns:**
+double - Valor de LineGap.
+### getTypoAscender() {#getTypoAscender--}
+```
+public double getTypoAscender()
+```
+
+
+Obtiene el valor de TypoAscender.
+
+**Returns:**
+double - Valor de TypoAscender.
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public double getTypoAscender(double fontSize)
+```
+
+
+Devuelve el ascendente tipográfico para un tamaño de fuente específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - Valor del ascendente tipográfico.
+### getTypoDescender() {#getTypoDescender--}
+```
+public double getTypoDescender()
+```
+
+
+Obtiene el valor de TypoDescender.
+
+**Returns:**
+double - Valor de TypoDescender.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public double getTypoDescender(double fontSize)
+```
+
+
+Devuelve el descendente tipográfico para un tamaño de fuente específico
+
+param fontSize Tamaño de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double |  |
+
+**Returns:**
+double - Valor del descendente tipográfico.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public double getTypoLineGap()
+```
+
+
+Obtiene el valor de TypoLineGap.
+
+**Returns:**
+double - Valor de TypoLineGap.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public double getTypoLineGap(double fontSize)
+```
+
+
+Devuelve el espacio entre líneas para un tamaño de fuente específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - Valor del espacio de línea.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Obtiene el valor de UnitsPerEM.
+
+**Returns:**
+long - Valor de UnitsPerEM.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+Obtiene el valor de IsFixedPitch.
+
+**Returns:**
+boolean - Valor de IsFixedPitch.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public double measureString(String unicode, double fontSize)
+```
+
+
+Mide la cadena y devuelve el ancho de la cadena.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| unicode | java.lang.String | Cadena Unicode. |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - Ancho de la cadena.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAscender(double value) {#setAscender-double-}
+```
+public void setAscender(double value)
+```
+
+
+Establece el valor de Ascender.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor del ascendente. |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public void setDescender(double value)
+```
+
+
+Establece el valor de Descender.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor del descendente. |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Establece el ancho del glifo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) |  |
+| valor | double |  |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public void setTypoAscender(double value)
+```
+
+
+Establece el valor de TypoAscender.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor de TypoAscender. |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public void setTypoDescender(double value)
+```
+
+
+Establece el valor de TypoDescender.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor de TypoDescender. |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public void setUnitsPerEM(long value)
+```
+
+
+Establece el valor de UnitsPerEM.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long | Valor de UnitsPerEM. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/cfffontssettings/_index.md
+++ b/spanish/java/com.aspose.font/cfffontssettings/_index.md
@@ -1,0 +1,162 @@
+---
+title: "CffFontsSettings"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Proporciona configuraciones comunes a fuentes CFF."
+type: docs
+weight: 22
+url: /es/java/com.aspose.font/cfffontssettings/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class CffFontsSettings
+```
+
+Proporciona configuraciones comunes a fuentes CFF.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [CffFontsSettings()](#CffFontsSettings--) | Constructor |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getUpdateStringsStrategy()](#getUpdateStringsStrategy--) | Obtiene la estrategia para actualizar cadenas en la estructura CFF String INDEX. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUpdateStringStrategy(CffUpdateStringIndexStrategy updateStringsStrategy)](#setUpdateStringStrategy-com.aspose.font.CffUpdateStringIndexStrategy-) | Especifica la estrategia para actualizar cadenas en la estructura CFF String INDEX. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CffFontsSettings() {#CffFontsSettings--}
+```
+public CffFontsSettings()
+```
+
+
+Constructor
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUpdateStringsStrategy() {#getUpdateStringsStrategy--}
+```
+public CffUpdateStringIndexStrategy getUpdateStringsStrategy()
+```
+
+
+Obtiene la estrategia para actualizar cadenas en la estructura CFF String INDEX. La opción AddStringAsIs se usa por defecto.
+
+**Returns:**
+[CffUpdateStringIndexStrategy](../../com.aspose.font/cffupdatestringindexstrategy)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUpdateStringStrategy(CffUpdateStringIndexStrategy updateStringsStrategy) {#setUpdateStringStrategy-com.aspose.font.CffUpdateStringIndexStrategy-}
+```
+public void setUpdateStringStrategy(CffUpdateStringIndexStrategy updateStringsStrategy)
+```
+
+
+Especifica la estrategia para actualizar cadenas en la estructura CFF String INDEX.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| updateStringsStrategy | [CffUpdateStringIndexStrategy](../../com.aspose.font/cffupdatestringindexstrategy) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/cffindexprovidertype/_index.md
+++ b/spanish/java/com.aspose.font/cffindexprovidertype/_index.md
@@ -1,0 +1,250 @@
+---
+title: "CffIndexProviderType"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Especifica las estructuras INDEX compatibles con la familia de interfaces del proveedor de índices."
+type: docs
+weight: 133
+url: /es/java/com.aspose.font/cffindexprovidertype/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum CffIndexProviderType extends Enum<CffIndexProviderType>
+```
+
+Especifica las estructuras INDEX compatibles con la familia de interfaces del proveedor de índices.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [NameIndex](#NameIndex) | Name INDEX |
+| [StringIndex](#StringIndex) | String INDEX |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NameIndex {#NameIndex}
+```
+public static final CffIndexProviderType NameIndex
+```
+
+
+Name INDEX
+
+### StringIndex {#StringIndex}
+```
+public static final CffIndexProviderType StringIndex
+```
+
+
+String INDEX
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static CffIndexProviderType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[CffIndexProviderType](../../com.aspose.font/cffindexprovidertype)
+### values() {#values--}
+```
+public static CffIndexProviderType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.CffIndexProviderType[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/cffparsingexception/_index.md
+++ b/spanish/java/com.aspose.font/cffparsingexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "CffParsingException"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa una excepción de análisis para fuentes del formato cff."
+type: docs
+weight: 23
+url: /es/java/com.aspose.font/cffparsingexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception), [com.aspose.font.CffFontException](../../com.aspose.font/cfffontexception)
+```
+public class CffParsingException extends CffFontException
+```
+
+Representa una excepción de análisis para fuentes en formato cff. La excepción puede lanzarse en caso de errores durante el proceso de análisis de fuentes.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [CffParsingException()](#CffParsingException--) | Inicializa un nuevo objeto CffParsingException. |
+| [CffParsingException(String message)](#CffParsingException-java.lang.String-) | Inicializa un nuevo objeto CffParsingException. |
+| [CffParsingException(String message, RuntimeException innerException)](#CffParsingException-java.lang.String-java.lang.RuntimeException-) | Inicializa un nuevo objeto CffParsingException. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CffParsingException() {#CffParsingException--}
+```
+public CffParsingException()
+```
+
+
+Inicializa un nuevo objeto CffParsingException.
+
+### CffParsingException(String message) {#CffParsingException-java.lang.String-}
+```
+public CffParsingException(String message)
+```
+
+
+Inicializa un nuevo objeto CffParsingException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+
+### CffParsingException(String message, RuntimeException innerException) {#CffParsingException-java.lang.String-java.lang.RuntimeException-}
+```
+public CffParsingException(String message, RuntimeException innerException)
+```
+
+
+Inicializa un nuevo objeto CffParsingException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+| innerException | java.lang.RuntimeException | La excepción que es la causa de la excepción actual. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/cffupdatestringindexstrategy/_index.md
+++ b/spanish/java/com.aspose.font/cffupdatestringindexstrategy/_index.md
@@ -1,0 +1,250 @@
+---
+title: "CffUpdateStringIndexStrategy"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Especifica cómo agregar cadenas al almacenamiento CFF String INDEX."
+type: docs
+weight: 134
+url: /es/java/com.aspose.font/cffupdatestringindexstrategy/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum CffUpdateStringIndexStrategy extends Enum<CffUpdateStringIndexStrategy>
+```
+
+Especifica cómo agregar cadenas al almacenamiento CFF String INDEX. Cuando intentamos agregar una cadena al CFF String INDEX, puede haber una situación en la que esa cadena ya esté presente en String INDEX. Usando la opción SearchForDuplicates podemos forzar la búsqueda en String INDEX para detectar si la cadena ya está presente o no. Este enfoque ahorra espacio en la estructura String INDEX, pero requiere más tiempo para agregar la cadena.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [AddStringAsIs](#AddStringAsIs) | Especifica que no se deben realizar comprobaciones de duplicados al agregar una cadena. |
+| [SearchForDuplicates](#SearchForDuplicates) | Especifica que la búsqueda de la cadena a agregar debe realizarse en la estructura String INDEX para evitar agregar duplicados. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AddStringAsIs {#AddStringAsIs}
+```
+public static final CffUpdateStringIndexStrategy AddStringAsIs
+```
+
+
+Especifica que no se deben realizar comprobaciones de duplicados al agregar una cadena. Este enfoque funciona más rápido, pero puede resultar en un uso ineficiente de la memoria para String INDEX.
+
+### SearchForDuplicates {#SearchForDuplicates}
+```
+public static final CffUpdateStringIndexStrategy SearchForDuplicates
+```
+
+
+Especifica que la búsqueda de la cadena a agregar debe realizarse en la estructura String INDEX para evitar agregar duplicados.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static CffUpdateStringIndexStrategy valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[CffUpdateStringIndexStrategy](../../com.aspose.font/cffupdatestringindexstrategy)
+### values() {#values--}
+```
+public static CffUpdateStringIndexStrategy[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.CffUpdateStringIndexStrategy[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/closepath/_index.md
+++ b/spanish/java/com.aspose.font/closepath/_index.md
@@ -1,0 +1,200 @@
+---
+title: "ClosePath"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la operación ClosePath."
+type: docs
+weight: 24
+url: /es/java/com.aspose.font/closepath/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IPathSegment](../../com.aspose.font/ipathsegment)
+```
+public class ClosePath implements IPathSegment
+```
+
+Representa la operación ClosePath.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clone()](#clone--) | Crea un nuevo objeto que es una copia de la instancia actual. |
+| [copy()](#copy--) | Crea una copia del objeto segmento. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getX()](#getX--) | Obtiene la coordenada x. |
+| [getY()](#getY--) | Obtiene la coordenada y. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [shift(double dx, double dy)](#shift-double-double-) | Realiza un desplazamiento por las coordenadas x e y. |
+| [toString()](#toString--) |  |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Transforma las coordenadas con la matriz de transformación. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Crea un nuevo objeto que es una copia de la instancia actual.
+
+**Returns:**
+java.lang.Object - Un nuevo objeto que es una copia de esta instancia.
+### copy() {#copy--}
+```
+public IPathSegment copy()
+```
+
+
+Crea una copia del objeto segmento.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getX() {#getX--}
+```
+public double getX()
+```
+
+
+Obtiene la coordenada x.
+
+**Returns:**
+double - Coordenada x.
+### getY() {#getY--}
+```
+public double getY()
+```
+
+
+Obtiene la coordenada y.
+
+**Returns:**
+double - Coordenada y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public void shift(double dx, double dy)
+```
+
+
+Realiza un desplazamiento por las coordenadas x e y.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| dx | double | Valor dx. |
+| dy | double | Valor dy. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public void transform(TransformationMatrix matrix)
+```
+
+
+Transforma las coordenadas con la matriz de transformación.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matriz de transformación. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/compositeglyph/_index.md
+++ b/spanish/java/com.aspose.font/compositeglyph/_index.md
@@ -1,0 +1,245 @@
+---
+title: "CompositeGlyph"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa un glifo compuesto de fuente."
+type: docs
+weight: 25
+url: /es/java/com.aspose.font/compositeglyph/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Glyph](../../com.aspose.font/glyph)
+```
+public class CompositeGlyph extends Glyph
+```
+
+Representa un glifo compuesto de fuente.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clone()](#clone--) | Devuelve una copia del glifo. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getComponents()](#getComponents--) | Obtiene la lista de componentes. |
+| [getGlyphBBox()](#getGlyphBBox--) | Obtiene el BBox del glifo. |
+| [getLeftSidebearingX()](#getLeftSidebearingX--) | Obtiene la coordenada x del margen lateral del glifo. |
+| [getLeftSidebearingY()](#getLeftSidebearingY--) | Obtiene la coordenada y del margen lateral del glifo. |
+| [getPath()](#getPath--) | Obtiene la ruta del glifo. |
+| [getSourceResolution()](#getSourceResolution--) | Obtiene la resolución del conjunto de comandos fuente. |
+| [getState()](#getState--) | Obtiene el estado del glifo. |
+| [getWidthVectorX()](#getWidthVectorX--) | Obtiene el vector de ancho del glifo. |
+| [getWidthVectorY()](#getWidthVectorY--) | Obtiene el vector de ancho del glifo. |
+| [hashCode()](#hashCode--) |  |
+| [isEmpty()](#isEmpty--) | Verdadero si el glifo no contiene instrucciones de dibujo. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Devuelve una copia del glifo.
+
+**Returns:**
+java.lang.Object - Copia de Glyph
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getComponents() {#getComponents--}
+```
+public CompositeGlyphComponentList getComponents()
+```
+
+
+Obtiene la lista de componentes.
+
+**Returns:**
+[CompositeGlyphComponentList](../../com.aspose.font/compositeglyphcomponentlist) - Components list.
+### getGlyphBBox() {#getGlyphBBox--}
+```
+public FontBBox getGlyphBBox()
+```
+
+
+Obtiene el BBox del glifo.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox
+### getLeftSidebearingX() {#getLeftSidebearingX--}
+```
+public double getLeftSidebearingX()
+```
+
+
+Obtiene la coordenada x del margen lateral del glifo.
+
+**Returns:**
+double - Coordenada x del margen lateral del glifo.
+### getLeftSidebearingY() {#getLeftSidebearingY--}
+```
+public double getLeftSidebearingY()
+```
+
+
+Obtiene la coordenada y del margen lateral del glifo.
+
+**Returns:**
+double - Coordenada y del margen lateral del glifo.
+### getPath() {#getPath--}
+```
+public SegmentPath getPath()
+```
+
+
+Obtiene la ruta del glifo.
+
+**Returns:**
+[SegmentPath](../../com.aspose.font/segmentpath) - Glyph path.
+### getSourceResolution() {#getSourceResolution--}
+```
+public int getSourceResolution()
+```
+
+
+Obtiene la resolución del conjunto de comandos fuente.
+
+**Returns:**
+int - Resolución del conjunto de comandos fuente.
+### getState() {#getState--}
+```
+public GlyphState getState()
+```
+
+
+Obtiene el estado del glifo.
+
+**Returns:**
+[GlyphState](../../com.aspose.font/glyphstate) - Glyph state.
+### getWidthVectorX() {#getWidthVectorX--}
+```
+public double getWidthVectorX()
+```
+
+
+Obtiene el vector de ancho del glifo. Coordenada x.
+
+**Returns:**
+double - Vector de ancho del glifo. Coordenada x.
+### getWidthVectorY() {#getWidthVectorY--}
+```
+public double getWidthVectorY()
+```
+
+
+Obtiene el vector de ancho del glifo. Coordenada y.
+
+**Returns:**
+double - Vector de ancho del glifo. Coordenada y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+Verdadero si el glifo no contiene instrucciones de dibujo.
+
+**Returns:**
+boolean - Verdadero si el glifo no contiene instrucciones de dibujo.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/compositeglyphcomponent/_index.md
+++ b/spanish/java/com.aspose.font/compositeglyphcomponent/_index.md
@@ -1,0 +1,146 @@
+---
+title: "CompositeGlyphComponent"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa un glifo componente compuesto con una matriz de colocación."
+type: docs
+weight: 26
+url: /es/java/com.aspose.font/compositeglyphcomponent/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class CompositeGlyphComponent
+```
+
+Representa el componente de glifo compuesto (glifo con matriz de colocación).
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGlyph()](#getGlyph--) | Obtiene el glifo componente. |
+| [getMatrix()](#getMatrix--) | Obtiene la matriz de transformación del componente. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyph() {#getGlyph--}
+```
+public Glyph getGlyph()
+```
+
+
+Obtiene el glifo componente.
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - The component glyph.
+### getMatrix() {#getMatrix--}
+```
+public TransformationMatrix getMatrix()
+```
+
+
+Obtiene la matriz de transformación del componente.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - The component transformation matrix.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/compositeglyphcomponentlist/_index.md
+++ b/spanish/java/com.aspose.font/compositeglyphcomponentlist/_index.md
@@ -1,0 +1,565 @@
+---
+title: "CompositeGlyphComponentList"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la lista de componentes de glifos compuestos."
+type: docs
+weight: 27
+url: /es/java/com.aspose.font/compositeglyphcomponentlist/
+---
+**Inheritance:**
+java.lang.Object, java.util.AbstractCollection, java.util.AbstractList, java.util.ArrayList
+```
+public class CompositeGlyphComponentList extends ArrayList<CompositeGlyphComponent>
+```
+
+Representa la lista de componentes de glifos compuestos.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>toArray(T[] arg0)](#-T-toArray-T---) |  |
+| [add(E arg0)](#add-E-) |  |
+| [add(int arg0, E arg1)](#add-int-E-) |  |
+| [addAll(int arg0, Collection<? extends E> arg1)](#addAll-int-java.util.Collection---extends-E--) |  |
+| [addAll(Collection<? extends E> arg0)](#addAll-java.util.Collection---extends-E--) |  |
+| [clear()](#clear--) |  |
+| [clone()](#clone--) |  |
+| [contains(Object arg0)](#contains-java.lang.Object-) |  |
+| [containsAll(Collection<?> arg0)](#containsAll-java.util.Collection----) |  |
+| [ensureCapacity(int arg0)](#ensureCapacity-int-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [forEach(Consumer<? super E> arg0)](#forEach-java.util.function.Consumer---super-E--) |  |
+| [get(int arg0)](#get-int-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object arg0)](#indexOf-java.lang.Object-) |  |
+| [isEmpty()](#isEmpty--) |  |
+| [iterator()](#iterator--) |  |
+| [lastIndexOf(Object arg0)](#lastIndexOf-java.lang.Object-) |  |
+| [listIterator()](#listIterator--) |  |
+| [listIterator(int arg0)](#listIterator-int-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(int arg0)](#remove-int-) |  |
+| [remove(Object arg0)](#remove-java.lang.Object-) |  |
+| [removeAll(Collection<?> arg0)](#removeAll-java.util.Collection----) |  |
+| [removeIf(Predicate<? super E> arg0)](#removeIf-java.util.function.Predicate---super-E--) |  |
+| [replaceAll(UnaryOperator<E> arg0)](#replaceAll-java.util.function.UnaryOperator-E--) |  |
+| [retainAll(Collection<?> arg0)](#retainAll-java.util.Collection----) |  |
+| [set(int arg0, E arg1)](#set-int-E-) |  |
+| [size()](#size--) |  |
+| [sort(Comparator<? super E> arg0)](#sort-java.util.Comparator---super-E--) |  |
+| [spliterator()](#spliterator--) |  |
+| [subList(int arg0, int arg1)](#subList-int-int-) |  |
+| [toArray()](#toArray--) |  |
+| [toString()](#toString--) |  |
+| [trimToSize()](#trimToSize--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>toArray(T[] arg0) {#-T-toArray-T---}
+```
+public T[] <T>toArray(T[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | T[] |  |
+
+**Returns:**
+T[]
+### add(E arg0) {#add-E-}
+```
+public boolean add(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+boolean
+### add(int arg0, E arg1) {#add-int-E-}
+```
+public void add(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+### addAll(int arg0, Collection<? extends E> arg1) {#addAll-int-java.util.Collection---extends-E--}
+```
+public boolean addAll(int arg0, Collection<? extends E> arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### addAll(Collection<? extends E> arg0) {#addAll-java.util.Collection---extends-E--}
+```
+public boolean addAll(Collection<? extends E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### contains(Object arg0) {#contains-java.lang.Object-}
+```
+public boolean contains(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### containsAll(Collection<?> arg0) {#containsAll-java.util.Collection----}
+```
+public boolean containsAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### ensureCapacity(int arg0) {#ensureCapacity-int-}
+```
+public void ensureCapacity(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### forEach(Consumer<? super E> arg0) {#forEach-java.util.function.Consumer---super-E--}
+```
+public void forEach(Consumer<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.function.Consumer<? super E> |  |
+
+### get(int arg0) {#get-int-}
+```
+public E get(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object arg0) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public Iterator<E> iterator()
+```
+
+
+
+
+**Returns:**
+java.util.Iterator<E>
+### lastIndexOf(Object arg0) {#lastIndexOf-java.lang.Object-}
+```
+public int lastIndexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### listIterator() {#listIterator--}
+```
+public ListIterator<E> listIterator()
+```
+
+
+
+
+**Returns:**
+java.util.ListIterator<E>
+### listIterator(int arg0) {#listIterator-int-}
+```
+public ListIterator<E> listIterator(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+java.util.ListIterator<E>
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(int arg0) {#remove-int-}
+```
+public E remove(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### remove(Object arg0) {#remove-java.lang.Object-}
+```
+public boolean remove(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### removeAll(Collection<?> arg0) {#removeAll-java.util.Collection----}
+```
+public boolean removeAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### removeIf(Predicate<? super E> arg0) {#removeIf-java.util.function.Predicate---super-E--}
+```
+public boolean removeIf(Predicate<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.function.Predicate<? super E> |  |
+
+**Returns:**
+boolean
+### replaceAll(UnaryOperator<E> arg0) {#replaceAll-java.util.function.UnaryOperator-E--}
+```
+public void replaceAll(UnaryOperator<E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.function.UnaryOperator<E> |  |
+
+### retainAll(Collection<?> arg0) {#retainAll-java.util.Collection----}
+```
+public boolean retainAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### set(int arg0, E arg1) {#set-int-E-}
+```
+public E set(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+**Returns:**
+E
+### size() {#size--}
+```
+public int size()
+```
+
+
+
+
+**Returns:**
+int
+### sort(Comparator<? super E> arg0) {#sort-java.util.Comparator---super-E--}
+```
+public void sort(Comparator<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.Comparator<? super E> |  |
+
+### spliterator() {#spliterator--}
+```
+public Spliterator<E> spliterator()
+```
+
+
+
+
+**Returns:**
+java.util.Spliterator<E>
+### subList(int arg0, int arg1) {#subList-int-int-}
+```
+public List<E> subList(int arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | int |  |
+
+**Returns:**
+java.util.List<E>
+### toArray() {#toArray--}
+```
+public Object[] toArray()
+```
+
+
+
+
+**Returns:**
+java.lang.Object[]
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### trimToSize() {#trimToSize--}
+```
+public void trimToSize()
+```
+
+
+
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/compressionutils/_index.md
+++ b/spanish/java/com.aspose.font/compressionutils/_index.md
@@ -1,0 +1,168 @@
+---
+title: "CompressionUtils"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Proporciona métodos utilitarios para compresión y descompresión."
+type: docs
+weight: 28
+url: /es/java/com.aspose.font/compressionutils/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class CompressionUtils
+```
+
+Proporciona métodos utilitarios para compresión y descompresión.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [CompressionUtils()](#CompressionUtils--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [decodeByBrotli(byte[] input)](#decodeByBrotli-byte---) | Descomprime el arreglo de bytes comprimido con Brotli proporcionado. |
+| [encodeByBrotli(byte[] buff, int buffLength)](#encodeByBrotli-byte---int-) | Comprime el arreglo de bytes proporcionado usando el algoritmo Brotli. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CompressionUtils() {#CompressionUtils--}
+```
+public CompressionUtils()
+```
+
+
+### decodeByBrotli(byte[] input) {#decodeByBrotli-byte---}
+```
+public static byte[] decodeByBrotli(byte[] input)
+```
+
+
+Descomprime el arreglo de bytes comprimido con Brotli proporcionado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| entrada | byte[] | Los datos comprimidos. |
+
+**Returns:**
+byte[] - El arreglo de bytes descomprimido.
+### encodeByBrotli(byte[] buff, int buffLength) {#encodeByBrotli-byte---int-}
+```
+public static byte[] encodeByBrotli(byte[] buff, int buffLength)
+```
+
+
+Comprime el arreglo de bytes proporcionado usando el algoritmo Brotli.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| buff | byte[] | El búfer de entrada para comprimir. |
+| buffLength | int | La longitud de los datos a comprimir. |
+
+**Returns:**
+byte[] - El arreglo de bytes comprimido.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/curveto/_index.md
+++ b/spanish/java/com.aspose.font/curveto/_index.md
@@ -1,0 +1,244 @@
+---
+title: "CurveTo"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la operación CurveTo."
+type: docs
+weight: 29
+url: /es/java/com.aspose.font/curveto/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IPathSegment](../../com.aspose.font/ipathsegment)
+```
+public class CurveTo implements IPathSegment
+```
+
+Representa la operación CurveTo.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clone()](#clone--) | Crea un nuevo objeto que es una copia de la instancia actual. |
+| [copy()](#copy--) | Crea una copia del objeto segmento. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getX1()](#getX1--) | Obtiene la coordenada x1. |
+| [getX2()](#getX2--) | Obtiene la coordenada x2. |
+| [getX3()](#getX3--) | Obtiene la coordenada x3. |
+| [getY1()](#getY1--) | Obtiene la coordenada y1. |
+| [getY2()](#getY2--) | Obtiene la coordenada y2. |
+| [getY3()](#getY3--) | Obtiene la coordenada y3. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [shift(double dx, double dy)](#shift-double-double-) | Realiza un desplazamiento por las coordenadas x e y. |
+| [toString()](#toString--) |  |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Transforma las coordenadas con la matriz de transformación. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Crea un nuevo objeto que es una copia de la instancia actual.
+
+**Returns:**
+java.lang.Object - Un nuevo objeto que es una copia de esta instancia.
+### copy() {#copy--}
+```
+public IPathSegment copy()
+```
+
+
+Crea una copia del objeto segmento.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getX1() {#getX1--}
+```
+public double getX1()
+```
+
+
+Obtiene la coordenada x1.
+
+**Returns:**
+double - Coordenada x1.
+### getX2() {#getX2--}
+```
+public double getX2()
+```
+
+
+Obtiene la coordenada x2.
+
+**Returns:**
+double - Coordenada x2.
+### getX3() {#getX3--}
+```
+public double getX3()
+```
+
+
+Obtiene la coordenada x3.
+
+**Returns:**
+double - Coordenada x3.
+### getY1() {#getY1--}
+```
+public double getY1()
+```
+
+
+Obtiene la coordenada y1.
+
+**Returns:**
+double - Coordenada y1.
+### getY2() {#getY2--}
+```
+public double getY2()
+```
+
+
+Obtiene la coordenada y2.
+
+**Returns:**
+double - Coordenada y2.
+### getY3() {#getY3--}
+```
+public double getY3()
+```
+
+
+Obtiene la coordenada y3.
+
+**Returns:**
+double - Coordenada y3.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public void shift(double dx, double dy)
+```
+
+
+Realiza un desplazamiento por las coordenadas x e y.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| dx | double | Valor dx. |
+| dy | double | Valor dy. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public void transform(TransformationMatrix matrix)
+```
+
+
+Transforma las coordenadas con la matriz de transformación.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matriz de transformación. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/encodingexception/_index.md
+++ b/spanish/java/com.aspose.font/encodingexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "EncodingException"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa una excepción de codificación."
+type: docs
+weight: 30
+url: /es/java/com.aspose.font/encodingexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class EncodingException extends FontException
+```
+
+Representa una excepción de codificación. La excepción puede lanzarse en caso de un problema con la codificación/decodificación de texto.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [EncodingException()](#EncodingException--) | Inicializa un nuevo objeto EncodingException. |
+| [EncodingException(String message)](#EncodingException-java.lang.String-) | Inicializa un nuevo objeto EncodingException. |
+| [EncodingException(String message, RuntimeException innerException)](#EncodingException-java.lang.String-java.lang.RuntimeException-) | Inicializa un nuevo objeto EncodingException. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EncodingException() {#EncodingException--}
+```
+public EncodingException()
+```
+
+
+Inicializa un nuevo objeto EncodingException.
+
+### EncodingException(String message) {#EncodingException-java.lang.String-}
+```
+public EncodingException(String message)
+```
+
+
+Inicializa un nuevo objeto EncodingException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+
+### EncodingException(String message, RuntimeException innerException) {#EncodingException-java.lang.String-java.lang.RuntimeException-}
+```
+public EncodingException(String message, RuntimeException innerException)
+```
+
+
+Inicializa un nuevo objeto EncodingException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+| innerException | java.lang.RuntimeException | La excepción que es la causa de la excepción actual. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/filesystemstreamsource/_index.md
+++ b/spanish/java/com.aspose.font/filesystemstreamsource/_index.md
@@ -1,0 +1,225 @@
+---
+title: "FileSystemStreamSource"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa una fuente de flujo basada en el sistema de archivos."
+type: docs
+weight: 31
+url: /es/java/com.aspose.font/filesystemstreamsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.StreamSource](../../com.aspose.font/streamsource)
+```
+public class FileSystemStreamSource extends StreamSource
+```
+
+Representa una fuente de flujo basada en el sistema de archivos.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FileSystemStreamSource(String fileName)](#FileSystemStreamSource-java.lang.String-) | Inicializa un nuevo objeto  FileSystemStreamSource . |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Clona el objeto FileSystemStreamSource. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileName()](#getFileName--) | Obtiene el nombre del archivo. |
+| [getFontStream()](#getFontStream--) | Devuelve el flujo del archivo de fuente. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento dentro de la fuente. |
+| [hashCode()](#hashCode--) |  |
+| [mustCloseAfterUse()](#mustCloseAfterUse--) | Los herederos pueden evitar que el flujo se cierre. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFileName(String value)](#setFileName-java.lang.String-) | Establece el nombre del archivo. |
+| [setOffset(long value)](#setOffset-long-) | Establece el desplazamiento dentro de la fuente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileSystemStreamSource(String fileName) {#FileSystemStreamSource-java.lang.String-}
+```
+public FileSystemStreamSource(String fileName)
+```
+
+
+Inicializa un nuevo objeto  FileSystemStreamSource .
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | java.lang.String | Nombre del archivo. |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Clona el objeto FileSystemStreamSource.
+
+**Returns:**
+java.lang.Object - Copia del objeto FileSystemStreamSource.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Obtiene el nombre del archivo.
+
+**Returns:**
+java.lang.String - Nombre de archivo.
+### getFontStream() {#getFontStream--}
+```
+public InputStream getFontStream()
+```
+
+
+Devuelve el flujo del archivo de fuente. No olvides cerrar el flujo después de usarlo.
+
+**Returns:**
+java.io.InputStream - Flujo del archivo de fuente.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento dentro de la fuente.
+
+**Returns:**
+long - Desplazamiento dentro de la fuente.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### mustCloseAfterUse() {#mustCloseAfterUse--}
+```
+public boolean mustCloseAfterUse()
+```
+
+
+Los herederos pueden evitar que el flujo se cierre. Devuelve verdadero si la fuente de flujo desea que el flujo se cierre después de su uso. De lo contrario, devuelve falso.
+
+**Returns:**
+boolean - Verdadero si la fuente de flujo desea que el flujo se cierre después de su uso, de lo contrario falso.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFileName(String value) {#setFileName-java.lang.String-}
+```
+public void setFileName(String value)
+```
+
+
+Establece el nombre del archivo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Nombre del archivo. |
+
+### setOffset(long value) {#setOffset-long-}
+```
+public void setOffset(long value)
+```
+
+
+Establece el desplazamiento dentro de la fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long | Desplazamiento dentro de la fuente. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/font/_index.md
+++ b/spanish/java/com.aspose.font/font/_index.md
@@ -1,0 +1,526 @@
+---
+title: "Fuente"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la clase base Font."
+type: docs
+weight: 32
+url: /es/java/com.aspose.font/font/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFont](../../com.aspose.font/ifont), [com.aspose.font.IGlyphAccessor](../../com.aspose.font/iglyphaccessor), [com.aspose.font.IFontSaver](../../com.aspose.font/ifontsaver)
+```
+public abstract class Font implements IFont, IGlyphAccessor, IFontSaver
+```
+
+Representa la clase base Font.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Convierte la fuente a otro formato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Devuelve todos los IDs de glifos disponibles en la fuente. |
+| [getClass()](#getClass--) |  |
+| [getEncoding()](#getEncoding--) | Obtiene la codificación de la fuente. |
+| [getFontDefinition()](#getFontDefinition--) | Obtiene la definición de la fuente. |
+| [getFontFamily()](#getFontFamily--) | Obtiene la familia de la fuente. |
+| [getFontName()](#getFontName--) | Obtiene el nombre del estilo de la fuente. |
+| [getFontNames()](#getFontNames--) | Obtiene los nombres de la fuente. |
+| [getFontSaver()](#getFontSaver--) | Obtiene la funcionalidad de guardado de la fuente. |
+| [getFontStyle()](#getFontStyle--) | Obtiene el estilo de la fuente. |
+| [getFontType()](#getFontType--) | Obtiene el tipo de la fuente. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Accesor de glifos de la fuente. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Devuelve el glifo por Id de glifo. |
+| [getGlyphIdType()](#getGlyphIdType--) | Especificación del tipo de id de glifo. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Obtiene la representación de glifos para texto. |
+| [getMetrics()](#getMetrics--) | Obtiene las métricas de la fuente. |
+| [getNumGlyphs()](#getNumGlyphs--) | Obtiene el número de glifos en la Fuente. |
+| [getPostscriptNames()](#getPostscriptNames--) | Obtiene los nombres de fuentes PostScript. |
+| [getStyle()](#getStyle--) | Obtiene el estilo de la fuente. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Abre una fuente, usando el objeto FontDefinition. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Abre una fuente, usando el tipo de fuente y la matriz de bytes de datos de fuente. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Abre una fuente, usando el tipo de fuente y la fuente de flujo. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Abre una fuente, usando el tipo de fuente y el nombre de archivo de fuente. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Guarda la Fuente en el formato original. |
+| [save(String fileName)](#save-java.lang.String-) | Guarda la Fuente en el formato original. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Guarda la Fuente en el formato especificado. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Establece la familia de la Fuente. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Establece el nombre de la cara de la Fuente. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Establece el estilo de la Fuente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public abstract Font convert(FontType fontType)
+```
+
+
+Convierte la fuente a otro formato.
+
+--------------------
+
+> ```
+> Note: TTF Font type is now supported only.
+> ```
+
+fontType Tipo de formato de fuente al que convertir.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) |  |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public abstract GlyphId[] getAllGlyphIds()
+```
+
+
+Devuelve todos los IDs de glifos disponibles en la fuente. El ID de glifo es un número único para un glifo, que depende del tipo de fuente. Por ejemplo: el ID de Type1 es un nombre de glifo, instancia de la clase ( GlyphStringId ). El ID de TTF es un índice entero, instancia de la clase ( GlyphInt32Id ).
+
+**Returns:**
+com.aspose.font.GlyphId[] - Identificadores de glifos.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncoding() {#getEncoding--}
+```
+public abstract IFontEncoding getEncoding()
+```
+
+
+Obtiene la codificación de la fuente.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public abstract FontDefinition getFontDefinition()
+```
+
+
+Obtiene la definición de la fuente.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public abstract String getFontFamily()
+```
+
+
+Obtiene la familia de la fuente.
+
+**Returns:**
+java.lang.String - Familia de la Fuente.
+### getFontName() {#getFontName--}
+```
+public abstract String getFontName()
+```
+
+
+Obtiene el nombre del estilo de la fuente.
+
+**Returns:**
+java.lang.String - Nombre de la cara de la Fuente.
+### getFontNames() {#getFontNames--}
+```
+public abstract MultiLanguageString getFontNames()
+```
+
+
+Obtiene los nombres de la fuente.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Obtiene la funcionalidad de guardado de la fuente.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public abstract int getFontStyle()
+```
+
+
+Obtiene el estilo de la Fuente. Este es un valor calculado y representado en tipo generalizado.
+
+**Returns:**
+int - Estilo de la Fuente. Normalmente, una combinación de valores de bandera constante de la clase FontStyle o 0.
+### getFontType() {#getFontType--}
+```
+public abstract FontType getFontType()
+```
+
+
+Obtiene el tipo de la fuente.
+
+--------------------
+
+> ```
+> Type1, TrueType etc.
+> ```
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Accesor de glifos de fuente. Recupera glifos e identificadores de glifos.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public abstract Glyph getGlyphById(GlyphId id)
+```
+
+
+Devuelve el glifo por ID de glifo. El ID de glifo es un número único para un glifo, que depende del tipo de fuente. GlyphId - objeto derivado. Por ejemplo: el ID de Type1 es un nombre de glifo, instancia de la clase ( GlyphStringId ). El ID de TTF es un índice entero, instancia de la clase ( GlyphInt32Id ).
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | Id de glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public abstract GlyphIdType getGlyphIdType()
+```
+
+
+Especificación del tipo de ID de glifo. Para los consumidores que necesitan conocer el tipo real de 'bytes[]'.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype) - Id type specification
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Obtiene la representación de glifos para texto.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| text | java.lang.String | Texto de entrada. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - matriz de GlyphId.
+### getMetrics() {#getMetrics--}
+```
+public abstract IFontMetrics getMetrics()
+```
+
+
+Obtiene las métricas de la fuente.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public abstract int getNumGlyphs()
+```
+
+
+Obtiene el número de glifos en la Fuente.
+
+**Returns:**
+int - Número de glifos en la fuente.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public abstract MultiLanguageString getPostscriptNames()
+```
+
+
+Obtiene los nombres de fuentes PostScript.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript font names.
+### getStyle() {#getStyle--}
+```
+public abstract String getStyle()
+```
+
+
+Obtiene el estilo de la fuente. Este es un valor de cadena sin procesar proporcionado por el archivo de fuente.
+
+**Returns:**
+java.lang.String - Estilo de la fuente.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Abre una fuente, usando el objeto FontDefinition.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Objeto de definición de fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Abre una fuente, usando el tipo de fuente y la matriz de bytes de datos de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fontData | byte[] | Arreglo de bytes para cargar la fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Abre una fuente, usando el tipo de fuente y la fuente de flujo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Fuente de flujo para la fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Abre una fuente, usando el tipo de fuente y el nombre de archivo de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fileName | java.lang.String | Nombre del archivo de fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Guarda la Fuente en el formato original.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.OutputStream | Flujo para guardar la fuente. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Guarda la Fuente en el formato original.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | java.lang.String | Archivo para guardar la fuente. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Guarda la Fuente en el formato especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.OutputStream | flujo para guardar la fuente |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | formato deseado |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public abstract void setFontFamily(String value)
+```
+
+
+Establece la familia de la Fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Nueva familia de fuente. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public abstract void setFontName(String value)
+```
+
+
+Establece el nombre de la cara de la Fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Nuevo nombre de la cara de fuente. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public abstract void setStyle(String value)
+```
+
+
+Establece el estilo de fuente. Este es un valor de cadena cruda proporcionado por el archivo de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Nuevo estilo de fuente. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fontagrumentexception/_index.md
+++ b/spanish/java/com.aspose.font/fontagrumentexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontAgrumentException"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa una excepción de argumento de Font."
+type: docs
+weight: 33
+url: /es/java/com.aspose.font/fontagrumentexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontAgrumentException extends FontException
+```
+
+Representa la excepción de argumento de fuente. La excepción puede lanzarse en caso de usos de argumentos incorrectos.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FontAgrumentException()](#FontAgrumentException--) | Inicializa un nuevo objeto FontAgrumentException. |
+| [FontAgrumentException(String message)](#FontAgrumentException-java.lang.String-) | Inicializa un nuevo objeto FontAgrumentException. |
+| [FontAgrumentException(String message, RuntimeException innerException)](#FontAgrumentException-java.lang.String-java.lang.RuntimeException-) | Inicializa un nuevo objeto FontAgrumentException. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontAgrumentException() {#FontAgrumentException--}
+```
+public FontAgrumentException()
+```
+
+
+Inicializa un nuevo objeto FontAgrumentException.
+
+### FontAgrumentException(String message) {#FontAgrumentException-java.lang.String-}
+```
+public FontAgrumentException(String message)
+```
+
+
+Inicializa un nuevo objeto FontAgrumentException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+
+### FontAgrumentException(String message, RuntimeException innerException) {#FontAgrumentException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontAgrumentException(String message, RuntimeException innerException)
+```
+
+
+Inicializa un nuevo objeto FontAgrumentException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+| innerException | java.lang.RuntimeException | La excepción que es la causa de la excepción actual. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fontbbox/_index.md
+++ b/spanish/java/com.aspose.font/fontbbox/_index.md
@@ -1,0 +1,168 @@
+---
+title: "FontBBox"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa el cuadro delimitador de la fuente."
+type: docs
+weight: 34
+url: /es/java/com.aspose.font/fontbbox/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontBBox
+```
+
+Representa el cuadro delimitador de la fuente.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getXMax()](#getXMax--) | Obtiene el valor XMax. |
+| [getXMin()](#getXMin--) | Obtiene el valor XMin. |
+| [getYMax()](#getYMax--) | Obtiene el valor YMax. |
+| [getYMin()](#getYMin--) | Obtiene el valor YMin. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getXMax() {#getXMax--}
+```
+public double getXMax()
+```
+
+
+Obtiene el valor XMax.
+
+**Returns:**
+double - valor XMax.
+### getXMin() {#getXMin--}
+```
+public double getXMin()
+```
+
+
+Obtiene el valor XMin.
+
+**Returns:**
+double - valor XMin.
+### getYMax() {#getYMax--}
+```
+public double getYMax()
+```
+
+
+Obtiene el valor YMax.
+
+**Returns:**
+double - valor YMax.
+### getYMin() {#getYMin--}
+```
+public double getYMin()
+```
+
+
+Obtiene el valor YMin.
+
+**Returns:**
+double - valor YMin.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fontcharactersmerger/_index.md
+++ b/spanish/java/com.aspose.font/fontcharactersmerger/_index.md
@@ -1,0 +1,200 @@
+---
+title: "FontCharactersMerger"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Declara la funcionalidad para combinar fuentes de diferentes tipos."
+type: docs
+weight: 35
+url: /es/java/com.aspose.font/fontcharactersmerger/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class FontCharactersMerger
+```
+
+Declara la funcionalidad para combinar fuentes de diferentes tipos. Se necesita un par de fuentes para la operación de combinación. Una fuente de este par se considera primaria. Esto significa que muchas características relacionadas con la fuente combinada final, como métricas, estructura de codificación y otras, se tomarán de esta fuente primaria. La otra fuente del par (secundaria) proporciona solo glifos para la fuente combinada final.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPrimaryFont()](#getPrimaryFont--) | Obtiene la fuente primaria. |
+| [getSecondaryFont()](#getSecondaryFont--) | Obtiene la fuente secundaria. |
+| [hashCode()](#hashCode--) |  |
+| [mergeFonts(GlyphId[] primaryFontGlyphs, GlyphId[] secondaryFontGlyphs, String newFontName)](#mergeFonts-com.aspose.font.GlyphId---com.aspose.font.GlyphId---java.lang.String-) | Fusiona fuentes basándose en las listas de glifos proporcionadas. |
+| [mergeFonts(int[] primaryFontCharCodes, int[] secondaryFontCharCodes, String newFontName)](#mergeFonts-int---int---java.lang.String-) | Fusiona fuentes basándose en las listas de códigos de caracteres proporcionadas. |
+| [mergeFonts(Map<Integer,GlyphId> primaryFontDict, Map<Integer,GlyphId> secondaryFontDict, String newFontName)](#mergeFonts-java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.lang.String-) | Esta versión del método está diseñada para casos en los que deseas establecer códigos de caracteres para los glifos en la fuente resultante de forma explícita. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPrimaryFont() {#getPrimaryFont--}
+```
+public abstract Font getPrimaryFont()
+```
+
+
+Obtiene la fuente primaria.
+
+**Returns:**
+[Font](../../com.aspose.font/font) - The primary font.
+### getSecondaryFont() {#getSecondaryFont--}
+```
+public abstract Font getSecondaryFont()
+```
+
+
+Obtiene la fuente secundaria.
+
+**Returns:**
+[Font](../../com.aspose.font/font) - The secondary font.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### mergeFonts(GlyphId[] primaryFontGlyphs, GlyphId[] secondaryFontGlyphs, String newFontName) {#mergeFonts-com.aspose.font.GlyphId---com.aspose.font.GlyphId---java.lang.String-}
+```
+public abstract Font mergeFonts(GlyphId[] primaryFontGlyphs, GlyphId[] secondaryFontGlyphs, String newFontName)
+```
+
+
+Fusiona fuentes basándose en las listas de glifos proporcionadas. Busca un código de carácter para cada glifo proporcionado y añade el código de carácter encontrado con el glifo correspondiente en la nueva fuente resultante.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| primaryFontGlyphs | [GlyphId\[\]](../../com.aspose.font/glyphid) | Lista de glifos a tomar de la fuente primaria. |
+| secondaryFontGlyphs | [GlyphId\[\]](../../com.aspose.font/glyphid) | Lista de glifos a tomar de la fuente secundaria. |
+| newFontName | java.lang.String | Nombre deseado para la fuente resultante. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Merged font
+### mergeFonts(int[] primaryFontCharCodes, int[] secondaryFontCharCodes, String newFontName) {#mergeFonts-int---int---java.lang.String-}
+```
+public abstract Font mergeFonts(int[] primaryFontCharCodes, int[] secondaryFontCharCodes, String newFontName)
+```
+
+
+Fusiona fuentes basándose en las listas de códigos de caracteres proporcionadas. Para crear la fuente resultante deseada, simplemente pasa los códigos de símbolos de las fuentes originales que deseas incluir en la fuente resultante. Los glifos relacionados con los códigos proporcionados se encontrarán automáticamente. Por ejemplo, si deseas incluir glifos relacionados con las letras A y B de la primera fuente y glifos relacionados con las letras C y D de la segunda fuente, simplemente llama a este método así: `mergeFonts(new uint[] { 'A', 'B' }, new uint[] { 'C', 'D' }, "NewFont")`
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| primaryFontCharCodes | int[] | Códigos a tomar de la fuente primaria. |
+| secondaryFontCharCodes | int[] | Códigos a tomar de la fuente secundaria. |
+| newFontName | java.lang.String | Nombre deseado para la fuente resultante. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Merged font.
+### mergeFonts(Map<Integer,GlyphId> primaryFontDict, Map<Integer,GlyphId> secondaryFontDict, String newFontName) {#mergeFonts-java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.lang.String-}
+```
+public abstract Font mergeFonts(Map<Integer,GlyphId> primaryFontDict, Map<Integer,GlyphId> secondaryFontDict, String newFontName)
+```
+
+
+Esta versión del método está diseñada para casos en los que deseas establecer códigos de caracteres para los glifos en la fuente resultante de forma explícita. No es obligatorio que el código del glifo que proporcionaste esté incluido en la fuente original. El propósito del código pasado es que se asocie con el identificador de glifo correspondiente en la fuente resultante. Por lo tanto, la regla para procesar cada par pasado mediante el parámetro de diccionario [código, identificador de glifo] es que solo se tomará el identificador de glifo de la fuente original y luego se vinculará con el código correspondiente en la fuente resultante. Esto puede ser útil cuando algunos códigos de la primera fuente entran en conflicto con los mismos códigos de la segunda fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| primaryFontDict | java.util.Map<java.lang.Integer,com.aspose.font.GlyphId> | Diccionario con pares [código de símbolo, identificador de glifo] de la fuente primaria. |
+| secondaryFontDict | java.util.Map<java.lang.Integer,com.aspose.font.GlyphId> | Diccionario con pares [código de símbolo, identificador de glifo] de la fuente secundaria. |
+| newFontName | java.lang.String | Nombre deseado para la fuente resultante. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Merged font.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fontconversionexception/_index.md
+++ b/spanish/java/com.aspose.font/fontconversionexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontConversionException"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa una excepción de conversión de Font."
+type: docs
+weight: 36
+url: /es/java/com.aspose.font/fontconversionexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontConversionException extends FontException
+```
+
+Representa una excepción de conversión de Font. La excepción puede lanzarse en caso de errores durante el proceso de conversión de Font.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FontConversionException()](#FontConversionException--) | Inicializa un nuevo objeto FontConversionException. |
+| [FontConversionException(String message)](#FontConversionException-java.lang.String-) | Inicializa un nuevo objeto FontConversionException. |
+| [FontConversionException(String message, RuntimeException innerException)](#FontConversionException-java.lang.String-java.lang.RuntimeException-) | Inicializa un nuevo objeto FontConversionException. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontConversionException() {#FontConversionException--}
+```
+public FontConversionException()
+```
+
+
+Inicializa un nuevo objeto FontConversionException.
+
+### FontConversionException(String message) {#FontConversionException-java.lang.String-}
+```
+public FontConversionException(String message)
+```
+
+
+Inicializa un nuevo objeto FontConversionException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+
+### FontConversionException(String message, RuntimeException innerException) {#FontConversionException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontConversionException(String message, RuntimeException innerException)
+```
+
+
+Inicializa un nuevo objeto FontConversionException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+| innerException | java.lang.RuntimeException | La excepción que es la causa de la excepción actual. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fontcreationexception/_index.md
+++ b/spanish/java/com.aspose.font/fontcreationexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontCreationException"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa una excepción de creación de Font."
+type: docs
+weight: 37
+url: /es/java/com.aspose.font/fontcreationexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontCreationException extends FontException
+```
+
+Representa una excepción de creación de fuente. La excepción puede lanzarse en caso de errores durante el proceso de creación de la fuente.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FontCreationException()](#FontCreationException--) | Inicializa un nuevo objeto FontCreationException. |
+| [FontCreationException(String message)](#FontCreationException-java.lang.String-) | Inicializa un nuevo objeto FontCreationException. |
+| [FontCreationException(String message, RuntimeException innerException)](#FontCreationException-java.lang.String-java.lang.RuntimeException-) | Inicializa un nuevo objeto FontCreationException. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontCreationException() {#FontCreationException--}
+```
+public FontCreationException()
+```
+
+
+Inicializa un nuevo objeto FontCreationException.
+
+### FontCreationException(String message) {#FontCreationException-java.lang.String-}
+```
+public FontCreationException(String message)
+```
+
+
+Inicializa un nuevo objeto FontCreationException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+
+### FontCreationException(String message, RuntimeException innerException) {#FontCreationException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontCreationException(String message, RuntimeException innerException)
+```
+
+
+Inicializa un nuevo objeto FontCreationException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+| innerException | java.lang.RuntimeException | La excepción que es la causa de la excepción actual. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fontdefinition/_index.md
+++ b/spanish/java/com.aspose.font/fontdefinition/_index.md
@@ -1,0 +1,390 @@
+---
+title: "FontDefinition"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la definición del conjunto de archivos de Font."
+type: docs
+weight: 38
+url: /es/java/com.aspose.font/fontdefinition/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontDefinition
+```
+
+Representa la definición del conjunto de archivos de fuente. Esta clase contiene campos que no están relacionados con los datos internos de la fuente. Estos campos describen la ubicación de la fuente y otros datos necesarios para cargar la fuente desde alguna fuente de fuente (archivo, memoria, etc.).
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FontDefinition(FontType fontType, String fileExtension, StreamSource streamSource)](#FontDefinition-com.aspose.font.FontType-java.lang.String-com.aspose.font.StreamSource-) | Crea una definición de fuente de un solo archivo. |
+| [FontDefinition(FontType fontType, StreamSource streamSource)](#FontDefinition-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Crea una definición de fuente de un solo archivo. |
+| [FontDefinition(String fontName, FontType fontType, String fileExtension, StreamSource streamSource)](#FontDefinition-java.lang.String-com.aspose.font.FontType-java.lang.String-com.aspose.font.StreamSource-) | Crea una definición de fuente de un solo archivo. |
+| [FontDefinition(FontType fontType, FontFileDefinition fileDefinition)](#FontDefinition-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-) | Crea una definición de fuente de un solo archivo. |
+| [FontDefinition(String fontName, FontType fontType, FontFileDefinition fileDefinition)](#FontDefinition-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-) | Crea una definición de fuente de un solo archivo. |
+| [FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition fileDefinition)](#FontDefinition-java.lang.String-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-) | Crea una definición de fuente de un solo archivo. |
+| [FontDefinition(FontType fontType, FontFileDefinition[] fileDefinitions)](#FontDefinition-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---) | Crea una definición de fuente de varios archivos. |
+| [FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition[] fileDefinitions)](#FontDefinition-java.lang.String-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---) | Crea una definición de fuente de varios archivos. |
+| [FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition fileDefinition)](#FontDefinition-com.aspose.font.MultiLanguageString-com.aspose.font.MultiLanguageString-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-) | Crea una definición de fuente de varios archivos. |
+| [FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition[] fileDefinitions)](#FontDefinition-com.aspose.font.MultiLanguageString-com.aspose.font.MultiLanguageString-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---) | Crea una definición de fuente de varios archivos. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileDefinitions()](#getFileDefinitions--) | Obtiene la colección de definiciones de archivos. |
+| [getFontName()](#getFontName--) | Devuelve el nombre de la fuente. |
+| [getFontNames()](#getFontNames--) | Obtiene los nombres de la fuente como un MultiLanguageString. |
+| [getFontType()](#getFontType--) | Obtiene el tipo de la fuente. |
+| [getPostscriptName()](#getPostscriptName--) | Obtiene el nombre de la fuente Postscript. |
+| [getPostscriptNames()](#getPostscriptNames--) | Obtiene los nombres de la fuente Postscript como un MultiLanguageString. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(StreamSource source, FontType fontType)](#open-com.aspose.font.StreamSource-com.aspose.font.FontType-) | Devuelve FontDefinition para la fuente de flujo de fuente y el tipo de fuente. |
+| [open(String fileName, FontType fontType)](#open-java.lang.String-com.aspose.font.FontType-) | Devuelve FontDefinition para el archivo de fuente y el tipo de fuente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontDefinition(FontType fontType, String fileExtension, StreamSource streamSource) {#FontDefinition-com.aspose.font.FontType-java.lang.String-com.aspose.font.StreamSource-}
+```
+public FontDefinition(FontType fontType, String fileExtension, StreamSource streamSource)
+```
+
+
+Crea una definición de fuente de un solo archivo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fileExtension | java.lang.String | Extensión del archivo de fuente. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Fuente de flujo de fuente. |
+
+### FontDefinition(FontType fontType, StreamSource streamSource) {#FontDefinition-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public FontDefinition(FontType fontType, StreamSource streamSource)
+```
+
+
+Crea una definición de fuente de un solo archivo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Fuente de flujo de fuente. |
+
+### FontDefinition(String fontName, FontType fontType, String fileExtension, StreamSource streamSource) {#FontDefinition-java.lang.String-com.aspose.font.FontType-java.lang.String-com.aspose.font.StreamSource-}
+```
+public FontDefinition(String fontName, FontType fontType, String fileExtension, StreamSource streamSource)
+```
+
+
+Crea una definición de fuente de un solo archivo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontName | java.lang.String | Nombre de fuente. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fileExtension | java.lang.String | Extensión del archivo de fuente. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Fuente de flujo de fuente. |
+
+### FontDefinition(FontType fontType, FontFileDefinition fileDefinition) {#FontDefinition-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-}
+```
+public FontDefinition(FontType fontType, FontFileDefinition fileDefinition)
+```
+
+
+Crea una definición de fuente de un solo archivo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fileDefinition | [FontFileDefinition](../../com.aspose.font/fontfiledefinition) | FontFileDefinition. |
+
+### FontDefinition(String fontName, FontType fontType, FontFileDefinition fileDefinition) {#FontDefinition-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-}
+```
+public FontDefinition(String fontName, FontType fontType, FontFileDefinition fileDefinition)
+```
+
+
+Crea una definición de fuente de un solo archivo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontName | java.lang.String | Nombre de fuente. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fileDefinition | [FontFileDefinition](../../com.aspose.font/fontfiledefinition) | FontFileDefinition. |
+
+### FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition fileDefinition) {#FontDefinition-java.lang.String-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-}
+```
+public FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition fileDefinition)
+```
+
+
+Crea una definición de fuente de un solo archivo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontName | java.lang.String | Nombre de fuente. |
+| postscriptName | java.lang.String | Nombre de la fuente Postscript. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fileDefinition | [FontFileDefinition](../../com.aspose.font/fontfiledefinition) | FontFileDefinition. |
+
+### FontDefinition(FontType fontType, FontFileDefinition[] fileDefinitions) {#FontDefinition-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---}
+```
+public FontDefinition(FontType fontType, FontFileDefinition[] fileDefinitions)
+```
+
+
+Crea una definición de fuente de varios archivos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fileDefinitions | [FontFileDefinition\[\]](../../com.aspose.font/fontfiledefinition) | Matriz de objetos FontFileDefinition. |
+
+### FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition[] fileDefinitions) {#FontDefinition-java.lang.String-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---}
+```
+public FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition[] fileDefinitions)
+```
+
+
+Crea una definición de fuente de varios archivos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontName | java.lang.String | Nombre de fuente. |
+| postscriptName | java.lang.String | Nombre de la fuente Postscript. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fileDefinitions | [FontFileDefinition\[\]](../../com.aspose.font/fontfiledefinition) | Matriz de objetos FontFileDefinition. |
+
+### FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition fileDefinition) {#FontDefinition-com.aspose.font.MultiLanguageString-com.aspose.font.MultiLanguageString-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-}
+```
+public FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition fileDefinition)
+```
+
+
+Crea una definición de fuente de varios archivos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Nombres de fuentes. |
+| postscriptNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Nombres de fuentes Postscript. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fileDefinition | [FontFileDefinition](../../com.aspose.font/fontfiledefinition) | FontFileDefinition. |
+
+### FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition[] fileDefinitions) {#FontDefinition-com.aspose.font.MultiLanguageString-com.aspose.font.MultiLanguageString-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---}
+```
+public FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition[] fileDefinitions)
+```
+
+
+Crea una definición de fuente de varios archivos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Nombres de fuentes. |
+| postscriptNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Nombres de fuentes Postscript. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fileDefinitions | [FontFileDefinition\[\]](../../com.aspose.font/fontfiledefinition) | Matriz de objetos FontFileDefinition. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileDefinitions() {#getFileDefinitions--}
+```
+public FontFileDefinition[] getFileDefinitions()
+```
+
+
+Obtiene la colección de definiciones de archivos.
+
+**Returns:**
+com.aspose.font.FontFileDefinition[] - Colección de definiciones de archivos.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Devuelve el nombre de la fuente.
+
+**Returns:**
+java.lang.String - Nombre de fuente.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Obtiene los nombres de la fuente como un MultiLanguageString.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names as a  MultiLanguageString .
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Obtiene el tipo de la fuente.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getPostscriptName() {#getPostscriptName--}
+```
+public String getPostscriptName()
+```
+
+
+Obtiene el nombre de la fuente Postscript.
+
+**Returns:**
+java.lang.String - Nombre de fuente Postscript.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Obtiene los nombres de la fuente Postscript como un MultiLanguageString.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names as a  MultiLanguageString .
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(StreamSource source, FontType fontType) {#open-com.aspose.font.StreamSource-com.aspose.font.FontType-}
+```
+public static FontDefinition open(StreamSource source, FontType fontType)
+```
+
+
+Devuelve FontDefinition para la fuente de flujo de fuente y el tipo de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| source | [StreamSource](../../com.aspose.font/streamsource) | Fuente de flujo de fuente. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - FontDefinition.
+### open(String fileName, FontType fontType) {#open-java.lang.String-com.aspose.font.FontType-}
+```
+public static FontDefinition open(String fileName, FontType fontType)
+```
+
+
+Devuelve FontDefinition para el archivo de fuente y el tipo de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | java.lang.String | Nombre del archivo de fuente. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - FontDefinition.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fontenvironment/_index.md
+++ b/spanish/java/com.aspose.font/fontenvironment/_index.md
@@ -1,0 +1,193 @@
+---
+title: "FontEnvironment"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Proporciona información sobre el entorno y la plataforma actuales."
+type: docs
+weight: 39
+url: /es/java/com.aspose.font/fontenvironment/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontEnvironment
+```
+
+Proporciona información sobre el entorno y la plataforma actuales.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCffCommonFontsSettings()](#getCffCommonFontsSettings--) | Configuraciones comunes a fuentes CFF. |
+| [getClass()](#getClass--) |  |
+| [getCurrent()](#getCurrent--) | Obtiene el entorno actual. |
+| [getCurrentPlatformId()](#getCurrentPlatformId--) | Obtiene el id de plataforma actual. |
+| [getFontSpecificEncodings()](#getFontSpecificEncodings--) | Almacena codificaciones específicas para fuentes conscientes del consumidor. |
+| [getStrictness()](#getStrictness--) | Algunas fuentes pueden contener datos inesperados, características no especificadas o pueden estar recortadas de forma aproximada. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setStrictness(FontEnvironment.ParsingStrictness value)](#setStrictness-com.aspose.font.FontEnvironment.ParsingStrictness-) | Algunas fuentes pueden contener datos inesperados, características no especificadas o pueden estar recortadas de forma aproximada. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCffCommonFontsSettings() {#getCffCommonFontsSettings--}
+```
+public static CffFontsSettings getCffCommonFontsSettings()
+```
+
+
+Configuraciones comunes a fuentes CFF.
+
+**Returns:**
+[CffFontsSettings](../../com.aspose.font/cfffontssettings)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCurrent() {#getCurrent--}
+```
+public static FontEnvironment getCurrent()
+```
+
+
+Obtiene el entorno actual.
+
+**Returns:**
+[FontEnvironment](../../com.aspose.font/fontenvironment) - Current environment.
+### getCurrentPlatformId() {#getCurrentPlatformId--}
+```
+public int getCurrentPlatformId()
+```
+
+
+Obtiene el id de plataforma actual.
+
+**Returns:**
+int - Id de plataforma actual.
+### getFontSpecificEncodings() {#getFontSpecificEncodings--}
+```
+public FontSpecificEncodings getFontSpecificEncodings()
+```
+
+
+Almacena codificaciones específicas para fuentes conscientes del consumidor. Por ejemplo, PDF usa codificaciones específicas de Adobe Symbol y ZapfDingbats.
+
+**Returns:**
+[FontSpecificEncodings](../../com.aspose.font/fontspecificencodings) - Specific encodings for consumer-aware Fonts.
+### getStrictness() {#getStrictness--}
+```
+public FontEnvironment.ParsingStrictness getStrictness()
+```
+
+
+Algunas fuentes pueden contener datos inesperados, características no especificadas o pueden estar recortadas de forma aproximada. Se recomienda una configuración tolerante para los usuarios que desean abrir cualquier fuente sin importar la posible insuficiencia de la fuente. No se garantiza que las estructuras internas de la fuente sean consistentes. Se recomienda una configuración estricta para los usuarios que desean abrir fuentes mayormente válidas y sólidas.
+
+**Returns:**
+[ParsingStrictness](../../com.aspose.font/parsingstrictness) - Strictness.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setStrictness(FontEnvironment.ParsingStrictness value) {#setStrictness-com.aspose.font.FontEnvironment.ParsingStrictness-}
+```
+public void setStrictness(FontEnvironment.ParsingStrictness value)
+```
+
+
+Algunas fuentes pueden contener datos inesperados, características no especificadas o pueden estar recortadas de forma aproximada. Se recomienda una configuración tolerante para los usuarios que desean abrir cualquier fuente sin importar la posible insuficiencia de la fuente. No se garantiza que las estructuras internas de la fuente sean consistentes. Se recomienda una configuración estricta para los usuarios que desean abrir fuentes mayormente válidas y sólidas.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ParsingStrictness](../../com.aspose.font/parsingstrictness) | Rigor. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fontexception/_index.md
+++ b/spanish/java/com.aspose.font/fontexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontException"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa una excepción común relacionada con el procesamiento de Font."
+type: docs
+weight: 40
+url: /es/java/com.aspose.font/fontexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException
+```
+public class FontException extends IllegalStateException
+```
+
+Representa una excepción común relacionada con el procesamiento de Font.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FontException()](#FontException--) | Inicializa un nuevo objeto FontException. |
+| [FontException(String message)](#FontException-java.lang.String-) | Inicializa un nuevo objeto FontException. |
+| [FontException(String message, RuntimeException innerException)](#FontException-java.lang.String-java.lang.RuntimeException-) | Inicializa un nuevo objeto FontException. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontException() {#FontException--}
+```
+public FontException()
+```
+
+
+Inicializa un nuevo objeto FontException.
+
+### FontException(String message) {#FontException-java.lang.String-}
+```
+public FontException(String message)
+```
+
+
+Inicializa un nuevo objeto FontException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+
+### FontException(String message, RuntimeException innerException) {#FontException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontException(String message, RuntimeException innerException)
+```
+
+
+Inicializa un nuevo objeto FontException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+| innerException | java.lang.RuntimeException | La excepción que es la causa de la excepción actual. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fontfactory/_index.md
+++ b/spanish/java/com.aspose.font/fontfactory/_index.md
@@ -1,0 +1,204 @@
+---
+title: "FontFactory"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Contiene funcionalidad para abrir fuentes de diferentes tipos y otros métodos para crear varios objetos."
+type: docs
+weight: 41
+url: /es/java/com.aspose.font/fontfactory/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontFactory
+```
+
+Contiene funcionalidad para abrir fuentes de diferentes tipos y otros métodos para crear varios objetos.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FontFactory()](#FontFactory--) | Constructor |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Abre una fuente, usando el objeto FontDefinition. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Abre una fuente, usando el tipo de fuente y la matriz de bytes de datos de fuente. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Abre una fuente, usando el tipo de fuente y la fuente de flujo. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Abre una fuente, usando el tipo de fuente y el nombre de archivo de fuente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontFactory() {#FontFactory--}
+```
+public FontFactory()
+```
+
+
+Constructor
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public Font open(FontDefinition fontDefinition)
+```
+
+
+Abre una fuente, usando el objeto FontDefinition.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Objeto de definición de fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public Font open(FontType fontType, byte[] fontData)
+```
+
+
+Abre una fuente, usando el tipo de fuente y la matriz de bytes de datos de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fontData | byte[] | Arreglo de bytes para cargar la fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Abre una fuente, usando el tipo de fuente y la fuente de flujo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Fuente de flujo para la fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public Font open(FontType fontType, String fileName)
+```
+
+
+Abre una fuente, usando el tipo de fuente y el nombre de archivo de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fileName | java.lang.String | Nombre del archivo de fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fontfiledefinition/_index.md
+++ b/spanish/java/com.aspose.font/fontfiledefinition/_index.md
@@ -1,0 +1,231 @@
+---
+title: "FontFileDefinition"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la definición del archivo Font."
+type: docs
+weight: 42
+url: /es/java/com.aspose.font/fontfiledefinition/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontFileDefinition
+```
+
+Representa la definición del archivo Font.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FontFileDefinition(StreamSource streamSource)](#FontFileDefinition-com.aspose.font.StreamSource-) | Crea una definición de archivo usando solo el contenido del archivo. |
+| [FontFileDefinition(String fileExtension, StreamSource streamSource)](#FontFileDefinition-java.lang.String-com.aspose.font.StreamSource-) | Crea una definición de archivo usando solo el contenido del archivo. |
+| [FontFileDefinition(String fileExtension, StreamSource streamSource, long offset)](#FontFileDefinition-java.lang.String-com.aspose.font.StreamSource-long-) | Crea una definición de archivo usando solo el contenido del archivo. |
+| [FontFileDefinition(File fontFile)](#FontFileDefinition-java.io.File-) | Crea una definición de archivo usando el archivo de fuente (representado por File) y el contenido del archivo. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileExtension()](#getFileExtension--) | Obtiene la extensión del archivo. |
+| [getFileName()](#getFileName--) | Obtiene el nombre del archivo. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento dentro del flujo. |
+| [getStreamSource()](#getStreamSource--) | Obtiene la fuente del flujo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontFileDefinition(StreamSource streamSource) {#FontFileDefinition-com.aspose.font.StreamSource-}
+```
+public FontFileDefinition(StreamSource streamSource)
+```
+
+
+Crea una definición de archivo usando solo el contenido del archivo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Fuente de flujo de fuente. |
+
+### FontFileDefinition(String fileExtension, StreamSource streamSource) {#FontFileDefinition-java.lang.String-com.aspose.font.StreamSource-}
+```
+public FontFileDefinition(String fileExtension, StreamSource streamSource)
+```
+
+
+Crea una definición de archivo usando solo el contenido del archivo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fileExtension | java.lang.String | Extensión del archivo de fuente. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Fuente de flujo de fuente. |
+
+### FontFileDefinition(String fileExtension, StreamSource streamSource, long offset) {#FontFileDefinition-java.lang.String-com.aspose.font.StreamSource-long-}
+```
+public FontFileDefinition(String fileExtension, StreamSource streamSource, long offset)
+```
+
+
+Crea una definición de archivo usando solo el contenido del archivo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fileExtension | java.lang.String | Extensión del archivo de fuente. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Fuente de flujo de fuente. |
+| desplazamiento | long | Desplazamiento a los datos de la fuente en la fuente del flujo. |
+
+### FontFileDefinition(File fontFile) {#FontFileDefinition-java.io.File-}
+```
+public FontFileDefinition(File fontFile)
+```
+
+
+Crea una definición de archivo usando el archivo de fuente (representado por File) y el contenido del archivo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontFile | java.io.File | Objeto File. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileExtension() {#getFileExtension--}
+```
+public String getFileExtension()
+```
+
+
+Obtiene la extensión del archivo.
+
+**Returns:**
+java.lang.String - Extensión de archivo.
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Obtiene el nombre del archivo.
+
+**Returns:**
+java.lang.String - Nombre de archivo.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento dentro del flujo.
+
+**Returns:**
+long - Desplazamiento dentro del flujo.
+### getStreamSource() {#getStreamSource--}
+```
+public StreamSource getStreamSource()
+```
+
+
+Obtiene la fuente del flujo.
+
+**Returns:**
+[StreamSource](../../com.aspose.font/streamsource) - The stream source.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fontmergeexception/_index.md
+++ b/spanish/java/com.aspose.font/fontmergeexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontMergeException"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa una excepción de combinación de Font."
+type: docs
+weight: 43
+url: /es/java/com.aspose.font/fontmergeexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontMergeException extends FontException
+```
+
+Representa la excepción de combinación de fuentes. La excepción puede lanzarse en caso de errores al combinar fuentes.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FontMergeException()](#FontMergeException--) | Inicializa un nuevo objeto FontMergeException. |
+| [FontMergeException(String message)](#FontMergeException-java.lang.String-) | Inicializa un nuevo objeto FontMergeException. |
+| [FontMergeException(String message, RuntimeException innerException)](#FontMergeException-java.lang.String-java.lang.RuntimeException-) | Inicializa un nuevo objeto FontMergeException. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontMergeException() {#FontMergeException--}
+```
+public FontMergeException()
+```
+
+
+Inicializa un nuevo objeto FontMergeException.
+
+### FontMergeException(String message) {#FontMergeException-java.lang.String-}
+```
+public FontMergeException(String message)
+```
+
+
+Inicializa un nuevo objeto FontMergeException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+
+### FontMergeException(String message, RuntimeException innerException) {#FontMergeException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontMergeException(String message, RuntimeException innerException)
+```
+
+
+Inicializa un nuevo objeto FontMergeException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+| innerException | java.lang.RuntimeException | La excepción que es la causa de la excepción actual. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fontmetrics/_index.md
+++ b/spanish/java/com.aspose.font/fontmetrics/_index.md
@@ -1,0 +1,470 @@
+---
+title: "FontMetrics"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa métricas de fuente."
+type: docs
+weight: 44
+url: /es/java/com.aspose.font/fontmetrics/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFontMetrics](../../com.aspose.font/ifontmetrics)
+```
+public abstract class FontMetrics implements IFontMetrics
+```
+
+Representa métricas de fuente.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAscender()](#getAscender--) | Obtiene el valor de Ascender. |
+| [getAscender(double fontSize)](#getAscender-double-) | Devuelve el ascender para un tamaño de fuente específico. |
+| [getClass()](#getClass--) |  |
+| [getDescender()](#getDescender--) | Obtiene el valor de Descender. |
+| [getDescender(double fontSize)](#getDescender-double-) | Devuelve el descender para un tamaño de fuente específico. |
+| [getFontBBox()](#getFontBBox--) | Obtiene el valor de FontBBox. |
+| [getFontMatrix()](#getFontMatrix--) | Obtiene el valor de FontMatrix. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Devuelve el Bbox del glifo. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Devuelve el ancho del glifo. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Devuelve el valor de kerning para el par de glifos. |
+| [getLineGap()](#getLineGap--) | Obtiene el valor de LineGap. |
+| [getTypoAscender()](#getTypoAscender--) | Obtiene el valor de TypoAscender. |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Devuelve el ascendente tipográfico para un tamaño de fuente específico. |
+| [getTypoDescender()](#getTypoDescender--) | Obtiene el valor de TypoDescender. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Devuelve el descendente tipográfico para un tamaño de fuente específico |
+| [getTypoLineGap()](#getTypoLineGap--) | Obtiene el valor de TypoLineGap. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Devuelve el espacio entre líneas para un tamaño de fuente específico. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Obtiene el valor de UnitsPerEM. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Obtiene el valor de IsFixedPitch. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Mide la cadena y devuelve el ancho de la cadena. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAscender(double value)](#setAscender-double-) | Establece el valor de Ascender. |
+| [setDescender(double value)](#setDescender-double-) | Establece el valor de Descender. |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) | Establece el ancho del glifo. |
+| [setTypoAscender(double value)](#setTypoAscender-double-) | Establece el valor de TypoAscender. |
+| [setTypoDescender(double value)](#setTypoDescender-double-) | Establece el valor de TypoDescender. |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) | Establece el valor de UnitsPerEM. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAscender() {#getAscender--}
+```
+public double getAscender()
+```
+
+
+Obtiene el valor de Ascender.
+
+**Returns:**
+double - valor de Ascender.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public double getAscender(double fontSize)
+```
+
+
+Devuelve el ascender para un tamaño de fuente específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - valor de Ascender.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescender() {#getDescender--}
+```
+public double getDescender()
+```
+
+
+Obtiene el valor de Descender.
+
+**Returns:**
+double - valor de Descender.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public double getDescender(double fontSize)
+```
+
+
+Devuelve el descender para un tamaño de fuente específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - valor de Descender.
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+Obtiene el valor de FontBBox.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - FontBBox value.
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+Obtiene el valor de FontMatrix.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - FontMatrix value.
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Devuelve el Bbox del glifo. Devuelve FontBBox si el Bbox no estaba definido para el glifo. Puede ser sobrescrito por herederos de codificación de fuente específicos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificador de glifo. |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox.
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Devuelve el ancho del glifo. Puede ser sobrescrito por herederos de codificación de fuentes específicas.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificador de glifo. |
+
+**Returns:**
+double - Ancho del glifo.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Devuelve el valor de kerning para el par de glifos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Primer glifo en el par. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Tamaño de fuente. |
+
+**Returns:**
+double - Valor de interletraje.
+### getLineGap() {#getLineGap--}
+```
+public double getLineGap()
+```
+
+
+Obtiene el valor de LineGap.
+
+**Returns:**
+double - Valor de LineGap.
+### getTypoAscender() {#getTypoAscender--}
+```
+public double getTypoAscender()
+```
+
+
+Obtiene el valor de TypoAscender.
+
+**Returns:**
+double - Valor de TypoAscender.
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public double getTypoAscender(double fontSize)
+```
+
+
+Devuelve el ascendente tipográfico para un tamaño de fuente específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - Valor del ascendente tipográfico.
+### getTypoDescender() {#getTypoDescender--}
+```
+public double getTypoDescender()
+```
+
+
+Obtiene el valor de TypoDescender.
+
+**Returns:**
+double - Valor de TypoDescender.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public double getTypoDescender(double fontSize)
+```
+
+
+Devuelve el descendente tipográfico para un tamaño de fuente específico
+
+param fontSize Tamaño de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double |  |
+
+**Returns:**
+double - Valor del descendente tipográfico.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public double getTypoLineGap()
+```
+
+
+Obtiene el valor de TypoLineGap.
+
+**Returns:**
+double - Valor de TypoLineGap.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public double getTypoLineGap(double fontSize)
+```
+
+
+Devuelve el espacio entre líneas para un tamaño de fuente específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - Valor del espacio de línea.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Obtiene el valor de UnitsPerEM.
+
+**Returns:**
+long - Valor de UnitsPerEM.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+Obtiene el valor de IsFixedPitch.
+
+**Returns:**
+boolean - Valor de IsFixedPitch.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public abstract double measureString(String unicode, double fontSize)
+```
+
+
+Mide la cadena y devuelve el ancho de la cadena.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| unicode | java.lang.String | Cadena Unicode. |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - Ancho de la cadena.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAscender(double value) {#setAscender-double-}
+```
+public void setAscender(double value)
+```
+
+
+Establece el valor de Ascender.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor del ascendente. |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public void setDescender(double value)
+```
+
+
+Establece el valor de Descender.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor del descendente. |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public abstract void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Establece el ancho del glifo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificador de glifo. |
+| valor | double | Nuevo ancho. |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public void setTypoAscender(double value)
+```
+
+
+Establece el valor de TypoAscender.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor de TypoAscender. |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public void setTypoDescender(double value)
+```
+
+
+Establece el valor de TypoDescender.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor de TypoDescender. |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public void setUnitsPerEM(long value)
+```
+
+
+Establece el valor de UnitsPerEM.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long | Valor de UnitsPerEM. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fontnotsupportedoperationexception/_index.md
+++ b/spanish/java/com.aspose.font/fontnotsupportedoperationexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontNotSupportedOperationException"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa una excepción de operación no soportada."
+type: docs
+weight: 45
+url: /es/java/com.aspose.font/fontnotsupportedoperationexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontNotSupportedOperationException extends FontException
+```
+
+Representa una excepción de operación no soportada. La excepción puede lanzarse en caso de que alguna operación no sea compatible con un tipo de fuente particular.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FontNotSupportedOperationException()](#FontNotSupportedOperationException--) | Inicializa un nuevo objeto FontNotSupportedOperationException. |
+| [FontNotSupportedOperationException(String message)](#FontNotSupportedOperationException-java.lang.String-) | Inicializa un nuevo objeto FontNotSupportedOperationException. |
+| [FontNotSupportedOperationException(String message, RuntimeException innerException)](#FontNotSupportedOperationException-java.lang.String-java.lang.RuntimeException-) | Inicializa un nuevo objeto FontNotSupportedOperationException. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontNotSupportedOperationException() {#FontNotSupportedOperationException--}
+```
+public FontNotSupportedOperationException()
+```
+
+
+Inicializa un nuevo objeto FontNotSupportedOperationException.
+
+### FontNotSupportedOperationException(String message) {#FontNotSupportedOperationException-java.lang.String-}
+```
+public FontNotSupportedOperationException(String message)
+```
+
+
+Inicializa un nuevo objeto FontNotSupportedOperationException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+
+### FontNotSupportedOperationException(String message, RuntimeException innerException) {#FontNotSupportedOperationException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontNotSupportedOperationException(String message, RuntimeException innerException)
+```
+
+
+Inicializa un nuevo objeto FontNotSupportedOperationException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+| innerException | java.lang.RuntimeException | La excepción que es la causa de la excepción actual. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fontsavingformats/_index.md
+++ b/spanish/java/com.aspose.font/fontsavingformats/_index.md
@@ -1,0 +1,277 @@
+---
+title: "FontSavingFormats"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Especifica el tipo de fuente."
+type: docs
+weight: 135
+url: /es/java/com.aspose.font/fontsavingformats/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum FontSavingFormats extends Enum<FontSavingFormats>
+```
+
+Especifica el tipo de fuente.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [OTF](#OTF) | Fuente OpenType. |
+| [SVG](#SVG) | Formato de fuente SVG (Scalable Vector Graphics) |
+| [TTF](#TTF) | Formato de fuente TTF (TrueType). |
+| [WOFF](#WOFF) | WOFF (Web Open Font Format). |
+| [WOFF2](#WOFF2) | Formato de archivo WOFF 2.0 |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OTF {#OTF}
+```
+public static final FontSavingFormats OTF
+```
+
+
+Fuente OpenType. El formato de fuente OpenType es una extensión del formato de fuente TrueType, añadiendo soporte para datos de fuentes PostScript.
+
+### SVG {#SVG}
+```
+public static final FontSavingFormats SVG
+```
+
+
+Formato de fuente SVG (Scalable Vector Graphics)
+
+### TTF {#TTF}
+```
+public static final FontSavingFormats TTF
+```
+
+
+Formato de fuente TTF (TrueType).
+
+### WOFF {#WOFF}
+```
+public static final FontSavingFormats WOFF
+```
+
+
+WOFF (Web Open Font Format).
+
+### WOFF2 {#WOFF2}
+```
+public static final FontSavingFormats WOFF2
+```
+
+
+Formato de archivo WOFF 2.0
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static FontSavingFormats valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[FontSavingFormats](../../com.aspose.font/fontsavingformats)
+### values() {#values--}
+```
+public static FontSavingFormats[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.FontSavingFormats[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fontspecificencodings/_index.md
+++ b/spanish/java/com.aspose.font/fontspecificencodings/_index.md
@@ -1,0 +1,139 @@
+---
+title: "FontSpecificEncodings"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa codificaciones específicas para fuentes conscientes del consumidor."
+type: docs
+weight: 46
+url: /es/java/com.aspose.font/fontspecificencodings/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontSpecificEncodings
+```
+
+Representa codificaciones específicas para fuentes conscientes del consumidor.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [registerEncoding(String fontName, String[] encoding)](#registerEncoding-java.lang.String-java.lang.String---) | Registrar codificación para Fuentes conscientes del consumidor. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### registerEncoding(String fontName, String[] encoding) {#registerEncoding-java.lang.String-java.lang.String---}
+```
+public void registerEncoding(String fontName, String[] encoding)
+```
+
+
+Registrar codificación para Fuentes conscientes del consumidor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontName | java.lang.String | Nombre de fuente. |
+| codificación | java.lang.String[] | Codificación. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fontstyle/_index.md
+++ b/spanish/java/com.aspose.font/fontstyle/_index.md
@@ -1,0 +1,155 @@
+---
+title: "FontStyle"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Enumeración de estilo de fuente"
+type: docs
+weight: 47
+url: /es/java/com.aspose.font/fontstyle/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class FontStyle
+```
+
+Enumeración de estilo de fuente
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [Bold](#Bold) | Especifica el estilo de fuente en negrita. |
+| [Italic](#Italic) | Especifica el estilo de fuente en cursiva. |
+| [Regular](#Regular) | Especifica el estilo de fuente regular. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Bold {#Bold}
+```
+public static final int Bold
+```
+
+
+Especifica el estilo de fuente en negrita.
+
+### Italic {#Italic}
+```
+public static final int Italic
+```
+
+
+Especifica el estilo de fuente en cursiva.
+
+### Regular {#Regular}
+```
+public static final int Regular
+```
+
+
+Especifica el estilo de fuente regular.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/fonttype/_index.md
+++ b/spanish/java/com.aspose.font/fonttype/_index.md
@@ -1,0 +1,268 @@
+---
+title: "FontType"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Especifica el tipo de fuente."
+type: docs
+weight: 136
+url: /es/java/com.aspose.font/fonttype/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum FontType extends Enum<FontType>
+```
+
+Especifica el tipo de fuente.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CFF](#CFF) | CFF (Formato de fuente compacto) Tipo de fuente. |
+| [OTF](#OTF) | Fuente OpenType. |
+| [TTF](#TTF) | TTF (TrueType) Tipo de fuente y relacionado. |
+| [Type1](#Type1) | Tipo de fuente Type1. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CFF {#CFF}
+```
+public static final FontType CFF
+```
+
+
+CFF (Formato de fuente compacto) Tipo de fuente.
+
+### OTF {#OTF}
+```
+public static final FontType OTF
+```
+
+
+Fuente OpenType. El formato de fuente OpenType es una extensión del formato de fuente TrueType, añadiendo soporte para datos de fuentes PostScript.
+
+### TTF {#TTF}
+```
+public static final FontType TTF
+```
+
+
+TTF (TrueType) Tipo de fuente y relacionado.
+
+### Type1 {#Type1}
+```
+public static final FontType Type1
+```
+
+
+Tipo de fuente Type1.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static FontType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype)
+### values() {#values--}
+```
+public static FontType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.FontType[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/gasprange/_index.md
+++ b/spanish/java/com.aspose.font/gasprange/_index.md
@@ -1,0 +1,163 @@
+---
+title: "GaspRange"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "La matriz de registros GaspRange proporciona comportamientos recomendados para varios tamaños ppem."
+type: docs
+weight: 48
+url: /es/java/com.aspose.font/gasprange/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class GaspRange
+```
+
+La matriz de registros GaspRange proporciona comportamientos recomendados para varios tamaños ppem.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [GaspRange(int rangeMaxPPEM, AsFoEnumSet<RangeGaspBehaviorFlags> rangeGaspBehaviorFlags)](#GaspRange-int-com.aspose.font.util.AsFoEnumSet-com.aspose.font.RangeGaspBehaviorFlags--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getRangeGaspBehaviorFlags()](#getRangeGaspBehaviorFlags--) | Obtiene los indicadores que describen el comportamiento deseado del rasterizador. |
+| [getRangeMaxPPEM()](#getRangeMaxPPEM--) | Obtiene el límite superior del rango, en PPEM. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GaspRange(int rangeMaxPPEM, AsFoEnumSet<RangeGaspBehaviorFlags> rangeGaspBehaviorFlags) {#GaspRange-int-com.aspose.font.util.AsFoEnumSet-com.aspose.font.RangeGaspBehaviorFlags--}
+```
+public GaspRange(int rangeMaxPPEM, AsFoEnumSet<RangeGaspBehaviorFlags> rangeGaspBehaviorFlags)
+```
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| rangeMaxPPEM | int |  |
+| rangeGaspBehaviorFlags | com.aspose.font.util.AsFoEnumSet<com.aspose.font.RangeGaspBehaviorFlags> |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getRangeGaspBehaviorFlags() {#getRangeGaspBehaviorFlags--}
+```
+public AsFoEnumSet<RangeGaspBehaviorFlags> getRangeGaspBehaviorFlags()
+```
+
+
+Obtiene los indicadores que describen el comportamiento deseado del rasterizador.
+
+**Returns:**
+[AsFoEnumSet](../../com.aspose.font.util/asfoenumset) - The flags describing desired rasterizer behavior.
+### getRangeMaxPPEM() {#getRangeMaxPPEM--}
+```
+public int getRangeMaxPPEM()
+```
+
+
+Obtiene el límite superior del rango, en PPEM.
+
+**Returns:**
+int - El límite superior del rango, en PPEM.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/glyph/_index.md
+++ b/spanish/java/com.aspose.font/glyph/_index.md
@@ -1,0 +1,237 @@
+---
+title: "Glyph"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa un glifo de fuente."
+type: docs
+weight: 49
+url: /es/java/com.aspose.font/glyph/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Cloneable
+```
+public class Glyph implements Cloneable
+```
+
+Representa un glifo de fuente.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clone()](#clone--) | Devuelve una copia del glifo. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGlyphBBox()](#getGlyphBBox--) | Obtiene el BBox del glifo. |
+| [getLeftSidebearingX()](#getLeftSidebearingX--) | Obtiene la coordenada x del margen lateral del glifo. |
+| [getLeftSidebearingY()](#getLeftSidebearingY--) | Obtiene la coordenada y del margen lateral del glifo. |
+| [getPath()](#getPath--) | Obtiene la ruta del glifo. |
+| [getSourceResolution()](#getSourceResolution--) | Obtiene la resolución del conjunto de comandos fuente. |
+| [getState()](#getState--) | Obtiene el estado del glifo. |
+| [getWidthVectorX()](#getWidthVectorX--) | Obtiene el vector de ancho del glifo. |
+| [getWidthVectorY()](#getWidthVectorY--) | Obtiene el vector de ancho del glifo. |
+| [hashCode()](#hashCode--) |  |
+| [isEmpty()](#isEmpty--) | Verdadero si el glifo no contiene instrucciones de dibujo. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Devuelve una copia del glifo.
+
+**Returns:**
+java.lang.Object - Copia del glifo.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphBBox() {#getGlyphBBox--}
+```
+public FontBBox getGlyphBBox()
+```
+
+
+Obtiene el BBox del glifo.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox
+### getLeftSidebearingX() {#getLeftSidebearingX--}
+```
+public double getLeftSidebearingX()
+```
+
+
+Obtiene la coordenada x del margen lateral del glifo.
+
+**Returns:**
+double - Coordenada x del margen lateral del glifo.
+### getLeftSidebearingY() {#getLeftSidebearingY--}
+```
+public double getLeftSidebearingY()
+```
+
+
+Obtiene la coordenada y del margen lateral del glifo.
+
+**Returns:**
+double - Coordenada y del margen lateral del glifo.
+### getPath() {#getPath--}
+```
+public SegmentPath getPath()
+```
+
+
+Obtiene la ruta del glifo.
+
+**Returns:**
+[SegmentPath](../../com.aspose.font/segmentpath) - Glyph path.
+### getSourceResolution() {#getSourceResolution--}
+```
+public int getSourceResolution()
+```
+
+
+Obtiene la resolución del conjunto de comandos fuente.
+
+**Returns:**
+int - Resolución del conjunto de comandos fuente.
+### getState() {#getState--}
+```
+public GlyphState getState()
+```
+
+
+Obtiene el estado del glifo.
+
+**Returns:**
+[GlyphState](../../com.aspose.font/glyphstate) - Glyph state.
+### getWidthVectorX() {#getWidthVectorX--}
+```
+public double getWidthVectorX()
+```
+
+
+Obtiene el vector de ancho del glifo. Coordenada x.
+
+**Returns:**
+double - Vector de ancho del glifo. Coordenada x.
+### getWidthVectorY() {#getWidthVectorY--}
+```
+public double getWidthVectorY()
+```
+
+
+Obtiene el vector de ancho del glifo. Coordenada y.
+
+**Returns:**
+double - Vector de ancho del glifo. Coordenada y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+Verdadero si el glifo no contiene instrucciones de dibujo.
+
+**Returns:**
+boolean - Verdadero si el glifo no contiene instrucciones de dibujo.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/glyphid/_index.md
+++ b/spanish/java/com.aspose.font/glyphid/_index.md
@@ -1,0 +1,180 @@
+---
+title: "GlyphId"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa los IDs de glifo disponibles en la fuente."
+type: docs
+weight: 50
+url: /es/java/com.aspose.font/glyphid/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class GlyphId
+```
+
+Representa los IDs de glifo, disponibles en la fuente. El ID de glifo es un número único para un glifo, que depende del tipo de fuente. Por ejemplo: el ID de Type1 es un nombre de glifo, instancia de la clase ( GlyphStringId ). El ID de TTF es un índice entero, instancia de la clase ( GlyphUInt32Id ).
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Devuelve verdadero si dos ID de glifo no son iguales. |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) | Devuelve el código hash del objeto. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(GlyphId obj1, Object obj2)](#op-Equality-com.aspose.font.GlyphId-java.lang.Object-) | Devuelve verdadero si dos ID de glifo son iguales. |
+| [op_Inequality(GlyphId obj1, Object obj2)](#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-) | Devuelve verdadero si dos ID de glifo no son iguales. |
+| [toGlyphStringId()](#toGlyphStringId--) | Conversión virtual a GlyphStringId. |
+| [toGlyphUInt32Id()](#toGlyphUInt32Id--) | Conversión virtual a GlyphUInt32Id. |
+| [toString()](#toString--) | Devuelve la representación en cadena del ID de glifo. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Devuelve verdadero si dos ID de glifo no son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj | java.lang.Object | Identificador de glifo para comparar. |
+
+**Returns:**
+boolean - Resultado de la comparación.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public abstract int hashCode()
+```
+
+
+Devuelve el código hash del objeto.
+
+**Returns:**
+int - Código hash del objeto.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(GlyphId obj1, Object obj2) {#op-Equality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Equality(GlyphId obj1, Object obj2)
+```
+
+
+Devuelve verdadero si dos ID de glifo son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Primer identificador de glifo para comparar. |
+| obj2 | java.lang.Object | Segundo identificador de glifo para comparar. |
+
+**Returns:**
+boolean - Resultado de la comparación.
+### op_Inequality(GlyphId obj1, Object obj2) {#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Inequality(GlyphId obj1, Object obj2)
+```
+
+
+Devuelve verdadero si dos ID de glifo no son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Primer identificador de glifo para comparar. |
+| obj2 | java.lang.Object | Segundo identificador de glifo para comparar. |
+
+**Returns:**
+boolean - Resultado de la comparación.
+### toGlyphStringId() {#toGlyphStringId--}
+```
+public GlyphStringId toGlyphStringId()
+```
+
+
+Conversión virtual a GlyphStringId. GlyphStringId sobrescribe para devolver la instancia.
+
+**Returns:**
+[GlyphStringId](../../com.aspose.font/glyphstringid) - null
+### toGlyphUInt32Id() {#toGlyphUInt32Id--}
+```
+public GlyphUInt32Id toGlyphUInt32Id()
+```
+
+
+Conversión virtual a GlyphUInt32Id. GlyphUInt32Id sobrescribe para devolver la instancia.
+
+**Returns:**
+[GlyphUInt32Id](../../com.aspose.font/glyphuint32id) - null
+### toString() {#toString--}
+```
+public abstract String toString()
+```
+
+
+Devuelve la representación en cadena del ID de glifo.
+
+**Returns:**
+java.lang.String - identificador de glifo
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/glyphidlist/_index.md
+++ b/spanish/java/com.aspose.font/glyphidlist/_index.md
@@ -1,0 +1,613 @@
+---
+title: "GlyphIdList"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa una lista de IDs de glifos."
+type: docs
+weight: 51
+url: /es/java/com.aspose.font/glyphidlist/
+---
+**Inheritance:**
+java.lang.Object, java.util.AbstractCollection, java.util.AbstractList, java.util.ArrayList
+```
+public class GlyphIdList extends ArrayList<GlyphId>
+```
+
+Representa una lista de IDs de glifos.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>toArray(T[] arg0)](#-T-toArray-T---) |  |
+| [add(E arg0)](#add-E-) |  |
+| [add(GlyphId glyphId)](#add-com.aspose.font.GlyphId-) | Agrega un id de glifo a la lista. |
+| [add(int arg0, E arg1)](#add-int-E-) |  |
+| [addAll(int arg0, Collection<? extends E> arg1)](#addAll-int-java.util.Collection---extends-E--) |  |
+| [addAll(Collection<? extends E> arg0)](#addAll-java.util.Collection---extends-E--) |  |
+| [clear()](#clear--) | Limpia la lista. |
+| [clone()](#clone--) |  |
+| [contains(GlyphId glyphId)](#contains-com.aspose.font.GlyphId-) | Devuelve true si el id del glifo está en la lista. |
+| [contains(Object arg0)](#contains-java.lang.Object-) |  |
+| [containsAll(Collection<?> arg0)](#containsAll-java.util.Collection----) |  |
+| [ensureCapacity(int arg0)](#ensureCapacity-int-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [forEach(Consumer<? super E> arg0)](#forEach-java.util.function.Consumer---super-E--) |  |
+| [get(int index)](#get-int-) | Devuelve el id del glifo por el índice. |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object arg0)](#indexOf-java.lang.Object-) |  |
+| [isEmpty()](#isEmpty--) |  |
+| [iterator()](#iterator--) |  |
+| [lastIndexOf(Object arg0)](#lastIndexOf-java.lang.Object-) |  |
+| [listIterator()](#listIterator--) |  |
+| [listIterator(int arg0)](#listIterator-int-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(GlyphId glyphId)](#remove-com.aspose.font.GlyphId-) | Elimina el id del glifo de la lista. |
+| [remove(int arg0)](#remove-int-) |  |
+| [remove(Object arg0)](#remove-java.lang.Object-) |  |
+| [removeAll(Collection<?> arg0)](#removeAll-java.util.Collection----) |  |
+| [removeIf(Predicate<? super E> arg0)](#removeIf-java.util.function.Predicate---super-E--) |  |
+| [replaceAll(UnaryOperator<E> arg0)](#replaceAll-java.util.function.UnaryOperator-E--) |  |
+| [retainAll(Collection<?> arg0)](#retainAll-java.util.Collection----) |  |
+| [set(int arg0, E arg1)](#set-int-E-) |  |
+| [size()](#size--) |  |
+| [sort(Comparator<? super E> arg0)](#sort-java.util.Comparator---super-E--) |  |
+| [spliterator()](#spliterator--) |  |
+| [subList(int arg0, int arg1)](#subList-int-int-) |  |
+| [toArray()](#toArray--) |  |
+| [toString()](#toString--) |  |
+| [trimToSize()](#trimToSize--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>toArray(T[] arg0) {#-T-toArray-T---}
+```
+public T[] <T>toArray(T[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | T[] |  |
+
+**Returns:**
+T[]
+### add(E arg0) {#add-E-}
+```
+public boolean add(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+boolean
+### add(GlyphId glyphId) {#add-com.aspose.font.GlyphId-}
+```
+public boolean add(GlyphId glyphId)
+```
+
+
+Agrega un id de glifo a la lista.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | identificador de glifo |
+
+**Returns:**
+boolean
+### add(int arg0, E arg1) {#add-int-E-}
+```
+public void add(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+### addAll(int arg0, Collection<? extends E> arg1) {#addAll-int-java.util.Collection---extends-E--}
+```
+public boolean addAll(int arg0, Collection<? extends E> arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### addAll(Collection<? extends E> arg0) {#addAll-java.util.Collection---extends-E--}
+```
+public boolean addAll(Collection<? extends E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Limpia la lista.
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### contains(GlyphId glyphId) {#contains-com.aspose.font.GlyphId-}
+```
+public boolean contains(GlyphId glyphId)
+```
+
+
+Devuelve true si el id del glifo está en la lista.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | identificador de glifo |
+
+**Returns:**
+boolean - true si el id del glifo está en la lista, de lo contrario false
+### contains(Object arg0) {#contains-java.lang.Object-}
+```
+public boolean contains(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### containsAll(Collection<?> arg0) {#containsAll-java.util.Collection----}
+```
+public boolean containsAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### ensureCapacity(int arg0) {#ensureCapacity-int-}
+```
+public void ensureCapacity(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### forEach(Consumer<? super E> arg0) {#forEach-java.util.function.Consumer---super-E--}
+```
+public void forEach(Consumer<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.function.Consumer<? super E> |  |
+
+### get(int index) {#get-int-}
+```
+public GlyphId get(int index)
+```
+
+
+Devuelve el id del glifo por el índice.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del glifo en la lista |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object arg0) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public Iterator<E> iterator()
+```
+
+
+
+
+**Returns:**
+java.util.Iterator<E>
+### lastIndexOf(Object arg0) {#lastIndexOf-java.lang.Object-}
+```
+public int lastIndexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### listIterator() {#listIterator--}
+```
+public ListIterator<E> listIterator()
+```
+
+
+
+
+**Returns:**
+java.util.ListIterator<E>
+### listIterator(int arg0) {#listIterator-int-}
+```
+public ListIterator<E> listIterator(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+java.util.ListIterator<E>
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(GlyphId glyphId) {#remove-com.aspose.font.GlyphId-}
+```
+public boolean remove(GlyphId glyphId)
+```
+
+
+Elimina el id del glifo de la lista.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | identificador de glifo |
+
+**Returns:**
+boolean - true si el elemento se elimina correctamente; de lo contrario, false
+### remove(int arg0) {#remove-int-}
+```
+public E remove(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### remove(Object arg0) {#remove-java.lang.Object-}
+```
+public boolean remove(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### removeAll(Collection<?> arg0) {#removeAll-java.util.Collection----}
+```
+public boolean removeAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### removeIf(Predicate<? super E> arg0) {#removeIf-java.util.function.Predicate---super-E--}
+```
+public boolean removeIf(Predicate<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.function.Predicate<? super E> |  |
+
+**Returns:**
+boolean
+### replaceAll(UnaryOperator<E> arg0) {#replaceAll-java.util.function.UnaryOperator-E--}
+```
+public void replaceAll(UnaryOperator<E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.function.UnaryOperator<E> |  |
+
+### retainAll(Collection<?> arg0) {#retainAll-java.util.Collection----}
+```
+public boolean retainAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### set(int arg0, E arg1) {#set-int-E-}
+```
+public E set(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+**Returns:**
+E
+### size() {#size--}
+```
+public int size()
+```
+
+
+
+
+**Returns:**
+int
+### sort(Comparator<? super E> arg0) {#sort-java.util.Comparator---super-E--}
+```
+public void sort(Comparator<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.Comparator<? super E> |  |
+
+### spliterator() {#spliterator--}
+```
+public Spliterator<E> spliterator()
+```
+
+
+
+
+**Returns:**
+java.util.Spliterator<E>
+### subList(int arg0, int arg1) {#subList-int-int-}
+```
+public List<E> subList(int arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | int |  |
+
+**Returns:**
+java.util.List<E>
+### toArray() {#toArray--}
+```
+public Object[] toArray()
+```
+
+
+
+
+**Returns:**
+java.lang.Object[]
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### trimToSize() {#trimToSize--}
+```
+public void trimToSize()
+```
+
+
+
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/glyphidtype/_index.md
+++ b/spanish/java/com.aspose.font/glyphidtype/_index.md
@@ -1,0 +1,250 @@
+---
+title: "GlyphIdType"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Especifica los tipos de identificador de glifo."
+type: docs
+weight: 137
+url: /es/java/com.aspose.font/glyphidtype/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum GlyphIdType extends Enum<GlyphIdType>
+```
+
+Especifica los tipos de identificador de glifo.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ASCIIStringName](#ASCIIStringName) | Nombre de glifo en cadena ASCII. |
+| [Int32Index](#Int32Index) | Índice de glifo entero. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ASCIIStringName {#ASCIIStringName}
+```
+public static final GlyphIdType ASCIIStringName
+```
+
+
+Nombre de glifo en cadena ASCII.
+
+### Int32Index {#Int32Index}
+```
+public static final GlyphIdType Int32Index
+```
+
+
+Índice de glifo entero.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static GlyphIdType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype)
+### values() {#values--}
+```
+public static GlyphIdType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.GlyphIdType[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/glyphoutlinerenderer/_index.md
+++ b/spanish/java/com.aspose.font/glyphoutlinerenderer/_index.md
@@ -1,0 +1,238 @@
+---
+title: "GlyphOutlineRenderer"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa el renderizador de contorno de glifos."
+type: docs
+weight: 52
+url: /es/java/com.aspose.font/glyphoutlinerenderer/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.GlyphRendererBase](../../com.aspose.font/glyphrendererbase)
+```
+public class GlyphOutlineRenderer extends GlyphRendererBase
+```
+
+Representa el renderizador de contorno de glifos.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [GlyphOutlineRenderer(IGlyphOutlinePainter painter)](#GlyphOutlineRenderer-com.aspose.font.IGlyphOutlinePainter-) | Inicializa un nuevo objeto GlyphOutlineRenderer. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [renderGlyph(IFont font, GlyphId glyphId)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-) | Renderiza el glifo. |
+| [renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renderiza el glifo, un objetivo de esta versión sobrecargada - para ser usado con caché de glifos. |
+| [renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-) | Renderiza el glifo. |
+| [renderGlyph(IFont font, long glyphIndex)](#renderGlyph-com.aspose.font.IFont-long-) | Renderiza el glifo |
+| [renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-) | Renderiza el glifo. |
+| [renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renderiza el glifo usando una ruta de glifo independiente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlyphOutlineRenderer(IGlyphOutlinePainter painter) {#GlyphOutlineRenderer-com.aspose.font.IGlyphOutlinePainter-}
+```
+public GlyphOutlineRenderer(IGlyphOutlinePainter painter)
+```
+
+
+Inicializa un nuevo objeto GlyphOutlineRenderer.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| painter | [IGlyphOutlinePainter](../../com.aspose.font/iglyphoutlinepainter) | Pintor de glifos. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### renderGlyph(IFont font, GlyphId glyphId) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId)
+```
+
+
+Renderiza el glifo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | La fuente que contiene el glifo. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Índice físico del glifo dentro de la fuente. Nota que esto no es un unicode. |
+
+### renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderiza el glifo, un objetivo de esta versión sobrecargada - para ser usado con caché de glifos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | La fuente que contiene el glifo. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Índice físico del glifo dentro de la fuente. Nota que esto no es un unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glifo a renderizar. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matriz que se aplica a las coordenadas del glifo. |
+
+### renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderiza el glifo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | La fuente que contiene el glifo. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Índice físico del glifo dentro de la fuente. Nota que esto no es un unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matriz que se aplica a las coordenadas del glifo. |
+
+### renderGlyph(IFont font, long glyphIndex) {#renderGlyph-com.aspose.font.IFont-long-}
+```
+public void renderGlyph(IFont font, long glyphIndex)
+```
+
+
+Renderiza el glifo
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | La fuente que contiene el glifo. |
+| glyphIndex | long | Índice físico del glifo dentro de la fuente. Nota que esto no es un unicode. |
+
+### renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderiza el glifo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | La fuente que contiene el glifo. |
+| glyphIndex | long | Índice físico del glifo dentro de la fuente. Nota que esto no es un unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matriz que se aplica a las coordenadas del glifo. |
+
+### renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public void renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderiza el glifo usando una ruta de glifo independiente. La familia de funciones RenderGlyph() cambia la ruta del glifo al renderizar. Esto lleva a la necesidad de recargar este glifo nuevamente. Esta función usa una copia de la ruta del glifo y no cambia la ruta original del glifo, por lo que el mismo glifo puede reutilizarse varias veces. Esta versión de la función está destinada a usarse con una caché de glifos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | La fuente que contiene el glifo. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Índice físico del glifo dentro de la fuente. Nota que esto no es un unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glifo a renderizar. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matriz que se aplica a las coordenadas del glifo. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/glyphrendererbase/_index.md
+++ b/spanish/java/com.aspose.font/glyphrendererbase/_index.md
@@ -1,0 +1,223 @@
+---
+title: "GlyphRendererBase"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la clase base para renderizadores de glifos."
+type: docs
+weight: 53
+url: /es/java/com.aspose.font/glyphrendererbase/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IGlyphRenderer](../../com.aspose.font/iglyphrenderer)
+```
+public abstract class GlyphRendererBase implements IGlyphRenderer
+```
+
+Representa la clase base para renderizadores de glifos.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [renderGlyph(IFont font, GlyphId glyphId)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-) | Renderiza el glifo. |
+| [renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renderiza el glifo, un objetivo de esta versión sobrecargada - para ser usado con caché de glifos. |
+| [renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-) | Renderiza el glifo. |
+| [renderGlyph(IFont font, long glyphIndex)](#renderGlyph-com.aspose.font.IFont-long-) | Renderiza el glifo |
+| [renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-) | Renderiza el glifo. |
+| [renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renderiza el glifo usando una ruta de glifo independiente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### renderGlyph(IFont font, GlyphId glyphId) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId)
+```
+
+
+Renderiza el glifo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | La fuente que contiene el glifo. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Índice físico del glifo dentro de la fuente. Nota que esto no es un unicode. |
+
+### renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderiza el glifo, un objetivo de esta versión sobrecargada - para ser usado con caché de glifos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | La fuente que contiene el glifo. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Índice físico del glifo dentro de la fuente. Nota que esto no es un unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glifo a renderizar. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matriz que se aplica a las coordenadas del glifo. |
+
+### renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderiza el glifo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | La fuente que contiene el glifo. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Índice físico del glifo dentro de la fuente. Nota que esto no es un unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matriz que se aplica a las coordenadas del glifo. |
+
+### renderGlyph(IFont font, long glyphIndex) {#renderGlyph-com.aspose.font.IFont-long-}
+```
+public void renderGlyph(IFont font, long glyphIndex)
+```
+
+
+Renderiza el glifo
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | La fuente que contiene el glifo. |
+| glyphIndex | long | Índice físico del glifo dentro de la fuente. Nota que esto no es un unicode. |
+
+### renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderiza el glifo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | La fuente que contiene el glifo. |
+| glyphIndex | long | Índice físico del glifo dentro de la fuente. Nota que esto no es un unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matriz que se aplica a las coordenadas del glifo. |
+
+### renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public void renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderiza el glifo usando una ruta de glifo independiente. La familia de funciones RenderGlyph() cambia la ruta del glifo al renderizar. Esto lleva a la necesidad de recargar este glifo nuevamente. Esta función usa una copia de la ruta del glifo y no cambia la ruta original del glifo, por lo que el mismo glifo puede reutilizarse varias veces. Esta versión de la función está destinada a usarse con una caché de glifos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | La fuente que contiene el glifo. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Índice físico del glifo dentro de la fuente. Nota que esto no es un unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glifo a renderizar. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matriz que se aplica a las coordenadas del glifo. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/glyphstate/_index.md
+++ b/spanish/java/com.aspose.font/glyphstate/_index.md
@@ -1,0 +1,250 @@
+---
+title: "GlyphState"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Especifica el estado del glifo."
+type: docs
+weight: 138
+url: /es/java/com.aspose.font/glyphstate/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum GlyphState extends Enum<GlyphState>
+```
+
+Especifica el estado del glifo.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ParsedWithErrors](#ParsedWithErrors) | El glifo se analizó con errores. |
+| [Success](#Success) | El glifo se analizó correctamente. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ParsedWithErrors {#ParsedWithErrors}
+```
+public static final GlyphState ParsedWithErrors
+```
+
+
+El glifo se analizó con errores.
+
+### Success {#Success}
+```
+public static final GlyphState Success
+```
+
+
+El glifo se analizó correctamente.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static GlyphState valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[GlyphState](../../com.aspose.font/glyphstate)
+### values() {#values--}
+```
+public static GlyphState[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.GlyphState[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/glyphstringid/_index.md
+++ b/spanish/java/com.aspose.font/glyphstringid/_index.md
@@ -1,0 +1,234 @@
+---
+title: "GlyphStringId"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa el ID de glifo de cadena."
+type: docs
+weight: 54
+url: /es/java/com.aspose.font/glyphstringid/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.GlyphId](../../com.aspose.font/glyphid)
+```
+public class GlyphStringId extends GlyphId
+```
+
+Representa el ID de glifo de cadena.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [GlyphStringId(String value)](#GlyphStringId-java.lang.String-) | Inicializa un nuevo objeto GlyphStringID. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Devuelve verdadero si los ID de cadena son iguales. |
+| [getClass()](#getClass--) |  |
+| [getNotDefId()](#getNotDefId--) | Obtiene el ID de glifo no definido. |
+| [getValue()](#getValue--) | Obtiene el valor de la cadena. |
+| [hashCode()](#hashCode--) | Implementación de GetHashCode. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(GlyphId obj1, Object obj2)](#op-Equality-com.aspose.font.GlyphId-java.lang.Object-) | Devuelve verdadero si dos ID de glifo son iguales. |
+| [op_Inequality(GlyphId obj1, Object obj2)](#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-) | Devuelve verdadero si dos ID de glifo no son iguales. |
+| [setValue(String value)](#setValue-java.lang.String-) | Establece el valor de la cadena. |
+| [toGlyphStringId()](#toGlyphStringId--) | Convertir GlyphId a GlyphStringId |
+| [toGlyphUInt32Id()](#toGlyphUInt32Id--) | Conversión virtual a GlyphUInt32Id. |
+| [toString()](#toString--) | Devuelve el valor de cadena del id del glifo. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlyphStringId(String value) {#GlyphStringId-java.lang.String-}
+```
+public GlyphStringId(String value)
+```
+
+
+Inicializa un nuevo objeto GlyphStringID.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Identificador de glifo. |
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Devuelve verdadero si los ID de cadena son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj | java.lang.Object | Identificador de cadena de glifo para comparar con. |
+
+**Returns:**
+boolean - Resultado de la comparación
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNotDefId() {#getNotDefId--}
+```
+public static GlyphStringId getNotDefId()
+```
+
+
+Obtiene el ID de glifo no definido.
+
+**Returns:**
+[GlyphStringId](../../com.aspose.font/glyphstringid) - Not defined glyph id.
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Obtiene el valor de la cadena.
+
+**Returns:**
+java.lang.String - Valor de cadena.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Implementación de GetHashCode.
+
+**Returns:**
+int - Código hash del objeto.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(GlyphId obj1, Object obj2) {#op-Equality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Equality(GlyphId obj1, Object obj2)
+```
+
+
+Devuelve verdadero si dos ID de glifo son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Primer identificador de glifo para comparar. |
+| obj2 | java.lang.Object | Segundo identificador de glifo para comparar. |
+
+**Returns:**
+boolean - Resultado de la comparación.
+### op_Inequality(GlyphId obj1, Object obj2) {#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Inequality(GlyphId obj1, Object obj2)
+```
+
+
+Devuelve verdadero si dos ID de glifo no son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Primer identificador de glifo para comparar. |
+| obj2 | java.lang.Object | Segundo identificador de glifo para comparar. |
+
+**Returns:**
+boolean - Resultado de la comparación.
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Establece el valor de la cadena.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Valor de cadena. |
+
+### toGlyphStringId() {#toGlyphStringId--}
+```
+public GlyphStringId toGlyphStringId()
+```
+
+
+Convertir GlyphId a GlyphStringId
+
+**Returns:**
+[GlyphStringId](../../com.aspose.font/glyphstringid) - this
+### toGlyphUInt32Id() {#toGlyphUInt32Id--}
+```
+public GlyphUInt32Id toGlyphUInt32Id()
+```
+
+
+Conversión virtual a GlyphUInt32Id. GlyphUInt32Id sobrescribe para devolver la instancia.
+
+**Returns:**
+[GlyphUInt32Id](../../com.aspose.font/glyphuint32id) - null
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+Devuelve el valor de cadena del id del glifo.
+
+**Returns:**
+java.lang.String - Identificador de glifo.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/glyphuint32id/_index.md
+++ b/spanish/java/com.aspose.font/glyphuint32id/_index.md
@@ -1,0 +1,268 @@
+---
+title: "GlyphUInt32Id"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa el ID de glifo entero."
+type: docs
+weight: 55
+url: /es/java/com.aspose.font/glyphuint32id/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.GlyphId](../../com.aspose.font/glyphid)
+```
+public class GlyphUInt32Id extends GlyphId
+```
+
+Representa el ID de glifo entero.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [GlyphUInt32Id(long value)](#GlyphUInt32Id-long-) | Inicializa un nuevo objeto GlyphUInt32Id. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Devuelve true si los Ids son iguales. |
+| [getClass()](#getClass--) |  |
+| [getNotDefId()](#getNotDefId--) | Obtiene el ID de glifo no definido. |
+| [getValue()](#getValue--) | Obtiene el valor int del ID. |
+| [hashCode()](#hashCode--) | Implementación de GetHashCode. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(GlyphId obj1, Object obj2)](#op-Equality-com.aspose.font.GlyphId-java.lang.Object-) | Devuelve verdadero si dos ID de glifo son iguales. |
+| [op_Equality(GlyphUInt32Id obj1, Object obj2)](#op-Equality-com.aspose.font.GlyphUInt32Id-java.lang.Object-) | Implementación del operador de igualdad. |
+| [op_Inequality(GlyphId obj1, Object obj2)](#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-) | Devuelve verdadero si dos ID de glifo no son iguales. |
+| [op_Inequality(GlyphUInt32Id obj1, Object obj2)](#op-Inequality-com.aspose.font.GlyphUInt32Id-java.lang.Object-) | Implementación del operador de desigualdad. |
+| [setValue(long value)](#setValue-long-) | Establece el valor int del ID. |
+| [toGlyphStringId()](#toGlyphStringId--) | Conversión virtual a GlyphStringId. |
+| [toGlyphUInt32Id()](#toGlyphUInt32Id--) | Convertir GlyphId a GlyphUInt32Id |
+| [toString()](#toString--) | Obtiene la representación en cadena del valor entero. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlyphUInt32Id(long value) {#GlyphUInt32Id-long-}
+```
+public GlyphUInt32Id(long value)
+```
+
+
+Inicializa un nuevo objeto GlyphUInt32Id.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long | Identificador de glifo. |
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Devuelve true si los Ids son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj | java.lang.Object | identificador de glifo para comparar con |
+
+**Returns:**
+boolean - resultado de la comparación
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNotDefId() {#getNotDefId--}
+```
+public static GlyphUInt32Id getNotDefId()
+```
+
+
+Obtiene el ID de glifo no definido.
+
+**Returns:**
+[GlyphUInt32Id](../../com.aspose.font/glyphuint32id) - Not defined glyph id.
+### getValue() {#getValue--}
+```
+public long getValue()
+```
+
+
+Obtiene el valor int del ID.
+
+**Returns:**
+long - Valor Int del ID.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Implementación de GetHashCode.
+
+**Returns:**
+int - código hash del objeto
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(GlyphId obj1, Object obj2) {#op-Equality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Equality(GlyphId obj1, Object obj2)
+```
+
+
+Devuelve verdadero si dos ID de glifo son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Primer identificador de glifo para comparar. |
+| obj2 | java.lang.Object | Segundo identificador de glifo para comparar. |
+
+**Returns:**
+boolean - Resultado de la comparación.
+### op_Equality(GlyphUInt32Id obj1, Object obj2) {#op-Equality-com.aspose.font.GlyphUInt32Id-java.lang.Object-}
+```
+public static boolean op_Equality(GlyphUInt32Id obj1, Object obj2)
+```
+
+
+Implementación del operador de igualdad.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj1 | [GlyphUInt32Id](../../com.aspose.font/glyphuint32id) | primer identificador de glifo para comparar |
+| obj2 | java.lang.Object | segundo identificador de glifo para comparar |
+
+**Returns:**
+boolean - resultado de la comparación
+### op_Inequality(GlyphId obj1, Object obj2) {#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Inequality(GlyphId obj1, Object obj2)
+```
+
+
+Devuelve verdadero si dos ID de glifo no son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Primer identificador de glifo para comparar. |
+| obj2 | java.lang.Object | Segundo identificador de glifo para comparar. |
+
+**Returns:**
+boolean - Resultado de la comparación.
+### op_Inequality(GlyphUInt32Id obj1, Object obj2) {#op-Inequality-com.aspose.font.GlyphUInt32Id-java.lang.Object-}
+```
+public static boolean op_Inequality(GlyphUInt32Id obj1, Object obj2)
+```
+
+
+Implementación del operador de desigualdad.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj1 | [GlyphUInt32Id](../../com.aspose.font/glyphuint32id) | primer identificador de glifo para comparar |
+| obj2 | java.lang.Object | segundo identificador de glifo para comparar |
+
+**Returns:**
+boolean - resultado de la comparación
+### setValue(long value) {#setValue-long-}
+```
+public void setValue(long value)
+```
+
+
+Establece el valor int del ID.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long | Valor entero del ID. |
+
+### toGlyphStringId() {#toGlyphStringId--}
+```
+public GlyphStringId toGlyphStringId()
+```
+
+
+Conversión virtual a GlyphStringId. GlyphStringId sobrescribe para devolver la instancia.
+
+**Returns:**
+[GlyphStringId](../../com.aspose.font/glyphstringid) - null
+### toGlyphUInt32Id() {#toGlyphUInt32Id--}
+```
+public GlyphUInt32Id toGlyphUInt32Id()
+```
+
+
+Convertir GlyphId a GlyphUInt32Id
+
+**Returns:**
+[GlyphUInt32Id](../../com.aspose.font/glyphuint32id) - this
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+Obtiene la representación en cadena del valor entero.
+
+**Returns:**
+java.lang.String - identificador de glifo
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/helpersfactory/_index.md
+++ b/spanish/java/com.aspose.font/helpersfactory/_index.md
@@ -1,0 +1,141 @@
+---
+title: "HelpersFactory"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Crea objetos relacionados con el espacio de nombres TtfHelpers"
+type: docs
+weight: 56
+url: /es/java/com.aspose.font/helpersfactory/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class HelpersFactory
+```
+
+Crea objetos relacionados con el espacio de nombres TtfHelpers
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontCharactersMerger(TtfFont font1, TtfFont font2)](#getFontCharactersMerger-com.aspose.font.TtfFont-com.aspose.font.TtfFont-) | Crea una instancia de IFontCharactersMerger |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontCharactersMerger(TtfFont font1, TtfFont font2) {#getFontCharactersMerger-com.aspose.font.TtfFont-com.aspose.font.TtfFont-}
+```
+public static IFontCharactersMerger getFontCharactersMerger(TtfFont font1, TtfFont font2)
+```
+
+
+Crea una instancia de IFontCharactersMerger
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font1 | [TtfFont](../../com.aspose.font/ttffont) | Primera fuente a combinar, esta fuente se considerará la fuente primaria |
+| font2 | [TtfFont](../../com.aspose.font/ttffont) | Segunda fuente a combinar |
+
+**Returns:**
+[IFontCharactersMerger](../../com.aspose.font/ifontcharactersmerger) -  IFontCharactersMerger  instance
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/icffindexdataprovider/_index.md
+++ b/spanish/java/com.aspose.font/icffindexdataprovider/_index.md
@@ -1,0 +1,38 @@
+---
+title: "ICffIndexDataProvider"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Interfaz básica para acceder a las estructuras INDEX de fuentes CFF."
+type: docs
+weight: 120
+url: /es/java/com.aspose.font/icffindexdataprovider/
+---```
+public interface ICffIndexDataProvider
+```
+
+Basic interface for accessing INDEX structures of CFF fonts.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getCount()](#getCount--) | The number of objects in the CFF INDEX structure. |
+| [getRawBytes()](#getRawBytes--) | Gets all the bytes of the CFF INDEX structure. |
+### getCount() {#getCount--}
+```
+public abstract int getCount()
+```
+
+
+The number of objects in the CFF INDEX structure.
+
+**Returns:**
+int
+### getRawBytes() {#getRawBytes--}
+```
+public abstract byte[] getRawBytes()
+```
+
+
+Gets all the bytes of the CFF INDEX structure.
+
+**Returns:**
+byte[] - Bytes of the CFF INDEX structure

--- a/spanish/java/com.aspose.font/iencodingparameters/_index.md
+++ b/spanish/java/com.aspose.font/iencodingparameters/_index.md
@@ -1,0 +1,12 @@
+---
+title: "IEncodingParameters"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Interfaz común para admitir parámetros de codificación."
+type: docs
+weight: 121
+url: /es/java/com.aspose.font/iencodingparameters/
+---```
+public interface IEncodingParameters
+```
+
+Common interface to support encoding parameters. Some font types can have multiple encoding algorithms/maps. So, this interface should be used to create concrete font encoding parameters.

--- a/spanish/java/com.aspose.font/ifont/_index.md
+++ b/spanish/java/com.aspose.font/ifont/_index.md
@@ -1,0 +1,223 @@
+---
+title: "IFont"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Declara la funcionalidad común para todos los formatos de fuente."
+type: docs
+weight: 122
+url: /es/java/com.aspose.font/ifont/
+---```
+public interface IFont
+```
+
+Declares common functionality for all font formats. Implemented by Font classes.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Converts the Font into another format. |
+| [getEncoding()](#getEncoding--) | Gets Font encoding. |
+| [getFontDefinition()](#getFontDefinition--) | Gets Font definition. |
+| [getFontFamily()](#getFontFamily--) | Gets Font family. |
+| [getFontName()](#getFontName--) | Gets Font face name. |
+| [getFontNames()](#getFontNames--) | Gets Font names. |
+| [getFontSaver()](#getFontSaver--) | Gets Font save functionality. |
+| [getFontStyle()](#getFontStyle--) | Gets Font style. |
+| [getFontType()](#getFontType--) | Gets Font type. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Gets Font glyph accessor. |
+| [getMetrics()](#getMetrics--) | Gets Font metrics. |
+| [getNumGlyphs()](#getNumGlyphs--) | Gets number of glyphs in the Font. |
+| [getPostscriptNames()](#getPostscriptNames--) | Gets postscript Font names. |
+| [getStyle()](#getStyle--) | Gets Font style. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Sets Font family. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Sets Font face name. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Sets Font style. |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public abstract Font convert(FontType fontType)
+```
+
+
+Converts the Font into another format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | type to convert to font into |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - font converted into format specified
+### getEncoding() {#getEncoding--}
+```
+public abstract IFontEncoding getEncoding()
+```
+
+
+Gets Font encoding.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public abstract FontDefinition getFontDefinition()
+```
+
+
+Gets Font definition.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public abstract String getFontFamily()
+```
+
+
+Gets Font family.
+
+**Returns:**
+java.lang.String - Font family.
+### getFontName() {#getFontName--}
+```
+public abstract String getFontName()
+```
+
+
+Gets Font face name.
+
+**Returns:**
+java.lang.String - Font face name.
+### getFontNames() {#getFontNames--}
+```
+public abstract MultiLanguageString getFontNames()
+```
+
+
+Gets Font names.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public abstract IFontSaver getFontSaver()
+```
+
+
+Gets Font save functionality.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public abstract int getFontStyle()
+```
+
+
+Gets Font style. This is a value computed and represented in generalized type.
+
+**Returns:**
+int - Font style. Usually, a combination of FontStyle class constant flag values or 0.
+### getFontType() {#getFontType--}
+```
+public abstract FontType getFontType()
+```
+
+
+Gets Font type.
+
+--------------------
+
+> ```
+> Type1, TrueType etc.
+> ```
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public abstract IGlyphAccessor getGlyphAccessor()
+```
+
+
+Gets Font glyph accessor. Retrieves glyphs and glyph identifiers.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getMetrics() {#getMetrics--}
+```
+public abstract IFontMetrics getMetrics()
+```
+
+
+Gets Font metrics.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public abstract int getNumGlyphs()
+```
+
+
+Gets number of glyphs in the Font.
+
+**Returns:**
+int - Number of glyphs in the Font..
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public abstract MultiLanguageString getPostscriptNames()
+```
+
+
+Gets postscript Font names.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names.
+### getStyle() {#getStyle--}
+```
+public abstract String getStyle()
+```
+
+
+Gets Font style. This is a raw string value provided by Font file.
+
+**Returns:**
+java.lang.String - Font style.
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public abstract void setFontFamily(String value)
+```
+
+
+Sets Font family.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | java.lang.String | New Font family. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public abstract void setFontName(String value)
+```
+
+
+Sets Font face name.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | java.lang.String | New Font face name. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public abstract void setStyle(String value)
+```
+
+
+Sets Font style. This is a raw string value provided by Font file.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | java.lang.String | New Font style. |
+

--- a/spanish/java/com.aspose.font/ifontcharactersmerger/_index.md
+++ b/spanish/java/com.aspose.font/ifontcharactersmerger/_index.md
@@ -1,0 +1,70 @@
+---
+title: "IFontCharactersMerger"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Declara la funcionalidad de ayuda para combinar fuentes TrueType."
+type: docs
+weight: 123
+url: /es/java/com.aspose.font/ifontcharactersmerger/
+---```
+public interface IFontCharactersMerger
+```
+
+Declares helpers functionality to merge TrueType fonts. Font which is passed by parameter font1 considered as primary. It means that many characteristics, related to final merged font, such as metrics, encoding structure and others, will be taken from this primary font.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [mergeFonts(GlyphId[] font1Glyphs, GlyphId[] font2Glyphs, String newFontName)](#mergeFonts-com.aspose.font.GlyphId---com.aspose.font.GlyphId---java.lang.String-) | Merges fonts based on glyphs lists passed. |
+| [mergeFonts(int[] font1CharCodes, int[] font2CharCodes, String newFontName)](#mergeFonts-int---int---java.lang.String-) | Merges fonts based on character codes lists passed. |
+| [mergeFonts(Map<Integer,GlyphId> font1Dict, Map<Integer,GlyphId> font2Dict, String newFontName)](#mergeFonts-java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.lang.String-) | This method version designed for cases when you want to set character codes for glyphs in resultant font explicitly. |
+### mergeFonts(GlyphId[] font1Glyphs, GlyphId[] font2Glyphs, String newFontName) {#mergeFonts-com.aspose.font.GlyphId---com.aspose.font.GlyphId---java.lang.String-}
+```
+public abstract TtfFont mergeFonts(GlyphId[] font1Glyphs, GlyphId[] font2Glyphs, String newFontName)
+```
+
+
+Merges fonts based on glyphs lists passed. Searches for a character code for every glyph passed and add found character code with correspondent glyph into resultant new font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font1Glyphs | [GlyphId\[\]](../../com.aspose.font/glyphid) | List of glyphs from first font |
+| font2Glyphs | [GlyphId\[\]](../../com.aspose.font/glyphid) | List of glyphs from second font |
+| newFontName | java.lang.String | Desired name for resultant font |
+
+**Returns:**
+[TtfFont](../../com.aspose.font/ttffont) - Merged font
+### mergeFonts(int[] font1CharCodes, int[] font2CharCodes, String newFontName) {#mergeFonts-int---int---java.lang.String-}
+```
+public abstract TtfFont mergeFonts(int[] font1CharCodes, int[] font2CharCodes, String newFontName)
+```
+
+
+Merges fonts based on character codes lists passed. To create desired resultant font just pass symbol codes from original fonts you want to include into resultant font. Glyphs related to codes passed will be found automatically. For example, if you want to include into resultant font glyphs related to letters A and B from first font and glyphs, related to letters C and D from second font, just call this method like this:  MergeFonts(new uint[] \{ 'A', 'B' \}, new uint[] \{ 'C', 'D' \}, "NewFont") 
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font1CharCodes | int[] | Codes to take from first font |
+| font2CharCodes | int[] | Codes to take from second font |
+| newFontName | java.lang.String | Desired name for resultant font |
+
+**Returns:**
+[TtfFont](../../com.aspose.font/ttffont) - Merged font
+### mergeFonts(Map<Integer,GlyphId> font1Dict, Map<Integer,GlyphId> font2Dict, String newFontName) {#mergeFonts-java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.lang.String-}
+```
+public abstract TtfFont mergeFonts(Map<Integer,GlyphId> font1Dict, Map<Integer,GlyphId> font2Dict, String newFontName)
+```
+
+
+This method version designed for cases when you want to set character codes for glyphs in resultant font explicitly. It's not mandatory that code for glyph you provided is included in original font. The sense of code passed is that it will be associated with correspondent glyph identifier in resultant font. So, rule to process every pair passed by dictionary parameter[code, glyph ideitifier] is that only glyph identifer will be taken from original font and then it will be linked with correspondent code in resultant font. It can be helpful when some codes from first font conflict with same codes from second font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font1Dict | java.util.Map<java.lang.Integer,com.aspose.font.GlyphId> | Dictionary with pairs [symbol code, glyph identifier] from first font |
+| font2Dict | java.util.Map<java.lang.Integer,com.aspose.font.GlyphId> | Dictionary with pairs [symbol code, glyph identifier] from second font |
+| newFontName | java.lang.String | Desired name for resultant font |
+
+**Returns:**
+[TtfFont](../../com.aspose.font/ttffont) - Merged font

--- a/spanish/java/com.aspose.font/ifontencoding/_index.md
+++ b/spanish/java/com.aspose.font/ifontencoding/_index.md
@@ -1,0 +1,96 @@
+---
+title: "IFontEncoding"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Define una interfaz para la codificación de fuentes."
+type: docs
+weight: 124
+url: /es/java/com.aspose.font/ifontencoding/
+---```
+public interface IFontEncoding
+```
+
+Defines an interface for Font encoding.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [decodeToGid(long charCode)](#decodeToGid-long-) | Decodes a character code and returns glyph id. |
+| [decodeToGidParameterized(IEncodingParameters parameters, long charCode)](#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-) | Parameterized decode method. |
+| [encode(long gid, long charCode)](#encode-long-long-) | Encodes the glyph. |
+| [gidToUnicode(GlyphId gid)](#gidToUnicode-com.aspose.font.GlyphId-) | Decodes Gid to unicode. |
+| [unicodeToGid(long unicode)](#unicodeToGid-long-) | Decodes a unicode and returns glyph id. |
+### decodeToGid(long charCode) {#decodeToGid-long-}
+```
+public abstract GlyphId decodeToGid(long charCode)
+```
+
+
+Decodes a character code and returns glyph id. Glyph id is a unique number for a glyph, which is font type dependent. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| charCode | long | Character code to get glyph identifier for. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to charCode passed.
+### decodeToGidParameterized(IEncodingParameters parameters, long charCode) {#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-}
+```
+public abstract GlyphId decodeToGidParameterized(IEncodingParameters parameters, long charCode)
+```
+
+
+Parameterized decode method. Some font types can have multiple encoding algorithms/maps. So,  IEncodingParameters  interface is used to create concrete font encoding parameters.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| parameters | [IEncodingParameters](../../com.aspose.font/iencodingparameters) | Implementation of  IEncodingParameters  interface. |
+| charCode | long | Character code to get glyph identifier for. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to char code passed.
+### encode(long gid, long charCode) {#encode-long-long-}
+```
+public abstract void encode(long gid, long charCode)
+```
+
+
+Encodes the glyph. For TTF Fonts the charCode is unicode.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| gid | long | Glyph id. |
+| charCode | long | Character code associated with the glyph id. |
+
+### gidToUnicode(GlyphId gid) {#gidToUnicode-com.aspose.font.GlyphId-}
+```
+public abstract long gidToUnicode(GlyphId gid)
+```
+
+
+Decodes Gid to unicode. Glyph id is a unique number for a glyph, which is font type dependent. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| gid | [GlyphId](../../com.aspose.font/glyphid) | Glyph identifier of symbol to decode. |
+
+**Returns:**
+long - Unicode value related to glyph id passed.
+### unicodeToGid(long unicode) {#unicodeToGid-long-}
+```
+public abstract GlyphId unicodeToGid(long unicode)
+```
+
+
+Decodes a unicode and returns glyph id. Glyph id is a unique number for a glyph, which is font type dependent. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| unicode | long | Unicode to get glyph identifier for. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to unicode passed.

--- a/spanish/java/com.aspose.font/ifontmetrics/_index.md
+++ b/spanish/java/com.aspose.font/ifontmetrics/_index.md
@@ -1,0 +1,357 @@
+---
+title: "IFontMetrics"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Define una interfaz para herramientas de métricas de fuentes."
+type: docs
+weight: 125
+url: /es/java/com.aspose.font/ifontmetrics/
+---```
+public interface IFontMetrics
+```
+
+Defines an interface for Font metrics tools.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getAscender()](#getAscender--) | Gets ascender value of the Font in font units. |
+| [getAscender(double fontSize)](#getAscender-double-) | Returns ascender for specific Font size. |
+| [getDescender()](#getDescender--) | Gets descender value of the Font in font units. |
+| [getDescender(double fontSize)](#getDescender-double-) | Returns descender for specific Font size. |
+| [getFontBBox()](#getFontBBox--) | Gets Font bounding box. |
+| [getFontMatrix()](#getFontMatrix--) | Gets Font transformation matrix. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Returns glyph BBox. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Returns glyph width. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Returns kerning value for the glyph pair. |
+| [getLineGap()](#getLineGap--) | Gets LineGap value of the Font in Font units. |
+| [getTypoAscender()](#getTypoAscender--) | Gets typographic ascender value of the Font in font units |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Returns typographic ascender for specific Font size. |
+| [getTypoDescender()](#getTypoDescender--) | Gets typographic descender value of the Font in Font units. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Returns typographic descender for specific Font size. |
+| [getTypoLineGap()](#getTypoLineGap--) | Gets typographic LineGap value of the Font in Font units. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Returns line gap for specific Font size. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Gets Gets units per em. |
+| [isFixedPitch()](#isFixedPitch--) | True, if the Font is monospaced. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Measures string and returns string width. |
+| [setAscender(double value)](#setAscender-double-) |  |
+| [setDescender(double value)](#setDescender-double-) |  |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) | Specifies glyph width. |
+| [setTypoAscender(double value)](#setTypoAscender-double-) |  |
+| [setTypoDescender(double value)](#setTypoDescender-double-) |  |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) |  |
+### getAscender() {#getAscender--}
+```
+public abstract double getAscender()
+```
+
+
+Gets ascender value of the Font in font units.
+
+**Returns:**
+double - Ascender value of the Font in font units.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public abstract double getAscender(double fontSize)
+```
+
+
+Returns ascender for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Ascender value.
+### getDescender() {#getDescender--}
+```
+public abstract double getDescender()
+```
+
+
+Gets descender value of the Font in font units.
+
+**Returns:**
+double - Descender value of the Font in font units.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public abstract double getDescender(double fontSize)
+```
+
+
+Returns descender for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Descender value.
+### getFontBBox() {#getFontBBox--}
+```
+public abstract FontBBox getFontBBox()
+```
+
+
+Gets Font bounding box.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Font bounding box.
+### getFontMatrix() {#getFontMatrix--}
+```
+public abstract TransformationMatrix getFontMatrix()
+```
+
+
+Gets Font transformation matrix.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - Font transformation matrix.
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public abstract FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Returns glyph BBox.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | glyph identifier |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - glyph BBox
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public abstract double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Returns glyph width.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph identifier. |
+
+**Returns:**
+double - Glyph width.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public abstract double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Returns kerning value for the glyph pair.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | First glyph in pair. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Font size. |
+
+**Returns:**
+double - Kerning value.
+### getLineGap() {#getLineGap--}
+```
+public abstract double getLineGap()
+```
+
+
+Gets LineGap value of the Font in Font units.
+
+**Returns:**
+double - LineGap value of the Font in Font units.
+### getTypoAscender() {#getTypoAscender--}
+```
+public abstract double getTypoAscender()
+```
+
+
+Gets typographic ascender value of the Font in font units
+
+**Returns:**
+double - Typographic ascender value of the Font in font units
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public abstract double getTypoAscender(double fontSize)
+```
+
+
+Returns typographic ascender for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Typographic ascender value.
+### getTypoDescender() {#getTypoDescender--}
+```
+public abstract double getTypoDescender()
+```
+
+
+Gets typographic descender value of the Font in Font units.
+
+**Returns:**
+double - Typographic descender value of the Font in Font units.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public abstract double getTypoDescender(double fontSize)
+```
+
+
+Returns typographic descender for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Typographic descender value.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public abstract double getTypoLineGap()
+```
+
+
+Gets typographic LineGap value of the Font in Font units.
+
+**Returns:**
+double - Typographic LineGap value of the Font in Font units.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public abstract double getTypoLineGap(double fontSize)
+```
+
+
+Returns line gap for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Line gap value.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public abstract long getUnitsPerEM()
+```
+
+
+Gets Gets units per em.
+
+**Returns:**
+long - Units per em.
+### isFixedPitch() {#isFixedPitch--}
+```
+public abstract boolean isFixedPitch()
+```
+
+
+True, if the Font is monospaced.
+
+**Returns:**
+boolean - True, if the Font is monospaced.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public abstract double measureString(String unicode, double fontSize)
+```
+
+
+Measures string and returns string width.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| unicode | java.lang.String | Unicode string. |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - String width.
+### setAscender(double value) {#setAscender-double-}
+```
+public abstract void setAscender(double value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | double |  |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public abstract void setDescender(double value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | double |  |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public abstract void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Specifies glyph width.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph identifier. |
+| value | double | Glyph width value. |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public abstract void setTypoAscender(double value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | double |  |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public abstract void setTypoDescender(double value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | double |  |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public abstract void setUnitsPerEM(long value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | long |  |
+

--- a/spanish/java/com.aspose.font/ifontsaver/_index.md
+++ b/spanish/java/com.aspose.font/ifontsaver/_index.md
@@ -1,0 +1,59 @@
+---
+title: "IFontSaver"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Define una interfaz para la funcionalidad de guardado de fuentes."
+type: docs
+weight: 126
+url: /es/java/com.aspose.font/ifontsaver/
+---```
+public interface IFontSaver
+```
+
+Defines an interface for Font save functionality.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Saves the Font into original format. |
+| [save(String fileName)](#save-java.lang.String-) | Saves the Font into original format. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Saves the Font into format specified. |
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public abstract void save(OutputStream stream)
+```
+
+
+Saves the Font into original format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| stream | java.io.OutputStream | stream to save font |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public abstract void save(String fileName)
+```
+
+
+Saves the Font into original format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fileName | java.lang.String | file to save font |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public abstract void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Saves the Font into format specified.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| stream | java.io.OutputStream | stream to save font |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | desired format |
+

--- a/spanish/java/com.aspose.font/iglyphaccessor/_index.md
+++ b/spanish/java/com.aspose.font/iglyphaccessor/_index.md
@@ -1,0 +1,70 @@
+---
+title: "IGlyphAccessor"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Define la funcionalidad para recuperar identificadores de glifos especificados y glifos."
+type: docs
+weight: 127
+url: /es/java/com.aspose.font/iglyphaccessor/
+---```
+public interface IGlyphAccessor
+```
+
+Defines functionality to retrieve specified glyph identifiers and glyphs.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Returns all glyph ids, available in the Font. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Returns glyph by glyph id. |
+| [getGlyphIdType()](#getGlyphIdType--) | Glyph id type specification. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Get glyphs representation for text. |
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public abstract GlyphId[] getAllGlyphIds()
+```
+
+
+Returns all glyph ids, available in the Font. Glyph id is a unique number for a glyph, which is font type dependent. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyph identifiers.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public abstract Glyph getGlyphById(GlyphId id)
+```
+
+
+Returns glyph by glyph id. Glyph id is a unique number for a glyph, which is font type dependent. GlyphId - derived object. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | glyph ID. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public abstract GlyphIdType getGlyphIdType()
+```
+
+
+Glyph id type specification.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype) - Id type specification.
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public abstract GlyphId[] getGlyphsForText(String text)
+```
+
+
+Get glyphs representation for text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Input text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - GlyphId array.

--- a/spanish/java/com.aspose.font/iglyphoutlinepainter/_index.md
+++ b/spanish/java/com.aspose.font/iglyphoutlinepainter/_index.md
@@ -1,0 +1,70 @@
+---
+title: "IGlyphOutlinePainter"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Define una forma esquemática de dibujar glifos."
+type: docs
+weight: 128
+url: /es/java/com.aspose.font/iglyphoutlinepainter/
+---
+**All Implemented Interfaces:**
+[com.aspose.font.IGlyphPainter](../../com.aspose.font/iglyphpainter)
+```
+public interface IGlyphOutlinePainter extends IGlyphPainter
+```
+
+Define una forma esquemática de dibujar glifos.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [closePath()](#closePath--) | Procesa la operación ClosePath. |
+| [curveTo(CurveTo curveTo)](#curveTo-com.aspose.font.CurveTo-) | Procesa la operación CurveTo. |
+| [lineTo(LineTo lineTo)](#lineTo-com.aspose.font.LineTo-) | Procesa la operación LineTo. |
+| [moveTo(MoveTo moveTo)](#moveTo-com.aspose.font.MoveTo-) | Procesa la operación MoveTo. |
+### closePath() {#closePath--}
+```
+public abstract void closePath()
+```
+
+
+Procesa la operación ClosePath.
+
+### curveTo(CurveTo curveTo) {#curveTo-com.aspose.font.CurveTo-}
+```
+public abstract void curveTo(CurveTo curveTo)
+```
+
+
+Procesa la operación CurveTo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| curveTo | [CurveTo](../../com.aspose.font/curveto) | Referencia CurveTo |
+
+### lineTo(LineTo lineTo) {#lineTo-com.aspose.font.LineTo-}
+```
+public abstract void lineTo(LineTo lineTo)
+```
+
+
+Procesa la operación LineTo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| lineTo | [LineTo](../../com.aspose.font/lineto) | Referencia LineTo |
+
+### moveTo(MoveTo moveTo) {#moveTo-com.aspose.font.MoveTo-}
+```
+public abstract void moveTo(MoveTo moveTo)
+```
+
+
+Procesa la operación MoveTo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| moveTo | [MoveTo](../../com.aspose.font/moveto) | Referencia MoveTo |
+

--- a/spanish/java/com.aspose.font/iglyphpainter/_index.md
+++ b/spanish/java/com.aspose.font/iglyphpainter/_index.md
@@ -1,0 +1,12 @@
+---
+title: "IGlyphPainter"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Define una forma de dibujar glifos."
+type: docs
+weight: 129
+url: /es/java/com.aspose.font/iglyphpainter/
+---```
+public interface IGlyphPainter
+```
+
+Defines a way to draw glyphs.

--- a/spanish/java/com.aspose.font/iglyphrenderer/_index.md
+++ b/spanish/java/com.aspose.font/iglyphrenderer/_index.md
@@ -1,0 +1,112 @@
+---
+title: "IGlyphRenderer"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Interfaz utilizada para renderizar glifos."
+type: docs
+weight: 130
+url: /es/java/com.aspose.font/iglyphrenderer/
+---```
+public interface IGlyphRenderer
+```
+
+Interface used to render glyphs.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [renderGlyph(IFont font, GlyphId glyphId)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-) | Renders glyph. |
+| [renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renders glyph, an objective of this overloaded version - to be used with cache for glyphs. |
+| [renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-) | Renders glyph. |
+| [renderGlyph(IFont font, long glyphIndex)](#renderGlyph-com.aspose.font.IFont-long-) | Renders glyph. |
+| [renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-) | Renders glyph. |
+| [renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renders glyph using independent glyph path. |
+### renderGlyph(IFont font, GlyphId glyphId) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-}
+```
+public abstract void renderGlyph(IFont font, GlyphId glyphId)
+```
+
+
+Renders glyph.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physical glyph index inside font. Note that this is not a unicode. |
+
+### renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public abstract void renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renders glyph, an objective of this overloaded version - to be used with cache for glyphs.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physical glyph index inside font. Note that this is not a unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glyph to render. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix that is applied to glyph coordinates. |
+
+### renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-}
+```
+public abstract void renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renders glyph.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physical glyph index inside font. Note that this is not a unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix that is applied to glyph coordinates. |
+
+### renderGlyph(IFont font, long glyphIndex) {#renderGlyph-com.aspose.font.IFont-long-}
+```
+public abstract void renderGlyph(IFont font, long glyphIndex)
+```
+
+
+Renders glyph.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphIndex | long | Physical glyph index inside font. Note that this is not a unicode. |
+
+### renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-}
+```
+public abstract void renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renders glyph.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphIndex | long | Physical glyph index inside font. Note that this is not a unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix that is applied to glyph coordinates. |
+
+### renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public abstract void renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renders glyph using independent glyph path. RenderGlyph() function family changes glyph path on rendering. It then leads to necessity reload this glyph again. This function uses copy of glyph path and doesn't changes original glyph path, so the same glyph could be reused multiple times. This version of function is intended for use with cache of glyphs.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physical glyph index inside font. Note that this is not a unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glyph to render. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix that is applied to glyph coordinates. |
+

--- a/spanish/java/com.aspose.font/incorrectfontdataexception/_index.md
+++ b/spanish/java/com.aspose.font/incorrectfontdataexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "IncorrectFontDataException"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa excepciones para casos en los que algunos valores del objeto Fuente son inválidos."
+type: docs
+weight: 57
+url: /es/java/com.aspose.font/incorrectfontdataexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class IncorrectFontDataException extends FontException
+```
+
+Representa excepciones para casos en los que algunos valores del objeto Fuente son inválidos.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [IncorrectFontDataException()](#IncorrectFontDataException--) | Inicializa un nuevo objeto FontAgrumentException. |
+| [IncorrectFontDataException(String message)](#IncorrectFontDataException-java.lang.String-) | Inicializa un nuevo objeto FontAgrumentException. |
+| [IncorrectFontDataException(String message, RuntimeException innerException)](#IncorrectFontDataException-java.lang.String-java.lang.RuntimeException-) | Inicializa un nuevo objeto FontAgrumentException. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IncorrectFontDataException() {#IncorrectFontDataException--}
+```
+public IncorrectFontDataException()
+```
+
+
+Inicializa un nuevo objeto FontAgrumentException.
+
+### IncorrectFontDataException(String message) {#IncorrectFontDataException-java.lang.String-}
+```
+public IncorrectFontDataException(String message)
+```
+
+
+Inicializa un nuevo objeto FontAgrumentException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+
+### IncorrectFontDataException(String message, RuntimeException innerException) {#IncorrectFontDataException-java.lang.String-java.lang.RuntimeException-}
+```
+public IncorrectFontDataException(String message, RuntimeException innerException)
+```
+
+
+Inicializa un nuevo objeto FontAgrumentException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+| innerException | java.lang.RuntimeException | La excepción que es la causa de la excepción actual. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ipathsegment/_index.md
+++ b/spanish/java/com.aspose.font/ipathsegment/_index.md
@@ -1,0 +1,59 @@
+---
+title: "IPathSegment"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la interfaz de cualquier segmento de ruta."
+type: docs
+weight: 131
+url: /es/java/com.aspose.font/ipathsegment/
+---
+**All Implemented Interfaces:**
+java.lang.Cloneable
+```
+public interface IPathSegment extends Cloneable
+```
+
+Representa la interfaz de cualquier segmento de ruta.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [copy()](#copy--) | Crea una copia del objeto segmento. |
+| [shift(double dx, double dy)](#shift-double-double-) | Realiza un desplazamiento por las coordenadas x e y. |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Transforma las coordenadas con la matriz de transformación. |
+### copy() {#copy--}
+```
+public abstract IPathSegment copy()
+```
+
+
+Crea una copia del objeto segmento.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public abstract void shift(double dx, double dy)
+```
+
+
+Realiza un desplazamiento por las coordenadas x e y.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| dx | double | Valor dx. |
+| dy | double | Valor dy. |
+
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public abstract void transform(TransformationMatrix matrix)
+```
+
+
+Transforma las coordenadas con la matriz de transformación.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matriz de transformación. |
+

--- a/spanish/java/com.aspose.font/isupportsnameaddressing/_index.md
+++ b/spanish/java/com.aspose.font/isupportsnameaddressing/_index.md
@@ -1,0 +1,27 @@
+---
+title: "ISupportsNameAddressing"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Define miembros que son específicos de codificaciones que admiten direccionamiento por nombre de glifo"
+type: docs
+weight: 132
+url: /es/java/com.aspose.font/isupportsnameaddressing/
+---```
+public interface ISupportsNameAddressing
+```
+
+Defines members that are specific to encodings that support glyph name addressing
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getNameToCharCodeIndex()](#getNameToCharCodeIndex--) | Returns name to code map object. |
+### getNameToCharCodeIndex() {#getNameToCharCodeIndex--}
+```
+public abstract NameToCodeMap getNameToCharCodeIndex()
+```
+
+
+Returns name to code map object.
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - name to code map object.

--- a/spanish/java/com.aspose.font/license/_index.md
+++ b/spanish/java/com.aspose.font/license/_index.md
@@ -1,0 +1,193 @@
+---
+title: "Licencia"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Proporciona métodos para licenciar el componente."
+type: docs
+weight: 58
+url: /es/java/com.aspose.font/license/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class License
+```
+
+Proporciona métodos para licenciar el componente.
+
+En este ejemplo, se intentará encontrar un archivo de licencia llamado MyLicense.lic en la carpeta que contiene el componente, en la carpeta que contiene el ensamblado que llama, en la carpeta del ensamblado de entrada y luego en los recursos incrustados del ensamblado que llama.
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [License()](#License--) | Inicializa una nueva instancia de esta clase. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLicense(InputStream stream)](#setLicense-java.io.InputStream-) | Licencia el componente. |
+| [setLicense(String licenseName)](#setLicense-java.lang.String-) | Licencia el componente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### License() {#License--}
+```
+public License()
+```
+
+
+Inicializa una nueva instancia de esta clase.
+
+En este ejemplo, se intentará encontrar un archivo de licencia llamado MyLicense.lic en la carpeta que contiene el componente, en la carpeta que contiene el ensamblado que llama, en la carpeta del ensamblado de entrada y luego en los recursos incrustados del ensamblado que llama.
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLicense(InputStream stream) {#setLicense-java.io.InputStream-}
+```
+public void setLicense(InputStream stream)
+```
+
+
+Licencia el componente.
+
+Un flujo que contiene la licencia.
+
+Utilice este método para cargar una licencia desde un flujo.
+
+License license = new License();
+license.setLicense(myStream);
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.InputStream | Flujo de licencia |
+
+### setLicense(String licenseName) {#setLicense-java.lang.String-}
+```
+public void setLicense(String licenseName)
+```
+
+
+Licencia el componente.
+
+Intenta encontrar la licencia en las siguientes ubicaciones:
+
+1. Ruta explícita.
+
+2. La carpeta del archivo JAR del componente.
+
+En este ejemplo, se intentará encontrar un archivo de licencia llamado MyLicense.lic en la carpeta que contiene el componente, en la carpeta que contiene el ensamblado que llama, en la carpeta del ensamblado de entrada y luego en los recursos incrustados del ensamblado que llama.
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| licenseName | java.lang.String | Puede ser un nombre de archivo completo o corto o el nombre de un recurso incrustado. Use una cadena vacía para cambiar al modo de evaluación. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/licenseflags/_index.md
+++ b/spanish/java/com.aspose.font/licenseflags/_index.md
@@ -1,0 +1,223 @@
+---
+title: "LicenseFlags"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa un contenedor auxiliar para banderas de incrustación del campo fsType de la tabla OS/2."
+type: docs
+weight: 59
+url: /es/java/com.aspose.font/licenseflags/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class LicenseFlags
+```
+
+Representa un contenedor auxiliar para las banderas de incrustación de la tabla 'OS/2' (campo fsType).
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFSType()](#getFSType--) | Obtiene el valor bruto de fsType de la tabla OS/2 o 0 si este campo no existe en la tabla. |
+| [hashCode()](#hashCode--) |  |
+| [isBitmapOnlyEmbedding()](#isBitmapOnlyEmbedding--) | Detecta si fsType permite la incrustación BitmapOnly. |
+| [isEditableEmbedding()](#isEditableEmbedding--) | Detecta si fsType permite la incrustación Editable. |
+| [isFSTypeAbsent()](#isFSTypeAbsent--) | Devuelve true si la bandera fsType está ausente en la tabla 'OS/2'. |
+| [isInstallableEmbedding()](#isInstallableEmbedding--) | Detecta si fsType es una incrustación Installable. |
+| [isNoSubsettingEmbedding()](#isNoSubsettingEmbedding--) | Detecta si fsType permite la incrustación NoSubsetting. |
+| [isPreviewAndPrintEmbedding()](#isPreviewAndPrintEmbedding--) | Detecta si fsType permite la incrustación Preview and Print. |
+| [isReservedType()](#isReservedType--) | Detecta si el bit reservado (bit 0) está activado para fsType. |
+| [isRestrictedLicenseEmbedding()](#isRestrictedLicenseEmbedding--) | Detecta si fsType es una incrustación Restricted License. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFSType() {#getFSType--}
+```
+public int getFSType()
+```
+
+
+Obtiene el valor bruto de fsType de la tabla OS/2 o 0 si este campo no existe en la tabla.
+
+**Returns:**
+int - Valor bruto de fsType de la tabla OS/2 o 0 si este campo no existe en la tabla.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isBitmapOnlyEmbedding() {#isBitmapOnlyEmbedding--}
+```
+public boolean isBitmapOnlyEmbedding()
+```
+
+
+Detecta si fsType permite la incrustación BitmapOnly.
+
+**Returns:**
+boolean - Detecta si fsType permite la incrustación BitmapOnly.
+### isEditableEmbedding() {#isEditableEmbedding--}
+```
+public boolean isEditableEmbedding()
+```
+
+
+Detecta si fsType permite la incrustación Editable.
+
+**Returns:**
+boolean - Detecta si fsType permite incrustación Editable.
+### isFSTypeAbsent() {#isFSTypeAbsent--}
+```
+public boolean isFSTypeAbsent()
+```
+
+
+Devuelve true si la bandera fsType está ausente en la tabla 'OS/2'.
+
+**Returns:**
+boolean - Verdadero si la bandera fsType está ausente en la tabla 'OS/2'.
+### isInstallableEmbedding() {#isInstallableEmbedding--}
+```
+public boolean isInstallableEmbedding()
+```
+
+
+Detecta si fsType es una incrustación Installable.
+
+**Returns:**
+boolean - Detecta si fsType es una incrustación Instalable.
+### isNoSubsettingEmbedding() {#isNoSubsettingEmbedding--}
+```
+public boolean isNoSubsettingEmbedding()
+```
+
+
+Detecta si fsType permite la incrustación NoSubsetting.
+
+**Returns:**
+boolean - Detecta si fsType permite incrustación NoSubsetting.
+### isPreviewAndPrintEmbedding() {#isPreviewAndPrintEmbedding--}
+```
+public boolean isPreviewAndPrintEmbedding()
+```
+
+
+Detecta si fsType permite la incrustación Preview and Print.
+
+**Returns:**
+boolean - Detecta si fsType permite incrustación de Vista previa e Impresión.
+### isReservedType() {#isReservedType--}
+```
+public boolean isReservedType()
+```
+
+
+Detecta si el bit reservado (bit 0) está activado para fsType.
+
+**Returns:**
+boolean - Detecta si el bit reservado (bit 0) está activado para fsType.
+### isRestrictedLicenseEmbedding() {#isRestrictedLicenseEmbedding--}
+```
+public boolean isRestrictedLicenseEmbedding()
+```
+
+
+Detecta si fsType es una incrustación Restricted License.
+
+**Returns:**
+boolean - Detecta si fsType es una incrustación de Licencia Restringida.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/licenserestrictionexception/_index.md
+++ b/spanish/java/com.aspose.font/licenserestrictionexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "LicenseRestrictionException"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa una excepción que se puede lanzar al intentar ejecutar una funcionalidad que está restringida en modo de evaluación."
+type: docs
+weight: 60
+url: /es/java/com.aspose.font/licenserestrictionexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class LicenseRestrictionException extends FontException
+```
+
+Representa una excepción que se puede lanzar al intentar ejecutar una funcionalidad que está restringida en modo de evaluación.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [LicenseRestrictionException()](#LicenseRestrictionException--) | Inicializa un nuevo objeto FontCreationException. |
+| [LicenseRestrictionException(String message)](#LicenseRestrictionException-java.lang.String-) | Inicializa un nuevo objeto FontCreationException. |
+| [LicenseRestrictionException(String message, RuntimeException innerException)](#LicenseRestrictionException-java.lang.String-java.lang.RuntimeException-) | Inicializa un nuevo objeto FontCreationException. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LicenseRestrictionException() {#LicenseRestrictionException--}
+```
+public LicenseRestrictionException()
+```
+
+
+Inicializa un nuevo objeto FontCreationException.
+
+### LicenseRestrictionException(String message) {#LicenseRestrictionException-java.lang.String-}
+```
+public LicenseRestrictionException(String message)
+```
+
+
+Inicializa un nuevo objeto FontCreationException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+
+### LicenseRestrictionException(String message, RuntimeException innerException) {#LicenseRestrictionException-java.lang.String-java.lang.RuntimeException-}
+```
+public LicenseRestrictionException(String message, RuntimeException innerException)
+```
+
+
+Inicializa un nuevo objeto FontCreationException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+| innerException | java.lang.RuntimeException | La excepción que es la causa de la excepción actual. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/linespacingtype/_index.md
+++ b/spanish/java/com.aspose.font/linespacingtype/_index.md
@@ -1,0 +1,250 @@
+---
+title: "RenderingUtils.LineSpacingType"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Tipo de interlineado."
+type: docs
+weight: 10
+url: /es/java/com.aspose.font/renderingutils.linespacingtype/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum RenderingUtils.LineSpacingType extends Enum<RenderingUtils.LineSpacingType>
+```
+
+Tipo de interlineado. Número de píxeles o porcentaje de la altura de la fuente.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [PercentOfFontHeight](#PercentOfFontHeight) | El valor del interlineado se establece en porcentaje de la altura de la fuente. |
+| [Pixels](#Pixels) | El valor del interlineado se establece en píxeles. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PercentOfFontHeight {#PercentOfFontHeight}
+```
+public static final RenderingUtils.LineSpacingType PercentOfFontHeight
+```
+
+
+El valor del interlineado se establece en porcentaje de la altura de la fuente.
+
+### Pixels {#Pixels}
+```
+public static final RenderingUtils.LineSpacingType Pixels
+```
+
+
+El valor del interlineado se establece en píxeles.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static RenderingUtils.LineSpacingType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[LineSpacingType](../../com.aspose.font/linespacingtype)
+### values() {#values--}
+```
+public static RenderingUtils.LineSpacingType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.RenderingUtils.LineSpacingType[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/lineto/_index.md
+++ b/spanish/java/com.aspose.font/lineto/_index.md
@@ -1,0 +1,200 @@
+---
+title: "LineTo"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la operación LineTo."
+type: docs
+weight: 61
+url: /es/java/com.aspose.font/lineto/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IPathSegment](../../com.aspose.font/ipathsegment)
+```
+public class LineTo implements IPathSegment
+```
+
+Representa la operación LineTo.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clone()](#clone--) | Crea un nuevo objeto que es una copia de la instancia actual. |
+| [copy()](#copy--) | Crea una copia del objeto segmento. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getX()](#getX--) | Obtiene la coordenada x. |
+| [getY()](#getY--) | Obtiene la coordenada y. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [shift(double dx, double dy)](#shift-double-double-) | Realiza un desplazamiento por las coordenadas x e y. |
+| [toString()](#toString--) |  |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Transforma las coordenadas con la matriz de transformación. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Crea un nuevo objeto que es una copia de la instancia actual.
+
+**Returns:**
+java.lang.Object - Un nuevo objeto que es una copia de esta instancia.
+### copy() {#copy--}
+```
+public IPathSegment copy()
+```
+
+
+Crea una copia del objeto segmento.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getX() {#getX--}
+```
+public double getX()
+```
+
+
+Obtiene la coordenada x.
+
+**Returns:**
+double - Coordenada x.
+### getY() {#getY--}
+```
+public double getY()
+```
+
+
+Obtiene la coordenada y.
+
+**Returns:**
+double - Coordenada y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public void shift(double dx, double dy)
+```
+
+
+Realiza un desplazamiento por las coordenadas x e y.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| dx | double | Valor dx. |
+| dy | double | Valor dy. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public void transform(TransformationMatrix matrix)
+```
+
+
+Transforma las coordenadas con la matriz de transformación.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matriz de transformación. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/longhormetric/_index.md
+++ b/spanish/java/com.aspose.font/longhormetric/_index.md
@@ -1,0 +1,185 @@
+---
+title: "TtfHmtxTable.LongHorMetric"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa el registro de métricas."
+type: docs
+weight: 10
+url: /es/java/com.aspose.font/ttfhmtxtable.longhormetric/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static class TtfHmtxTable.LongHorMetric
+```
+
+Representa el registro de métricas.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [LongHorMetric()](#LongHorMetric--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clone()](#clone--) |  |
+| [equals(TtfHmtxTable.LongHorMetric obj1, TtfHmtxTable.LongHorMetric obj2)](#equals-com.aspose.font.TtfHmtxTable.LongHorMetric-com.aspose.font.TtfHmtxTable.LongHorMetric-) |  |
+| [equals(Object obj)](#equals-java.lang.Object-) |  |
+| [getAdvanceWidth()](#getAdvanceWidth--) | Obtiene el valor del ancho de avance. |
+| [getClass()](#getClass--) |  |
+| [getLeftSideBearing()](#getLeftSideBearing--) | Obtiene el valor del margen izquierdo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LongHorMetric() {#LongHorMetric--}
+```
+public LongHorMetric()
+```
+
+
+### clone() {#clone--}
+```
+public TtfHmtxTable.LongHorMetric clone()
+```
+
+
+
+
+**Returns:**
+[LongHorMetric](../../com.aspose.font/longhormetric)
+### equals(TtfHmtxTable.LongHorMetric obj1, TtfHmtxTable.LongHorMetric obj2) {#equals-com.aspose.font.TtfHmtxTable.LongHorMetric-com.aspose.font.TtfHmtxTable.LongHorMetric-}
+```
+public static boolean equals(TtfHmtxTable.LongHorMetric obj1, TtfHmtxTable.LongHorMetric obj2)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj1 | [LongHorMetric](../../com.aspose.font/longhormetric) |  |
+| obj2 | [LongHorMetric](../../com.aspose.font/longhormetric) |  |
+
+**Returns:**
+boolean
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdvanceWidth() {#getAdvanceWidth--}
+```
+public int getAdvanceWidth()
+```
+
+
+Obtiene el valor del ancho de avance.
+
+**Returns:**
+int - Valor del ancho de avance.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLeftSideBearing() {#getLeftSideBearing--}
+```
+public short getLeftSideBearing()
+```
+
+
+Obtiene el valor del margen izquierdo.
+
+**Returns:**
+short - Valor del margen izquierdo.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/longvermetric/_index.md
+++ b/spanish/java/com.aspose.font/longvermetric/_index.md
@@ -1,0 +1,185 @@
+---
+title: "TtfVmtxTable.LongVerMetric"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa el registro de métricas verticales."
+type: docs
+weight: 10
+url: /es/java/com.aspose.font/ttfvmtxtable.longvermetric/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static class TtfVmtxTable.LongVerMetric
+```
+
+Representa el registro de métricas verticales.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [LongVerMetric()](#LongVerMetric--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clone()](#clone--) |  |
+| [equals(TtfVmtxTable.LongVerMetric obj1, TtfVmtxTable.LongVerMetric obj2)](#equals-com.aspose.font.TtfVmtxTable.LongVerMetric-com.aspose.font.TtfVmtxTable.LongVerMetric-) |  |
+| [equals(Object obj)](#equals-java.lang.Object-) |  |
+| [getAdvanceHeight()](#getAdvanceHeight--) | Obtiene el valor de altura de avance. |
+| [getClass()](#getClass--) |  |
+| [getTopSideBearing()](#getTopSideBearing--) | Obtiene el valor del margen superior. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LongVerMetric() {#LongVerMetric--}
+```
+public LongVerMetric()
+```
+
+
+### clone() {#clone--}
+```
+public TtfVmtxTable.LongVerMetric clone()
+```
+
+
+
+
+**Returns:**
+[LongVerMetric](../../com.aspose.font/longvermetric)
+### equals(TtfVmtxTable.LongVerMetric obj1, TtfVmtxTable.LongVerMetric obj2) {#equals-com.aspose.font.TtfVmtxTable.LongVerMetric-com.aspose.font.TtfVmtxTable.LongVerMetric-}
+```
+public static boolean equals(TtfVmtxTable.LongVerMetric obj1, TtfVmtxTable.LongVerMetric obj2)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj1 | [LongVerMetric](../../com.aspose.font/longvermetric) |  |
+| obj2 | [LongVerMetric](../../com.aspose.font/longvermetric) |  |
+
+**Returns:**
+boolean
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdvanceHeight() {#getAdvanceHeight--}
+```
+public int getAdvanceHeight()
+```
+
+
+Obtiene el valor de altura de avance.
+
+**Returns:**
+int - El valor de altura de avance.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getTopSideBearing() {#getTopSideBearing--}
+```
+public short getTopSideBearing()
+```
+
+
+Obtiene el valor del margen superior.
+
+**Returns:**
+short - El valor del margen superior.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/maclanguageid/_index.md
+++ b/spanish/java/com.aspose.font/maclanguageid/_index.md
@@ -1,0 +1,1201 @@
+---
+title: "MacLanguageId"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Enumeración de ID de idioma de la plataforma Macintosh."
+type: docs
+weight: 63
+url: /es/java/com.aspose.font/maclanguageid/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class MacLanguageId
+```
+
+Enumeración de ID de idioma de la plataforma Macintosh.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [Afrikaans](#Afrikaans) | Valor de LanguageId de Afrikaans |
+| [Albanian](#Albanian) | Valor de LanguageId de Albanés |
+| [Amharic](#Amharic) | Valor de LanguageId de Amhárico |
+| [Arabic](#Arabic) | Valor de LanguageId de Árabe |
+| [Armenian](#Armenian) | Valor de LanguageId de Armenio |
+| [Assamese](#Assamese) | Valor de LanguageId de Assamés |
+| [Aymara](#Aymara) | Aymara LanguageId valor |
+| [Azerbaijani_Arabic](#Azerbaijani-Arabic) | Azerbaiyano (alfabeto árabe) LanguageId valor |
+| [Azerbaijani_Cyrillic](#Azerbaijani-Cyrillic) | Azerbaiyano (alfabeto cirílico) LanguageId valor |
+| [Azerbaijani_Roman](#Azerbaijani-Roman) | Azerbaiyano (alfabeto romano) LanguageId valor |
+| [Basque](#Basque) | Vasco LanguageId valor |
+| [Bengali](#Bengali) | Bengalí LanguageId valor |
+| [Breton](#Breton) | Bretón LanguageId valor |
+| [Bulgarian](#Bulgarian) | Búlgaro LanguageId valor |
+| [Burmese](#Burmese) | Birmano LanguageId valor |
+| [Byelorussian](#Byelorussian) | Bielorruso LanguageId valor |
+| [Catalan](#Catalan) | Catalán LanguageId valor |
+| [Chinese_Simplified](#Chinese-Simplified) | Chino (simplificado) LanguageId valor |
+| [Chinese_Traditional](#Chinese-Traditional) | Chino (tradicional) LanguageId valor |
+| [Croatian](#Croatian) | Croata LanguageId valor |
+| [Czech](#Czech) | Checo LanguageId valor |
+| [Danish](#Danish) | Danés LanguageId valor |
+| [Dutch](#Dutch) | Holandés LanguageId valor |
+| [Dzongkha](#Dzongkha) | Dzongkha LanguageId valor |
+| [English](#English) | Inglés LanguageId valor |
+| [Esperanto](#Esperanto) | Esperanto LanguageId valor |
+| [Estonian](#Estonian) | Estonio LanguageId valor |
+| [Faroese](#Faroese) | Feroés LanguageId valor |
+| [Farsi_Persian](#Farsi-Persian) | Farsi/persa LanguageId valor |
+| [Finnish](#Finnish) | Finlandés LanguageId valor |
+| [Flemish](#Flemish) | Flamenco LanguageId valor |
+| [French](#French) | Valor de LanguageId en francés |
+| [Galician](#Galician) | Valor de LanguageId en gallego |
+| [Galla](#Galla) | Valor de LanguageId en galla |
+| [Georgian](#Georgian) | Valor de LanguageId en georgiano |
+| [German](#German) | Valor de LanguageId en alemán |
+| [Greek](#Greek) | Valor de LanguageId en griego |
+| [Greek_Polytonic](#Greek-Polytonic) | Valor de LanguageId en griego (polítono) |
+| [Greenlandic](#Greenlandic) | Valor de LanguageId en groenlandés |
+| [Guarani](#Guarani) | Valor de LanguageId en guaraní |
+| [Gujarati](#Gujarati) | Valor de LanguageId en gujarati |
+| [Hebrew](#Hebrew) | Valor de LanguageId en hebreo |
+| [Hindi](#Hindi) | Valor de LanguageId en hindi |
+| [Hungarian](#Hungarian) | Valor de LanguageId en húngaro |
+| [Icelandic](#Icelandic) | Valor de LanguageId en islandés |
+| [Indonesian](#Indonesian) | Valor de LanguageId en indonesio |
+| [Inuktitut](#Inuktitut) | Valor de LanguageId en inuktitut |
+| [Irish_Gaelic](#Irish-Gaelic) | Valor de LanguageId en gaélico irlandés |
+| [Irish_Gaelic_WDA](#Irish-Gaelic-WDA) | Valor de LanguageId en gaélico irlandés (con punto arriba) |
+| [Italian](#Italian) | Valor de LanguageId en italiano |
+| [Japanese](#Japanese) | Valor de LanguageId en japonés |
+| [Javanese](#Javanese) | Valor de LanguageId en javanés (alfabeto romano) |
+| [Kannada](#Kannada) | Valor de LanguageId en canarés |
+| [Kashmiri](#Kashmiri) | Valor de LanguageId en cachemiro |
+| [Kazakh](#Kazakh) | Valor de LanguageId en kazajo |
+| [Khmer](#Khmer) | Valor de LanguageId en jemer |
+| [Kinyarwanda_Ruanda](#Kinyarwanda-Ruanda) | Kinyarwanda/Ruanda valor de LanguageId |
+| [Kirghiz](#Kirghiz) | Kirghiz valor de LanguageId |
+| [Korean](#Korean) | Korean valor de LanguageId |
+| [Kurdish](#Kurdish) | Kurdish valor de LanguageId |
+| [Lao](#Lao) | Lao valor de LanguageId |
+| [Latin](#Latin) | Latin valor de LanguageId |
+| [Latvian](#Latvian) | Latvian valor de LanguageId |
+| [Lithuanian](#Lithuanian) | Lithuanian valor de LanguageId |
+| [Macedonian](#Macedonian) | Macedonian valor de LanguageId |
+| [Malagasy](#Malagasy) | Malagasy valor de LanguageId |
+| [Malay_Arabic](#Malay-Arabic) | Malay (Arabic script) valor de LanguageId |
+| [Malay_Roman](#Malay-Roman) | Malay (Roman script) valor de LanguageId |
+| [Malayalam](#Malayalam) | Malayalam valor de LanguageId |
+| [Maltese](#Maltese) | Maltese valor de LanguageId |
+| [Manx_Gaelic](#Manx-Gaelic) | Manx Gaelic valor de LanguageId |
+| [Marathi](#Marathi) | Marathi valor de LanguageId |
+| [Moldavian](#Moldavian) | Moldavian valor de LanguageId |
+| [Mongolian_Cyrillic](#Mongolian-Cyrillic) | Mongolian (Cyrillic script) valor de LanguageId |
+| [Mongolian_Mongolian](#Mongolian-Mongolian) | Mongolian (Mongolian script) valor de LanguageId |
+| [Nepali](#Nepali) | Nepali valor de LanguageId |
+| [Norwegian](#Norwegian) | Norwegian valor de LanguageId |
+| [Nyanja_Chewa](#Nyanja-Chewa) | Nyanja/Chewa valor de LanguageId |
+| [Oriya](#Oriya) | Oriya valor de LanguageId |
+| [Pashto](#Pashto) | Pashto valor de LanguageId |
+| [Polish](#Polish) | Polish valor de LanguageId |
+| [Portuguese](#Portuguese) | Portugués LanguageId valor |
+| [Punjabi](#Punjabi) | Punyabí LanguageId valor |
+| [Quechua](#Quechua) | Quechua LanguageId valor |
+| [Romanian](#Romanian) | Rumano LanguageId valor |
+| [Rundi](#Rundi) | Rundi LanguageId valor |
+| [Russian](#Russian) | Ruso LanguageId valor |
+| [Sami](#Sami) | Sami LanguageId valor |
+| [Sanskrit](#Sanskrit) | Sánscrito LanguageId valor |
+| [Scottish_Gaelic](#Scottish-Gaelic) | Gaélico escocés LanguageId valor |
+| [Serbian](#Serbian) | Serbio LanguLanguageIdageID valor |
+| [Sindhi](#Sindhi) | Sindhi LanguageId valor |
+| [Sinhalese](#Sinhalese) | Cingalés LanguageId valor |
+| [Slovak](#Slovak) | Eslovaco LanguageId valor |
+| [Slovenian](#Slovenian) | Esloveno LanguageId valor |
+| [Somali](#Somali) | Somalí LanguageId valor |
+| [Spanish](#Spanish) | Español LanguageId valor |
+| [Sundanese](#Sundanese) | Sundanés (alfabeto romano) LanguageId valor |
+| [Swahili](#Swahili) | Suajili LanguageId valor |
+| [Swedish](#Swedish) | Sueco LanguageId valor |
+| [Tagalog](#Tagalog) | Tagalo LanguageId valor |
+| [Tajiki](#Tajiki) | Tayiko LanguageId valor |
+| [Tamil](#Tamil) | Tamil LanguagLanguageIdeID valor |
+| [Tatar](#Tatar) | Tártaro LanguageId valor |
+| [Telugu](#Telugu) | Telugu LanguageId valor |
+| [Thai](#Thai) | Tailandés LanguageId valor |
+| [Tibetan](#Tibetan) | Valor de LanguageId tibetano |
+| [Tigrinya](#Tigrinya) | Valor de LanguageId tigrinya |
+| [Tongan](#Tongan) | Valor de LanguageId tongano |
+| [Turkish](#Turkish) | Valor de LanguageId turco |
+| [Turkmen](#Turkmen) | Valor de LanguageId turcomano |
+| [Uighur](#Uighur) | Valor de LanguageId uigur |
+| [Ukrainian](#Ukrainian) | Valor de LanguageId ucraniano |
+| [Urdu](#Urdu) | Valor de LanguageId urdu |
+| [Uzbek](#Uzbek) | Valor de LanguageId uzbeko |
+| [Vietnamese](#Vietnamese) | Valor de LanguageId vietnamita |
+| [Welsh](#Welsh) | Valor de LanguageId galés |
+| [Yiddish](#Yiddish) | Valor de LanguageId yidis |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getId()](#getId--) | Obtenga el valor entero. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Afrikaans {#Afrikaans}
+```
+public static final MacLanguageId Afrikaans
+```
+
+
+Valor de LanguageId de Afrikaans
+
+### Albanian {#Albanian}
+```
+public static final MacLanguageId Albanian
+```
+
+
+Valor de LanguageId de Albanés
+
+### Amharic {#Amharic}
+```
+public static final MacLanguageId Amharic
+```
+
+
+Valor de LanguageId de Amhárico
+
+### Arabic {#Arabic}
+```
+public static final MacLanguageId Arabic
+```
+
+
+Valor de LanguageId de Árabe
+
+### Armenian {#Armenian}
+```
+public static final MacLanguageId Armenian
+```
+
+
+Valor de LanguageId de Armenio
+
+### Assamese {#Assamese}
+```
+public static final MacLanguageId Assamese
+```
+
+
+Valor de LanguageId de Assamés
+
+### Aymara {#Aymara}
+```
+public static final MacLanguageId Aymara
+```
+
+
+Aymara LanguageId valor
+
+### Azerbaijani_Arabic {#Azerbaijani-Arabic}
+```
+public static final MacLanguageId Azerbaijani_Arabic
+```
+
+
+Azerbaiyano (alfabeto árabe) LanguageId valor
+
+### Azerbaijani_Cyrillic {#Azerbaijani-Cyrillic}
+```
+public static final MacLanguageId Azerbaijani_Cyrillic
+```
+
+
+Azerbaiyano (alfabeto cirílico) LanguageId valor
+
+### Azerbaijani_Roman {#Azerbaijani-Roman}
+```
+public static final MacLanguageId Azerbaijani_Roman
+```
+
+
+Azerbaiyano (alfabeto romano) LanguageId valor
+
+### Basque {#Basque}
+```
+public static final MacLanguageId Basque
+```
+
+
+Vasco LanguageId valor
+
+### Bengali {#Bengali}
+```
+public static final MacLanguageId Bengali
+```
+
+
+Bengalí LanguageId valor
+
+### Breton {#Breton}
+```
+public static final MacLanguageId Breton
+```
+
+
+Bretón LanguageId valor
+
+### Bulgarian {#Bulgarian}
+```
+public static final MacLanguageId Bulgarian
+```
+
+
+Búlgaro LanguageId valor
+
+### Burmese {#Burmese}
+```
+public static final MacLanguageId Burmese
+```
+
+
+Birmano LanguageId valor
+
+### Byelorussian {#Byelorussian}
+```
+public static final MacLanguageId Byelorussian
+```
+
+
+Bielorruso LanguageId valor
+
+### Catalan {#Catalan}
+```
+public static final MacLanguageId Catalan
+```
+
+
+Catalán LanguageId valor
+
+### Chinese_Simplified {#Chinese-Simplified}
+```
+public static final MacLanguageId Chinese_Simplified
+```
+
+
+Chino (simplificado) LanguageId valor
+
+### Chinese_Traditional {#Chinese-Traditional}
+```
+public static final MacLanguageId Chinese_Traditional
+```
+
+
+Chino (tradicional) LanguageId valor
+
+### Croatian {#Croatian}
+```
+public static final MacLanguageId Croatian
+```
+
+
+Croata LanguageId valor
+
+### Czech {#Czech}
+```
+public static final MacLanguageId Czech
+```
+
+
+Checo LanguageId valor
+
+### Danish {#Danish}
+```
+public static final MacLanguageId Danish
+```
+
+
+Danés LanguageId valor
+
+### Dutch {#Dutch}
+```
+public static final MacLanguageId Dutch
+```
+
+
+Holandés LanguageId valor
+
+### Dzongkha {#Dzongkha}
+```
+public static final MacLanguageId Dzongkha
+```
+
+
+Dzongkha LanguageId valor
+
+### English {#English}
+```
+public static final MacLanguageId English
+```
+
+
+Inglés LanguageId valor
+
+### Esperanto {#Esperanto}
+```
+public static final MacLanguageId Esperanto
+```
+
+
+Esperanto LanguageId valor
+
+### Estonian {#Estonian}
+```
+public static final MacLanguageId Estonian
+```
+
+
+Estonio LanguageId valor
+
+### Faroese {#Faroese}
+```
+public static final MacLanguageId Faroese
+```
+
+
+Feroés LanguageId valor
+
+### Farsi_Persian {#Farsi-Persian}
+```
+public static final MacLanguageId Farsi_Persian
+```
+
+
+Farsi/persa LanguageId valor
+
+### Finnish {#Finnish}
+```
+public static final MacLanguageId Finnish
+```
+
+
+Finlandés LanguageId valor
+
+### Flemish {#Flemish}
+```
+public static final MacLanguageId Flemish
+```
+
+
+Flamenco LanguageId valor
+
+### French {#French}
+```
+public static final MacLanguageId French
+```
+
+
+Valor de LanguageId en francés
+
+### Galician {#Galician}
+```
+public static final MacLanguageId Galician
+```
+
+
+Valor de LanguageId en gallego
+
+### Galla {#Galla}
+```
+public static final MacLanguageId Galla
+```
+
+
+Valor de LanguageId en galla
+
+### Georgian {#Georgian}
+```
+public static final MacLanguageId Georgian
+```
+
+
+Valor de LanguageId en georgiano
+
+### German {#German}
+```
+public static final MacLanguageId German
+```
+
+
+Valor de LanguageId en alemán
+
+### Greek {#Greek}
+```
+public static final MacLanguageId Greek
+```
+
+
+Valor de LanguageId en griego
+
+### Greek_Polytonic {#Greek-Polytonic}
+```
+public static final MacLanguageId Greek_Polytonic
+```
+
+
+Valor de LanguageId en griego (polítono)
+
+### Greenlandic {#Greenlandic}
+```
+public static final MacLanguageId Greenlandic
+```
+
+
+Valor de LanguageId en groenlandés
+
+### Guarani {#Guarani}
+```
+public static final MacLanguageId Guarani
+```
+
+
+Valor de LanguageId en guaraní
+
+### Gujarati {#Gujarati}
+```
+public static final MacLanguageId Gujarati
+```
+
+
+Valor de LanguageId en gujarati
+
+### Hebrew {#Hebrew}
+```
+public static final MacLanguageId Hebrew
+```
+
+
+Valor de LanguageId en hebreo
+
+### Hindi {#Hindi}
+```
+public static final MacLanguageId Hindi
+```
+
+
+Valor de LanguageId en hindi
+
+### Hungarian {#Hungarian}
+```
+public static final MacLanguageId Hungarian
+```
+
+
+Valor de LanguageId en húngaro
+
+### Icelandic {#Icelandic}
+```
+public static final MacLanguageId Icelandic
+```
+
+
+Valor de LanguageId en islandés
+
+### Indonesian {#Indonesian}
+```
+public static final MacLanguageId Indonesian
+```
+
+
+Valor de LanguageId en indonesio
+
+### Inuktitut {#Inuktitut}
+```
+public static final MacLanguageId Inuktitut
+```
+
+
+Valor de LanguageId en inuktitut
+
+### Irish_Gaelic {#Irish-Gaelic}
+```
+public static final MacLanguageId Irish_Gaelic
+```
+
+
+Valor de LanguageId en gaélico irlandés
+
+### Irish_Gaelic_WDA {#Irish-Gaelic-WDA}
+```
+public static final MacLanguageId Irish_Gaelic_WDA
+```
+
+
+Valor de LanguageId en gaélico irlandés (con punto arriba)
+
+### Italian {#Italian}
+```
+public static final MacLanguageId Italian
+```
+
+
+Valor de LanguageId en italiano
+
+### Japanese {#Japanese}
+```
+public static final MacLanguageId Japanese
+```
+
+
+Valor de LanguageId en japonés
+
+### Javanese {#Javanese}
+```
+public static final MacLanguageId Javanese
+```
+
+
+Valor de LanguageId en javanés (alfabeto romano)
+
+### Kannada {#Kannada}
+```
+public static final MacLanguageId Kannada
+```
+
+
+Valor de LanguageId en canarés
+
+### Kashmiri {#Kashmiri}
+```
+public static final MacLanguageId Kashmiri
+```
+
+
+Valor de LanguageId en cachemiro
+
+### Kazakh {#Kazakh}
+```
+public static final MacLanguageId Kazakh
+```
+
+
+Valor de LanguageId en kazajo
+
+### Khmer {#Khmer}
+```
+public static final MacLanguageId Khmer
+```
+
+
+Valor de LanguageId en jemer
+
+### Kinyarwanda_Ruanda {#Kinyarwanda-Ruanda}
+```
+public static final MacLanguageId Kinyarwanda_Ruanda
+```
+
+
+Kinyarwanda/Ruanda valor de LanguageId
+
+### Kirghiz {#Kirghiz}
+```
+public static final MacLanguageId Kirghiz
+```
+
+
+Kirghiz valor de LanguageId
+
+### Korean {#Korean}
+```
+public static final MacLanguageId Korean
+```
+
+
+Korean valor de LanguageId
+
+### Kurdish {#Kurdish}
+```
+public static final MacLanguageId Kurdish
+```
+
+
+Kurdish valor de LanguageId
+
+### Lao {#Lao}
+```
+public static final MacLanguageId Lao
+```
+
+
+Lao valor de LanguageId
+
+### Latin {#Latin}
+```
+public static final MacLanguageId Latin
+```
+
+
+Latin valor de LanguageId
+
+### Latvian {#Latvian}
+```
+public static final MacLanguageId Latvian
+```
+
+
+Latvian valor de LanguageId
+
+### Lithuanian {#Lithuanian}
+```
+public static final MacLanguageId Lithuanian
+```
+
+
+Lithuanian valor de LanguageId
+
+### Macedonian {#Macedonian}
+```
+public static final MacLanguageId Macedonian
+```
+
+
+Macedonian valor de LanguageId
+
+### Malagasy {#Malagasy}
+```
+public static final MacLanguageId Malagasy
+```
+
+
+Malagasy valor de LanguageId
+
+### Malay_Arabic {#Malay-Arabic}
+```
+public static final MacLanguageId Malay_Arabic
+```
+
+
+Malay (Arabic script) valor de LanguageId
+
+### Malay_Roman {#Malay-Roman}
+```
+public static final MacLanguageId Malay_Roman
+```
+
+
+Malay (Roman script) valor de LanguageId
+
+### Malayalam {#Malayalam}
+```
+public static final MacLanguageId Malayalam
+```
+
+
+Malayalam valor de LanguageId
+
+### Maltese {#Maltese}
+```
+public static final MacLanguageId Maltese
+```
+
+
+Maltese valor de LanguageId
+
+### Manx_Gaelic {#Manx-Gaelic}
+```
+public static final MacLanguageId Manx_Gaelic
+```
+
+
+Manx Gaelic valor de LanguageId
+
+### Marathi {#Marathi}
+```
+public static final MacLanguageId Marathi
+```
+
+
+Marathi valor de LanguageId
+
+### Moldavian {#Moldavian}
+```
+public static final MacLanguageId Moldavian
+```
+
+
+Moldavian valor de LanguageId
+
+### Mongolian_Cyrillic {#Mongolian-Cyrillic}
+```
+public static final MacLanguageId Mongolian_Cyrillic
+```
+
+
+Mongolian (Cyrillic script) valor de LanguageId
+
+### Mongolian_Mongolian {#Mongolian-Mongolian}
+```
+public static final MacLanguageId Mongolian_Mongolian
+```
+
+
+Mongolian (Mongolian script) valor de LanguageId
+
+### Nepali {#Nepali}
+```
+public static final MacLanguageId Nepali
+```
+
+
+Nepali valor de LanguageId
+
+### Norwegian {#Norwegian}
+```
+public static final MacLanguageId Norwegian
+```
+
+
+Norwegian valor de LanguageId
+
+### Nyanja_Chewa {#Nyanja-Chewa}
+```
+public static final MacLanguageId Nyanja_Chewa
+```
+
+
+Nyanja/Chewa valor de LanguageId
+
+### Oriya {#Oriya}
+```
+public static final MacLanguageId Oriya
+```
+
+
+Oriya valor de LanguageId
+
+### Pashto {#Pashto}
+```
+public static final MacLanguageId Pashto
+```
+
+
+Pashto valor de LanguageId
+
+### Polish {#Polish}
+```
+public static final MacLanguageId Polish
+```
+
+
+Polish valor de LanguageId
+
+### Portuguese {#Portuguese}
+```
+public static final MacLanguageId Portuguese
+```
+
+
+Portugués LanguageId valor
+
+### Punjabi {#Punjabi}
+```
+public static final MacLanguageId Punjabi
+```
+
+
+Punyabí LanguageId valor
+
+### Quechua {#Quechua}
+```
+public static final MacLanguageId Quechua
+```
+
+
+Quechua LanguageId valor
+
+### Romanian {#Romanian}
+```
+public static final MacLanguageId Romanian
+```
+
+
+Rumano LanguageId valor
+
+### Rundi {#Rundi}
+```
+public static final MacLanguageId Rundi
+```
+
+
+Rundi LanguageId valor
+
+### Russian {#Russian}
+```
+public static final MacLanguageId Russian
+```
+
+
+Ruso LanguageId valor
+
+### Sami {#Sami}
+```
+public static final MacLanguageId Sami
+```
+
+
+Sami LanguageId valor
+
+### Sanskrit {#Sanskrit}
+```
+public static final MacLanguageId Sanskrit
+```
+
+
+Sánscrito LanguageId valor
+
+### Scottish_Gaelic {#Scottish-Gaelic}
+```
+public static final MacLanguageId Scottish_Gaelic
+```
+
+
+Gaélico escocés LanguageId valor
+
+### Serbian {#Serbian}
+```
+public static final MacLanguageId Serbian
+```
+
+
+Serbio LanguLanguageIdageID valor
+
+### Sindhi {#Sindhi}
+```
+public static final MacLanguageId Sindhi
+```
+
+
+Sindhi LanguageId valor
+
+### Sinhalese {#Sinhalese}
+```
+public static final MacLanguageId Sinhalese
+```
+
+
+Cingalés LanguageId valor
+
+### Slovak {#Slovak}
+```
+public static final MacLanguageId Slovak
+```
+
+
+Eslovaco LanguageId valor
+
+### Slovenian {#Slovenian}
+```
+public static final MacLanguageId Slovenian
+```
+
+
+Esloveno LanguageId valor
+
+### Somali {#Somali}
+```
+public static final MacLanguageId Somali
+```
+
+
+Somalí LanguageId valor
+
+### Spanish {#Spanish}
+```
+public static final MacLanguageId Spanish
+```
+
+
+Español LanguageId valor
+
+### Sundanese {#Sundanese}
+```
+public static final MacLanguageId Sundanese
+```
+
+
+Sundanés (alfabeto romano) LanguageId valor
+
+### Swahili {#Swahili}
+```
+public static final MacLanguageId Swahili
+```
+
+
+Suajili LanguageId valor
+
+### Swedish {#Swedish}
+```
+public static final MacLanguageId Swedish
+```
+
+
+Sueco LanguageId valor
+
+### Tagalog {#Tagalog}
+```
+public static final MacLanguageId Tagalog
+```
+
+
+Tagalo LanguageId valor
+
+### Tajiki {#Tajiki}
+```
+public static final MacLanguageId Tajiki
+```
+
+
+Tayiko LanguageId valor
+
+### Tamil {#Tamil}
+```
+public static final MacLanguageId Tamil
+```
+
+
+Tamil LanguagLanguageIdeID valor
+
+### Tatar {#Tatar}
+```
+public static final MacLanguageId Tatar
+```
+
+
+Tártaro LanguageId valor
+
+### Telugu {#Telugu}
+```
+public static final MacLanguageId Telugu
+```
+
+
+Telugu LanguageId valor
+
+### Thai {#Thai}
+```
+public static final MacLanguageId Thai
+```
+
+
+Tailandés LanguageId valor
+
+### Tibetan {#Tibetan}
+```
+public static final MacLanguageId Tibetan
+```
+
+
+Valor de LanguageId tibetano
+
+### Tigrinya {#Tigrinya}
+```
+public static final MacLanguageId Tigrinya
+```
+
+
+Valor de LanguageId tigrinya
+
+### Tongan {#Tongan}
+```
+public static final MacLanguageId Tongan
+```
+
+
+Valor de LanguageId tongano
+
+### Turkish {#Turkish}
+```
+public static final MacLanguageId Turkish
+```
+
+
+Valor de LanguageId turco
+
+### Turkmen {#Turkmen}
+```
+public static final MacLanguageId Turkmen
+```
+
+
+Valor de LanguageId turcomano
+
+### Uighur {#Uighur}
+```
+public static final MacLanguageId Uighur
+```
+
+
+Valor de LanguageId uigur
+
+### Ukrainian {#Ukrainian}
+```
+public static final MacLanguageId Ukrainian
+```
+
+
+Valor de LanguageId ucraniano
+
+### Urdu {#Urdu}
+```
+public static final MacLanguageId Urdu
+```
+
+
+Valor de LanguageId urdu
+
+### Uzbek {#Uzbek}
+```
+public static final MacLanguageId Uzbek
+```
+
+
+Valor de LanguageId uzbeko
+
+### Vietnamese {#Vietnamese}
+```
+public static final MacLanguageId Vietnamese
+```
+
+
+Valor de LanguageId vietnamita
+
+### Welsh {#Welsh}
+```
+public static final MacLanguageId Welsh
+```
+
+
+Valor de LanguageId galés
+
+### Yiddish {#Yiddish}
+```
+public static final MacLanguageId Yiddish
+```
+
+
+Valor de LanguageId yidis
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getId() {#getId--}
+```
+public int getId()
+```
+
+
+Obtenga el valor entero.
+
+**Returns:**
+int - El valor entero.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/macplatformspecificid/_index.md
+++ b/spanish/java/com.aspose.font/macplatformspecificid/_index.md
@@ -1,0 +1,529 @@
+---
+title: "MacPlatformSpecificId"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la enumeración PlatformSpecificId de la plataforma Macintosh."
+type: docs
+weight: 140
+url: /es/java/com.aspose.font/macplatformspecificid/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum MacPlatformSpecificId extends Enum<MacPlatformSpecificId>
+```
+
+Representa la enumeración PlatformSpecificId de la plataforma Macintosh.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [Arabic](#Arabic) | Valor específico de plataforma Árabe. |
+| [Armenian](#Armenian) | Valor específico de plataforma Armenia. |
+| [Bengali](#Bengali) | Valor específico de plataforma Bengalí. |
+| [Burmese](#Burmese) | Valor específico de plataforma Birmano. |
+| [Devanagari](#Devanagari) | Valor específico de plataforma Devanagari. |
+| [Geez](#Geez) | Valor específico de plataforma Geez. |
+| [Georgian](#Georgian) | Valor específico de plataforma Georgiano. |
+| [Greek](#Greek) | Valor específico de plataforma Griego. |
+| [Gujarati](#Gujarati) | Valor específico de plataforma Gujarati. |
+| [Gurmukhi](#Gurmukhi) | Valor específico de plataforma Gurmukhi. |
+| [Hebrew](#Hebrew) | Valor específico de plataforma Hebreo. |
+| [Japanese](#Japanese) | Valor específico de plataforma Japonés. |
+| [Kannada](#Kannada) | Valor específico de plataforma Kannada. |
+| [Khmer](#Khmer) | Valor específico de plataforma Jemer. |
+| [Korean](#Korean) | Valor específico de plataforma Coreano. |
+| [Laotian](#Laotian) | Valor específico de plataforma Lao. |
+| [Malayalam](#Malayalam) | Valor específico de plataforma Malayalam. |
+| [Mongolian](#Mongolian) | Valor específico de plataforma Mongol. |
+| [Oriya](#Oriya) | Valor específico de plataforma Oriya. |
+| [RSymbol](#RSymbol) | Valor específico de plataforma RSymbol. |
+| [Roman](#Roman) | Valor específico de plataforma Romano. |
+| [Russian](#Russian) | Valor específico de plataforma Ruso. |
+| [Simplified_Chinese](#Simplified-Chinese) | Valor específico de plataforma Chino simplificado. |
+| [Sindhi](#Sindhi) | Valor específico de la plataforma Sindhi. |
+| [Sinhalese](#Sinhalese) | Valor específico de la plataforma Cingalés. |
+| [Slavic](#Slavic) | Valor específico de la plataforma eslava. |
+| [Tamil](#Tamil) | Valor específico de la plataforma Tamil. |
+| [Telugu](#Telugu) | Valor específico de la plataforma Telugu. |
+| [Thai](#Thai) | Valor específico de la plataforma tailandés. |
+| [Tibetan](#Tibetan) | Valor específico de la plataforma tibetano. |
+| [Traditional_Chinese](#Traditional-Chinese) | Valor específico de la plataforma chino tradicional. |
+| [Uninterpreted](#Uninterpreted) | Valor específico de la plataforma no interpretado. |
+| [Vietnamese](#Vietnamese) | Valor específico de la plataforma vietnamita. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Arabic {#Arabic}
+```
+public static final MacPlatformSpecificId Arabic
+```
+
+
+Valor específico de plataforma Árabe.
+
+### Armenian {#Armenian}
+```
+public static final MacPlatformSpecificId Armenian
+```
+
+
+Valor específico de plataforma Armenia.
+
+### Bengali {#Bengali}
+```
+public static final MacPlatformSpecificId Bengali
+```
+
+
+Valor específico de plataforma Bengalí.
+
+### Burmese {#Burmese}
+```
+public static final MacPlatformSpecificId Burmese
+```
+
+
+Valor específico de plataforma Birmano.
+
+### Devanagari {#Devanagari}
+```
+public static final MacPlatformSpecificId Devanagari
+```
+
+
+Valor específico de plataforma Devanagari.
+
+### Geez {#Geez}
+```
+public static final MacPlatformSpecificId Geez
+```
+
+
+Valor específico de plataforma Geez.
+
+### Georgian {#Georgian}
+```
+public static final MacPlatformSpecificId Georgian
+```
+
+
+Valor específico de plataforma Georgiano.
+
+### Greek {#Greek}
+```
+public static final MacPlatformSpecificId Greek
+```
+
+
+Valor específico de plataforma Griego.
+
+### Gujarati {#Gujarati}
+```
+public static final MacPlatformSpecificId Gujarati
+```
+
+
+Valor específico de plataforma Gujarati.
+
+### Gurmukhi {#Gurmukhi}
+```
+public static final MacPlatformSpecificId Gurmukhi
+```
+
+
+Valor específico de plataforma Gurmukhi.
+
+### Hebrew {#Hebrew}
+```
+public static final MacPlatformSpecificId Hebrew
+```
+
+
+Valor específico de plataforma Hebreo.
+
+### Japanese {#Japanese}
+```
+public static final MacPlatformSpecificId Japanese
+```
+
+
+Valor específico de plataforma Japonés.
+
+### Kannada {#Kannada}
+```
+public static final MacPlatformSpecificId Kannada
+```
+
+
+Valor específico de plataforma Kannada.
+
+### Khmer {#Khmer}
+```
+public static final MacPlatformSpecificId Khmer
+```
+
+
+Valor específico de plataforma Jemer.
+
+### Korean {#Korean}
+```
+public static final MacPlatformSpecificId Korean
+```
+
+
+Valor específico de plataforma Coreano.
+
+### Laotian {#Laotian}
+```
+public static final MacPlatformSpecificId Laotian
+```
+
+
+Valor específico de plataforma Lao.
+
+### Malayalam {#Malayalam}
+```
+public static final MacPlatformSpecificId Malayalam
+```
+
+
+Valor específico de plataforma Malayalam.
+
+### Mongolian {#Mongolian}
+```
+public static final MacPlatformSpecificId Mongolian
+```
+
+
+Valor específico de plataforma Mongol.
+
+### Oriya {#Oriya}
+```
+public static final MacPlatformSpecificId Oriya
+```
+
+
+Valor específico de plataforma Oriya.
+
+### RSymbol {#RSymbol}
+```
+public static final MacPlatformSpecificId RSymbol
+```
+
+
+Valor específico de plataforma RSymbol.
+
+### Roman {#Roman}
+```
+public static final MacPlatformSpecificId Roman
+```
+
+
+Valor específico de plataforma Romano.
+
+### Russian {#Russian}
+```
+public static final MacPlatformSpecificId Russian
+```
+
+
+Valor específico de plataforma Ruso.
+
+### Simplified_Chinese {#Simplified-Chinese}
+```
+public static final MacPlatformSpecificId Simplified_Chinese
+```
+
+
+Valor específico de plataforma Chino simplificado.
+
+### Sindhi {#Sindhi}
+```
+public static final MacPlatformSpecificId Sindhi
+```
+
+
+Valor específico de la plataforma Sindhi.
+
+### Sinhalese {#Sinhalese}
+```
+public static final MacPlatformSpecificId Sinhalese
+```
+
+
+Valor específico de la plataforma Cingalés.
+
+### Slavic {#Slavic}
+```
+public static final MacPlatformSpecificId Slavic
+```
+
+
+Valor específico de la plataforma eslava.
+
+### Tamil {#Tamil}
+```
+public static final MacPlatformSpecificId Tamil
+```
+
+
+Valor específico de la plataforma Tamil.
+
+### Telugu {#Telugu}
+```
+public static final MacPlatformSpecificId Telugu
+```
+
+
+Valor específico de la plataforma Telugu.
+
+### Thai {#Thai}
+```
+public static final MacPlatformSpecificId Thai
+```
+
+
+Valor específico de la plataforma tailandés.
+
+### Tibetan {#Tibetan}
+```
+public static final MacPlatformSpecificId Tibetan
+```
+
+
+Valor específico de la plataforma tibetano.
+
+### Traditional_Chinese {#Traditional-Chinese}
+```
+public static final MacPlatformSpecificId Traditional_Chinese
+```
+
+
+Valor específico de la plataforma chino tradicional.
+
+### Uninterpreted {#Uninterpreted}
+```
+public static final MacPlatformSpecificId Uninterpreted
+```
+
+
+Valor específico de la plataforma no interpretado.
+
+### Vietnamese {#Vietnamese}
+```
+public static final MacPlatformSpecificId Vietnamese
+```
+
+
+Valor específico de la plataforma vietnamita.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static MacPlatformSpecificId valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[MacPlatformSpecificId](../../com.aspose.font/macplatformspecificid)
+### values() {#values--}
+```
+public static MacPlatformSpecificId[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.MacPlatformSpecificId[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/metered/_index.md
+++ b/spanish/java/com.aspose.font/metered/_index.md
@@ -1,0 +1,185 @@
+---
+title: "Medido"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Proporciona métodos para establecer la clave medida."
+type: docs
+weight: 64
+url: /es/java/com.aspose.font/metered/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class Metered
+```
+
+Proporciona métodos para establecer la clave medida.
+
+--------------------
+
+En este ejemplo, se intentará establecer la clave pública y privada medida
+
+```
+The component jar file:
+  
+ 	Metered metered = new Metered();
+ 	matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Metered()](#Metered--) | Inicializa una nueva instancia de esta clase. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getConsumptionCredit()](#getConsumptionCredit--) | Obtiene el crédito de consumo |
+| [getConsumptionQuantity()](#getConsumptionQuantity--) | Obtiene el tamaño del archivo de consumo |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setMeteredKey(String publicKey, String privateKey)](#setMeteredKey-java.lang.String-java.lang.String-) | Establece la clave pública y privada medida |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Metered() {#Metered--}
+```
+public Metered()
+```
+
+
+Inicializa una nueva instancia de esta clase.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConsumptionCredit() {#getConsumptionCredit--}
+```
+public static double getConsumptionCredit()
+```
+
+
+Obtiene el crédito de consumo
+
+**Returns:**
+double - cantidad de consumo
+### getConsumptionQuantity() {#getConsumptionQuantity--}
+```
+public static double getConsumptionQuantity()
+```
+
+
+Obtiene el tamaño del archivo de consumo
+
+**Returns:**
+double - cantidad de consumo
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setMeteredKey(String publicKey, String privateKey) {#setMeteredKey-java.lang.String-java.lang.String-}
+```
+public void setMeteredKey(String publicKey, String privateKey)
+```
+
+
+Establece la clave pública y privada medida
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| publicKey | java.lang.String | clave pública |
+| privateKey | java.lang.String | clave privada |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/metriclist/_index.md
+++ b/spanish/java/com.aspose.font/metriclist/_index.md
@@ -1,0 +1,162 @@
+---
+title: "TtfHmtxTable.MetricList"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la lista de métricas"
+type: docs
+weight: 11
+url: /es/java/com.aspose.font/ttfhmtxtable.metriclist/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static class TtfHmtxTable.MetricList
+```
+
+Representa la lista de métricas
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int glyphIndex)](#get-int-) | Obtiene métricas por índice de glifo. |
+| [getClass()](#getClass--) |  |
+| [getRawList()](#getRawList--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [size()](#size--) | Obtiene el recuento de métricas. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int glyphIndex) {#get-int-}
+```
+public TtfHmtxTable.LongHorMetric get(int glyphIndex)
+```
+
+
+Obtiene métricas por índice de glifo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphIndex | int | Índice de glifo para obtener métricas. |
+
+**Returns:**
+[LongHorMetric](../../com.aspose.font/longhormetric) - Metrics record.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getRawList() {#getRawList--}
+```
+public System.Collections.Generic.List<TtfHmtxTable.LongHorMetric> getRawList()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List<com.aspose.font.TtfHmtxTable.LongHorMetric>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+Obtiene el recuento de métricas.
+
+**Returns:**
+int - Recuento de métricas.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/moveto/_index.md
+++ b/spanish/java/com.aspose.font/moveto/_index.md
@@ -1,0 +1,200 @@
+---
+title: "MoveTo"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la operación MoveTo."
+type: docs
+weight: 65
+url: /es/java/com.aspose.font/moveto/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IPathSegment](../../com.aspose.font/ipathsegment)
+```
+public class MoveTo implements IPathSegment
+```
+
+Representa la operación MoveTo.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clone()](#clone--) | Crea un nuevo objeto que es una copia de la instancia actual. |
+| [copy()](#copy--) | Crea una copia del objeto segmento. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getX()](#getX--) | Obtiene la coordenada x. |
+| [getY()](#getY--) | Obtiene la coordenada y. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [shift(double dx, double dy)](#shift-double-double-) | Realiza un desplazamiento por las coordenadas x e y. |
+| [toString()](#toString--) |  |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Transforma las coordenadas con la matriz de transformación. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Crea un nuevo objeto que es una copia de la instancia actual.
+
+**Returns:**
+java.lang.Object - Un nuevo objeto que es una copia de esta instancia.
+### copy() {#copy--}
+```
+public IPathSegment copy()
+```
+
+
+Crea una copia del objeto segmento.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getX() {#getX--}
+```
+public double getX()
+```
+
+
+Obtiene la coordenada x.
+
+**Returns:**
+double - Coordenada x.
+### getY() {#getY--}
+```
+public double getY()
+```
+
+
+Obtiene la coordenada y.
+
+**Returns:**
+double - Coordenada y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public void shift(double dx, double dy)
+```
+
+
+Realiza un desplazamiento por las coordenadas x e y.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| dx | double | Valor dx. |
+| dy | double | Valor dy. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public void transform(TransformationMatrix matrix)
+```
+
+
+Transforma las coordenadas con la matriz de transformación.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matriz de transformación. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/mslanguageid/_index.md
+++ b/spanish/java/com.aspose.font/mslanguageid/_index.md
@@ -1,0 +1,1984 @@
+---
+title: "MSLanguageId"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Enumeración de ID de idioma de la plataforma Microsoft."
+type: docs
+weight: 62
+url: /es/java/com.aspose.font/mslanguageid/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class MSLanguageId
+```
+
+Enumeración de ID de idioma de la plataforma Microsoft.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [Afrikaans](#Afrikaans) | Valor de LanguageId para Afrikaans (Región: Sudáfrica, SA) |
+| [Albanian](#Albanian) | Albanés (Región: Albania, SQI) valor de LanguageId |
+| [Alsatian](#Alsatian) | Alsaciano (Región: Francia) valor de LanguageId |
+| [Amharic](#Amharic) | Amhárico (Región: Etiopía) valor de LanguageId |
+| [Arabic_Algeria](#Arabic-Algeria) | Árabe (Región: Argelia) valor de LanguageId |
+| [Arabic_Bahrain](#Arabic-Bahrain) | Árabe (Región: Baréin) valor de LanguageId |
+| [Arabic_Egypt](#Arabic-Egypt) | Árabe (Región: Egipto) valor de LanguageId |
+| [Arabic_Iraq](#Arabic-Iraq) | Árabe (Región: Irak) valor de LanguageId |
+| [Arabic_Jordan](#Arabic-Jordan) | Árabe (Región: Jordania) valor de LanguageId |
+| [Arabic_Kuwait](#Arabic-Kuwait) | Árabe (Región: Kuwait) valor de LanguageId |
+| [Arabic_Lebanon](#Arabic-Lebanon) | Árabe (Región: Líbano) valor de LanguageId |
+| [Arabic_Libya](#Arabic-Libya) | Árabe (Región: Libia) valor de LanguageId |
+| [Arabic_Morocco](#Arabic-Morocco) | Árabe (Región: Marruecos) valor de LanguageId |
+| [Arabic_Oman](#Arabic-Oman) | Árabe (Región: Omán) valor de LanguageId |
+| [Arabic_Qatar](#Arabic-Qatar) | Árabe (Región: Catar) valor de LanguageId |
+| [Arabic_Saudi_Arabia](#Arabic-Saudi-Arabia) | Árabe (Región: Arabia Saudita) valor de LanguageId |
+| [Arabic_Syria](#Arabic-Syria) | Árabe (Región: Siria) valor de LanguageId |
+| [Arabic_Tunisia](#Arabic-Tunisia) | Árabe (Región: Túnez) valor de LanguageId |
+| [Arabic_U_A_E](#Arabic-U-A-E) | Árabe (Región: EAU) |
+| [Arabic_Yemen](#Arabic-Yemen) | Árabe (Región: Yemen) valor de LanguageId |
+| [Armenian](#Armenian) | Armenio (Región: Armenia) valor de LanguageId |
+| [Assamese](#Assamese) | Asamés (Región: India) valor de LanguageId |
+| [Azeri_Cyrillic](#Azeri-Cyrillic) | Azerí (Cirílico, Región: Azerbaiyán) valor de LanguageId |
+| [Azeri_Latin](#Azeri-Latin) | Azerí (Latín, Región: Azerbaiyán) valor de LanguageId |
+| [Bashkir](#Bashkir) | Bashkir (Región: Rusia) valor de LanguageId |
+| [Basque](#Basque) | Vasco (Región: País Vasco, EUQ) valor de LanguageId |
+| [Belarusian](#Belarusian) | Bielorruso (Región: Belarus, BEL) valor de LanguageId |
+| [Bengali_Bangladesh](#Bengali-Bangladesh) | Bengalí (Región: Bangladesh) valor de LanguageId |
+| [Bengali_India](#Bengali-India) | Bengalí (Región: India) valor de LanguageId |
+| [Bosnian_Cyrillic](#Bosnian-Cyrillic) | Bosnio (Cirílico, Región: Bosnia y Herzegovina) valor de LanguageId |
+| [Bosnian_Latin](#Bosnian-Latin) | Bosnio (Latín, Región: Bosnia y Herzegovina) valor de LanguageId |
+| [Breton](#Breton) | Bretón (Región: Francia) valor de LanguageId |
+| [Bulgarian](#Bulgarian) | Búlgaro (Región: Bulgaria, BGR) valor de LanguageId |
+| [Catalan](#Catalan) | Catalán (Región: Catalán, CAT) valor de LanguageId |
+| [Chinese_Hong_Kong](#Chinese-Hong-Kong) | Chino (Región: Hong Kong S.A.R.) |
+| [Chinese_Macao](#Chinese-Macao) | Chino (Región: Macao S.A.R.) |
+| [Chinese_PRC](#Chinese-PRC) | Chino (Región: República Popular de China) valor de LanguageId |
+| [Chinese_Singapore](#Chinese-Singapore) | Chino (Región: Singapur) valor de LanguageId |
+| [Chinese_Taiwan](#Chinese-Taiwan) | Chino (Región: Taiwán) valor de LanguageId |
+| [Corsican](#Corsican) | Córsico (Región: Francia) valor de LanguageId |
+| [Croatian](#Croatian) | Croata (Región: Croacia, SHL) valor de LanguageId |
+| [Croatian_Latin](#Croatian-Latin) | Croata (Latín, Región: Bosnia y Herzegovina) valor de LanguageId |
+| [Czech](#Czech) | Checo (Región: República Checa, CSY) valor de LanguageId |
+| [Danish](#Danish) | Danés (Región: Dinamarca, DAN) valor de LanguageId |
+| [Dari](#Dari) | Dari (Región: Afganistán) valor de LanguageId |
+| [Divehi](#Divehi) | Divehi (Región: Maldivas) valor de LanguageId |
+| [Dutch_Belgium](#Dutch-Belgium) | Holandés (Flamenco, Región: Bélgica, NLB) valor de LanguageId |
+| [Dutch_Netherlands](#Dutch-Netherlands) | Holandés (Estándar, Región: Países Bajos, NLD) valor de LanguageId |
+| [English_Australia](#English-Australia) | Inglés (Australiano, Región: Australia, ENA) valor de LanguageId |
+| [English_Belize](#English-Belize) | Inglés (Región: Belice) valor de LanguageId |
+| [English_Canada](#English-Canada) | Inglés (Canadiense, Región: Canadá, ENC) valor de LanguageId |
+| [English_Caribbean](#English-Caribbean) | Inglés (Región: Caribe) valor de LanguageId |
+| [English_India](#English-India) | Inglés (Región: India) valor de LanguageId |
+| [English_Ireland](#English-Ireland) | Inglés (Región: Irlanda, ENI) valor de LanguageId |
+| [English_Jamaica](#English-Jamaica) | Inglés (Región: Jamaica) valor de LanguageId |
+| [English_Malaysia](#English-Malaysia) | Inglés (Región: Malasia) valor de LanguageId |
+| [English_New_Zealand](#English-New-Zealand) | Inglés (Región: Nueva Zelanda, ENZ) valor de LanguageId |
+| [English_ROP](#English-ROP) | Inglés (Región: República de Filipinas, ROP) valor de LanguageId |
+| [English_Singapore](#English-Singapore) | Inglés (Región: Singapur) valor de LanguageId |
+| [English_South_Africa](#English-South-Africa) | Inglés (Región: Sudáfrica, SA) valor de LanguageId |
+| [English_TT](#English-TT) | Inglés (Región: Trinidad y Tobago, TT) valor de LanguageId |
+| [English_United_Kingdom](#English-United-Kingdom) | Inglés (Británico, Región: Reino Unido, ENG) valor de LanguageId |
+| [English_United_States](#English-United-States) | Inglés (Estadounidense, Región: Estados Unidos, ENU) valor de LanguageId |
+| [English_Zimbabwe](#English-Zimbabwe) | Inglés (Región: Zimbabue) valor de LanguageId |
+| [Estonian](#Estonian) | Estonio (Región: Estonia, ETI) valor de LanguageId |
+| [Faroese](#Faroese) | Feroés (Región: Islas Feroe) valor de LanguageId |
+| [Filipino](#Filipino) | Filipino (Región: Filipinas) valor de LanguageId |
+| [Finnish](#Finnish) | Finlandés (Región: Finlandia, FIN) valor de LanguageId |
+| [French_Belgium](#French-Belgium) | Francés (Belga, Región: Bélgica, FRB) valor de LanguageId |
+| [French_Canada](#French-Canada) | Francés (Canadiense, Región: Canadá, FRC) valor de LanguageId |
+| [French_France](#French-France) | Francés (Estándar, Región: Francia, FRA) valor de LanguageId |
+| [French_Luxembourg](#French-Luxembourg) | Francés (Región: Luxemburgo, FRL) valor de LanguageId |
+| [French_MC](#French-MC) | Francés (Región: Principado de Mónaco, MC) valor de LanguageId |
+| [French_Switzerland](#French-Switzerland) | Francés (Suizo, Región: Suiza, FRS) valor de LanguageId |
+| [Frisian](#Frisian) | Frisón (Región: Países Bajos, NLD) valor de LanguageId |
+| [Galician](#Galician) | Gallego (Región: Galicia) valor de LanguageId |
+| [Georgian](#Georgian) | Georgiano (Región: Georgia) LanguageId valor |
+| [German_Austria](#German-Austria) | Alemán (Austríaco, Región: Austria, DEA) LanguageId valor |
+| [German_Germany](#German-Germany) | Alemán (Estándar, Región: Alemania, DEU) LanguageId valor |
+| [German_Liechtenstein](#German-Liechtenstein) | Alemán (Región: Liechtenstein, DEC) LanguageId valor |
+| [German_Luxembourg](#German-Luxembourg) | Alemán (Región: Luxemburgo, DEL) LanguageId valor |
+| [German_Switzerland](#German-Switzerland) | Alemán (Suizo, Región: Suiza, DES) LanguageId valor |
+| [Greek](#Greek) | Griego (Región: Grecia, ELL) LanguageId valor |
+| [Greenlandic](#Greenlandic) | Groenlandés (Región: Groenlandia) LanguageId valor |
+| [Gujarati](#Gujarati) | Guyaratí (Región: India) LanguageId valor |
+| [Hausa](#Hausa) | Hausa (Latín, Región: Nigeria) LanguageId valor |
+| [Hebrew](#Hebrew) | Hebreo (Región: Israel) LanguageId valor |
+| [Hindi](#Hindi) | Hindi (Región: India) LanguageId valor |
+| [Hungarian](#Hungarian) | Húngaro (Región: Hungría, HUN) LanguageId valor |
+| [Icelandic](#Icelandic) | Islandés (Región: Islandia, ISL) LanguageId valor |
+| [Igbo](#Igbo) | Igbo (Región: Nigeria) LanguageId valor |
+| [Indonesian](#Indonesian) | Indonesio (Región: Indonesia) LanguageId valor |
+| [Inuktitut](#Inuktitut) | Inuktitut (Región: Canadá) LanguageId valor |
+| [Inuktitut_Latin](#Inuktitut-Latin) | Inuktitut (Latín, Región: Canadá) LanguageId valor |
+| [Irish](#Irish) | Irlandés (Región: Irlanda) LanguageId valor |
+| [Italian_Italy](#Italian-Italy) | Italiano (Estándar, Región: Italia, ITA) LanguageId valor |
+| [Italian_Switzerland](#Italian-Switzerland) | Italiano (Suizo, Región: Suiza, ITS) LanguageId valor |
+| [Japanese](#Japanese) | Japonés (Región: Japón) LanguageId valor |
+| [Kannada](#Kannada) | Canarés (Región: India) LanguageId valor |
+| [Kazakh](#Kazakh) | Kazajo (Región: Kazajistán) LanguageId valor |
+| [Khmer](#Khmer) | Jemer (Región: Camboya) LanguageId valor |
+| [Kiche](#Kiche) | K’iche (Región: Guatemala) valor LanguageId |
+| [Kinyarwanda](#Kinyarwanda) | Kinyarwanda (Región: Rwanda) valor LanguageId |
+| [Kiswahili](#Kiswahili) | Kiswahili (Región: Kenya) valor LanguageId |
+| [Konkani](#Konkani) | Konkani (Región: India) valor LanguageId |
+| [Korean](#Korean) | Korean (Región: Korea) valor LanguageId |
+| [Kyrgyz](#Kyrgyz) | Kyrgyz (Región: Kyrgyzstan) valor LanguageId |
+| [Lao](#Lao) | Lao (Región: Lao P.D.R.) |
+| [Latvian](#Latvian) | Latvian (Región: Latvia, LVI) valor LanguageId |
+| [Lithuanian](#Lithuanian) | Lithuanian (Región: Lithuania, LTH) valor LanguageId |
+| [Lower_Sorbian](#Lower-Sorbian) | Lower Sorbian (Región: Germany) valor LanguageId |
+| [Luxembourgish](#Luxembourgish) | Luxembourgish (Región: Luxembourg) valor LanguageId |
+| [Macedonian](#Macedonian) | Macedonian (Región: North Macedonia) valor LanguageId |
+| [Malay_Brunei_Darussalam](#Malay-Brunei-Darussalam) | Malay (Región: Brunei Darussalam) valor LanguageId |
+| [Malay_Malaysia](#Malay-Malaysia) | Malay (Región: Malaysia) valor LanguageId |
+| [Malayalam](#Malayalam) | Malayalam (Región: India) valor LanguageId |
+| [Maltese](#Maltese) | Maltese (Región: Malta) valor LanguageId |
+| [Maori](#Maori) | Maori (Región: New Zealand) valor LanguageId |
+| [Mapudungun](#Mapudungun) | Mapudungun (Región: Chile) valor LanguageId |
+| [Marathi](#Marathi) | Marathi (Región: India) valor LanguageId |
+| [Mohawk](#Mohawk) | Mohawk (Región: Mohawk) valor LanguageId |
+| [Mongolian_Cyrillic](#Mongolian-Cyrillic) | Mongolian (Cirílico, Región: Mongolia) valor LanguageId |
+| [Mongolian_Traditional](#Mongolian-Traditional) | Mongolian (Tradicional, Región: República Popular de China) valor LanguageId |
+| [Nepali](#Nepali) | Nepali (Región: Nepal) valor LanguageId |
+| [Norwegian_Bokmal](#Norwegian-Bokmal) | Norwegian (Bokmål, Región: Norway, NOR) valor LanguageId |
+| [Norwegian_Nynorsk](#Norwegian-Nynorsk) | Norwegian (Nynorsk, Región: Norway, NON) valor LanguageId |
+| [Occitan](#Occitan) | Occitano (Región: Francia) LanguageId valor |
+| [Odia](#Odia) | Odia (anteriormente Oriya, Región: India) LanguageId valor |
+| [Pashto](#Pashto) | Pastún (Región: Afganistán) LanguageId valor |
+| [Polish](#Polish) | Polaco (Región: Polonia, PLK) LanguageId valor |
+| [Portuguese_Brazil](#Portuguese-Brazil) | Portugués (brasileño, Región: Brasil, PTB) LanguageId valor |
+| [Portuguese_Portugal](#Portuguese-Portugal) | Portugués (estándar, Región: Portugal, PTG) LanguageId valor |
+| [Punjabi](#Punjabi) | Panyabí (Región: India) LanguageId valor |
+| [Quechua_Bolivia](#Quechua-Bolivia) | Quechua (Región: Bolivia) LanguageId valor |
+| [Quechua_Ecuador](#Quechua-Ecuador) | Quechua (Región: Ecuador) LanguageId valor |
+| [Quechua_Peru](#Quechua-Peru) | Quechua (Región: Perú) LanguageId valor |
+| [Romanian](#Romanian) | Rumano (Región: Rumania, ROM) LanguageId valor |
+| [Romansh](#Romansh) | Romanche (Región: Suiza) LanguageId valor |
+| [Russian](#Russian) | Ruso (Región: Rusia, RUS) LanguageId valor |
+| [Sami_Inari](#Sami-Inari) | Sami (Inari, Región: Finlandia) LanguageId valor |
+| [Sami_Lule_Norway](#Sami-Lule-Norway) | Sami (Lule, Región: Noruega) LanguageId valor |
+| [Sami_Lule_Sweden](#Sami-Lule-Sweden) | Sami (Lule, Región: Suecia) LanguageId valor |
+| [Sami_Northern_Finland](#Sami-Northern-Finland) | Sami (del Norte, Región: Finlandia) LanguageId valor |
+| [Sami_Northern_Norway](#Sami-Northern-Norway) | Sami (del Norte, Región: Noruega) LanguageId valor |
+| [Sami_Northern_Sweden](#Sami-Northern-Sweden) | Sami (del Norte, Región: Suecia) LanguageId valor |
+| [Sami_Skolt](#Sami-Skolt) | Sami (Skolt, Región: Finlandia) LanguageId valor |
+| [Sami_Southern_Norway](#Sami-Southern-Norway) | Sami (del Sur, Región: Noruega) LanguageId valor |
+| [Sami_Southern_Sweden](#Sami-Southern-Sweden) | Sami (del Sur, Región: Suecia) LanguageId valor |
+| [Sanskrit](#Sanskrit) | Sánscrito (Región: India) LanguageId valor |
+| [Serbian_Cyrillic_BIH](#Serbian-Cyrillic-BIH) | Serbio (Cirílico, Región: Bosnia y Herzegovina) LanguageId valor |
+| [Serbian_Cyrillic_Serbia](#Serbian-Cyrillic-Serbia) | Serbio (Cirílico, Región: Serbia) LanguageId valor |
+| [Serbian_Latin_BIH](#Serbian-Latin-BIH) | Serbio (Latín, Región: Bosnia y Herzegovina) valor de LanguageId |
+| [Serbian_Latin_Serbia](#Serbian-Latin-Serbia) | Serbio (Latín, Región: Serbia) valor de LanguageId |
+| [Sesotho_Sa_Leboa](#Sesotho-Sa-Leboa) | Sesotho sa Leboa (Sotho del Norte, Región: Sudáfrica, SA) valor de LanguageId |
+| [Setswana](#Setswana) | Setswana (Región: Sudáfrica, SA) valor de LanguageId |
+| [Sinhala](#Sinhala) | Cingalés (Región: Sri Lanka) valor de LanguageId |
+| [Slovak](#Slovak) | Eslovaco (Región: Eslovaquia, SKY) valor de LanguageId |
+| [Slovenian](#Slovenian) | Esloveno (Región: Eslovenia, SLV) valor de LanguageId |
+| [Spanish_Argentina](#Spanish-Argentina) | Español (Región: Argentina) valor de LanguageId |
+| [Spanish_Bolivia](#Spanish-Bolivia) | Español (Región: Bolivia) valor de LanguageId |
+| [Spanish_Chile](#Spanish-Chile) | Español (Región: Chile) valor de LanguageId |
+| [Spanish_Colombia](#Spanish-Colombia) | Español (Región: Colombia) valor de LanguageId |
+| [Spanish_Costa_Rica](#Spanish-Costa-Rica) | Español (Región: Costa Rica) valor de LanguageId |
+| [Spanish_Dominican_Republic](#Spanish-Dominican-Republic) | Español (Región: República Dominicana) valor de LanguageId |
+| [Spanish_Ecuador](#Spanish-Ecuador) | Español (Región: Ecuador) valor de LanguageId |
+| [Spanish_El_Salvador](#Spanish-El-Salvador) | Español (Región: El Salvador) valor de LanguageId |
+| [Spanish_Guatemala](#Spanish-Guatemala) | Español (Región: Guatemala) valor de LanguageId |
+| [Spanish_Honduras](#Spanish-Honduras) | Español (Región: Honduras) valor de LanguageId |
+| [Spanish_Mexico](#Spanish-Mexico) | Español (Mexicano, Región: México, ESM) valor de LanguageId |
+| [Spanish_Modern_Sort](#Spanish-Modern-Sort) | Español (Orden Moderno, Región: España, ESN) valor de LanguageId |
+| [Spanish_Nicaragua](#Spanish-Nicaragua) | Español (Región: Nicaragua) valor de LanguageId |
+| [Spanish_Panama](#Spanish-Panama) | Español (Región: Panamá) valor de LanguageId |
+| [Spanish_Paraguay](#Spanish-Paraguay) | Español (Región: Paraguay) valor de LanguageId |
+| [Spanish_Peru](#Spanish-Peru) | Español (Región: Perú) valor de LanguageId |
+| [Spanish_Puerto_Rico](#Spanish-Puerto-Rico) | Español (Región: Puerto Rico) valor de LanguageId |
+| [Spanish_Traditional_Sort](#Spanish-Traditional-Sort) | Español (Orden Tradicional, Región: España, ESP) valor de LanguageId |
+| [Spanish_United_States](#Spanish-United-States) | Español (Región: Estados Unidos) valor de LanguageId |
+| [Spanish_Uruguay](#Spanish-Uruguay) | Español (Región: Uruguay) valor de LanguageId |
+| [Spanish_Venezuela](#Spanish-Venezuela) | Español (Región: Venezuela) valor de LanguageId |
+| [Swedish_Finland](#Swedish-Finland) | Sueco (Región: Finlandia) valor de LanguageId |
+| [Swedish_Sweden](#Swedish-Sweden) | Sueco (Región: Suecia, SVE) valor de LanguageId |
+| [Syriac](#Syriac) | Siríaco (Región: Siria) valor de LanguageId |
+| [Tajik](#Tajik) | Tayiko (Cyrillic, Región: Tayikistán) valor de LanguageId |
+| [Tamazight](#Tamazight) | Tamazight (Latin, Región: Argelia) valor de LanguageId |
+| [Tamil](#Tamil) | Tamil (Región: India) valor de LanguageId |
+| [Tatar](#Tatar) | Tártaro (Región: Rusia) valor de LanguageId |
+| [Telugu](#Telugu) | Telugú (Región: India) valor de LanguageId |
+| [Thai](#Thai) | Tailandés (Región: Tailandia) valor de LanguageId |
+| [Tibetan](#Tibetan) | Tibetano (Región: PRC) valor de LanguageId |
+| [Turkish](#Turkish) | Turco (Región: Turquía, TRK) valor de LanguageId |
+| [Turkmen](#Turkmen) | Turcomano (Región: Turkmenistán) valor de LanguageId |
+| [Uighur](#Uighur) | Uigur (Región: PRC) valor de LanguageId |
+| [Ukrainian](#Ukrainian) | Ucraniano (Región: Ucrania, UKR) valor de LanguageId |
+| [Upper_Sorbian](#Upper-Sorbian) | Alto sorabo (Región: Alemania) valor de LanguageId |
+| [Urdu](#Urdu) | Urdu (Región: República Islámica de Pakistán) valor de LanguageId |
+| [Uzbek_Cyrillic](#Uzbek-Cyrillic) | Uzbeko (Cyrillic, Región: Uzbekistán) valor de LanguageId |
+| [Uzbek_Latin](#Uzbek-Latin) | Uzbeko (Latin, Región: Uzbekistán) valor de LanguageId |
+| [Vietnamese](#Vietnamese) | Vietnamita (Región: Vietnam) valor de LanguageId |
+| [Welsh](#Welsh) | Galés (Región: Reino Unido) valor de LanguageId |
+| [Wolof](#Wolof) | Wolof (Región: Senegal) valor de LanguageId |
+| [Yakut](#Yakut) | Yakut (Región: Rusia) valor de LanguageId |
+| [Yi](#Yi) | Yi (Región: PRC) valor de LanguageId |
+| [Yoruba](#Yoruba) | Yoruba (Región: Nigeria) valor de LanguageId |
+| [isiXhosa](#isiXhosa) | isiXhosa (Región: Sudáfrica, SA) valor de LanguageId |
+| [isiZulu](#isiZulu) | isiZulu (Región: Sudáfrica, SA) valor de LanguageId |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getId()](#getId--) | Obtenga el valor entero. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Afrikaans {#Afrikaans}
+```
+public static final MSLanguageId Afrikaans
+```
+
+
+Valor de LanguageId para Afrikaans (Región: Sudáfrica, SA)
+
+### Albanian {#Albanian}
+```
+public static final MSLanguageId Albanian
+```
+
+
+Albanés (Región: Albania, SQI) valor de LanguageId
+
+### Alsatian {#Alsatian}
+```
+public static final MSLanguageId Alsatian
+```
+
+
+Alsaciano (Región: Francia) valor de LanguageId
+
+### Amharic {#Amharic}
+```
+public static final MSLanguageId Amharic
+```
+
+
+Amhárico (Región: Etiopía) valor de LanguageId
+
+### Arabic_Algeria {#Arabic-Algeria}
+```
+public static final MSLanguageId Arabic_Algeria
+```
+
+
+Árabe (Región: Argelia) valor de LanguageId
+
+### Arabic_Bahrain {#Arabic-Bahrain}
+```
+public static final MSLanguageId Arabic_Bahrain
+```
+
+
+Árabe (Región: Baréin) valor de LanguageId
+
+### Arabic_Egypt {#Arabic-Egypt}
+```
+public static final MSLanguageId Arabic_Egypt
+```
+
+
+Árabe (Región: Egipto) valor de LanguageId
+
+### Arabic_Iraq {#Arabic-Iraq}
+```
+public static final MSLanguageId Arabic_Iraq
+```
+
+
+Árabe (Región: Irak) valor de LanguageId
+
+### Arabic_Jordan {#Arabic-Jordan}
+```
+public static final MSLanguageId Arabic_Jordan
+```
+
+
+Árabe (Región: Jordania) valor de LanguageId
+
+### Arabic_Kuwait {#Arabic-Kuwait}
+```
+public static final MSLanguageId Arabic_Kuwait
+```
+
+
+Árabe (Región: Kuwait) valor de LanguageId
+
+### Arabic_Lebanon {#Arabic-Lebanon}
+```
+public static final MSLanguageId Arabic_Lebanon
+```
+
+
+Árabe (Región: Líbano) valor de LanguageId
+
+### Arabic_Libya {#Arabic-Libya}
+```
+public static final MSLanguageId Arabic_Libya
+```
+
+
+Árabe (Región: Libia) valor de LanguageId
+
+### Arabic_Morocco {#Arabic-Morocco}
+```
+public static final MSLanguageId Arabic_Morocco
+```
+
+
+Árabe (Región: Marruecos) valor de LanguageId
+
+### Arabic_Oman {#Arabic-Oman}
+```
+public static final MSLanguageId Arabic_Oman
+```
+
+
+Árabe (Región: Omán) valor de LanguageId
+
+### Arabic_Qatar {#Arabic-Qatar}
+```
+public static final MSLanguageId Arabic_Qatar
+```
+
+
+Árabe (Región: Catar) valor de LanguageId
+
+### Arabic_Saudi_Arabia {#Arabic-Saudi-Arabia}
+```
+public static final MSLanguageId Arabic_Saudi_Arabia
+```
+
+
+Árabe (Región: Arabia Saudita) valor de LanguageId
+
+### Arabic_Syria {#Arabic-Syria}
+```
+public static final MSLanguageId Arabic_Syria
+```
+
+
+Árabe (Región: Siria) valor de LanguageId
+
+### Arabic_Tunisia {#Arabic-Tunisia}
+```
+public static final MSLanguageId Arabic_Tunisia
+```
+
+
+Árabe (Región: Túnez) valor de LanguageId
+
+### Arabic_U_A_E {#Arabic-U-A-E}
+```
+public static final MSLanguageId Arabic_U_A_E
+```
+
+
+Árabe (Región: U.A.E.) valor de LanguageId
+
+### Arabic_Yemen {#Arabic-Yemen}
+```
+public static final MSLanguageId Arabic_Yemen
+```
+
+
+Árabe (Región: Yemen) valor de LanguageId
+
+### Armenian {#Armenian}
+```
+public static final MSLanguageId Armenian
+```
+
+
+Armenio (Región: Armenia) valor de LanguageId
+
+### Assamese {#Assamese}
+```
+public static final MSLanguageId Assamese
+```
+
+
+Asamés (Región: India) valor de LanguageId
+
+### Azeri_Cyrillic {#Azeri-Cyrillic}
+```
+public static final MSLanguageId Azeri_Cyrillic
+```
+
+
+Azerí (Cirílico, Región: Azerbaiyán) valor de LanguageId
+
+### Azeri_Latin {#Azeri-Latin}
+```
+public static final MSLanguageId Azeri_Latin
+```
+
+
+Azerí (Latín, Región: Azerbaiyán) valor de LanguageId
+
+### Bashkir {#Bashkir}
+```
+public static final MSLanguageId Bashkir
+```
+
+
+Bashkir (Región: Rusia) valor de LanguageId
+
+### Basque {#Basque}
+```
+public static final MSLanguageId Basque
+```
+
+
+Vasco (Región: País Vasco, EUQ) valor de LanguageId
+
+### Belarusian {#Belarusian}
+```
+public static final MSLanguageId Belarusian
+```
+
+
+Bielorruso (Región: Belarus, BEL) valor de LanguageId
+
+### Bengali_Bangladesh {#Bengali-Bangladesh}
+```
+public static final MSLanguageId Bengali_Bangladesh
+```
+
+
+Bengalí (Región: Bangladesh) valor de LanguageId
+
+### Bengali_India {#Bengali-India}
+```
+public static final MSLanguageId Bengali_India
+```
+
+
+Bengalí (Región: India) valor de LanguageId
+
+### Bosnian_Cyrillic {#Bosnian-Cyrillic}
+```
+public static final MSLanguageId Bosnian_Cyrillic
+```
+
+
+Bosnio (Cirílico, Región: Bosnia y Herzegovina) valor de LanguageId
+
+### Bosnian_Latin {#Bosnian-Latin}
+```
+public static final MSLanguageId Bosnian_Latin
+```
+
+
+Bosnio (Latín, Región: Bosnia y Herzegovina) valor de LanguageId
+
+### Breton {#Breton}
+```
+public static final MSLanguageId Breton
+```
+
+
+Bretón (Región: Francia) valor de LanguageId
+
+### Bulgarian {#Bulgarian}
+```
+public static final MSLanguageId Bulgarian
+```
+
+
+Búlgaro (Región: Bulgaria, BGR) valor de LanguageId
+
+### Catalan {#Catalan}
+```
+public static final MSLanguageId Catalan
+```
+
+
+Catalán (Región: Catalán, CAT) valor de LanguageId
+
+### Chinese_Hong_Kong {#Chinese-Hong-Kong}
+```
+public static final MSLanguageId Chinese_Hong_Kong
+```
+
+
+Chino (Región: Hong Kong S.A.R.) valor de LanguageId
+
+### Chinese_Macao {#Chinese-Macao}
+```
+public static final MSLanguageId Chinese_Macao
+```
+
+
+Chino (Región: Macao S.A.R.) valor de LanguageId
+
+### Chinese_PRC {#Chinese-PRC}
+```
+public static final MSLanguageId Chinese_PRC
+```
+
+
+Chino (Región: República Popular de China) valor de LanguageId
+
+### Chinese_Singapore {#Chinese-Singapore}
+```
+public static final MSLanguageId Chinese_Singapore
+```
+
+
+Chino (Región: Singapur) valor de LanguageId
+
+### Chinese_Taiwan {#Chinese-Taiwan}
+```
+public static final MSLanguageId Chinese_Taiwan
+```
+
+
+Chino (Región: Taiwán) valor de LanguageId
+
+### Corsican {#Corsican}
+```
+public static final MSLanguageId Corsican
+```
+
+
+Córsico (Región: Francia) valor de LanguageId
+
+### Croatian {#Croatian}
+```
+public static final MSLanguageId Croatian
+```
+
+
+Croata (Región: Croacia, SHL) valor de LanguageId
+
+### Croatian_Latin {#Croatian-Latin}
+```
+public static final MSLanguageId Croatian_Latin
+```
+
+
+Croata (Latín, Región: Bosnia y Herzegovina) valor de LanguageId
+
+### Czech {#Czech}
+```
+public static final MSLanguageId Czech
+```
+
+
+Checo (Región: República Checa, CSY) valor de LanguageId
+
+### Danish {#Danish}
+```
+public static final MSLanguageId Danish
+```
+
+
+Danés (Región: Dinamarca, DAN) valor de LanguageId
+
+### Dari {#Dari}
+```
+public static final MSLanguageId Dari
+```
+
+
+Dari (Región: Afganistán) valor de LanguageId
+
+### Divehi {#Divehi}
+```
+public static final MSLanguageId Divehi
+```
+
+
+Divehi (Región: Maldivas) valor de LanguageId
+
+### Dutch_Belgium {#Dutch-Belgium}
+```
+public static final MSLanguageId Dutch_Belgium
+```
+
+
+Holandés (Flamenco, Región: Bélgica, NLB) valor de LanguageId
+
+### Dutch_Netherlands {#Dutch-Netherlands}
+```
+public static final MSLanguageId Dutch_Netherlands
+```
+
+
+Holandés (Estándar, Región: Países Bajos, NLD) valor de LanguageId
+
+### English_Australia {#English-Australia}
+```
+public static final MSLanguageId English_Australia
+```
+
+
+Inglés (Australiano, Región: Australia, ENA) valor de LanguageId
+
+### English_Belize {#English-Belize}
+```
+public static final MSLanguageId English_Belize
+```
+
+
+Inglés (Región: Belice) valor de LanguageId
+
+### English_Canada {#English-Canada}
+```
+public static final MSLanguageId English_Canada
+```
+
+
+Inglés (Canadiense, Región: Canadá, ENC) valor de LanguageId
+
+### English_Caribbean {#English-Caribbean}
+```
+public static final MSLanguageId English_Caribbean
+```
+
+
+Inglés (Región: Caribe) valor de LanguageId
+
+### English_India {#English-India}
+```
+public static final MSLanguageId English_India
+```
+
+
+Inglés (Región: India) valor de LanguageId
+
+### English_Ireland {#English-Ireland}
+```
+public static final MSLanguageId English_Ireland
+```
+
+
+Inglés (Región: Irlanda, ENI) valor de LanguageId
+
+### English_Jamaica {#English-Jamaica}
+```
+public static final MSLanguageId English_Jamaica
+```
+
+
+Inglés (Región: Jamaica) valor de LanguageId
+
+### English_Malaysia {#English-Malaysia}
+```
+public static final MSLanguageId English_Malaysia
+```
+
+
+Inglés (Región: Malasia) valor de LanguageId
+
+### English_New_Zealand {#English-New-Zealand}
+```
+public static final MSLanguageId English_New_Zealand
+```
+
+
+Inglés (Región: Nueva Zelanda, ENZ) valor de LanguageId
+
+### English_ROP {#English-ROP}
+```
+public static final MSLanguageId English_ROP
+```
+
+
+Inglés (Región: República de Filipinas, ROP) valor de LanguageId
+
+### English_Singapore {#English-Singapore}
+```
+public static final MSLanguageId English_Singapore
+```
+
+
+Inglés (Región: Singapur) valor de LanguageId
+
+### English_South_Africa {#English-South-Africa}
+```
+public static final MSLanguageId English_South_Africa
+```
+
+
+Inglés (Región: Sudáfrica, SA) valor de LanguageId
+
+### English_TT {#English-TT}
+```
+public static final MSLanguageId English_TT
+```
+
+
+Inglés (Región: Trinidad y Tobago, TT) valor de LanguageId
+
+### English_United_Kingdom {#English-United-Kingdom}
+```
+public static final MSLanguageId English_United_Kingdom
+```
+
+
+Inglés (Británico, Región: Reino Unido, ENG) valor de LanguageId
+
+### English_United_States {#English-United-States}
+```
+public static final MSLanguageId English_United_States
+```
+
+
+Inglés (Estadounidense, Región: Estados Unidos, ENU) valor de LanguageId
+
+### English_Zimbabwe {#English-Zimbabwe}
+```
+public static final MSLanguageId English_Zimbabwe
+```
+
+
+Inglés (Región: Zimbabue) valor de LanguageId
+
+### Estonian {#Estonian}
+```
+public static final MSLanguageId Estonian
+```
+
+
+Estonio (Región: Estonia, ETI) valor de LanguageId
+
+### Faroese {#Faroese}
+```
+public static final MSLanguageId Faroese
+```
+
+
+Feroés (Región: Islas Feroe) valor de LanguageId
+
+### Filipino {#Filipino}
+```
+public static final MSLanguageId Filipino
+```
+
+
+Filipino (Región: Filipinas) valor de LanguageId
+
+### Finnish {#Finnish}
+```
+public static final MSLanguageId Finnish
+```
+
+
+Finlandés (Región: Finlandia, FIN) valor de LanguageId
+
+### French_Belgium {#French-Belgium}
+```
+public static final MSLanguageId French_Belgium
+```
+
+
+Francés (Belga, Región: Bélgica, FRB) valor de LanguageId
+
+### French_Canada {#French-Canada}
+```
+public static final MSLanguageId French_Canada
+```
+
+
+Francés (Canadiense, Región: Canadá, FRC) valor de LanguageId
+
+### French_France {#French-France}
+```
+public static final MSLanguageId French_France
+```
+
+
+Francés (Estándar, Región: Francia, FRA) valor de LanguageId
+
+### French_Luxembourg {#French-Luxembourg}
+```
+public static final MSLanguageId French_Luxembourg
+```
+
+
+Francés (Región: Luxemburgo, FRL) valor de LanguageId
+
+### French_MC {#French-MC}
+```
+public static final MSLanguageId French_MC
+```
+
+
+Francés (Región: Principado de Mónaco, MC) valor de LanguageId
+
+### French_Switzerland {#French-Switzerland}
+```
+public static final MSLanguageId French_Switzerland
+```
+
+
+Francés (Suizo, Región: Suiza, FRS) valor de LanguageId
+
+### Frisian {#Frisian}
+```
+public static final MSLanguageId Frisian
+```
+
+
+Frisón (Región: Países Bajos, NLD) valor de LanguageId
+
+### Galician {#Galician}
+```
+public static final MSLanguageId Galician
+```
+
+
+Gallego (Región: Galicia) valor de LanguageId
+
+### Georgian {#Georgian}
+```
+public static final MSLanguageId Georgian
+```
+
+
+Georgiano (Región: Georgia) LanguageId valor
+
+### German_Austria {#German-Austria}
+```
+public static final MSLanguageId German_Austria
+```
+
+
+Alemán (Austríaco, Región: Austria, DEA) LanguageId valor
+
+### German_Germany {#German-Germany}
+```
+public static final MSLanguageId German_Germany
+```
+
+
+Alemán (Estándar, Región: Alemania, DEU) LanguageId valor
+
+### German_Liechtenstein {#German-Liechtenstein}
+```
+public static final MSLanguageId German_Liechtenstein
+```
+
+
+Alemán (Región: Liechtenstein, DEC) LanguageId valor
+
+### German_Luxembourg {#German-Luxembourg}
+```
+public static final MSLanguageId German_Luxembourg
+```
+
+
+Alemán (Región: Luxemburgo, DEL) LanguageId valor
+
+### German_Switzerland {#German-Switzerland}
+```
+public static final MSLanguageId German_Switzerland
+```
+
+
+Alemán (Suizo, Región: Suiza, DES) LanguageId valor
+
+### Greek {#Greek}
+```
+public static final MSLanguageId Greek
+```
+
+
+Griego (Región: Grecia, ELL) LanguageId valor
+
+### Greenlandic {#Greenlandic}
+```
+public static final MSLanguageId Greenlandic
+```
+
+
+Groenlandés (Región: Groenlandia) LanguageId valor
+
+### Gujarati {#Gujarati}
+```
+public static final MSLanguageId Gujarati
+```
+
+
+Guyaratí (Región: India) LanguageId valor
+
+### Hausa {#Hausa}
+```
+public static final MSLanguageId Hausa
+```
+
+
+Hausa (Latín, Región: Nigeria) LanguageId valor
+
+### Hebrew {#Hebrew}
+```
+public static final MSLanguageId Hebrew
+```
+
+
+Hebreo (Región: Israel) LanguageId valor
+
+### Hindi {#Hindi}
+```
+public static final MSLanguageId Hindi
+```
+
+
+Hindi (Región: India) LanguageId valor
+
+### Hungarian {#Hungarian}
+```
+public static final MSLanguageId Hungarian
+```
+
+
+Húngaro (Región: Hungría, HUN) LanguageId valor
+
+### Icelandic {#Icelandic}
+```
+public static final MSLanguageId Icelandic
+```
+
+
+Islandés (Región: Islandia, ISL) LanguageId valor
+
+### Igbo {#Igbo}
+```
+public static final MSLanguageId Igbo
+```
+
+
+Igbo (Región: Nigeria) LanguageId valor
+
+### Indonesian {#Indonesian}
+```
+public static final MSLanguageId Indonesian
+```
+
+
+Indonesio (Región: Indonesia) LanguageId valor
+
+### Inuktitut {#Inuktitut}
+```
+public static final MSLanguageId Inuktitut
+```
+
+
+Inuktitut (Región: Canadá) LanguageId valor
+
+### Inuktitut_Latin {#Inuktitut-Latin}
+```
+public static final MSLanguageId Inuktitut_Latin
+```
+
+
+Inuktitut (Latín, Región: Canadá) LanguageId valor
+
+### Irish {#Irish}
+```
+public static final MSLanguageId Irish
+```
+
+
+Irlandés (Región: Irlanda) LanguageId valor
+
+### Italian_Italy {#Italian-Italy}
+```
+public static final MSLanguageId Italian_Italy
+```
+
+
+Italiano (Estándar, Región: Italia, ITA) LanguageId valor
+
+### Italian_Switzerland {#Italian-Switzerland}
+```
+public static final MSLanguageId Italian_Switzerland
+```
+
+
+Italiano (Suizo, Región: Suiza, ITS) LanguageId valor
+
+### Japanese {#Japanese}
+```
+public static final MSLanguageId Japanese
+```
+
+
+Japonés (Región: Japón) LanguageId valor
+
+### Kannada {#Kannada}
+```
+public static final MSLanguageId Kannada
+```
+
+
+Canarés (Región: India) LanguageId valor
+
+### Kazakh {#Kazakh}
+```
+public static final MSLanguageId Kazakh
+```
+
+
+Kazajo (Región: Kazajistán) LanguageId valor
+
+### Khmer {#Khmer}
+```
+public static final MSLanguageId Khmer
+```
+
+
+Jemer (Región: Camboya) LanguageId valor
+
+### Kiche {#Kiche}
+```
+public static final MSLanguageId Kiche
+```
+
+
+K’iche (Región: Guatemala) valor LanguageId
+
+### Kinyarwanda {#Kinyarwanda}
+```
+public static final MSLanguageId Kinyarwanda
+```
+
+
+Kinyarwanda (Región: Rwanda) valor LanguageId
+
+### Kiswahili {#Kiswahili}
+```
+public static final MSLanguageId Kiswahili
+```
+
+
+Kiswahili (Región: Kenya) valor LanguageId
+
+### Konkani {#Konkani}
+```
+public static final MSLanguageId Konkani
+```
+
+
+Konkani (Región: India) valor LanguageId
+
+### Korean {#Korean}
+```
+public static final MSLanguageId Korean
+```
+
+
+Korean (Región: Korea) valor LanguageId
+
+### Kyrgyz {#Kyrgyz}
+```
+public static final MSLanguageId Kyrgyz
+```
+
+
+Kyrgyz (Región: Kyrgyzstan) valor LanguageId
+
+### Lao {#Lao}
+```
+public static final MSLanguageId Lao
+```
+
+
+Lao (Región: Lao P.D.R.) valor de LanguageId
+
+### Latvian {#Latvian}
+```
+public static final MSLanguageId Latvian
+```
+
+
+Latvian (Región: Latvia, LVI) valor LanguageId
+
+### Lithuanian {#Lithuanian}
+```
+public static final MSLanguageId Lithuanian
+```
+
+
+Lithuanian (Región: Lithuania, LTH) valor LanguageId
+
+### Lower_Sorbian {#Lower-Sorbian}
+```
+public static final MSLanguageId Lower_Sorbian
+```
+
+
+Lower Sorbian (Región: Germany) valor LanguageId
+
+### Luxembourgish {#Luxembourgish}
+```
+public static final MSLanguageId Luxembourgish
+```
+
+
+Luxembourgish (Región: Luxembourg) valor LanguageId
+
+### Macedonian {#Macedonian}
+```
+public static final MSLanguageId Macedonian
+```
+
+
+Macedonian (Región: North Macedonia) valor LanguageId
+
+### Malay_Brunei_Darussalam {#Malay-Brunei-Darussalam}
+```
+public static final MSLanguageId Malay_Brunei_Darussalam
+```
+
+
+Malay (Región: Brunei Darussalam) valor LanguageId
+
+### Malay_Malaysia {#Malay-Malaysia}
+```
+public static final MSLanguageId Malay_Malaysia
+```
+
+
+Malay (Región: Malaysia) valor LanguageId
+
+### Malayalam {#Malayalam}
+```
+public static final MSLanguageId Malayalam
+```
+
+
+Malayalam (Región: India) valor LanguageId
+
+### Maltese {#Maltese}
+```
+public static final MSLanguageId Maltese
+```
+
+
+Maltese (Región: Malta) valor LanguageId
+
+### Maori {#Maori}
+```
+public static final MSLanguageId Maori
+```
+
+
+Maori (Región: New Zealand) valor LanguageId
+
+### Mapudungun {#Mapudungun}
+```
+public static final MSLanguageId Mapudungun
+```
+
+
+Mapudungun (Región: Chile) valor LanguageId
+
+### Marathi {#Marathi}
+```
+public static final MSLanguageId Marathi
+```
+
+
+Marathi (Región: India) valor LanguageId
+
+### Mohawk {#Mohawk}
+```
+public static final MSLanguageId Mohawk
+```
+
+
+Mohawk (Región: Mohawk) valor LanguageId
+
+### Mongolian_Cyrillic {#Mongolian-Cyrillic}
+```
+public static final MSLanguageId Mongolian_Cyrillic
+```
+
+
+Mongolian (Cirílico, Región: Mongolia) valor LanguageId
+
+### Mongolian_Traditional {#Mongolian-Traditional}
+```
+public static final MSLanguageId Mongolian_Traditional
+```
+
+
+Mongolian (Tradicional, Región: República Popular de China) valor LanguageId
+
+### Nepali {#Nepali}
+```
+public static final MSLanguageId Nepali
+```
+
+
+Nepali (Región: Nepal) valor LanguageId
+
+### Norwegian_Bokmal {#Norwegian-Bokmal}
+```
+public static final MSLanguageId Norwegian_Bokmal
+```
+
+
+Norwegian (Bokmål, Región: Norway, NOR) valor LanguageId
+
+### Norwegian_Nynorsk {#Norwegian-Nynorsk}
+```
+public static final MSLanguageId Norwegian_Nynorsk
+```
+
+
+Norwegian (Nynorsk, Región: Norway, NON) valor LanguageId
+
+### Occitan {#Occitan}
+```
+public static final MSLanguageId Occitan
+```
+
+
+Occitano (Región: Francia) LanguageId valor
+
+### Odia {#Odia}
+```
+public static final MSLanguageId Odia
+```
+
+
+Odia (anteriormente Oriya, Región: India) LanguageId valor
+
+### Pashto {#Pashto}
+```
+public static final MSLanguageId Pashto
+```
+
+
+Pastún (Región: Afganistán) LanguageId valor
+
+### Polish {#Polish}
+```
+public static final MSLanguageId Polish
+```
+
+
+Polaco (Región: Polonia, PLK) LanguageId valor
+
+### Portuguese_Brazil {#Portuguese-Brazil}
+```
+public static final MSLanguageId Portuguese_Brazil
+```
+
+
+Portugués (brasileño, Región: Brasil, PTB) LanguageId valor
+
+### Portuguese_Portugal {#Portuguese-Portugal}
+```
+public static final MSLanguageId Portuguese_Portugal
+```
+
+
+Portugués (estándar, Región: Portugal, PTG) LanguageId valor
+
+### Punjabi {#Punjabi}
+```
+public static final MSLanguageId Punjabi
+```
+
+
+Panyabí (Región: India) LanguageId valor
+
+### Quechua_Bolivia {#Quechua-Bolivia}
+```
+public static final MSLanguageId Quechua_Bolivia
+```
+
+
+Quechua (Región: Bolivia) LanguageId valor
+
+### Quechua_Ecuador {#Quechua-Ecuador}
+```
+public static final MSLanguageId Quechua_Ecuador
+```
+
+
+Quechua (Región: Ecuador) LanguageId valor
+
+### Quechua_Peru {#Quechua-Peru}
+```
+public static final MSLanguageId Quechua_Peru
+```
+
+
+Quechua (Región: Perú) LanguageId valor
+
+### Romanian {#Romanian}
+```
+public static final MSLanguageId Romanian
+```
+
+
+Rumano (Región: Rumania, ROM) LanguageId valor
+
+### Romansh {#Romansh}
+```
+public static final MSLanguageId Romansh
+```
+
+
+Romanche (Región: Suiza) LanguageId valor
+
+### Russian {#Russian}
+```
+public static final MSLanguageId Russian
+```
+
+
+Ruso (Región: Rusia, RUS) LanguageId valor
+
+### Sami_Inari {#Sami-Inari}
+```
+public static final MSLanguageId Sami_Inari
+```
+
+
+Sami (Inari, Región: Finlandia) LanguageId valor
+
+### Sami_Lule_Norway {#Sami-Lule-Norway}
+```
+public static final MSLanguageId Sami_Lule_Norway
+```
+
+
+Sami (Lule, Región: Noruega) LanguageId valor
+
+### Sami_Lule_Sweden {#Sami-Lule-Sweden}
+```
+public static final MSLanguageId Sami_Lule_Sweden
+```
+
+
+Sami (Lule, Región: Suecia) LanguageId valor
+
+### Sami_Northern_Finland {#Sami-Northern-Finland}
+```
+public static final MSLanguageId Sami_Northern_Finland
+```
+
+
+Sami (del Norte, Región: Finlandia) LanguageId valor
+
+### Sami_Northern_Norway {#Sami-Northern-Norway}
+```
+public static final MSLanguageId Sami_Northern_Norway
+```
+
+
+Sami (del Norte, Región: Noruega) LanguageId valor
+
+### Sami_Northern_Sweden {#Sami-Northern-Sweden}
+```
+public static final MSLanguageId Sami_Northern_Sweden
+```
+
+
+Sami (del Norte, Región: Suecia) LanguageId valor
+
+### Sami_Skolt {#Sami-Skolt}
+```
+public static final MSLanguageId Sami_Skolt
+```
+
+
+Sami (Skolt, Región: Finlandia) LanguageId valor
+
+### Sami_Southern_Norway {#Sami-Southern-Norway}
+```
+public static final MSLanguageId Sami_Southern_Norway
+```
+
+
+Sami (del Sur, Región: Noruega) LanguageId valor
+
+### Sami_Southern_Sweden {#Sami-Southern-Sweden}
+```
+public static final MSLanguageId Sami_Southern_Sweden
+```
+
+
+Sami (del Sur, Región: Suecia) LanguageId valor
+
+### Sanskrit {#Sanskrit}
+```
+public static final MSLanguageId Sanskrit
+```
+
+
+Sánscrito (Región: India) LanguageId valor
+
+### Serbian_Cyrillic_BIH {#Serbian-Cyrillic-BIH}
+```
+public static final MSLanguageId Serbian_Cyrillic_BIH
+```
+
+
+Serbio (Cirílico, Región: Bosnia y Herzegovina) LanguageId valor
+
+### Serbian_Cyrillic_Serbia {#Serbian-Cyrillic-Serbia}
+```
+public static final MSLanguageId Serbian_Cyrillic_Serbia
+```
+
+
+Serbio (Cirílico, Región: Serbia) LanguageId valor
+
+### Serbian_Latin_BIH {#Serbian-Latin-BIH}
+```
+public static final MSLanguageId Serbian_Latin_BIH
+```
+
+
+Serbio (Latín, Región: Bosnia y Herzegovina) valor de LanguageId
+
+### Serbian_Latin_Serbia {#Serbian-Latin-Serbia}
+```
+public static final MSLanguageId Serbian_Latin_Serbia
+```
+
+
+Serbio (Latín, Región: Serbia) valor de LanguageId
+
+### Sesotho_Sa_Leboa {#Sesotho-Sa-Leboa}
+```
+public static final MSLanguageId Sesotho_Sa_Leboa
+```
+
+
+Sesotho sa Leboa (Sotho del Norte, Región: Sudáfrica, SA) valor de LanguageId
+
+### Setswana {#Setswana}
+```
+public static final MSLanguageId Setswana
+```
+
+
+Setswana (Región: Sudáfrica, SA) valor de LanguageId
+
+### Sinhala {#Sinhala}
+```
+public static final MSLanguageId Sinhala
+```
+
+
+Cingalés (Región: Sri Lanka) valor de LanguageId
+
+### Slovak {#Slovak}
+```
+public static final MSLanguageId Slovak
+```
+
+
+Eslovaco (Región: Eslovaquia, SKY) valor de LanguageId
+
+### Slovenian {#Slovenian}
+```
+public static final MSLanguageId Slovenian
+```
+
+
+Esloveno (Región: Eslovenia, SLV) valor de LanguageId
+
+### Spanish_Argentina {#Spanish-Argentina}
+```
+public static final MSLanguageId Spanish_Argentina
+```
+
+
+Español (Región: Argentina) valor de LanguageId
+
+### Spanish_Bolivia {#Spanish-Bolivia}
+```
+public static final MSLanguageId Spanish_Bolivia
+```
+
+
+Español (Región: Bolivia) valor de LanguageId
+
+### Spanish_Chile {#Spanish-Chile}
+```
+public static final MSLanguageId Spanish_Chile
+```
+
+
+Español (Región: Chile) valor de LanguageId
+
+### Spanish_Colombia {#Spanish-Colombia}
+```
+public static final MSLanguageId Spanish_Colombia
+```
+
+
+Español (Región: Colombia) valor de LanguageId
+
+### Spanish_Costa_Rica {#Spanish-Costa-Rica}
+```
+public static final MSLanguageId Spanish_Costa_Rica
+```
+
+
+Español (Región: Costa Rica) valor de LanguageId
+
+### Spanish_Dominican_Republic {#Spanish-Dominican-Republic}
+```
+public static final MSLanguageId Spanish_Dominican_Republic
+```
+
+
+Español (Región: República Dominicana) valor de LanguageId
+
+### Spanish_Ecuador {#Spanish-Ecuador}
+```
+public static final MSLanguageId Spanish_Ecuador
+```
+
+
+Español (Región: Ecuador) valor de LanguageId
+
+### Spanish_El_Salvador {#Spanish-El-Salvador}
+```
+public static final MSLanguageId Spanish_El_Salvador
+```
+
+
+Español (Región: El Salvador) valor de LanguageId
+
+### Spanish_Guatemala {#Spanish-Guatemala}
+```
+public static final MSLanguageId Spanish_Guatemala
+```
+
+
+Español (Región: Guatemala) valor de LanguageId
+
+### Spanish_Honduras {#Spanish-Honduras}
+```
+public static final MSLanguageId Spanish_Honduras
+```
+
+
+Español (Región: Honduras) valor de LanguageId
+
+### Spanish_Mexico {#Spanish-Mexico}
+```
+public static final MSLanguageId Spanish_Mexico
+```
+
+
+Español (Mexicano, Región: México, ESM) valor de LanguageId
+
+### Spanish_Modern_Sort {#Spanish-Modern-Sort}
+```
+public static final MSLanguageId Spanish_Modern_Sort
+```
+
+
+Español (Orden Moderno, Región: España, ESN) valor de LanguageId
+
+### Spanish_Nicaragua {#Spanish-Nicaragua}
+```
+public static final MSLanguageId Spanish_Nicaragua
+```
+
+
+Español (Región: Nicaragua) valor de LanguageId
+
+### Spanish_Panama {#Spanish-Panama}
+```
+public static final MSLanguageId Spanish_Panama
+```
+
+
+Español (Región: Panamá) valor de LanguageId
+
+### Spanish_Paraguay {#Spanish-Paraguay}
+```
+public static final MSLanguageId Spanish_Paraguay
+```
+
+
+Español (Región: Paraguay) valor de LanguageId
+
+### Spanish_Peru {#Spanish-Peru}
+```
+public static final MSLanguageId Spanish_Peru
+```
+
+
+Español (Región: Perú) valor de LanguageId
+
+### Spanish_Puerto_Rico {#Spanish-Puerto-Rico}
+```
+public static final MSLanguageId Spanish_Puerto_Rico
+```
+
+
+Español (Región: Puerto Rico) valor de LanguageId
+
+### Spanish_Traditional_Sort {#Spanish-Traditional-Sort}
+```
+public static final MSLanguageId Spanish_Traditional_Sort
+```
+
+
+Español (Orden Tradicional, Región: España, ESP) valor de LanguageId
+
+### Spanish_United_States {#Spanish-United-States}
+```
+public static final MSLanguageId Spanish_United_States
+```
+
+
+Español (Región: Estados Unidos) valor de LanguageId
+
+### Spanish_Uruguay {#Spanish-Uruguay}
+```
+public static final MSLanguageId Spanish_Uruguay
+```
+
+
+Español (Región: Uruguay) valor de LanguageId
+
+### Spanish_Venezuela {#Spanish-Venezuela}
+```
+public static final MSLanguageId Spanish_Venezuela
+```
+
+
+Español (Región: Venezuela) valor de LanguageId
+
+### Swedish_Finland {#Swedish-Finland}
+```
+public static final MSLanguageId Swedish_Finland
+```
+
+
+Sueco (Región: Finlandia) valor de LanguageId
+
+### Swedish_Sweden {#Swedish-Sweden}
+```
+public static final MSLanguageId Swedish_Sweden
+```
+
+
+Sueco (Región: Suecia, SVE) valor de LanguageId
+
+### Syriac {#Syriac}
+```
+public static final MSLanguageId Syriac
+```
+
+
+Siríaco (Región: Siria) valor de LanguageId
+
+### Tajik {#Tajik}
+```
+public static final MSLanguageId Tajik
+```
+
+
+Tayiko (Cyrillic, Región: Tayikistán) valor de LanguageId
+
+### Tamazight {#Tamazight}
+```
+public static final MSLanguageId Tamazight
+```
+
+
+Tamazight (Latin, Región: Argelia) valor de LanguageId
+
+### Tamil {#Tamil}
+```
+public static final MSLanguageId Tamil
+```
+
+
+Tamil (Región: India) valor de LanguageId
+
+### Tatar {#Tatar}
+```
+public static final MSLanguageId Tatar
+```
+
+
+Tártaro (Región: Rusia) valor de LanguageId
+
+### Telugu {#Telugu}
+```
+public static final MSLanguageId Telugu
+```
+
+
+Telugú (Región: India) valor de LanguageId
+
+### Thai {#Thai}
+```
+public static final MSLanguageId Thai
+```
+
+
+Tailandés (Región: Tailandia) valor de LanguageId
+
+### Tibetan {#Tibetan}
+```
+public static final MSLanguageId Tibetan
+```
+
+
+Tibetano (Región: PRC) valor de LanguageId
+
+### Turkish {#Turkish}
+```
+public static final MSLanguageId Turkish
+```
+
+
+Turco (Región: Turquía, TRK) valor de LanguageId
+
+### Turkmen {#Turkmen}
+```
+public static final MSLanguageId Turkmen
+```
+
+
+Turcomano (Región: Turkmenistán) valor de LanguageId
+
+### Uighur {#Uighur}
+```
+public static final MSLanguageId Uighur
+```
+
+
+Uigur (Región: PRC) valor de LanguageId
+
+### Ukrainian {#Ukrainian}
+```
+public static final MSLanguageId Ukrainian
+```
+
+
+Ucraniano (Región: Ucrania, UKR) valor de LanguageId
+
+### Upper_Sorbian {#Upper-Sorbian}
+```
+public static final MSLanguageId Upper_Sorbian
+```
+
+
+Alto sorabo (Región: Alemania) valor de LanguageId
+
+### Urdu {#Urdu}
+```
+public static final MSLanguageId Urdu
+```
+
+
+Urdu (Región: República Islámica de Pakistán) valor de LanguageId
+
+### Uzbek_Cyrillic {#Uzbek-Cyrillic}
+```
+public static final MSLanguageId Uzbek_Cyrillic
+```
+
+
+Uzbeko (Cyrillic, Región: Uzbekistán) valor de LanguageId
+
+### Uzbek_Latin {#Uzbek-Latin}
+```
+public static final MSLanguageId Uzbek_Latin
+```
+
+
+Uzbeko (Latin, Región: Uzbekistán) valor de LanguageId
+
+### Vietnamese {#Vietnamese}
+```
+public static final MSLanguageId Vietnamese
+```
+
+
+Vietnamita (Región: Vietnam) valor de LanguageId
+
+### Welsh {#Welsh}
+```
+public static final MSLanguageId Welsh
+```
+
+
+Galés (Región: Reino Unido) valor de LanguageId
+
+### Wolof {#Wolof}
+```
+public static final MSLanguageId Wolof
+```
+
+
+Wolof (Región: Senegal) valor de LanguageId
+
+### Yakut {#Yakut}
+```
+public static final MSLanguageId Yakut
+```
+
+
+Yakut (Región: Rusia) valor de LanguageId
+
+### Yi {#Yi}
+```
+public static final MSLanguageId Yi
+```
+
+
+Yi (Región: PRC) valor de LanguageId
+
+### Yoruba {#Yoruba}
+```
+public static final MSLanguageId Yoruba
+```
+
+
+Yoruba (Región: Nigeria) valor de LanguageId
+
+### isiXhosa {#isiXhosa}
+```
+public static final MSLanguageId isiXhosa
+```
+
+
+isiXhosa (Región: Sudáfrica, SA) valor de LanguageId
+
+### isiZulu {#isiZulu}
+```
+public static final MSLanguageId isiZulu
+```
+
+
+isiZulu (Región: Sudáfrica, SA) valor de LanguageId
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getId() {#getId--}
+```
+public int getId()
+```
+
+
+Obtenga el valor entero.
+
+**Returns:**
+int - El valor entero.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/msplatformspecificid/_index.md
+++ b/spanish/java/com.aspose.font/msplatformspecificid/_index.md
@@ -1,0 +1,331 @@
+---
+title: "MSPlatformSpecificId"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la enumeración PlatformSpecificId de la plataforma Microsoft."
+type: docs
+weight: 139
+url: /es/java/com.aspose.font/msplatformspecificid/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum MSPlatformSpecificId extends Enum<MSPlatformSpecificId>
+```
+
+Representa la enumeración PlatformSpecificId de la plataforma Microsoft.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [Big5](#Big5) | Big5 MS MSPlatformSpecificId. |
+| [Johab](#Johab) | Johab MS MSPlatformSpecificId. |
+| [PRC](#PRC) | PRC MS MSPlatformSpecificId. |
+| [Reserved1](#Reserved1) | Reserved1 MS MSPlatformSpecificId. |
+| [Reserved2](#Reserved2) | Reserved2 MS MSPlatformSpecificId. |
+| [Reserved3](#Reserved3) | Reserved3 MS MSPlatformSpecificId. |
+| [ShiftJIS](#ShiftJIS) | ShiftJIS MS MSPlatformSpecificId. |
+| [Symbol](#Symbol) | Symbol MS MSPlatformSpecificId. |
+| [Unicode_BMP_UCS2](#Unicode-BMP-UCS2) | Unicode BMP (UCS2) MS PlatformSpecificId. |
+| [Unicode_UCS4](#Unicode-UCS4) | Unicode\_UCS4 MS MSPlatformSpecificId. |
+| [Wansung](#Wansung) | Wansung MS MSPlatformSpecificId. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Big5 {#Big5}
+```
+public static final MSPlatformSpecificId Big5
+```
+
+
+Big5 MS MSPlatformSpecificId.
+
+### Johab {#Johab}
+```
+public static final MSPlatformSpecificId Johab
+```
+
+
+Johab MS MSPlatformSpecificId.
+
+### PRC {#PRC}
+```
+public static final MSPlatformSpecificId PRC
+```
+
+
+PRC MS MSPlatformSpecificId.
+
+### Reserved1 {#Reserved1}
+```
+public static final MSPlatformSpecificId Reserved1
+```
+
+
+Reserved1 MS MSPlatformSpecificId.
+
+### Reserved2 {#Reserved2}
+```
+public static final MSPlatformSpecificId Reserved2
+```
+
+
+Reserved2 MS MSPlatformSpecificId.
+
+### Reserved3 {#Reserved3}
+```
+public static final MSPlatformSpecificId Reserved3
+```
+
+
+Reserved3 MS MSPlatformSpecificId.
+
+### ShiftJIS {#ShiftJIS}
+```
+public static final MSPlatformSpecificId ShiftJIS
+```
+
+
+ShiftJIS MS MSPlatformSpecificId.
+
+### Symbol {#Symbol}
+```
+public static final MSPlatformSpecificId Symbol
+```
+
+
+Symbol MS MSPlatformSpecificId.
+
+### Unicode_BMP_UCS2 {#Unicode-BMP-UCS2}
+```
+public static final MSPlatformSpecificId Unicode_BMP_UCS2
+```
+
+
+Unicode BMP (UCS2) MS PlatformSpecificId.
+
+### Unicode_UCS4 {#Unicode-UCS4}
+```
+public static final MSPlatformSpecificId Unicode_UCS4
+```
+
+
+Unicode\_UCS4 MS MSPlatformSpecificId.
+
+### Wansung {#Wansung}
+```
+public static final MSPlatformSpecificId Wansung
+```
+
+
+Wansung MS MSPlatformSpecificId.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static MSPlatformSpecificId valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[MSPlatformSpecificId](../../com.aspose.font/msplatformspecificid)
+### values() {#values--}
+```
+public static MSPlatformSpecificId[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.MSPlatformSpecificId[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/multilanguagestring/_index.md
+++ b/spanish/java/com.aspose.font/multilanguagestring/_index.md
@@ -1,0 +1,296 @@
+---
+title: "MultiLanguageString"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa una cadena multilingüe."
+type: docs
+weight: 66
+url: /es/java/com.aspose.font/multilanguagestring/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class MultiLanguageString
+```
+
+Representa una cadena multilingüe.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [MultiLanguageString()](#MultiLanguageString--) | Crea una cadena multilingüe vacía. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addLanguageString(String str, int languageId)](#addLanguageString-java.lang.String-int-) | Agrega una cadena de un idioma específico. |
+| [containsString(String str)](#containsString-java.lang.String-) | Devuelve true si la cadena está presente en todas las cadenas de idioma. |
+| [equals(Object objToCompare)](#equals-java.lang.Object-) | Devuelve true si los objetos se consideran iguales. |
+| [getAllLanguageIds()](#getAllLanguageIds--) | Obtiene los identificadores de idioma para todas las cadenas o una matriz vacía si no hay cadenas presentes. |
+| [getAllStrings()](#getAllStrings--) | Devuelve todas las cadenas de todos los idiomas. |
+| [getClass()](#getClass--) |  |
+| [getEnglishString()](#getEnglishString--) | Devuelve la cadena en inglés si se encuentra. |
+| [getStringForLanguageId(int languageId)](#getStringForLanguageId-int-) | Devuelve la cadena relacionada con el identificador de idioma proporcionado, si se encuentra. |
+| [hashCode()](#hashCode--) | Implementación de GetHashCode. |
+| [isEmpty()](#isEmpty--) | True, si MultiLanguageString no tiene cadenas de idiomas. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(MultiLanguageString obj1, String obj2)](#op-Equality-com.aspose.font.MultiLanguageString-java.lang.String-) | Implementación del operador de igualdad. |
+| [op_Equality(String obj1, MultiLanguageString obj2)](#op-Equality-java.lang.String-com.aspose.font.MultiLanguageString-) | Implementación del operador de igualdad. |
+| [op_Inequality(MultiLanguageString obj1, String obj2)](#op-Inequality-com.aspose.font.MultiLanguageString-java.lang.String-) | Implementación del operador de desigualdad. |
+| [op_Inequality(String obj1, MultiLanguageString obj2)](#op-Inequality-java.lang.String-com.aspose.font.MultiLanguageString-) | Implementación del operador de desigualdad. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MultiLanguageString() {#MultiLanguageString--}
+```
+public MultiLanguageString()
+```
+
+
+Crea una cadena multilingüe vacía.
+
+### addLanguageString(String str, int languageId) {#addLanguageString-java.lang.String-int-}
+```
+public void addLanguageString(String str, int languageId)
+```
+
+
+Agrega una cadena de un idioma específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| str | java.lang.String | Cadena a agregar |
+| languageId | int | Identificador de idioma |
+
+### containsString(String str) {#containsString-java.lang.String-}
+```
+public boolean containsString(String str)
+```
+
+
+Devuelve true si la cadena está presente en todas las cadenas de idioma.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| str | java.lang.String | Cadena a comprobar. |
+
+**Returns:**
+boolean - True si la cadena está presente en todas las cadenas de idioma.
+### equals(Object objToCompare) {#equals-java.lang.Object-}
+```
+public boolean equals(Object objToCompare)
+```
+
+
+Devuelve true si los objetos se consideran iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| objToCompare | java.lang.Object | objeto a comparar con |
+
+**Returns:**
+boolean - resultado de la comparación
+### getAllLanguageIds() {#getAllLanguageIds--}
+```
+public int[] getAllLanguageIds()
+```
+
+
+Obtiene los identificadores de idioma para todas las cadenas o una matriz vacía si no hay cadenas presentes.
+
+**Returns:**
+int[] - Matriz con identificadores de idioma o matriz vacía si no hay cadenas presentes.
+### getAllStrings() {#getAllStrings--}
+```
+public String[] getAllStrings()
+```
+
+
+Devuelve todas las cadenas de todos los idiomas.
+
+**Returns:**
+java.lang.String[] - Matriz de todas las cadenas de todos los idiomas.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEnglishString() {#getEnglishString--}
+```
+public String getEnglishString()
+```
+
+
+Devuelve la cadena en inglés si se encuentra. De lo contrario, devuelve la primera cadena que no sea en inglés.
+
+**Returns:**
+java.lang.String - Cadena en inglés si se encuentra, de lo contrario la primera cadena que no sea en inglés.
+### getStringForLanguageId(int languageId) {#getStringForLanguageId-int-}
+```
+public String getStringForLanguageId(int languageId)
+```
+
+
+Devuelve la cadena relacionada con el identificador de idioma proporcionado, si se encuentra. Cadena vacía en caso contrario.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| languageId | int | Identificador de idioma. |
+
+**Returns:**
+java.lang.String - Cadena relacionada con el identificador de idioma proporcionado, si se encuentra. Cadena vacía en caso contrario.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Implementación de GetHashCode.
+
+**Returns:**
+int - código hash del objeto
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+True, si MultiLanguageString no tiene cadenas de idiomas.
+
+**Returns:**
+boolean - Verdadero, si MultiLanguageString no tiene cadenas de idiomas.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(MultiLanguageString obj1, String obj2) {#op-Equality-com.aspose.font.MultiLanguageString-java.lang.String-}
+```
+public static boolean op_Equality(MultiLanguageString obj1, String obj2)
+```
+
+
+Implementación del operador de igualdad.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj1 | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | primer objeto a comparar |
+| obj2 | java.lang.String | segundo objeto a comparar |
+
+**Returns:**
+boolean - resultado de la comparación
+### op_Equality(String obj1, MultiLanguageString obj2) {#op-Equality-java.lang.String-com.aspose.font.MultiLanguageString-}
+```
+public static boolean op_Equality(String obj1, MultiLanguageString obj2)
+```
+
+
+Implementación del operador de igualdad.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj1 | java.lang.String | cadena a comparar |
+| obj2 | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | cadena multilingüe a comparar |
+
+**Returns:**
+boolean - resultado de la comparación
+### op_Inequality(MultiLanguageString obj1, String obj2) {#op-Inequality-com.aspose.font.MultiLanguageString-java.lang.String-}
+```
+public static boolean op_Inequality(MultiLanguageString obj1, String obj2)
+```
+
+
+Implementación del operador de desigualdad.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj1 | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | cadena a comparar |
+| obj2 | java.lang.String | cadena multilingüe a comparar |
+
+**Returns:**
+boolean - resultado de la comparación
+### op_Inequality(String obj1, MultiLanguageString obj2) {#op-Inequality-java.lang.String-com.aspose.font.MultiLanguageString-}
+```
+public static boolean op_Inequality(String obj1, MultiLanguageString obj2)
+```
+
+
+Implementación del operador de desigualdad.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj1 | java.lang.String | cadena a comparar |
+| obj2 | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | cadena multilingüe a comparar |
+
+**Returns:**
+boolean - resultado de la comparación
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/nameid/_index.md
+++ b/spanish/java/com.aspose.font/nameid/_index.md
@@ -1,0 +1,380 @@
+---
+title: "NameId"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la enumeración NameId."
+type: docs
+weight: 67
+url: /es/java/com.aspose.font/nameid/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class NameId
+```
+
+Representa la enumeración NameId.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CompatibleFull](#CompatibleFull) | 18 Compatible Full (solo Macintosh); En Macintosh, el nombre del menú se construye usando el recurso de Fuente. |
+| [CopyrightNotice](#CopyrightNotice) | 0 Aviso de derechos de autor. |
+| [DarkBackground](#DarkBackground) | Este ID, si se usa en el CPAL table\\u2019s Palette Labels Array, especifica que la paleta de colores correspondiente en la tabla CPAL es apropiada para usar con la fuente al mostrarla en un fondo oscuro como negro. |
+| [Description](#Description) | 10 Descripción; descripción del tipo de letra. |
+| [DesignerName](#DesignerName) | 9 Diseñador; nombre del diseñador del tipo de letra. |
+| [FontFamily](#FontFamily) | 1 Familia de fuente. |
+| [FontSubfamily](#FontSubfamily) | 2 Subfamilia de fuente. |
+| [FullName](#FullName) | 4 Nombre completo de la fuente. |
+| [LicenseDescription](#LicenseDescription) | 13 Descripción de la licencia; descripción de cómo se puede usar legalmente la fuente, o diferentes escenarios de ejemplo para el uso con licencia. |
+| [LicenseInfoUrl](#LicenseInfoUrl) | 14 URL de información de la licencia, donde se puede encontrar información adicional de la licencia. |
+| [LightBackground](#LightBackground) | Esta ID, si se usa en la matriz de etiquetas de paleta de la tabla CPAL\\u2019s, especifica que la paleta de colores correspondiente en la tabla CPAL es apropiada para usar con la fuente al mostrarla en un fondo claro como blanco |
+| [ManufacturerName](#ManufacturerName) | 8 Nombre del fabricante. |
+| [PostScriptCID](#PostScriptCID) | Su presencia en una fuente significa que el nameID 6 contiene un nombre de fuente PostScript que está destinado a usarse con la invocación \\u201ccomposefont\\u201d para invocar la fuente en un intérprete PostScript |
+| [PostScriptName](#PostScriptName) | 6 Nombre PostScript de la fuente. |
+| [PreferredFamily](#PreferredFamily) | 15 Reservado 16 Familia preferida (solo Windows); En Windows, el nombre de la familia se muestra en el menú de fuentes; el nombre de subfamilia se presenta como el nombre de estilo. |
+| [PreferredSubfamily](#PreferredSubfamily) | 17 Subfamilia preferida (solo Windows); En Windows, el nombre de la familia se muestra en el menú de fuentes; el nombre de subfamilia se presenta como el nombre de estilo. |
+| [SampleText](#SampleText) | 19 Texto de muestra. |
+| [TrademarkNotice](#TrademarkNotice) | 7 Aviso de marca registrada. |
+| [UniqueFontId](#UniqueFontId) | 3 Especificación Apple: Identificación única de subfamilia. 3 Especificación MS: Identificador único de fuente. |
+| [UrlDesigner](#UrlDesigner) | 12 URL del diseñador de la fuente (con protocolo, p.ej., http://, ftp://) |
+| [UrlVendor](#UrlVendor) | 11 URL del proveedor de la fuente (con protocolo, p.ej., http://, ftp://). |
+| [VariationsPostScriptNamePrefix](#VariationsPostScriptNamePrefix) | Si está presente en una fuente variable, puede usarse como prefijo de familia en el algoritmo de generación de nombres PostScript para fuentes de variación. |
+| [Version](#Version) | 5 Versión de la tabla de nombres. |
+| [WwsFamilyName](#WwsFamilyName) | Utilizado para proporcionar un nombre de familia conforme a WWS en caso de que las entradas para los IDs 16 y 17 no se ajusten al modelo WWS. |
+| [WwsSubfamilyName](#WwsSubfamilyName) | Usado junto con el ID 21, este ID proporciona un nombre de subfamilia conforme a WWS (reflejando solo atributos de peso, anchura y pendiente) en caso de que las entradas para los IDs 16 y 17 no se ajusten al modelo WWS. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fromId(int id)](#fromId-int-) | Crea un ID de nombre a partir de un valor entero. |
+| [getClass()](#getClass--) |  |
+| [getId()](#getId--) | Obtenga el valor entero. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CompatibleFull {#CompatibleFull}
+```
+public static final NameId CompatibleFull
+```
+
+
+18 Compatible Full (solo Macintosh); En Macintosh, el nombre del menú se construye usando el recurso de fuente. Normalmente coincide con el Nombre completo. Si deseas que el nombre de la fuente aparezca diferente al Nombre completo, puedes insertar el Nombre completo compatible en el ID 18. Este nombre no lo usa el propio Mac OS, pero puede ser usado por desarrolladores de aplicaciones (p.ej., Adobe).
+
+### CopyrightNotice {#CopyrightNotice}
+```
+public static final NameId CopyrightNotice
+```
+
+
+0 Aviso de derechos de autor.
+
+### DarkBackground {#DarkBackground}
+```
+public static final NameId DarkBackground
+```
+
+
+Este ID, si se usa en el CPAL table\\u2019s Palette Labels Array, especifica que la paleta de colores correspondiente en la tabla CPAL es apropiada para usar con la fuente al mostrarla en un fondo oscuro como negro.
+
+### Description {#Description}
+```
+public static final NameId Description
+```
+
+
+10 Descripción; descripción del tipo de letra. Puede contener información de revisión, recomendaciones de uso, historia, características, etc.
+
+### DesignerName {#DesignerName}
+```
+public static final NameId DesignerName
+```
+
+
+9 Diseñador; nombre del diseñador del tipo de letra.
+
+### FontFamily {#FontFamily}
+```
+public static final NameId FontFamily
+```
+
+
+1 Familia de fuente. Esta cadena es el nombre de la familia de la fuente que el usuario ve en plataformas Macintosh.
+
+### FontSubfamily {#FontSubfamily}
+```
+public static final NameId FontSubfamily
+```
+
+
+2 Subfamilia de fuente. Esta cadena es la familia de fuentes que el usuario ve en plataformas Macintosh.
+
+### FullName {#FullName}
+```
+public static final NameId FullName
+```
+
+
+4 Nombre completo de la fuente.
+
+### LicenseDescription {#LicenseDescription}
+```
+public static final NameId LicenseDescription
+```
+
+
+13 Descripción de la licencia; descripción de cómo se puede usar legalmente la fuente, o diferentes escenarios de ejemplo para el uso con licencia. Este campo debe redactarse en lenguaje claro, no en jerga legal.
+
+### LicenseInfoUrl {#LicenseInfoUrl}
+```
+public static final NameId LicenseInfoUrl
+```
+
+
+14 URL de información de la licencia, donde se puede encontrar información adicional de la licencia.
+
+### LightBackground {#LightBackground}
+```
+public static final NameId LightBackground
+```
+
+
+Esta ID, si se usa en la matriz de etiquetas de paleta de la tabla CPAL\\u2019s, especifica que la paleta de colores correspondiente en la tabla CPAL es apropiada para usar con la fuente al mostrarla en un fondo claro como blanco
+
+### ManufacturerName {#ManufacturerName}
+```
+public static final NameId ManufacturerName
+```
+
+
+8 Nombre del fabricante.
+
+### PostScriptCID {#PostScriptCID}
+```
+public static final NameId PostScriptCID
+```
+
+
+Su presencia en una fuente significa que el nameID 6 contiene un nombre de fuente PostScript que está destinado a usarse con la invocación \\u201ccomposefont\\u201d para invocar la fuente en un intérprete PostScript
+
+### PostScriptName {#PostScriptName}
+```
+public static final NameId PostScriptName
+```
+
+
+6 Nombre PostScript de la fuente. Nota: Una fuente puede tener solo un nombre PostScript y ese nombre debe ser ASCII.
+
+### PreferredFamily {#PreferredFamily}
+```
+public static final NameId PreferredFamily
+```
+
+
+15 Reservado 16 Familia preferida (solo Windows); En Windows, el nombre de la familia se muestra en el menú de fuentes; el nombre de la subfamilia se presenta como el nombre de estilo. Por razones históricas, las familias de fuentes han contenido un máximo de cuatro estilos, pero los diseñadores de fuentes pueden agrupar más de cuatro fuentes en una sola familia. Los ID de familia preferida y subfamilia preferida permiten a los diseñadores de fuentes incluir los agrupamientos de familia/subfamilia preferidos. Estos ID solo están presentes si son diferentes de los ID 1 y 2.
+
+### PreferredSubfamily {#PreferredSubfamily}
+```
+public static final NameId PreferredSubfamily
+```
+
+
+17 Subfamilia preferida (solo Windows); En Windows, el nombre de la familia se muestra en el menú de fuentes; el nombre de la subfamilia se presenta como el nombre de estilo. Por razones históricas, las familias de fuentes han contenido un máximo de cuatro estilos, pero los diseñadores de fuentes pueden agrupar más de cuatro fuentes en una sola familia. Los ID de familia preferida y subfamilia preferida permiten a los diseñadores de fuentes incluir los agrupamientos de familia/subfamilia preferidos. Estos ID solo están presentes si son diferentes de los ID 1 y 2.
+
+### SampleText {#SampleText}
+```
+public static final NameId SampleText
+```
+
+
+19 Texto de muestra. Esto puede ser el nombre de la fuente, o cualquier otro texto que el diseñador considere el mejor ejemplo para mostrar cómo se ve la fuente.
+
+### TrademarkNotice {#TrademarkNotice}
+```
+public static final NameId TrademarkNotice
+```
+
+
+7 Aviso de marca registrada.
+
+### UniqueFontId {#UniqueFontId}
+```
+public static final NameId UniqueFontId
+```
+
+
+3 Especificación Apple: Identificación única de subfamilia. 3 Especificación MS: Identificador único de fuente.
+
+### UrlDesigner {#UrlDesigner}
+```
+public static final NameId UrlDesigner
+```
+
+
+12 URL del diseñador de la fuente (con protocolo, p.ej., http://, ftp://)
+
+### UrlVendor {#UrlVendor}
+```
+public static final NameId UrlVendor
+```
+
+
+11 URL del proveedor de la fuente (con protocolo, p. ej., http://, ftp://). Si se incrusta un número de serie único en la URL, puede usarse para registrar la fuente.
+
+### VariationsPostScriptNamePrefix {#VariationsPostScriptNamePrefix}
+```
+public static final NameId VariationsPostScriptNamePrefix
+```
+
+
+Si está presente en una fuente variable, puede usarse como prefijo de familia en el algoritmo de generación de nombres PostScript para fuentes de variación.
+
+### Version {#Version}
+```
+public static final NameId Version
+```
+
+
+5 Versión de la tabla de nombres.
+
+### WwsFamilyName {#WwsFamilyName}
+```
+public static final NameId WwsFamilyName
+```
+
+
+Utilizado para proporcionar un nombre de familia conforme a WWS en caso de que las entradas para los IDs 16 y 17 no se ajusten al modelo WWS.
+
+### WwsSubfamilyName {#WwsSubfamilyName}
+```
+public static final NameId WwsSubfamilyName
+```
+
+
+Usado junto con el ID 21, este ID proporciona un nombre de subfamilia conforme a WWS (reflejando solo atributos de peso, anchura y pendiente) en caso de que las entradas para los IDs 16 y 17 no se ajusten al modelo WWS.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fromId(int id) {#fromId-int-}
+```
+public static NameId fromId(int id)
+```
+
+
+Crea un ID de nombre a partir de un valor entero.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| id | int | Un valor entero. |
+
+**Returns:**
+[NameId](../../com.aspose.font/nameid) - The name id.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getId() {#getId--}
+```
+public int getId()
+```
+
+
+Obtenga el valor entero.
+
+**Returns:**
+int - El valor entero.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/nameindexdataprovider/_index.md
+++ b/spanish/java/com.aspose.font/nameindexdataprovider/_index.md
@@ -1,0 +1,250 @@
+---
+title: "NameIndexDataProvider"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Proporciona configuraciones comunes a fuentes CFF."
+type: docs
+weight: 68
+url: /es/java/com.aspose.font/nameindexdataprovider/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.ICffIndexDataProvider](../../com.aspose.font/icffindexdataprovider)
+```
+public abstract class NameIndexDataProvider implements ICffIndexDataProvider
+```
+
+Proporciona configuraciones comunes a fuentes CFF.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [NameIndexDataProvider()](#NameIndexDataProvider--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addName(String name)](#addName-java.lang.String-) | Agrega un nombre de fuente a la estructura Name INDEX. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el nombre de la fuente en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de objetos en la estructura CFF INDEX. |
+| [getName(int index)](#getName-int-) | Obtiene el nombre de la fuente en el índice especificado. |
+| [getRawBytes()](#getRawBytes--) | Obtiene todos los bytes de la estructura CFF INDEX. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeName(int index)](#removeName-int-) | Elimina el nombre en el índice especificado. |
+| [set(int index, String name)](#set-int-java.lang.String-) | Especifica el nombre de la fuente en el índice especificado. |
+| [setName(String name, int index)](#setName-java.lang.String-int-) | Establece el nombre de la fuente en el índice especificado. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NameIndexDataProvider() {#NameIndexDataProvider--}
+```
+public NameIndexDataProvider()
+```
+
+
+### addName(String name) {#addName-java.lang.String-}
+```
+public abstract void addName(String name)
+```
+
+
+Agrega un nombre de fuente a la estructura Name INDEX. Use este método con precaución porque cada nombre de fuente en la estructura CFF Name INDEX debe tener una estructura DICT correspondiente en el índice Top DICT según la especificación CFF.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public abstract String get(int index)
+```
+
+
+Obtiene el nombre de la fuente en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | Índice de fuente. |
+
+**Returns:**
+java.lang.String - Nombre de fuente.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public abstract int getCount()
+```
+
+
+Obtiene el número de objetos en la estructura CFF INDEX.
+
+**Returns:**
+int
+### getName(int index) {#getName-int-}
+```
+public abstract String getName(int index)
+```
+
+
+Obtiene el nombre de la fuente en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | Índice de fuente. |
+
+**Returns:**
+java.lang.String - El nombre de la fuente.
+### getRawBytes() {#getRawBytes--}
+```
+public abstract byte[] getRawBytes()
+```
+
+
+Obtiene todos los bytes de la estructura CFF INDEX.
+
+**Returns:**
+byte[] - Bytes de la estructura CFF INDEX
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeName(int index) {#removeName-int-}
+```
+public abstract void removeName(int index)
+```
+
+
+Elimina el nombre en el índice especificado. Use este método con precaución porque cada nombre de fuente en la estructura CFF Name INDEX debe tener una estructura DICT correspondiente en el índice Top DICT según la especificación CFF.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | Índice de fuente. |
+
+### set(int index, String name) {#set-int-java.lang.String-}
+```
+public abstract void set(int index, String name)
+```
+
+
+Especifica el nombre de la fuente en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | Índice de fuente. |
+| nombre | java.lang.String | Nombre de fuente. |
+
+### setName(String name, int index) {#setName-java.lang.String-int-}
+```
+public abstract void setName(String name, int index)
+```
+
+
+Establece el nombre de la fuente en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String | Nombre de fuente. |
+| índice | int | Índice de fuente. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/namerecord/_index.md
+++ b/spanish/java/com.aspose.font/namerecord/_index.md
@@ -1,0 +1,190 @@
+---
+title: "NameRecord"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la estructura NameRecord de la tabla de nombres."
+type: docs
+weight: 69
+url: /es/java/com.aspose.font/namerecord/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class NameRecord
+```
+
+Representa la estructura NameRecord de la tabla 'name'
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [NameRecord()](#NameRecord--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getLanguageId()](#getLanguageId--) | Obtiene el identificador de idioma. |
+| [getNameId()](#getNameId--) | Obtiene el identificador de nombre. |
+| [getPlatformId()](#getPlatformId--) | Obtiene el código de identificador de plataforma. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Obtiene el identificador de codificación específico de la plataforma. |
+| [getString()](#getString--) | Obtiene la cadena en el almacenamiento de cadenas relacionada con este registro de nombre. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NameRecord() {#NameRecord--}
+```
+public NameRecord()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLanguageId() {#getLanguageId--}
+```
+public int getLanguageId()
+```
+
+
+Obtiene el identificador de idioma.
+
+**Returns:**
+int - Identificador de idioma.
+### getNameId() {#getNameId--}
+```
+public int getNameId()
+```
+
+
+Obtiene el identificador de nombre.
+
+**Returns:**
+int - Identificador de nombre.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Obtiene el código de identificador de plataforma.
+
+**Returns:**
+int - Código de identificador de plataforma.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Obtiene el identificador de codificación específico de la plataforma.
+
+**Returns:**
+int - Identificador de codificación específico de la plataforma.
+### getString() {#getString--}
+```
+public String getString()
+```
+
+
+Obtiene la cadena en el almacenamiento de cadenas relacionada con este registro de nombre.
+
+**Returns:**
+java.lang.String - Cadena en el almacenamiento de cadenas relacionada con este registro de nombre.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/nametocodemap/_index.md
+++ b/spanish/java/com.aspose.font/nametocodemap/_index.md
@@ -1,0 +1,178 @@
+---
+title: "NameToCodeMap"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa el mapa de nombre a código."
+type: docs
+weight: 70
+url: /es/java/com.aspose.font/nametocodemap/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class NameToCodeMap
+```
+
+Representa el mapa de nombre a código.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [containsKey(String name)](#containsKey-java.lang.String-) | Devuelve verdadero en caso de que la clave ya esté en el mapa. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(String name)](#get-java.lang.String-) | Obtiene el código por nombre. |
+| [getClass()](#getClass--) |  |
+| [getKeys()](#getKeys--) | Devuelve la colección de nombres de cadena. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [size()](#size--) | Obtiene el recuento de pares nombre-código en el mapa. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### containsKey(String name) {#containsKey-java.lang.String-}
+```
+public boolean containsKey(String name)
+```
+
+
+Devuelve verdadero en caso de que la clave ya esté en el mapa.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String | Nombre del glifo. |
+
+**Returns:**
+boolean - Verdadero o falso.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(String name) {#get-java.lang.String-}
+```
+public int get(String name)
+```
+
+
+Obtiene el código por nombre.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String | Nombre del glifo. |
+
+**Returns:**
+int - Código del glifo.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getKeys() {#getKeys--}
+```
+public Collection<String> getKeys()
+```
+
+
+Devuelve la colección de nombres de cadena.
+
+**Returns:**
+java.util.Collection<java.lang.String> - colección de nombres de cadena.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+Obtiene el recuento de pares nombre-código en el mapa.
+
+**Returns:**
+int - Recuento de pares nombre-código en el mapa.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/offsetslist/_index.md
+++ b/spanish/java/com.aspose.font/offsetslist/_index.md
@@ -1,0 +1,151 @@
+---
+title: "TtfLocaTable.OffsetsList"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la lista de desplazamientos de glifos."
+type: docs
+weight: 10
+url: /es/java/com.aspose.font/ttflocatable.offsetslist/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static class TtfLocaTable.OffsetsList
+```
+
+Representa la lista de desplazamientos de glifos.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el desplazamiento por índice. |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [size()](#size--) | Obtiene el recuento de desplazamientos de glifos. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public long get(int index)
+```
+
+
+Obtiene el desplazamiento por índice.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | Índice de desplazamiento. |
+
+**Returns:**
+long - Desplazamiento de glifo.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+Obtiene el recuento de desplazamientos de glifos.
+
+**Returns:**
+int - Recuento de desplazamientos de glifos.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/parsingstrictness/_index.md
+++ b/spanish/java/com.aspose.font/parsingstrictness/_index.md
@@ -1,0 +1,248 @@
+---
+title: "FontEnvironment.ParsingStrictness"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: 
+type: docs
+weight: 10
+url: /es/java/com.aspose.font/fontenvironment.parsingstrictness/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum FontEnvironment.ParsingStrictness extends Enum<FontEnvironment.ParsingStrictness>
+```
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [Strict](#Strict) | Especifica el tipo estricto. |
+| [Tolerant](#Tolerant) | Especifica el tipo tolerante. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Strict {#Strict}
+```
+public static final FontEnvironment.ParsingStrictness Strict
+```
+
+
+Especifica el tipo estricto.
+
+### Tolerant {#Tolerant}
+```
+public static final FontEnvironment.ParsingStrictness Tolerant
+```
+
+
+Especifica el tipo tolerante.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static FontEnvironment.ParsingStrictness valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[ParsingStrictness](../../com.aspose.font/parsingstrictness)
+### values() {#values--}
+```
+public static FontEnvironment.ParsingStrictness[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.FontEnvironment.ParsingStrictness[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/pathsegmentcollection/_index.md
+++ b/spanish/java/com.aspose.font/pathsegmentcollection/_index.md
@@ -1,0 +1,565 @@
+---
+title: "PathSegmentCollection"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa una colección de segmentos de ruta."
+type: docs
+weight: 71
+url: /es/java/com.aspose.font/pathsegmentcollection/
+---
+**Inheritance:**
+java.lang.Object, java.util.AbstractCollection, java.util.AbstractList, java.util.ArrayList
+```
+public class PathSegmentCollection extends ArrayList<IPathSegment>
+```
+
+Representa una colección de segmentos de ruta.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>toArray(T[] arg0)](#-T-toArray-T---) |  |
+| [add(E arg0)](#add-E-) |  |
+| [add(int arg0, E arg1)](#add-int-E-) |  |
+| [addAll(int arg0, Collection<? extends E> arg1)](#addAll-int-java.util.Collection---extends-E--) |  |
+| [addAll(Collection<? extends E> arg0)](#addAll-java.util.Collection---extends-E--) |  |
+| [clear()](#clear--) |  |
+| [clone()](#clone--) |  |
+| [contains(Object arg0)](#contains-java.lang.Object-) |  |
+| [containsAll(Collection<?> arg0)](#containsAll-java.util.Collection----) |  |
+| [ensureCapacity(int arg0)](#ensureCapacity-int-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [forEach(Consumer<? super E> arg0)](#forEach-java.util.function.Consumer---super-E--) |  |
+| [get(int arg0)](#get-int-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object arg0)](#indexOf-java.lang.Object-) |  |
+| [isEmpty()](#isEmpty--) |  |
+| [iterator()](#iterator--) |  |
+| [lastIndexOf(Object arg0)](#lastIndexOf-java.lang.Object-) |  |
+| [listIterator()](#listIterator--) |  |
+| [listIterator(int arg0)](#listIterator-int-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(int arg0)](#remove-int-) |  |
+| [remove(Object arg0)](#remove-java.lang.Object-) |  |
+| [removeAll(Collection<?> arg0)](#removeAll-java.util.Collection----) |  |
+| [removeIf(Predicate<? super E> arg0)](#removeIf-java.util.function.Predicate---super-E--) |  |
+| [replaceAll(UnaryOperator<E> arg0)](#replaceAll-java.util.function.UnaryOperator-E--) |  |
+| [retainAll(Collection<?> arg0)](#retainAll-java.util.Collection----) |  |
+| [set(int arg0, E arg1)](#set-int-E-) |  |
+| [size()](#size--) |  |
+| [sort(Comparator<? super E> arg0)](#sort-java.util.Comparator---super-E--) |  |
+| [spliterator()](#spliterator--) |  |
+| [subList(int arg0, int arg1)](#subList-int-int-) |  |
+| [toArray()](#toArray--) |  |
+| [toString()](#toString--) |  |
+| [trimToSize()](#trimToSize--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>toArray(T[] arg0) {#-T-toArray-T---}
+```
+public T[] <T>toArray(T[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | T[] |  |
+
+**Returns:**
+T[]
+### add(E arg0) {#add-E-}
+```
+public boolean add(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+boolean
+### add(int arg0, E arg1) {#add-int-E-}
+```
+public void add(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+### addAll(int arg0, Collection<? extends E> arg1) {#addAll-int-java.util.Collection---extends-E--}
+```
+public boolean addAll(int arg0, Collection<? extends E> arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### addAll(Collection<? extends E> arg0) {#addAll-java.util.Collection---extends-E--}
+```
+public boolean addAll(Collection<? extends E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### contains(Object arg0) {#contains-java.lang.Object-}
+```
+public boolean contains(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### containsAll(Collection<?> arg0) {#containsAll-java.util.Collection----}
+```
+public boolean containsAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### ensureCapacity(int arg0) {#ensureCapacity-int-}
+```
+public void ensureCapacity(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### forEach(Consumer<? super E> arg0) {#forEach-java.util.function.Consumer---super-E--}
+```
+public void forEach(Consumer<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.function.Consumer<? super E> |  |
+
+### get(int arg0) {#get-int-}
+```
+public E get(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object arg0) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public Iterator<E> iterator()
+```
+
+
+
+
+**Returns:**
+java.util.Iterator<E>
+### lastIndexOf(Object arg0) {#lastIndexOf-java.lang.Object-}
+```
+public int lastIndexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### listIterator() {#listIterator--}
+```
+public ListIterator<E> listIterator()
+```
+
+
+
+
+**Returns:**
+java.util.ListIterator<E>
+### listIterator(int arg0) {#listIterator-int-}
+```
+public ListIterator<E> listIterator(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+java.util.ListIterator<E>
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(int arg0) {#remove-int-}
+```
+public E remove(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### remove(Object arg0) {#remove-java.lang.Object-}
+```
+public boolean remove(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### removeAll(Collection<?> arg0) {#removeAll-java.util.Collection----}
+```
+public boolean removeAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### removeIf(Predicate<? super E> arg0) {#removeIf-java.util.function.Predicate---super-E--}
+```
+public boolean removeIf(Predicate<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.function.Predicate<? super E> |  |
+
+**Returns:**
+boolean
+### replaceAll(UnaryOperator<E> arg0) {#replaceAll-java.util.function.UnaryOperator-E--}
+```
+public void replaceAll(UnaryOperator<E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.function.UnaryOperator<E> |  |
+
+### retainAll(Collection<?> arg0) {#retainAll-java.util.Collection----}
+```
+public boolean retainAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### set(int arg0, E arg1) {#set-int-E-}
+```
+public E set(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+**Returns:**
+E
+### size() {#size--}
+```
+public int size()
+```
+
+
+
+
+**Returns:**
+int
+### sort(Comparator<? super E> arg0) {#sort-java.util.Comparator---super-E--}
+```
+public void sort(Comparator<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.util.Comparator<? super E> |  |
+
+### spliterator() {#spliterator--}
+```
+public Spliterator<E> spliterator()
+```
+
+
+
+
+**Returns:**
+java.util.Spliterator<E>
+### subList(int arg0, int arg1) {#subList-int-int-}
+```
+public List<E> subList(int arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | int |  |
+
+**Returns:**
+java.util.List<E>
+### toArray() {#toArray--}
+```
+public Object[] toArray()
+```
+
+
+
+
+**Returns:**
+java.lang.Object[]
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### trimToSize() {#trimToSize--}
+```
+public void trimToSize()
+```
+
+
+
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/platformid/_index.md
+++ b/spanish/java/com.aspose.font/platformid/_index.md
@@ -1,0 +1,268 @@
+---
+title: "PlatformId"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la enumeración PlatformId."
+type: docs
+weight: 141
+url: /es/java/com.aspose.font/platformid/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum PlatformId extends Enum<PlatformId>
+```
+
+Representa la enumeración PlatformId.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ISO](#ISO) | Value2 especificación de Apple: (reservado; no usar) especificación de MS: codificación ISO. |
+| [Macintosh](#Macintosh) | Valor 1 código del Script Manager de Macintosh. |
+| [Microsoft](#Microsoft) | Valor 3 codificación de Microsoft. |
+| [Unicode](#Unicode) | Valor 0 Unicode |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ISO {#ISO}
+```
+public static final PlatformId ISO
+```
+
+
+Value2 especificación de Apple: (reservado; no usar) especificación de MS: codificación ISO. Tenga en cuenta que la ID de plataforma 2 (ISO) ha sido obsoleta desde la Especificación OpenType v1.3. Se pretendía representar ISO/IEC 10646, a diferencia de Unicode; ambos estándares tienen asignaciones de códigos de caracteres idénticas.
+
+### Macintosh {#Macintosh}
+```
+public static final PlatformId Macintosh
+```
+
+
+Valor 1 código del Script Manager de Macintosh.
+
+### Microsoft {#Microsoft}
+```
+public static final PlatformId Microsoft
+```
+
+
+Valor 3 codificación de Microsoft.
+
+### Unicode {#Unicode}
+```
+public static final PlatformId Unicode
+```
+
+
+Valor 0 Unicode
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static PlatformId valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[PlatformId](../../com.aspose.font/platformid)
+### values() {#values--}
+```
+public static PlatformId[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.PlatformId[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/renderingutils/_index.md
+++ b/spanish/java/com.aspose.font/renderingutils/_index.md
@@ -1,0 +1,202 @@
+---
+title: "RenderingUtils"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Proporciona métodos utilitarios para el renderizado."
+type: docs
+weight: 72
+url: /es/java/com.aspose.font/renderingutils/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class RenderingUtils
+```
+
+Proporciona métodos utilitarios para el renderizado.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [drawText(Font font, GlyphId[] glyphIds, double fontSize)](#drawText-com.aspose.font.Font-com.aspose.font.GlyphId---double-) | Renderizando texto en BitMap. |
+| [drawText(Font font, GlyphId[] glyphIds, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)](#drawText-com.aspose.font.Font-com.aspose.font.GlyphId---double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-) | Renderizando texto en BitMap. |
+| [drawText(Font font, String text, double fontSize)](#drawText-com.aspose.font.Font-java.lang.String-double-) | Renderizando texto en BitMap. |
+| [drawText(Font font, String text, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)](#drawText-com.aspose.font.Font-java.lang.String-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-) | Renderizando texto en BitMap. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### drawText(Font font, GlyphId[] glyphIds, double fontSize) {#drawText-com.aspose.font.Font-com.aspose.font.GlyphId---double-}
+```
+public static InputStream drawText(Font font, GlyphId[] glyphIds, double fontSize)
+```
+
+
+Renderizando texto en BitMap. Devuelve el resultado en formato PNG como flujo de bytes.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.font/font) | Fuente |
+| glyphIds | [GlyphId\[\]](../../com.aspose.font/glyphid) | Texto representado como una matriz de identificadores de glifos |
+| fontSize | double | Tamaño de fuente |
+
+**Returns:**
+java.io.InputStream - Imagen en formato PNG como flujo de bytes
+### drawText(Font font, GlyphId[] glyphIds, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth) {#drawText-com.aspose.font.Font-com.aspose.font.GlyphId---double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-}
+```
+public static InputStream drawText(Font font, GlyphId[] glyphIds, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)
+```
+
+
+Renderizando texto en BitMap. Devuelve el resultado en formato PNG como flujo de bytes.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.font/font) | Fuente |
+| glyphIds | [GlyphId\[\]](../../com.aspose.font/glyphid) | Texto representado como una matriz de identificadores de glifos |
+| fontSize | double | Tamaño de fuente |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Tipo de interlineado. Número de píxeles o porcentaje de la altura de la fuente |
+| lineSpacingValue | int | Valor del interlineado |
+| maxWidth | int | Ancho máximo en píxeles para la imagen |
+
+**Returns:**
+java.io.InputStream - Imagen en formato PNG como flujo de bytes
+### drawText(Font font, String text, double fontSize) {#drawText-com.aspose.font.Font-java.lang.String-double-}
+```
+public static InputStream drawText(Font font, String text, double fontSize)
+```
+
+
+Renderizando texto en BitMap.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.font/font) | La fuente. |
+| text | java.lang.String | El texto. |
+| fontSize | double | El tamaño de la fuente. |
+
+**Returns:**
+java.io.InputStream - La imagen PNG con el texto como una secuencia de bytes.
+### drawText(Font font, String text, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth) {#drawText-com.aspose.font.Font-java.lang.String-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-}
+```
+public static InputStream drawText(Font font, String text, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)
+```
+
+
+Renderizando texto en BitMap.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.font/font) | La fuente. |
+| text | java.lang.String | El texto. |
+| fontSize | double | El tamaño de la fuente. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | El tipo de interlineado. Número de píxeles o porcentaje de la altura de la fuente. |
+| lineSpacingValue | int | El valor del interlineado. |
+| maxWidth | int | El ancho máximo en píxeles para la imagen resultante. |
+
+**Returns:**
+java.io.InputStream - La imagen PNG con el texto como una secuencia de bytes.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/segmentpath/_index.md
+++ b/spanish/java/com.aspose.font/segmentpath/_index.md
@@ -1,0 +1,149 @@
+---
+title: "SegmentPath"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la ruta de renderizado."
+type: docs
+weight: 73
+url: /es/java/com.aspose.font/segmentpath/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Cloneable
+```
+public class SegmentPath implements Cloneable
+```
+
+Representa la ruta de renderizado.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clone()](#clone--) | Clona la Ruta. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getSegments()](#getSegments--) | Obtiene los segmentos de la ruta. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Clona la Ruta.
+
+**Returns:**
+java.lang.Object - Copia de la ruta.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSegments() {#getSegments--}
+```
+public PathSegmentCollection getSegments()
+```
+
+
+Obtiene los segmentos de la ruta.
+
+**Returns:**
+[PathSegmentCollection](../../com.aspose.font/pathsegmentcollection) - Path segments.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/streamsource/_index.md
+++ b/spanish/java/com.aspose.font/streamsource/_index.md
@@ -1,0 +1,195 @@
+---
+title: "StreamSource"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Define una forma de obtener un flujo de archivo cuando se necesita."
+type: docs
+weight: 74
+url: /es/java/com.aspose.font/streamsource/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class StreamSource
+```
+
+Define una forma de obtener un flujo de archivo cuando se necesita.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [StreamSource()](#StreamSource--) | Inicializa la instancia de la fuente de flujo. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Clona el objeto de la fuente de flujo. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontStream()](#getFontStream--) | Devuelve el flujo de Font. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento dentro de la fuente. |
+| [hashCode()](#hashCode--) |  |
+| [mustCloseAfterUse()](#mustCloseAfterUse--) | Los herederos pueden evitar que el flujo se cierre. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOffset(long value)](#setOffset-long-) | Establece el desplazamiento dentro de la fuente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StreamSource() {#StreamSource--}
+```
+public StreamSource()
+```
+
+
+Inicializa la instancia de la fuente de flujo.
+
+### deepClone() {#deepClone--}
+```
+public abstract Object deepClone()
+```
+
+
+Clona el objeto de la fuente de flujo.
+
+**Returns:**
+java.lang.Object - Copia del objeto de la fuente de flujo.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontStream() {#getFontStream--}
+```
+public abstract InputStream getFontStream()
+```
+
+
+Devuelve el flujo de Font.
+
+**Returns:**
+java.io.InputStream - Flujo de Font.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento dentro de la fuente.
+
+**Returns:**
+long - Desplazamiento dentro de la fuente.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### mustCloseAfterUse() {#mustCloseAfterUse--}
+```
+public boolean mustCloseAfterUse()
+```
+
+
+Los herederos pueden evitar que el flujo se cierre. Devuelve verdadero si la fuente de flujo desea que el flujo se cierre después de su uso. De lo contrario, devuelve falso.
+
+**Returns:**
+boolean - Verdadero si la fuente de flujo desea que el flujo se cierre después de su uso, de lo contrario falso.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOffset(long value) {#setOffset-long-}
+```
+public void setOffset(long value)
+```
+
+
+Establece el desplazamiento dentro de la fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long | Desplazamiento dentro de la fuente. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/stringindexdataprovider/_index.md
+++ b/spanish/java/com.aspose.font/stringindexdataprovider/_index.md
@@ -1,0 +1,250 @@
+---
+title: "StringIndexDataProvider"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Declara la funcionalidad para acceder a la estructura CFF String INDEX."
+type: docs
+weight: 75
+url: /es/java/com.aspose.font/stringindexdataprovider/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.ICffIndexDataProvider](../../com.aspose.font/icffindexdataprovider)
+```
+public abstract class StringIndexDataProvider implements ICffIndexDataProvider
+```
+
+Declara la funcionalidad para acceder a la estructura CFF String INDEX.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [StringIndexDataProvider()](#StringIndexDataProvider--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addString(String value)](#addString-java.lang.String-) | Agrega cadena en la estructura CFF String INDEX. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene/establece la cadena en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | El número de objetos en la estructura CFF INDEX. |
+| [getRawBytes()](#getRawBytes--) | Obtiene todos los bytes de la estructura CFF INDEX. |
+| [getString(int index)](#getString-int-) | Obtiene la cadena en el índice especificado de la estructura CFF String INDEX. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeString(int index)](#removeString-int-) | Elimina la cadena de la estructura CFF String Index en el índice especificado. |
+| [set(int index, String value)](#set-int-java.lang.String-) |  |
+| [setString(String value, int index)](#setString-java.lang.String-int-) | Establece la cadena en la estructura CFF String Index en el índice especificado. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StringIndexDataProvider() {#StringIndexDataProvider--}
+```
+public StringIndexDataProvider()
+```
+
+
+### addString(String value) {#addString-java.lang.String-}
+```
+public abstract void addString(String value)
+```
+
+
+Agrega cadena en la estructura CFF String INDEX.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Valor de cadena |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public abstract String get(int index)
+```
+
+
+Obtiene/establece la cadena en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | Índice de cadena, el índice significa un número ordinal en la estructura CFF INDEX, no SID |
+
+**Returns:**
+java.lang.String - Cadena
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public abstract int getCount()
+```
+
+
+El número de objetos en la estructura CFF INDEX.
+
+**Returns:**
+int
+### getRawBytes() {#getRawBytes--}
+```
+public abstract byte[] getRawBytes()
+```
+
+
+Obtiene todos los bytes de la estructura CFF INDEX.
+
+**Returns:**
+byte[] - Bytes de la estructura CFF INDEX
+### getString(int index) {#getString-int-}
+```
+public abstract String getString(int index)
+```
+
+
+Obtiene la cadena en el índice especificado de la estructura CFF String INDEX.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | Índice de cadena, el índice significa número ordinal en la estructura CFF INDEX, no SID |
+
+**Returns:**
+java.lang.String - Cadena
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeString(int index) {#removeString-int-}
+```
+public abstract void removeString(int index)
+```
+
+
+Elimina la cadena de la estructura CFF String Index en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | Índice de cadena, el índice significa un número ordinal en la estructura CFF INDEX, no SID |
+
+### set(int index, String value) {#set-int-java.lang.String-}
+```
+public abstract void set(int index, String value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+| valor | java.lang.String |  |
+
+### setString(String value, int index) {#setString-java.lang.String-int-}
+```
+public abstract void setString(String value, int index)
+```
+
+
+Establece la cadena en la estructura CFF String Index en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Valor de cadena |
+| índice | int | Índice de cadena, el índice significa número ordinal en la estructura CFF INDEX, no SID |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/svgconversionexception/_index.md
+++ b/spanish/java/com.aspose.font/svgconversionexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "SvgConversionException"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la excepción de conversión de fuentes para el formato SVG."
+type: docs
+weight: 76
+url: /es/java/com.aspose.font/svgconversionexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class SvgConversionException extends FontException
+```
+
+Representa una excepción de conversión de fuentes para el formato SVG. La excepción puede lanzarse en caso de errores durante el proceso de conversión de fuentes.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [SvgConversionException()](#SvgConversionException--) | Inicializa un nuevo objeto SvgConversionException. |
+| [SvgConversionException(String message)](#SvgConversionException-java.lang.String-) | Inicializa un nuevo objeto SvgConversionException. |
+| [SvgConversionException(String message, RuntimeException innerException)](#SvgConversionException-java.lang.String-java.lang.RuntimeException-) | Inicializa un nuevo objeto SvgConversionException. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SvgConversionException() {#SvgConversionException--}
+```
+public SvgConversionException()
+```
+
+
+Inicializa un nuevo objeto SvgConversionException.
+
+### SvgConversionException(String message) {#SvgConversionException-java.lang.String-}
+```
+public SvgConversionException(String message)
+```
+
+
+Inicializa un nuevo objeto SvgConversionException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+
+### SvgConversionException(String message, RuntimeException innerException) {#SvgConversionException-java.lang.String-java.lang.RuntimeException-}
+```
+public SvgConversionException(String message, RuntimeException innerException)
+```
+
+
+Inicializa un nuevo objeto SvgConversionException.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+| innerException | java.lang.RuntimeException | La excepción que es la causa de la excepción actual. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/topdictdataprovider/_index.md
+++ b/spanish/java/com.aspose.font/topdictdataprovider/_index.md
@@ -1,0 +1,968 @@
+---
+title: "TopDictDataProvider"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Declara la funcionalidad para leer/actualizar la estructura CFF Top DICT."
+type: docs
+weight: 77
+url: /es/java/com.aspose.font/topdictdataprovider/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class TopDictDataProvider
+```
+
+Declara la funcionalidad para leer/actualizar la estructura CFF Top DICT.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBaseFontName()](#getBaseFontName--) |  |
+| [getCidCount()](#getCidCount--) |  |
+| [getCidFontRevision()](#getCidFontRevision--) |  |
+| [getCidFontType()](#getCidFontType--) |  |
+| [getCidFontVersion()](#getCidFontVersion--) |  |
+| [getClass()](#getClass--) |  |
+| [getCopyright()](#getCopyright--) |  |
+| [getFamilyName()](#getFamilyName--) |  |
+| [getFontBBox()](#getFontBBox--) |  |
+| [getFontMatrix()](#getFontMatrix--) |  |
+| [getFontName()](#getFontName--) |  |
+| [getFullName()](#getFullName--) |  |
+| [getItalicAngle()](#getItalicAngle--) |  |
+| [getNotice()](#getNotice--) |  |
+| [getPaintType()](#getPaintType--) |  |
+| [getPostScript()](#getPostScript--) |  |
+| [getPrivateDictProvider()](#getPrivateDictProvider--) |  |
+| [getRos(int[] registrySid, int[] orderingSid, int[] supplement)](#getRos-int---int---int---) |  |
+| [getRos(String[] registry, String[] ordering, int[] supplement)](#getRos-java.lang.String---java.lang.String---int---) |  |
+| [getStrokeWidth()](#getStrokeWidth--) |  |
+| [getSyntheticBase()](#getSyntheticBase--) |  |
+| [getUidBase()](#getUidBase--) |  |
+| [getUnderlinePosition()](#getUnderlinePosition--) |  |
+| [getUnderlineThickness()](#getUnderlineThickness--) |  |
+| [getUniqueId()](#getUniqueId--) |  |
+| [getVersion()](#getVersion--) |  |
+| [getWeight()](#getWeight--) |  |
+| [getXuid()](#getXuid--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBaseFontName(String value)](#setBaseFontName-java.lang.String-) |  |
+| [setBaseFontNameSid(int sid)](#setBaseFontNameSid-int-) |  |
+| [setCidCount(int value)](#setCidCount-int-) |  |
+| [setCidFontRevision(int value)](#setCidFontRevision-int-) |  |
+| [setCidFontType(int value)](#setCidFontType-int-) |  |
+| [setCidFontVersion(int value)](#setCidFontVersion-int-) |  |
+| [setCopyright(String value)](#setCopyright-java.lang.String-) |  |
+| [setCopyrightSid(int sid)](#setCopyrightSid-int-) |  |
+| [setFamilyName(String value)](#setFamilyName-java.lang.String-) |  |
+| [setFamilyNameSid(int sid)](#setFamilyNameSid-int-) |  |
+| [setFixedPitch(boolean value)](#setFixedPitch-boolean-) |  |
+| [setFontBBox(FontBBox value)](#setFontBBox-com.aspose.font.FontBBox-) |  |
+| [setFontMatrix(TransformationMatrix value)](#setFontMatrix-com.aspose.font.TransformationMatrix-) |  |
+| [setFontName(String value)](#setFontName-java.lang.String-) |  |
+| [setFontNameSid(int sid)](#setFontNameSid-int-) |  |
+| [setFullName(String value)](#setFullName-java.lang.String-) |  |
+| [setFullNameSid(int sid)](#setFullNameSid-int-) |  |
+| [setItalicAngle(int value)](#setItalicAngle-int-) |  |
+| [setNotice(String value)](#setNotice-java.lang.String-) |  |
+| [setNoticeSid(int sid)](#setNoticeSid-int-) |  |
+| [setPaintType(int value)](#setPaintType-int-) |  |
+| [setPostScript(String value)](#setPostScript-java.lang.String-) |  |
+| [setPostScriptSid(int sid)](#setPostScriptSid-int-) |  |
+| [setRos(int registry, int ordering, int supplement)](#setRos-int-int-int-) |  |
+| [setRos(String registry, String ordering, int supplement)](#setRos-java.lang.String-java.lang.String-int-) |  |
+| [setStrokeWidth(int value)](#setStrokeWidth-int-) |  |
+| [setSyntheticBase(int value)](#setSyntheticBase-int-) |  |
+| [setUidBase(int value)](#setUidBase-int-) |  |
+| [setUnderlinePosition(int value)](#setUnderlinePosition-int-) |  |
+| [setUnderlineThickness(int value)](#setUnderlineThickness-int-) |  |
+| [setUniqueId(int value)](#setUniqueId-int-) |  |
+| [setVersion(String value)](#setVersion-java.lang.String-) |  |
+| [setVersionSid(int sid)](#setVersionSid-int-) |  |
+| [setWeight(String value)](#setWeight-java.lang.String-) |  |
+| [setWeightSid(int sid)](#setWeightSid-int-) |  |
+| [setXuid(double[] value)](#setXuid-double---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBaseFontName() {#getBaseFontName--}
+```
+public String getBaseFontName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getCidCount() {#getCidCount--}
+```
+public int getCidCount()
+```
+
+
+
+
+**Returns:**
+int
+### getCidFontRevision() {#getCidFontRevision--}
+```
+public int getCidFontRevision()
+```
+
+
+
+
+**Returns:**
+int
+### getCidFontType() {#getCidFontType--}
+```
+public int getCidFontType()
+```
+
+
+
+
+**Returns:**
+int
+### getCidFontVersion() {#getCidFontVersion--}
+```
+public int getCidFontVersion()
+```
+
+
+
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCopyright() {#getCopyright--}
+```
+public String getCopyright()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getFamilyName() {#getFamilyName--}
+```
+public String getFamilyName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox)
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix)
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getFullName() {#getFullName--}
+```
+public String getFullName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getItalicAngle() {#getItalicAngle--}
+```
+public int getItalicAngle()
+```
+
+
+
+
+**Returns:**
+int
+### getNotice() {#getNotice--}
+```
+public String getNotice()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getPaintType() {#getPaintType--}
+```
+public int getPaintType()
+```
+
+
+
+
+**Returns:**
+int
+### getPostScript() {#getPostScript--}
+```
+public String getPostScript()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getPrivateDictProvider() {#getPrivateDictProvider--}
+```
+public PrivateDictDataProvider getPrivateDictProvider()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.PrivateDictDataProvider
+### getRos(int[] registrySid, int[] orderingSid, int[] supplement) {#getRos-int---int---int---}
+```
+public void getRos(int[] registrySid, int[] orderingSid, int[] supplement)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| registrySid | int[] |  |
+| orderingSid | int[] |  |
+| suplemento | int[] |  |
+
+### getRos(String[] registry, String[] ordering, int[] supplement) {#getRos-java.lang.String---java.lang.String---int---}
+```
+public void getRos(String[] registry, String[] ordering, int[] supplement)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| registry | java.lang.String[] |  |
+| ordering | java.lang.String[] |  |
+| suplemento | int[] |  |
+
+### getStrokeWidth() {#getStrokeWidth--}
+```
+public int getStrokeWidth()
+```
+
+
+
+
+**Returns:**
+int
+### getSyntheticBase() {#getSyntheticBase--}
+```
+public int getSyntheticBase()
+```
+
+
+
+
+**Returns:**
+int
+### getUidBase() {#getUidBase--}
+```
+public int getUidBase()
+```
+
+
+
+
+**Returns:**
+int
+### getUnderlinePosition() {#getUnderlinePosition--}
+```
+public int getUnderlinePosition()
+```
+
+
+
+
+**Returns:**
+int
+### getUnderlineThickness() {#getUnderlineThickness--}
+```
+public int getUnderlineThickness()
+```
+
+
+
+
+**Returns:**
+int
+### getUniqueId() {#getUniqueId--}
+```
+public int getUniqueId()
+```
+
+
+
+
+**Returns:**
+int
+### getVersion() {#getVersion--}
+```
+public String getVersion()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getWeight() {#getWeight--}
+```
+public String getWeight()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getXuid() {#getXuid--}
+```
+public double[] getXuid()
+```
+
+
+
+
+**Returns:**
+double[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBaseFontName(String value) {#setBaseFontName-java.lang.String-}
+```
+public int setBaseFontName(String value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+**Returns:**
+int
+### setBaseFontNameSid(int sid) {#setBaseFontNameSid-int-}
+```
+public void setBaseFontNameSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| sid | int |  |
+
+### setCidCount(int value) {#setCidCount-int-}
+```
+public void setCidCount(int value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setCidFontRevision(int value) {#setCidFontRevision-int-}
+```
+public void setCidFontRevision(int value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setCidFontType(int value) {#setCidFontType-int-}
+```
+public void setCidFontType(int value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setCidFontVersion(int value) {#setCidFontVersion-int-}
+```
+public void setCidFontVersion(int value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setCopyright(String value) {#setCopyright-java.lang.String-}
+```
+public int setCopyright(String value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+**Returns:**
+int
+### setCopyrightSid(int sid) {#setCopyrightSid-int-}
+```
+public void setCopyrightSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| sid | int |  |
+
+### setFamilyName(String value) {#setFamilyName-java.lang.String-}
+```
+public int setFamilyName(String value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+**Returns:**
+int
+### setFamilyNameSid(int sid) {#setFamilyNameSid-int-}
+```
+public void setFamilyNameSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| sid | int |  |
+
+### setFixedPitch(boolean value) {#setFixedPitch-boolean-}
+```
+public void setFixedPitch(boolean value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setFontBBox(FontBBox value) {#setFontBBox-com.aspose.font.FontBBox-}
+```
+public void setFontBBox(FontBBox value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [FontBBox](../../com.aspose.font/fontbbox) |  |
+
+### setFontMatrix(TransformationMatrix value) {#setFontMatrix-com.aspose.font.TransformationMatrix-}
+```
+public void setFontMatrix(TransformationMatrix value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [TransformationMatrix](../../com.aspose.font/transformationmatrix) |  |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public int setFontName(String value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+**Returns:**
+int
+### setFontNameSid(int sid) {#setFontNameSid-int-}
+```
+public void setFontNameSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| sid | int |  |
+
+### setFullName(String value) {#setFullName-java.lang.String-}
+```
+public int setFullName(String value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+**Returns:**
+int
+### setFullNameSid(int sid) {#setFullNameSid-int-}
+```
+public void setFullNameSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| sid | int |  |
+
+### setItalicAngle(int value) {#setItalicAngle-int-}
+```
+public void setItalicAngle(int value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setNotice(String value) {#setNotice-java.lang.String-}
+```
+public int setNotice(String value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+**Returns:**
+int
+### setNoticeSid(int sid) {#setNoticeSid-int-}
+```
+public void setNoticeSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| sid | int |  |
+
+### setPaintType(int value) {#setPaintType-int-}
+```
+public void setPaintType(int value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPostScript(String value) {#setPostScript-java.lang.String-}
+```
+public int setPostScript(String value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+**Returns:**
+int
+### setPostScriptSid(int sid) {#setPostScriptSid-int-}
+```
+public void setPostScriptSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| sid | int |  |
+
+### setRos(int registry, int ordering, int supplement) {#setRos-int-int-int-}
+```
+public void setRos(int registry, int ordering, int supplement)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| registry | int |  |
+| ordering | int |  |
+| suplemento | int |  |
+
+### setRos(String registry, String ordering, int supplement) {#setRos-java.lang.String-java.lang.String-int-}
+```
+public void setRos(String registry, String ordering, int supplement)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| registry | java.lang.String |  |
+| ordering | java.lang.String |  |
+| suplemento | int |  |
+
+### setStrokeWidth(int value) {#setStrokeWidth-int-}
+```
+public void setStrokeWidth(int value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSyntheticBase(int value) {#setSyntheticBase-int-}
+```
+public void setSyntheticBase(int value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setUidBase(int value) {#setUidBase-int-}
+```
+public void setUidBase(int value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setUnderlinePosition(int value) {#setUnderlinePosition-int-}
+```
+public void setUnderlinePosition(int value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setUnderlineThickness(int value) {#setUnderlineThickness-int-}
+```
+public void setUnderlineThickness(int value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setUniqueId(int value) {#setUniqueId-int-}
+```
+public void setUniqueId(int value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setVersion(String value) {#setVersion-java.lang.String-}
+```
+public int setVersion(String value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+**Returns:**
+int
+### setVersionSid(int sid) {#setVersionSid-int-}
+```
+public void setVersionSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| sid | int |  |
+
+### setWeight(String value) {#setWeight-java.lang.String-}
+```
+public int setWeight(String value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+**Returns:**
+int
+### setWeightSid(int sid) {#setWeightSid-int-}
+```
+public void setWeightSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| sid | int |  |
+
+### setXuid(double[] value) {#setXuid-double---}
+```
+public void setXuid(double[] value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/transformationmatrix/_index.md
+++ b/spanish/java/com.aspose.font/transformationmatrix/_index.md
@@ -1,0 +1,412 @@
+---
+title: "Matriz de Transformación"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa una matriz 3x3  A   B   0   C   D   0   TX  TY  1 ."
+type: docs
+weight: 78
+url: /es/java/com.aspose.font/transformationmatrix/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TransformationMatrix
+```
+
+Representa una matriz 3x3 | A B 0 | | C D 0 | | TX TY 1 |. Transforma las coordenadas de la siguiente manera: x1 = A\*x + C\*y + TX y1 = B\*x + D\*y + TY.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [TransformationMatrix()](#TransformationMatrix--) | Crea una matriz estándar 1 a 1: [ A B C D TX TY ] = [ 1, 0, 0, 1, 0, 0] |
+| [TransformationMatrix(double[] matrixArray)](#TransformationMatrix-double---) | Acepta una matriz de transformación con la siguiente representación de arreglo: [ A B C D TX TY ] |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Proporciona acceso al arreglo subyacente. |
+| [getA()](#getA--) | Obtiene el valor A de la matriz de transformación. |
+| [getB()](#getB--) | Obtiene el valor B de la matriz de transformación. |
+| [getC()](#getC--) | Obtiene el valor C de la matriz de transformación. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Obtiene el valor D de la matriz de transformación. |
+| [getTX()](#getTX--) | Obtiene el valor TX de la matriz de transformación. |
+| [getTY()](#getTY--) | Obtiene el valor TY de la matriz de transformación. |
+| [hashCode()](#hashCode--) |  |
+| [multiply(TransformationMatrix matrix)](#multiply-com.aspose.font.TransformationMatrix-) | Multiplica con otra matriz de transformación. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [scale(double x, double y, double[] x1, double[] y1)](#scale-double-double-double---double---) | Escala x e y con la matriz de transformación: x1 = A\*x + C\*y; y1 = B\*x + D\*y. |
+| [setA(double value)](#setA-double-) | Establece el valor A de la matriz de transformación. |
+| [setB(double value)](#setB-double-) | Establece el valor B de la matriz de transformación. |
+| [setC(double value)](#setC-double-) | Establece el valor C de la matriz de transformación. |
+| [setD(double value)](#setD-double-) | Establece el valor D de la matriz de transformación. |
+| [setTX(double value)](#setTX-double-) | Establece el valor TX de la matriz de transformación. |
+| [setTY(double value)](#setTY-double-) | Establece el valor TY de la matriz de transformación. |
+| [toArray()](#toArray--) | Asigna un nuevo arreglo, copia la matriz de transformación y lo devuelve. |
+| [toString()](#toString--) |  |
+| [transform(double x, double y, double[] x1, double[] y1)](#transform-double-double-double---double---) | Transforma x e y con la matriz de transformación: x1 = A\*x + C\*y + TX; y1 = B\*x + D\*y + TY. |
+| [unScale(double x1, double y1, double[] x, double[] y)](#unScale-double-double-double---double---) | Escala de vuelta x1 y y1 y devuelve x e y antes de la matriz de transformación. |
+| [unTransform(double x1, double y1, double[] x, double[] y)](#unTransform-double-double-double---double---) | Transforma de vuelta x1 y y1 y devuelve x e y antes de la matriz de transformación. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TransformationMatrix() {#TransformationMatrix--}
+```
+public TransformationMatrix()
+```
+
+
+Crea una matriz estándar 1 a 1: [ A B C D TX TY ] = [ 1, 0, 0, 1, 0, 0]
+
+### TransformationMatrix(double[] matrixArray) {#TransformationMatrix-double---}
+```
+public TransformationMatrix(double[] matrixArray)
+```
+
+
+Acepta una matriz de transformación con la siguiente representación de arreglo: [ A B C D TX TY ]
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| matrixArray | double[] | Arreglo con valores de la matriz de transformación, debe tener 6 elementos. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public double get(int index)
+```
+
+
+Proporciona acceso al arreglo subyacente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | Índice en el arreglo de la matriz de transformación. |
+
+**Returns:**
+double - El elemento del arreglo subyacente por índice.
+### getA() {#getA--}
+```
+public double getA()
+```
+
+
+Obtiene el valor A de la matriz de transformación.
+
+**Returns:**
+double - Un valor de la matriz de transformación.
+### getB() {#getB--}
+```
+public double getB()
+```
+
+
+Obtiene el valor B de la matriz de transformación.
+
+**Returns:**
+double - Valor de la matriz de transformación B.
+### getC() {#getC--}
+```
+public double getC()
+```
+
+
+Obtiene el valor C de la matriz de transformación.
+
+**Returns:**
+double - Valor de la matriz de transformación C.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public double getD()
+```
+
+
+Obtiene el valor D de la matriz de transformación.
+
+**Returns:**
+double - Valor de la matriz de transformación D.
+### getTX() {#getTX--}
+```
+public double getTX()
+```
+
+
+Obtiene el valor TX de la matriz de transformación.
+
+**Returns:**
+double - Valor de la matriz de transformación TX.
+### getTY() {#getTY--}
+```
+public double getTY()
+```
+
+
+Obtiene el valor TY de la matriz de transformación.
+
+**Returns:**
+double - Valor de la matriz de transformación TY.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### multiply(TransformationMatrix matrix) {#multiply-com.aspose.font.TransformationMatrix-}
+```
+public TransformationMatrix multiply(TransformationMatrix matrix)
+```
+
+
+Multiplica con otra matriz de transformación. No cambia la matriz de transformación original, devuelve un nuevo objeto TransformationMatrix.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matriz de transformación con la que multiplicar. |
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - New TransformationMatrix object.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### scale(double x, double y, double[] x1, double[] y1) {#scale-double-double-double---double---}
+```
+public void scale(double x, double y, double[] x1, double[] y1)
+```
+
+
+Escala x e y con la matriz de transformación: x1 = A\*x + C\*y; y1 = B\*x + D\*y.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| x | double | Coordenada x original |
+| y | double | Coordenada y original. |
+| x1 | double[] | Coordenada x escalada. |
+| y1 | double[] | Coordenada y escalada. |
+
+### setA(double value) {#setA-double-}
+```
+public void setA(double value)
+```
+
+
+Establece el valor A de la matriz de transformación.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor de la matriz de transformación A. |
+
+### setB(double value) {#setB-double-}
+```
+public void setB(double value)
+```
+
+
+Establece el valor B de la matriz de transformación.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor de la matriz de transformación B. |
+
+### setC(double value) {#setC-double-}
+```
+public void setC(double value)
+```
+
+
+Establece el valor C de la matriz de transformación.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor de la matriz de transformación C. |
+
+### setD(double value) {#setD-double-}
+```
+public void setD(double value)
+```
+
+
+Establece el valor D de la matriz de transformación.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor de la matriz de transformación D. |
+
+### setTX(double value) {#setTX-double-}
+```
+public void setTX(double value)
+```
+
+
+Establece el valor TX de la matriz de transformación.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor de la matriz de transformación TX. |
+
+### setTY(double value) {#setTY-double-}
+```
+public void setTY(double value)
+```
+
+
+Establece el valor TY de la matriz de transformación.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor de la matriz de transformación TY. |
+
+### toArray() {#toArray--}
+```
+public double[] toArray()
+```
+
+
+Asigna un nuevo arreglo, copia la matriz de transformación y lo devuelve.
+
+**Returns:**
+double[] - TransformationMatrix en forma de arreglo.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(double x, double y, double[] x1, double[] y1) {#transform-double-double-double---double---}
+```
+public void transform(double x, double y, double[] x1, double[] y1)
+```
+
+
+Transforma x e y con la matriz de transformación: x1 = A\*x + C\*y + TX; y1 = B\*x + D\*y + TY.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| x | double | Coordenada x original. |
+| y | double | Coordenada y original. |
+| x1 | double[] | Coordenada x transformada. |
+| y1 | double[] | Coordenada y transformada. |
+
+### unScale(double x1, double y1, double[] x, double[] y) {#unScale-double-double-double---double---}
+```
+public void unScale(double x1, double y1, double[] x, double[] y)
+```
+
+
+Escala de vuelta x1 y y1 y devuelve x e y antes de la matriz de transformación.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| x1 | double | Coordenada x1 |
+| y1 | double | Coordenada y1 |
+| x | double[] | Coordenada x reescalada. |
+| y | double[] | Coordenada y reescalada. |
+
+### unTransform(double x1, double y1, double[] x, double[] y) {#unTransform-double-double-double---double---}
+```
+public void unTransform(double x1, double y1, double[] x, double[] y)
+```
+
+
+Transforma de vuelta x1 y y1 y devuelve x e y antes de la matriz de transformación.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| x1 | double | Coordenada x1. |
+| y1 | double | Coordenada y1. |
+| x | double[] | Coordenada x transformada de nuevo. |
+| y | double[] | Coordenada y transformada de nuevo. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttcfontfiledefinition/_index.md
+++ b/spanish/java/com.aspose.font/ttcfontfiledefinition/_index.md
@@ -1,0 +1,200 @@
+---
+title: "TtcFontFileDefinition"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la definición de archivo para la fuente TTC."
+type: docs
+weight: 79
+url: /es/java/com.aspose.font/ttcfontfiledefinition/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.FontFileDefinition](../../com.aspose.font/fontfiledefinition)
+```
+public class TtcFontFileDefinition extends FontFileDefinition
+```
+
+Representa la definición de archivo para la fuente TTC.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [TtcFontFileDefinition(int fontIndex, String fileExtension, StreamSource streamSource, long offset)](#TtcFontFileDefinition-int-java.lang.String-com.aspose.font.StreamSource-long-) | Crea una definición de archivo usando solo el contenido del archivo. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileExtension()](#getFileExtension--) | Obtiene la extensión del archivo. |
+| [getFileName()](#getFileName--) | Obtiene el nombre del archivo. |
+| [getFontIndex()](#getFontIndex--) | Obtiene el índice de fuente dentro de la fuente TTC. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento dentro del flujo. |
+| [getStreamSource()](#getStreamSource--) | Obtiene la fuente del flujo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TtcFontFileDefinition(int fontIndex, String fileExtension, StreamSource streamSource, long offset) {#TtcFontFileDefinition-int-java.lang.String-com.aspose.font.StreamSource-long-}
+```
+public TtcFontFileDefinition(int fontIndex, String fileExtension, StreamSource streamSource, long offset)
+```
+
+
+Crea una definición de archivo usando solo el contenido del archivo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontIndex | int | Índice de fuente dentro de la colección de fuentes TTC. |
+| fileExtension | java.lang.String | Extensión de la colección de archivos de fuentes. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Origen de la colección de archivos de fuentes. |
+| desplazamiento | long | Desplazamiento a los datos de la fuente en la colección de archivos de fuentes, ver Cabecera TTC, Tabla de Desplazamiento en la especificación del archivo de fuentes OpenType. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileExtension() {#getFileExtension--}
+```
+public String getFileExtension()
+```
+
+
+Obtiene la extensión del archivo.
+
+**Returns:**
+java.lang.String - Extensión de archivo.
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Obtiene el nombre del archivo.
+
+**Returns:**
+java.lang.String - Nombre de archivo.
+### getFontIndex() {#getFontIndex--}
+```
+public long getFontIndex()
+```
+
+
+Obtiene el índice de fuente dentro de la fuente TTC.
+
+**Returns:**
+long - Índice de fuente dentro del TTC.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento dentro del flujo.
+
+**Returns:**
+long - Desplazamiento dentro del flujo.
+### getStreamSource() {#getStreamSource--}
+```
+public StreamSource getStreamSource()
+```
+
+
+Obtiene la fuente del flujo.
+
+**Returns:**
+[StreamSource](../../com.aspose.font/streamsource) - The stream source.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttcfontsource/_index.md
+++ b/spanish/java/com.aspose.font/ttcfontsource/_index.md
@@ -1,0 +1,170 @@
+---
+title: "TtcFontSource"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la fuente TTC."
+type: docs
+weight: 80
+url: /es/java/com.aspose.font/ttcfontsource/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+com.aspose.font.IFontSource
+```
+public class TtcFontSource implements IFontSource
+```
+
+Representa la fuente TTC.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [TtcFontSource(StreamSource source)](#TtcFontSource-com.aspose.font.StreamSource-) | Crea una fuente TTC basada en el objeto que proporciona la secuencia IStreamSource. |
+| [TtcFontSource(String filePath)](#TtcFontSource-java.lang.String-) | Crea una fuente TTC basada en la ruta del archivo de colección de fuentes ttc. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontDefinitions()](#getFontDefinitions--) | Devuelve una matriz de definiciones de fuentes de la fuente TTC. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TtcFontSource(StreamSource source) {#TtcFontSource-com.aspose.font.StreamSource-}
+```
+public TtcFontSource(StreamSource source)
+```
+
+
+Crea una fuente TTC basada en el objeto que proporciona la secuencia IStreamSource.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| source | [StreamSource](../../com.aspose.font/streamsource) | Secuencia de origen de la cual extraer los datos de la colección de fuentes TTC. |
+
+### TtcFontSource(String filePath) {#TtcFontSource-java.lang.String-}
+```
+public TtcFontSource(String filePath)
+```
+
+
+Crea una fuente TTC basada en la ruta del archivo de colección de fuentes ttc.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| filePath | java.lang.String | Archivo de colección de fuentes. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontDefinitions() {#getFontDefinitions--}
+```
+public FontDefinition[] getFontDefinitions()
+```
+
+
+Devuelve una matriz de definiciones de fuentes de la fuente TTC.
+
+**Returns:**
+com.aspose.font.FontDefinition[] - Todas las definiciones de fuentes del origen de fuente TTC.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfcfftable/_index.md
+++ b/spanish/java/com.aspose.font/ttfcfftable/_index.md
@@ -1,0 +1,182 @@
+---
+title: "TtfCffTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla cff del archivo de fuente TTF."
+type: docs
+weight: 90
+url: /es/java/com.aspose.font/ttfcfftable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfCffTable extends TtfTableBase
+```
+
+Representa la tabla "cff" del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCffSource()](#getCffSource--) | Bytes sin procesar para contornos en la representación Compact Font Format. |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCffSource(StreamSource streamSource)](#setCffSource-com.aspose.font.StreamSource-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCffSource() {#getCffSource--}
+```
+public StreamSource getCffSource()
+```
+
+
+Bytes sin procesar para contornos en la representación Compact Font Format.
+
+**Returns:**
+[StreamSource](../../com.aspose.font/streamsource) - Raw bytes for outlines in Compact Font Format representation.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - Etiqueta de tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCffSource(StreamSource streamSource) {#setCffSource-com.aspose.font.StreamSource-}
+```
+public void setCffSource(StreamSource streamSource)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfcmapformat0table/_index.md
+++ b/spanish/java/com.aspose.font/ttfcmapformat0table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat0Table"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la subtabla Format0 CMap del archivo de fuente TTF."
+type: docs
+weight: 81
+url: /es/java/com.aspose.font/ttfcmapformat0table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat0Table extends TtfCMapFormatBaseTable
+```
+
+Representa la subtabla Format0 CMap del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Obtiene todos los códigos de la subtabla actual del CMap. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Obtiene un índice de glifo para un código de carácter dado. |
+| [getPlatformId()](#getPlatformId--) | Obtiene PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Obtiene PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Obtiene todos los códigos de la subtabla actual del CMap.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Todos los códigos de la subtabla actual del CMap.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Obtiene un índice de glifo para un código de carácter dado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| charCode | long | Código de carácter. |
+
+**Returns:**
+long - Índice de glifo.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Obtiene PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Obtiene PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfcmapformat10table/_index.md
+++ b/spanish/java/com.aspose.font/ttfcmapformat10table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat10Table"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la subtabla Format10 CMap del archivo de fuente TTF."
+type: docs
+weight: 82
+url: /es/java/com.aspose.font/ttfcmapformat10table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat10Table extends TtfCMapFormatBaseTable
+```
+
+Representa la subtabla Format10 CMap del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Obtiene todos los códigos de la subtabla actual del CMap. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Obtiene un índice de glifo para un código de carácter dado. |
+| [getPlatformId()](#getPlatformId--) | Obtiene PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Obtiene PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Obtiene todos los códigos de la subtabla actual del CMap.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Todos los códigos de la subtabla actual del CMap.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Obtiene un índice de glifo para un código de carácter dado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| charCode | long | Código de carácter. |
+
+**Returns:**
+long - Índice de glifo.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Obtiene PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Obtiene PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfcmapformat12table/_index.md
+++ b/spanish/java/com.aspose.font/ttfcmapformat12table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat12Table"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la subtabla Format8 CMap del archivo de fuente TTF."
+type: docs
+weight: 83
+url: /es/java/com.aspose.font/ttfcmapformat12table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat12Table extends TtfCMapFormatBaseTable
+```
+
+Representa la subtabla Format8 CMap del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Obtiene todos los códigos de la subtabla actual del CMap. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Obtiene un índice de glifo para un código de carácter dado. |
+| [getPlatformId()](#getPlatformId--) | Obtiene PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Obtiene PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Obtiene todos los códigos de la subtabla actual del CMap.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Todos los códigos de la subtabla actual del CMap.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Obtiene un índice de glifo para un código de carácter dado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| charCode | long | Código de carácter |
+
+**Returns:**
+long - Índice de glifo.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Obtiene PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Obtiene PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfcmapformat2table/_index.md
+++ b/spanish/java/com.aspose.font/ttfcmapformat2table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat2Table"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la subtabla Format2 CMap del archivo de fuente TTF."
+type: docs
+weight: 84
+url: /es/java/com.aspose.font/ttfcmapformat2table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat2Table extends TtfCMapFormatBaseTable
+```
+
+Representa la subtabla Format2 CMap del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Obtiene todos los códigos de la subtabla actual del CMap. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Obtiene un índice de glifo para un código de carácter dado. |
+| [getPlatformId()](#getPlatformId--) | Obtiene PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Obtiene PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Obtiene todos los códigos de la subtabla actual del CMap.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Todos los códigos de la subtabla actual del CMap.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Obtiene un índice de glifo para un código de carácter dado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| charCode | long | Código de carácter. |
+
+**Returns:**
+long - Índice de glifo.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Obtiene PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Obtiene PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfcmapformat4table/_index.md
+++ b/spanish/java/com.aspose.font/ttfcmapformat4table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat4Table"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la subtabla Format4 CMap del archivo de fuente TTF."
+type: docs
+weight: 85
+url: /es/java/com.aspose.font/ttfcmapformat4table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat4Table extends TtfCMapFormatBaseTable
+```
+
+Representa la subtabla Format4 CMap del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Obtiene todos los códigos de la subtabla actual del CMap. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Obtiene un índice de glifo para un código de carácter dado. |
+| [getPlatformId()](#getPlatformId--) | Obtiene PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Obtiene PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Obtiene todos los códigos de la subtabla actual del CMap.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Todos los códigos de la subtabla actual del CMap.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Obtiene un índice de glifo para un código de carácter dado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| charCode | long | Código de carácter. |
+
+**Returns:**
+long - Índice de glifo.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Obtiene PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Obtiene PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfcmapformat6table/_index.md
+++ b/spanish/java/com.aspose.font/ttfcmapformat6table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat6Table"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la subtabla Format6 CMap del archivo de fuente TTF."
+type: docs
+weight: 86
+url: /es/java/com.aspose.font/ttfcmapformat6table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat6Table extends TtfCMapFormatBaseTable
+```
+
+Representa la subtabla Format6 CMap del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Obtiene todos los códigos de la subtabla actual del CMap. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Obtiene un índice de glifo para un código de carácter dado. |
+| [getPlatformId()](#getPlatformId--) | Obtiene PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Obtiene PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Obtiene todos los códigos de la subtabla actual del CMap.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Todos los códigos de la subtabla actual del CMap.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Obtiene un índice de glifo para un código de carácter dado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| charCode | long | Código de carácter. |
+
+**Returns:**
+long - Índice de glifo.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Obtiene PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Obtiene PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfcmapformat8table/_index.md
+++ b/spanish/java/com.aspose.font/ttfcmapformat8table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat8Table"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la subtabla Format8 CMap del archivo de fuente TTF."
+type: docs
+weight: 87
+url: /es/java/com.aspose.font/ttfcmapformat8table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat8Table extends TtfCMapFormatBaseTable
+```
+
+Representa la subtabla Format8 CMap del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Obtiene todos los códigos de la subtabla actual del CMap. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Obtiene un índice de glifo para un código de carácter dado. |
+| [getPlatformId()](#getPlatformId--) | Obtiene PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Obtiene PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Obtiene todos los códigos de la subtabla actual del CMap.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Todos los códigos de la subtabla actual del CMap.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Obtiene un índice de glifo para un código de carácter dado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| charCode | long | Código de carácter. |
+
+**Returns:**
+long - Índice de glifo.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Obtiene PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Obtiene PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfcmapformatbasetable/_index.md
+++ b/spanish/java/com.aspose.font/ttfcmapformatbasetable/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormatBaseTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la clase base de la subtabla CMap."
+type: docs
+weight: 88
+url: /es/java/com.aspose.font/ttfcmapformatbasetable/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TtfCMapFormatBaseTable
+```
+
+Representa la clase base de la subtabla CMap.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Obtiene todos los códigos de la subtabla actual del CMap. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Obtiene un índice de glifo para un código de carácter dado |
+| [getPlatformId()](#getPlatformId--) | Obtiene PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Obtiene PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Obtiene todos los códigos de la subtabla actual del CMap.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Todos los códigos de la subtabla actual del CMap.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Obtiene un índice de glifo para un código de carácter dado
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| charCode | long | código de carácter |
+
+**Returns:**
+long - Índice de glifo.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Obtiene PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Obtiene PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfcmapsubtabledescription/_index.md
+++ b/spanish/java/com.aspose.font/ttfcmapsubtabledescription/_index.md
@@ -1,0 +1,157 @@
+---
+title: "TtfCMapTable.TtfCMapSubtableDescription"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Proporciona información breve sobre la subtabla CMap."
+type: docs
+weight: 10
+url: /es/java/com.aspose.font/ttfcmaptable.ttfcmapsubtabledescription/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract static class TtfCMapTable.TtfCMapSubtableDescription
+```
+
+Proporciona información breve sobre la subtabla CMap.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFormat()](#getFormat--) | Obtiene el formato de la subtabla. |
+| [getPlatformId()](#getPlatformId--) | Obtiene el id de la plataforma. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Obtiene el id de codificación específico de la plataforma. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Obtiene el formato de la subtabla.
+
+**Returns:**
+int - Formato de subtabla.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Obtiene el id de la plataforma.
+
+**Returns:**
+int - Id de plataforma.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Obtiene el id de codificación específico de la plataforma.
+
+**Returns:**
+int - Id de codificación específico de la plataforma.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfcmaptable/_index.md
+++ b/spanish/java/com.aspose.font/ttfcmaptable/_index.md
@@ -1,0 +1,196 @@
+---
+title: "TtfCMapTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla cmap del archivo de fuente TTF."
+type: docs
+weight: 89
+url: /es/java/com.aspose.font/ttfcmaptable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfCMapTable extends TtfTableBase
+```
+
+Representa la tabla "cmap" del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [findUnicodeTable()](#findUnicodeTable--) | Busca y devuelve el CMap Unicode. |
+| [getAllSubtables()](#getAllSubtables--) | Devuelve todas las subtablas de la tabla CMap. |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getPlatformTables(int platformId, int platformSpecificId)](#getPlatformTables-int-int-) | Devuelve las subtablas CMap para planformId y platformSpecificId. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### findUnicodeTable() {#findUnicodeTable--}
+```
+public TtfCMapFormatBaseTable findUnicodeTable()
+```
+
+
+Busca y devuelve el CMap Unicode. Si hay un CMap ucs-4, lo devuelve primero; de lo contrario, devuelve cualquier CMap Unicode que pueda encontrar.
+
+**Returns:**
+[TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable) - Unicode subtable.
+### getAllSubtables() {#getAllSubtables--}
+```
+public TtfCMapTable.TtfCMapSubtableDescription[] getAllSubtables()
+```
+
+
+Devuelve todas las subtablas de la tabla CMap.
+
+**Returns:**
+com.aspose.font.TtfCMapTable.TtfCMapSubtableDescription[] - matriz de objetos TtfCmapSubtableDescription
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getPlatformTables(int platformId, int platformSpecificId) {#getPlatformTables-int-int-}
+```
+public TtfCMapFormatBaseTable[] getPlatformTables(int platformId, int platformSpecificId)
+```
+
+
+Devuelve las subtablas CMap para planformId y platformSpecificId.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| platformId | int | Id de plataforma. |
+| platformSpecificId | int | Id de codificación específica de la plataforma. |
+
+**Returns:**
+com.aspose.font.TtfCMapFormatBaseTable[] - subtablas CMap.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - Etiqueta de tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfcvttable/_index.md
+++ b/spanish/java/com.aspose.font/ttfcvttable/_index.md
@@ -1,0 +1,168 @@
+---
+title: "TtfCvtTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla de valores de control (CVT) del archivo de fuente TTF."
+type: docs
+weight: 91
+url: /es/java/com.aspose.font/ttfcvttable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfCvtTable extends TtfTableBase
+```
+
+Representa la tabla de valores de control (CVT) del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getControlValues()](#getControlValues--) | Obtiene la lista de valores referenciables por instrucciones. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getControlValues() {#getControlValues--}
+```
+public short[] getControlValues()
+```
+
+
+Obtiene la lista de valores referenciables por instrucciones.
+
+**Returns:**
+short[] - Lista de valores referenciables por instrucciones.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - Etiqueta de tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfencoding/_index.md
+++ b/spanish/java/com.aspose.font/ttfencoding/_index.md
@@ -1,0 +1,207 @@
+---
+title: "TtfEncoding"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la codificación de la fuente TTF."
+type: docs
+weight: 92
+url: /es/java/com.aspose.font/ttfencoding/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFontEncoding](../../com.aspose.font/ifontencoding)
+```
+public class TtfEncoding implements IFontEncoding
+```
+
+Representa la codificación de la fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [decodeToGid(long unicode)](#decodeToGid-long-) | La implementación DecodeToGlyphId de la fuente TTF busca la tabla unicode y devuelve el id de glifo para el carácter unicode. |
+| [decodeToGidParameterized(IEncodingParameters parameters, long charCode)](#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-) | La versión parametrizada permite usar una tabla CMap específica (no unicode). |
+| [encode(long gid, long charCode)](#encode-long-long-) | Codifica el glifo. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [gidToUnicode(GlyphId glyphId)](#gidToUnicode-com.aspose.font.GlyphId-) | Decodifica el id de glifo a unicode. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [unicodeToGid(long unicode)](#unicodeToGid-long-) | Decodifica un unicode y devuelve el id de glifo. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### decodeToGid(long unicode) {#decodeToGid-long-}
+```
+public GlyphId decodeToGid(long unicode)
+```
+
+
+La implementación DecodeToGlyphId de la fuente TTF busca la tabla unicode y devuelve el id de glifo para el carácter unicode. El id de glifo es un número único para un glifo, que depende del tipo de fuente. Por ejemplo: el id de Type1 es un nombre de glifo, instancia de la clase ( GlyphStringId ). El id de TTF es un índice entero, instancia de la clase ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| unicode | long | Código de carácter para obtener el identificador del glifo. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to character code passed.
+### decodeToGidParameterized(IEncodingParameters parameters, long charCode) {#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-}
+```
+public GlyphId decodeToGidParameterized(IEncodingParameters parameters, long charCode)
+```
+
+
+La versión parametrizada permite usar una tabla CMap específica (no unicode).
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| parameters | [IEncodingParameters](../../com.aspose.font/iencodingparameters) | Implementación de la interfaz IEncodingParameters. |
+| charCode | long | código de carácter para obtener el identificador de glifo. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to character code passed.
+### encode(long gid, long charCode) {#encode-long-long-}
+```
+public void encode(long gid, long charCode)
+```
+
+
+Codifica el glifo. Para fuentes TTF el código de carácter es unicode.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| gid | long | Identificador de glifo. |
+| charCode | long | Código de carácter. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### gidToUnicode(GlyphId glyphId) {#gidToUnicode-com.aspose.font.GlyphId-}
+```
+public long gidToUnicode(GlyphId glyphId)
+```
+
+
+Decodifica el id de glifo a unicode. El id de glifo es un número único para un glifo, que depende del tipo de fuente. Por ejemplo: el id de Type1 es un nombre de glifo, instancia de la clase ( GlyphStringId ). El id de TTF es un índice entero, instancia de la clase ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificador de glifo del símbolo a decodificar. |
+
+**Returns:**
+long - Valor Unicode relacionado con el id de glifo pasado.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unicodeToGid(long unicode) {#unicodeToGid-long-}
+```
+public GlyphId unicodeToGid(long unicode)
+```
+
+
+Decodifica un unicode y devuelve el id de glifo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| unicode | long | Unicode para obtener el identificador del glifo. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to unicode passed.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfencodingparameters/_index.md
+++ b/spanish/java/com.aspose.font/ttfencodingparameters/_index.md
@@ -1,0 +1,196 @@
+---
+title: "TtfEncodingParameters"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa los parámetros de codificación TTF."
+type: docs
+weight: 93
+url: /es/java/com.aspose.font/ttfencodingparameters/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IEncodingParameters](../../com.aspose.font/iencodingparameters)
+```
+public class TtfEncodingParameters implements IEncodingParameters
+```
+
+Representa los parámetros de codificación TTF. Debe usarse para solicitar una codificación específica del tipo de letra TTF.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [TtfEncodingParameters(int platformId, int platformSpecificId)](#TtfEncodingParameters-int-int-) | Inicializa una nueva instancia de la clase TtfEncodingParameters. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPlatformId()](#getPlatformId--) | Obtiene el valor de PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Obtiene el valor de PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setPlatformId(int value)](#setPlatformId-int-) | Establece el valor de PlatformId. |
+| [setPlatformSpecificId(int value)](#setPlatformSpecificId-int-) | Establece el valor de PlatformSpecificId. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TtfEncodingParameters(int platformId, int platformSpecificId) {#TtfEncodingParameters-int-int-}
+```
+public TtfEncodingParameters(int platformId, int platformSpecificId)
+```
+
+
+Inicializa una nueva instancia de la clase TtfEncodingParameters. Toma Platform Id y Platform-specific encoding id como parámetros. Estos parámetros se utilizan para solicitar una subtabla CMap especial de la tabla CMap principal de la fuente, ver la tabla 'CMap', 'name' en la especificación del archivo de fuente OpenType.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| platformId | int | Identificador de plataforma. |
+| platformSpecificId | int | Identificador de codificación específico de la plataforma. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Obtiene el valor de PlatformId.
+
+**Returns:**
+int - valor de PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Obtiene el valor de PlatformSpecificId.
+
+**Returns:**
+int - valor de PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setPlatformId(int value) {#setPlatformId-int-}
+```
+public void setPlatformId(int value)
+```
+
+
+Establece el valor de PlatformId.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int | Valor de PlatformId. |
+
+### setPlatformSpecificId(int value) {#setPlatformSpecificId-int-}
+```
+public void setPlatformSpecificId(int value)
+```
+
+
+Establece el valor de PlatformSpecificId.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int | Valor de PlatformSpecificId. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttffont/_index.md
+++ b/spanish/java/com.aspose.font/ttffont/_index.md
@@ -1,0 +1,648 @@
+---
+title: "TtfFont"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la fuente TrueType TTF."
+type: docs
+weight: 94
+url: /es/java/com.aspose.font/ttffont/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Font](../../com.aspose.font/font)
+```
+public class TtfFont extends Font
+```
+
+Representa la fuente TrueType (TTF).
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Convierte la fuente a otro formato. |
+| [convert(FontType fontType, Collection<Integer> limitingCharacterSet)](#convert-com.aspose.font.FontType-java.util.Collection-java.lang.Integer--) | Convierte la fuente a otro formato con un conjunto de caracteres limitado  *Nota: el tipo de fuente TTF ahora solo es compatible.* |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Devuelve una matriz de todos los identificadores de glifos disponibles en la fuente. |
+| [getCffFont()](#getCffFont--) | Obtiene la fuente CFF si está presente. |
+| [getClass()](#getClass--) |  |
+| [getEncoding()](#getEncoding--) | Obtiene la codificación de la fuente. |
+| [getFontDefinition()](#getFontDefinition--) | Obtiene la definición de la fuente. |
+| [getFontFamily()](#getFontFamily--) | Obtiene la familia de la fuente. |
+| [getFontName()](#getFontName--) | Obtiene el nombre del estilo de la fuente. |
+| [getFontNames()](#getFontNames--) | Obtiene los nombres de la fuente. |
+| [getFontSaver()](#getFontSaver--) | Obtiene la funcionalidad de guardado de la fuente. |
+| [getFontStyle()](#getFontStyle--) | Obtiene el estilo de la fuente. |
+| [getFontType()](#getFontType--) | Obtiene el tipo de la fuente. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Accesor de glifos de la fuente. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Devuelve el glifo por su identificador. |
+| [getGlyphById(String glyphName)](#getGlyphById-java.lang.String-) | Devuelve el glifo por su nombre. |
+| [getGlyphById(long id)](#getGlyphById-long-) | Devuelve el glifo por su identificador. |
+| [getGlyphComponentsById(GlyphId id, GlyphIdList componentsToPopulate)](#getGlyphComponentsById-com.aspose.font.GlyphId-com.aspose.font.GlyphIdList-) | Obtiene un glifo mediante el identificador de glifo proporcionado y llena la lista de identificadores de glifos pasada con los componentes de este glifo. |
+| [getGlyphComponentsById(String glyphName, GlyphIdList componentsToPopulate)](#getGlyphComponentsById-java.lang.String-com.aspose.font.GlyphIdList-) | Obtiene un glifo mediante el nombre de glifo proporcionado y llena la lista de identificadores de glifos pasada con los componentes de este glifo. |
+| [getGlyphComponentsById(long id, GlyphIdList componentsToPopulate)](#getGlyphComponentsById-long-com.aspose.font.GlyphIdList-) | Obtiene un glifo mediante el índice de glifo proporcionado y llena la lista de identificadores de glifos pasada con los componentes de este glifo. |
+| [getGlyphIdType()](#getGlyphIdType--) | Obtiene la especificación del tipo de identificador de glifo. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Obtén la representación de glifos para el texto. |
+| [getMetrics()](#getMetrics--) | Obtiene las métricas de la fuente. |
+| [getNumGlyphs()](#getNumGlyphs--) | Obtiene el número de glifos en la Fuente. |
+| [getPostscriptNames()](#getPostscriptNames--) | Obtiene los nombres de fuentes Postscript. |
+| [getStyle()](#getStyle--) | Obtiene el estilo de la fuente. |
+| [getTtfTables()](#getTtfTables--) | Obtiene las tablas TTF. |
+| [hashCode()](#hashCode--) |  |
+| [isSymbolic()](#isSymbolic--) | Devuelve true en caso de que la Fuente sea simbólica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Abre una fuente, usando el objeto FontDefinition. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Abre una fuente, usando el tipo de fuente y la matriz de bytes de datos de fuente. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Abre una fuente, usando el tipo de fuente y la fuente de flujo. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Abre una fuente, usando el tipo de fuente y el nombre de archivo de fuente. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Guarda la Fuente en el formato original. |
+| [save(String fileName)](#save-java.lang.String-) | Guarda la Fuente en el formato original. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Guarda la Fuente en el formato especificado. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Establece la familia de la Fuente. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Establece el nombre de la cara de la Fuente. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Establece el estilo de la Fuente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public Font convert(FontType fontType)
+```
+
+
+Convierte la Fuente a otro formato. Nota: el tipo de Fuente TTF ahora solo es compatible.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de formato de fuente al que convertir. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### convert(FontType fontType, Collection<Integer> limitingCharacterSet) {#convert-com.aspose.font.FontType-java.util.Collection-java.lang.Integer--}
+```
+public Font convert(FontType fontType, Collection<Integer> limitingCharacterSet)
+```
+
+
+Convierte la fuente a otro formato con un conjunto de caracteres limitado  *Nota: el tipo de fuente TTF ahora solo es compatible.*
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de formato de fuente al que convertir. |
+| limitingCharacterSet | java.util.Collection<java.lang.Integer> | Conjunto de caracteres limitante. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public GlyphId[] getAllGlyphIds()
+```
+
+
+Devuelve una matriz de todos los ids de glifos disponibles en la Fuente. El id de glifo es un número único para un glifo, que depende del tipo de fuente. El id de glifo de Fuente TTF puede ser una instancia de la clase ( GlyphStringId ) o de la clase ( GlyphUInt32Id ). La dirección de glifos por nombre (string) es compatible con Fuentes TTF mediante el mapeo de la tabla Post. En caso de que haya una Fuente CFF, se utilizan las estructuras CFF para direccionar los glifos por nombre.
+
+**Returns:**
+com.aspose.font.GlyphId[] - Identificadores de glifos.
+### getCffFont() {#getCffFont--}
+```
+public Font getCffFont()
+```
+
+
+Obtiene la fuente CFF si está presente.
+
+**Returns:**
+[Font](../../com.aspose.font/font) - CFF Font.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncoding() {#getEncoding--}
+```
+public IFontEncoding getEncoding()
+```
+
+
+Obtiene la codificación de la fuente.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public FontDefinition getFontDefinition()
+```
+
+
+Obtiene la definición de la fuente.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public String getFontFamily()
+```
+
+
+Obtiene la familia de la fuente.
+
+**Returns:**
+java.lang.String - Familia de la Fuente.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Obtiene el nombre del estilo de la fuente.
+
+**Returns:**
+java.lang.String - Nombre de la cara de la Fuente.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Obtiene los nombres de la fuente.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Obtiene la funcionalidad de guardado de la fuente.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public int getFontStyle()
+```
+
+
+Obtiene el estilo de la Fuente. Este es un valor calculado y representado en tipo generalizado.
+
+**Returns:**
+int - Estilo de la Fuente. Normalmente, una combinación de valores de bandera constante de la clase FontStyle o 0.
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Obtiene el tipo de Fuente. Devuelve el valor FontType.TTF.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Accesor de glifos de fuente. Recupera glifos e identificadores de glifos.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public Glyph getGlyphById(GlyphId id)
+```
+
+
+Devuelve el glifo por su id de glifo. El id de glifo es un número único para un glifo, que depende del tipo de fuente. El id de glifo de una fuente TTF puede ser una instancia de la clase ( GlyphStringId ) o de la clase ( GlyphUInt32Id ). La direccionamiento de glifos por nombre (string) es compatible con fuentes TTF mediante el mapeo de la tabla Post. En caso de que haya una fuente CFF, se utilizan las estructuras CFF para direccionar glifos por nombre.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) |  |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph)
+### getGlyphById(String glyphName) {#getGlyphById-java.lang.String-}
+```
+public Glyph getGlyphById(String glyphName)
+```
+
+
+Devuelve el glifo por su nombre. La direccionamiento de glifos por nombre (string) es compatible con fuentes TTF mediante el mapeo de la tabla Post. En caso de que haya una fuente CFF, se utilizan las estructuras CFF para direccionar glifos por nombre.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphName | java.lang.String | Identificador de cadena de glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(long id) {#getGlyphById-long-}
+```
+public Glyph getGlyphById(long id)
+```
+
+
+Devuelve el glifo por su identificador.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| id | long | Índice de glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphComponentsById(GlyphId id, GlyphIdList componentsToPopulate) {#getGlyphComponentsById-com.aspose.font.GlyphId-com.aspose.font.GlyphIdList-}
+```
+public void getGlyphComponentsById(GlyphId id, GlyphIdList componentsToPopulate)
+```
+
+
+Obtiene un glifo mediante el identificador de glifo proporcionado y llena la lista de identificadores de glifos pasada con los componentes de este glifo. El id de glifo es un número único para un glifo, que depende del tipo de fuente. El id de glifo de una fuente TTF puede ser una instancia de la clase ( GlyphStringId ) o de la clase ( GlyphUInt32Id ). La direccionamiento de glifos por nombre (string) es compatible con fuentes TTF mediante el mapeo de la tabla Post. En caso de que haya una fuente CFF, se utilizan las estructuras CFF para direccionar glifos por nombre.
+
+--------------------
+
+Debe pasarse una colección vacía componentsToPopulate que contendrá la lista de ids de componentes de glifos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | Id de glifo. |
+| componentsToPopulate | [GlyphIdList](../../com.aspose.font/glyphidlist) | Lista de identificadores de glifos a llenar. |
+
+### getGlyphComponentsById(String glyphName, GlyphIdList componentsToPopulate) {#getGlyphComponentsById-java.lang.String-com.aspose.font.GlyphIdList-}
+```
+public void getGlyphComponentsById(String glyphName, GlyphIdList componentsToPopulate)
+```
+
+
+Obtiene un glifo mediante el nombre de glifo proporcionado y llena la lista de identificadores de glifos pasada con los componentes de este glifo.
+
+--------------------
+
+Debe pasarse una colección vacía componentsToPopulate que contendrá la lista de ids de componentes de glifos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphName | java.lang.String | Nombre del glifo. |
+| componentsToPopulate | [GlyphIdList](../../com.aspose.font/glyphidlist) | Lista de identificadores de glifos a llenar. |
+
+### getGlyphComponentsById(long id, GlyphIdList componentsToPopulate) {#getGlyphComponentsById-long-com.aspose.font.GlyphIdList-}
+```
+public void getGlyphComponentsById(long id, GlyphIdList componentsToPopulate)
+```
+
+
+Obtiene un glifo mediante el índice de glifo proporcionado y llena la lista de identificadores de glifos pasada con los componentes de este glifo.
+
+--------------------
+
+Debe pasarse una colección vacía componentsToPopulate que contendrá la lista de ids de componentes de glifos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| id | long | Índice de glifo. |
+| componentsToPopulate | [GlyphIdList](../../com.aspose.font/glyphidlist) | Lista de identificadores de glifos a llenar. |
+
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public GlyphIdType getGlyphIdType()
+```
+
+
+Obtiene la especificación del tipo de identificador de glifo.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype) - Glyph id type specification.
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Obtén la representación de glifos para el texto.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| text | java.lang.String | Texto de entrada. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - matriz de GlyphId.
+### getMetrics() {#getMetrics--}
+```
+public IFontMetrics getMetrics()
+```
+
+
+Obtiene las métricas de la fuente.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Obtiene el número de glifos en la Fuente.
+
+**Returns:**
+int - Número de glifos en la fuente.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Obtiene los nombres de fuentes Postscript.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript font names.
+### getStyle() {#getStyle--}
+```
+public String getStyle()
+```
+
+
+Obtiene el estilo de la fuente. Este es un valor de cadena sin procesar proporcionado por el archivo de fuente.
+
+**Returns:**
+java.lang.String - Estilo de la fuente.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Obtiene las tablas TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - TTF tables.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isSymbolic() {#isSymbolic--}
+```
+public boolean isSymbolic()
+```
+
+
+Devuelve true en caso de que la Fuente sea simbólica.
+
+**Returns:**
+boolean - Verdadero en caso de que la fuente sea simbólica.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Abre una fuente, usando el objeto FontDefinition.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Objeto de definición de fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Abre una fuente, usando el tipo de fuente y la matriz de bytes de datos de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fontData | byte[] | Arreglo de bytes para cargar la fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Abre una fuente, usando el tipo de fuente y la fuente de flujo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Fuente de flujo para la fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Abre una fuente, usando el tipo de fuente y el nombre de archivo de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fileName | java.lang.String | Nombre del archivo de fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Guarda la Fuente en el formato original.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.OutputStream | Flujo para guardar la fuente. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Guarda la Fuente en el formato original.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | java.lang.String | Archivo para guardar la fuente. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Guarda la Fuente en el formato especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.OutputStream | flujo para guardar la fuente |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | formato deseado |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public void setFontFamily(String value)
+```
+
+
+Establece la familia de la Fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Nueva familia de fuente. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public void setFontName(String value)
+```
+
+
+Establece el nombre de la cara de la Fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Nuevo nombre de la cara de fuente. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public void setStyle(String value)
+```
+
+
+Establece el estilo de fuente. Este es un valor de cadena cruda proporcionado por el archivo de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Nuevo estilo de fuente. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttffontmetrics/_index.md
+++ b/spanish/java/com.aspose.font/ttffontmetrics/_index.md
@@ -1,0 +1,484 @@
+---
+title: "TtfFontMetrics"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa las métricas de la fuente TTF."
+type: docs
+weight: 95
+url: /es/java/com.aspose.font/ttffontmetrics/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.FontMetrics](../../com.aspose.font/fontmetrics)
+```
+public class TtfFontMetrics extends FontMetrics
+```
+
+Representa las métricas de la fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAscender()](#getAscender--) | Obtiene el valor del ascendente. |
+| [getAscender(double fontSize)](#getAscender-double-) | Devuelve el ascender para un tamaño de fuente específico. |
+| [getClass()](#getClass--) |  |
+| [getDescender()](#getDescender--) | Obtiene el valor del descendente. |
+| [getDescender(double fontSize)](#getDescender-double-) | Devuelve el descender para un tamaño de fuente específico. |
+| [getFontBBox()](#getFontBBox--) | Obtiene el valor de FontBBox. |
+| [getFontMatrix()](#getFontMatrix--) | Obtiene el valor de FontBBox. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Devuelve el Bbox del glifo. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Devuelve el ancho de los glifos por id de glifo. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Devuelve el valor de kerning para el par de glifos. |
+| [getLineGap()](#getLineGap--) | Obtiene el valor de LineGap. |
+| [getTypoAscender()](#getTypoAscender--) | Obtiene el valor de TypoAscender. |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Devuelve el ascendente tipográfico para un tamaño de fuente específico. |
+| [getTypoDescender()](#getTypoDescender--) | Obtiene el valor de TypoDescender. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Devuelve el descendente tipográfico para un tamaño de fuente específico |
+| [getTypoLineGap()](#getTypoLineGap--) | Obtiene el valor de TypoLineGap. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Devuelve el espacio entre líneas para un tamaño de fuente específico. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Obtiene el valor de UnitsPerEM. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Obtiene el valor de IsFixedPitch. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Mide la cadena y devuelve el ancho de la cadena. |
+| [measureString(long[] charCodes, double fontSize)](#measureString-long---double-) | Mide el texto representado como una matriz de códigos de caracteres y devuelve el ancho de la cadena. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAscender(double value)](#setAscender-double-) | Establece el valor del ascendente. |
+| [setDescender(double value)](#setDescender-double-) | Establece el valor del descendente. |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) | Establece el ancho del glifo. |
+| [setTypoAscender(double value)](#setTypoAscender-double-) | Establece el valor de TypoAscender. |
+| [setTypoDescender(double value)](#setTypoDescender-double-) | Establece el valor de TypoDescender. |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAscender() {#getAscender--}
+```
+public double getAscender()
+```
+
+
+Obtiene el valor del ascendente.
+
+**Returns:**
+double - valor de Ascender.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public double getAscender(double fontSize)
+```
+
+
+Devuelve el ascender para un tamaño de fuente específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - valor de Ascender.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescender() {#getDescender--}
+```
+public double getDescender()
+```
+
+
+Obtiene el valor del descendente.
+
+**Returns:**
+double - valor de Descender.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public double getDescender(double fontSize)
+```
+
+
+Devuelve el descender para un tamaño de fuente específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - valor de Descender.
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+Obtiene el valor de FontBBox.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox)
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+Obtiene el valor de FontBBox.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix)
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Devuelve el Bbox del glifo. Devuelve FontBBox si el Bbox no estaba definido para el glifo. Puede ser sobrescrito por herederos de codificación de fuente específicos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificador de glifo. |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox.
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Devuelve el ancho de los glifos por id de glifo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificador de glifo. |
+
+**Returns:**
+double - Ancho del glifo.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Devuelve el valor de kerning para el par de glifos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Primer glifo en el par. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Tamaño de fuente. |
+
+**Returns:**
+double - Valor de interletraje
+### getLineGap() {#getLineGap--}
+```
+public double getLineGap()
+```
+
+
+Obtiene el valor de LineGap.
+
+**Returns:**
+double - Valor de LineGap.
+### getTypoAscender() {#getTypoAscender--}
+```
+public double getTypoAscender()
+```
+
+
+Obtiene el valor de TypoAscender.
+
+**Returns:**
+double - Valor de TypoAscender.
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public double getTypoAscender(double fontSize)
+```
+
+
+Devuelve el ascendente tipográfico para un tamaño de fuente específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - Valor del ascendente tipográfico.
+### getTypoDescender() {#getTypoDescender--}
+```
+public double getTypoDescender()
+```
+
+
+Obtiene el valor de TypoDescender.
+
+**Returns:**
+double - Valor de TypoDescender.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public double getTypoDescender(double fontSize)
+```
+
+
+Devuelve el descendente tipográfico para un tamaño de fuente específico
+
+param fontSize Tamaño de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double |  |
+
+**Returns:**
+double - Valor del descendente tipográfico.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public double getTypoLineGap()
+```
+
+
+Obtiene el valor de TypoLineGap.
+
+**Returns:**
+double - Valor de TypoLineGap.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public double getTypoLineGap(double fontSize)
+```
+
+
+Devuelve el espacio entre líneas para un tamaño de fuente específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - Valor del espacio de línea.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Obtiene el valor de UnitsPerEM.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+Obtiene el valor de IsFixedPitch.
+
+**Returns:**
+boolean - Valor de IsFixedPitch.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public double measureString(String unicode, double fontSize)
+```
+
+
+Mide la cadena y devuelve el ancho de la cadena.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| unicode | java.lang.String | Cadena Unicode. |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - Ancho de la cadena.
+### measureString(long[] charCodes, double fontSize) {#measureString-long---double-}
+```
+public double measureString(long[] charCodes, double fontSize)
+```
+
+
+Mide el texto representado como una matriz de códigos de caracteres y devuelve el ancho de la cadena.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| charCodes | long[] | Cadena de texto representada como una matriz de códigos de caracteres. |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - Ancho de la cadena.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAscender(double value) {#setAscender-double-}
+```
+public void setAscender(double value)
+```
+
+
+Establece el valor del ascendente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor del ascendente. |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public void setDescender(double value)
+```
+
+
+Establece el valor del descendente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor del descendente. |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Establece el ancho del glifo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificador de glifo. |
+| valor | double | Nuevo ancho. |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public void setTypoAscender(double value)
+```
+
+
+Establece el valor de TypoAscender.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor de TypoAscender. |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public void setTypoDescender(double value)
+```
+
+
+Establece el valor de TypoDescender.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor de TypoDescender. |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public void setUnitsPerEM(long value)
+```
+
+
+Establece el valor de UnitsPerEM.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttffpgmtable/_index.md
+++ b/spanish/java/com.aspose.font/ttffpgmtable/_index.md
@@ -1,0 +1,168 @@
+---
+title: "TtfFpgmTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla fpgm del archivo de fuente TTF."
+type: docs
+weight: 96
+url: /es/java/com.aspose.font/ttffpgmtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfFpgmTable extends TtfTableBase
+```
+
+Representa la tabla "fpgm" del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getProgram()](#getProgram--) | Obtiene el programa fpgm. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getProgram() {#getProgram--}
+```
+public byte[] getProgram()
+```
+
+
+Obtiene el programa fpgm.
+
+**Returns:**
+byte[] - Programa fpgm.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - Etiqueta de tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfgasptable/_index.md
+++ b/spanish/java/com.aspose.font/ttfgasptable/_index.md
@@ -1,0 +1,190 @@
+---
+title: "TtfGaspTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla gasp del archivo de fuente TTF."
+type: docs
+weight: 97
+url: /es/java/com.aspose.font/ttfgasptable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfGaspTable extends TtfTableBase
+```
+
+Representa la tabla "gasp" del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGaspRanges()](#getGaspRanges--) | Obtiene la lista de registros GaspRange que proporciona comportamientos recomendados para varios tamaños ppem. |
+| [getNumRanges()](#getNumRanges--) | Obtiene registros GaspRange. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [getVersion()](#getVersion--) | Obtiene la versión de la tabla. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGaspRanges() {#getGaspRanges--}
+```
+public List<GaspRange> getGaspRanges()
+```
+
+
+Obtiene la lista de registros GaspRange que proporciona comportamientos recomendados para varios tamaños ppem.
+
+**Returns:**
+java.util.List<com.aspose.font.GaspRange> - La lista de GaspRange.
+### getNumRanges() {#getNumRanges--}
+```
+public int getNumRanges()
+```
+
+
+Obtiene registros GaspRange.
+
+**Returns:**
+int - Registros GaspRange.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - La etiqueta de la tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public int getVersion()
+```
+
+
+Obtiene la versión de la tabla.
+
+**Returns:**
+int - La versión de la tabla.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfglyftable/_index.md
+++ b/spanish/java/com.aspose.font/ttfglyftable/_index.md
@@ -1,0 +1,189 @@
+---
+title: "TtfGlyfTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla glyf del archivo de fuente TTF."
+type: docs
+weight: 98
+url: /es/java/com.aspose.font/ttfglyftable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfGlyfTable extends TtfTableBase
+```
+
+Representa la tabla "glyf" del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [containsGlyph(int glyphIndex)](#containsGlyph-int-) | Devuelve true en caso de que la tabla contenga un glifo con glyphIndex. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGlyph(long glyphIndex)](#getGlyph-long-) | Devuelve un glifo por índice de glifo. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### containsGlyph(int glyphIndex) {#containsGlyph-int-}
+```
+public boolean containsGlyph(int glyphIndex)
+```
+
+
+Devuelve true en caso de que la tabla contenga un glifo con glyphIndex.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphIndex | int | Índice de glifo. |
+
+**Returns:**
+boolean - True si la tabla contiene un glifo para el índice especificado, false en caso contrario.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyph(long glyphIndex) {#getGlyph-long-}
+```
+public Glyph getGlyph(long glyphIndex)
+```
+
+
+Devuelve un glifo por índice de glifo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphIndex | long | Índice de glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph Glyph related to index specified.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - Etiqueta de tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfheadtable/_index.md
+++ b/spanish/java/com.aspose.font/ttfheadtable/_index.md
@@ -1,0 +1,344 @@
+---
+title: "TtfHeadTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla head del archivo de fuente TTF."
+type: docs
+weight: 99
+url: /es/java/com.aspose.font/ttfheadtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfHeadTable extends TtfTableBase
+```
+
+Representa la tabla "head" del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCheckSumAdjustment()](#getCheckSumAdjustment--) | Obtiene uint32 checkSumAdjustment. |
+| [getClass()](#getClass--) |  |
+| [getCreated()](#getCreated--) | Obtiene longDateTime creado fecha internacional. |
+| [getFlags()](#getFlags--) | Obtiene uint16 flags. |
+| [getFontDirectionHint()](#getFontDirectionHint--) | Obtiene int16 fontDirectionHint. 0 Glifos de dirección mixta; 1 Solo glifos fuertemente de izquierda a derecha; 2 Como 1 pero también contiene neutrales; -1 Solo glifos fuertemente de derecha a izquierda; -2 Como -1 pero también contiene neutrales. |
+| [getFontRevision()](#getFontRevision--) | Obtiene fixed fontRevision establecido por el fabricante de la fuente. |
+| [getGlyphDataFormat()](#getGlyphDataFormat--) | Obtiene int16 glyphDataFormat 0 para el formato actual. |
+| [getIndexToLocFormat()](#getIndexToLocFormat--) | Obtiene int16 indexToLocFormat 0 para desplazamientos cortos, 1 para largos. |
+| [getLowestRecPPEM()](#getLowestRecPPEM--) | Obtiene uint16 lowestRecPPEM el tamaño legible más pequeño en píxeles. |
+| [getMacStyle()](#getMacStyle--) | Obtiene uint16 macStyle. |
+| [getMagicNumber()](#getMagicNumber--) | Obtiene uint32 magicNumber establecido en 0x5F0F3CF5. |
+| [getModified()](#getModified--) | Obtiene longDateTime modificado fecha internacional. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Obtiene uint16 unitsPerEM rango de 64 a 16384. |
+| [getVersion()](#getVersion--) | Versión Fixed 0x00010000 si (versión 1.0). |
+| [getXMax()](#getXMax--) | Obtiene FWord xMax para todas las cajas delimitadoras de glifos. |
+| [getXMin()](#getXMin--) | Obtiene FWord xMin para todas las cajas delimitadoras de glifos. |
+| [getYMax()](#getYMax--) | Obtiene FWord yMax para todas las cajas delimitadoras de glifos. |
+| [getYMin()](#getYMin--) | Obtiene FWord yMin para todas las cajas delimitadoras de glifos. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCheckSumAdjustment() {#getCheckSumAdjustment--}
+```
+public long getCheckSumAdjustment()
+```
+
+
+Obtiene uint32 checkSumAdjustment. Para calcularlo: establézcalo en 0, calcule la suma de verificación para la tabla 'head' y colóquela en el directorio de tablas, sume toda la fuente como uint32, luego almacene B1B0AFBA - suma. La suma de verificación para la tabla 'head' no será incorrecta. Eso está bien.
+
+**Returns:**
+long - Uint32 checkSumAdjustment.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCreated() {#getCreated--}
+```
+public Date getCreated()
+```
+
+
+Obtiene longDateTime creado fecha internacional.
+
+**Returns:**
+java.util.Date - LongDateTime creado fecha internacional.
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Obtiene uint16 flags.
+
+**Returns:**
+int - UInt16 flags.
+### getFontDirectionHint() {#getFontDirectionHint--}
+```
+public short getFontDirectionHint()
+```
+
+
+Obtiene int16 fontDirectionHint. 0 Glifos de dirección mixta; 1 Solo glifos fuertemente de izquierda a derecha; 2 Como 1 pero también contiene neutrales; -1 Solo glifos fuertemente de derecha a izquierda; -2 Como -1 pero también contiene neutrales.
+
+**Returns:**
+short - Int16 fontDirectionHint.
+### getFontRevision() {#getFontRevision--}
+```
+public float getFontRevision()
+```
+
+
+Obtiene fixed fontRevision establecido por el fabricante de la fuente.
+
+**Returns:**
+float - Fixed fontRevision establecido por el fabricante de la fuente.
+### getGlyphDataFormat() {#getGlyphDataFormat--}
+```
+public short getGlyphDataFormat()
+```
+
+
+Obtiene int16 glyphDataFormat 0 para el formato actual.
+
+**Returns:**
+short - Int16 glyphDataFormat 0 para el formato actual.
+### getIndexToLocFormat() {#getIndexToLocFormat--}
+```
+public short getIndexToLocFormat()
+```
+
+
+Obtiene int16 indexToLocFormat 0 para desplazamientos cortos, 1 para largos.
+
+**Returns:**
+short - Int16 indexToLocFormat 0 para desplazamientos cortos, 1 para largos.
+### getLowestRecPPEM() {#getLowestRecPPEM--}
+```
+public int getLowestRecPPEM()
+```
+
+
+Obtiene uint16 lowestRecPPEM el tamaño legible más pequeño en píxeles.
+
+**Returns:**
+int - UInt16 lowestRecPPEM el tamaño legible más pequeño en píxeles.
+### getMacStyle() {#getMacStyle--}
+```
+public int getMacStyle()
+```
+
+
+Obtiene uint16 macStyle.
+
+**Returns:**
+int - UInt16 macStyle.
+### getMagicNumber() {#getMagicNumber--}
+```
+public long getMagicNumber()
+```
+
+
+Obtiene uint32 magicNumber establecido en 0x5F0F3CF5.
+
+**Returns:**
+long - UInt32 magicNumber establecido en 0x5F0F3CF5.
+### getModified() {#getModified--}
+```
+public Date getModified()
+```
+
+
+Obtiene longDateTime modificado fecha internacional.
+
+**Returns:**
+java.util.Date - LongDateTime fecha internacional modificada.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - Etiqueta de tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Obtiene uint16 unitsPerEM rango de 64 a 16384.
+
+**Returns:**
+long - UInt16 unitsPerEM rango de 64 a 16384.
+### getVersion() {#getVersion--}
+```
+public float getVersion()
+```
+
+
+Versión Fixed 0x00010000 si (versión 1.0).
+
+**Returns:**
+float - Versión fija 0x00010000 si (versión 1.0).
+### getXMax() {#getXMax--}
+```
+public short getXMax()
+```
+
+
+Obtiene FWord xMax para todas las cajas delimitadoras de glifos.
+
+**Returns:**
+short - FWord xMax para todas las cajas delimitadoras de glifos.
+### getXMin() {#getXMin--}
+```
+public short getXMin()
+```
+
+
+Obtiene FWord xMin para todas las cajas delimitadoras de glifos.
+
+**Returns:**
+short - FWord xMin para todas las cajas delimitadoras de glifos.
+### getYMax() {#getYMax--}
+```
+public short getYMax()
+```
+
+
+Obtiene FWord yMax para todas las cajas delimitadoras de glifos.
+
+**Returns:**
+short - FWord yMax para todas las cajas delimitadoras de glifos.
+### getYMin() {#getYMin--}
+```
+public short getYMin()
+```
+
+
+Obtiene FWord yMin para todas las cajas delimitadoras de glifos.
+
+**Returns:**
+short - FWord yMin para todas las cajas delimitadoras de glifos.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfhheatable/_index.md
+++ b/spanish/java/com.aspose.font/ttfhheatable/_index.md
@@ -1,0 +1,300 @@
+---
+title: "TtfHheaTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla hhea del archivo de fuente TTF."
+type: docs
+weight: 100
+url: /es/java/com.aspose.font/ttfhheatable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfHheaTable extends TtfTableBase
+```
+
+Representa la tabla "hhea" del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdvanceWidthMax()](#getAdvanceWidthMax--) | Obtiene uFWord advanceWidthMax debe ser consistente con las métricas horizontales. |
+| [getAscent()](#getAscent--) | Obtiene la ascensión. |
+| [getCaretOffset()](#getCaretOffset--) | Obtiene el desplazamiento del caret. |
+| [getCaretSlopeRise()](#getCaretSlopeRise--) | Obtiene la elevación del deslizamiento del caret. |
+| [getCaretSlopeRun()](#getCaretSlopeRun--) | Obtiene la ejecución del deslizamiento del caret. |
+| [getClass()](#getClass--) |  |
+| [getDescent()](#getDescent--) | Obtiene la caída. |
+| [getLineGap()](#getLineGap--) | Obtiene el espacio entre líneas. |
+| [getMetricDataFormat()](#getMetricDataFormat--) | Obtiene el formato de los datos de métricas. |
+| [getMinLeftSideBearing()](#getMinLeftSideBearing--) | Obtiene el valor MinLeftSideBearing. |
+| [getMinRightSideBearing()](#getMinRightSideBearing--) | Obtiene el valor MinRightSideBearing. |
+| [getNumOfLongHorMetrics()](#getNumOfLongHorMetrics--) | Obtiene uint16 numOfLongHorMetrics número de anchos de avance en la tabla de métricas. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [getVersion()](#getVersion--) | Obtiene la versión. |
+| [getXMaxExtent()](#getXMaxExtent--) | Obtiene el valor XMaxExtent. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdvanceWidthMax() {#getAdvanceWidthMax--}
+```
+public int getAdvanceWidthMax()
+```
+
+
+Obtiene uFWord advanceWidthMax debe ser consistente con las métricas horizontales.
+
+**Returns:**
+int - uFWord advanceWidthMax debe ser consistente con las métricas horizontales.
+### getAscent() {#getAscent--}
+```
+public short getAscent()
+```
+
+
+Obtiene la ascensión.
+
+**Returns:**
+short - La ascensión.
+### getCaretOffset() {#getCaretOffset--}
+```
+public short getCaretOffset()
+```
+
+
+Obtiene el desplazamiento del caret.
+
+**Returns:**
+short - El desplazamiento del caret.
+### getCaretSlopeRise() {#getCaretSlopeRise--}
+```
+public short getCaretSlopeRise()
+```
+
+
+Obtiene la elevación del deslizamiento del caret.
+
+**Returns:**
+short - La elevación del deslizamiento del caret.
+### getCaretSlopeRun() {#getCaretSlopeRun--}
+```
+public short getCaretSlopeRun()
+```
+
+
+Obtiene la ejecución del deslizamiento del caret.
+
+**Returns:**
+short - La ejecución del deslizamiento del caret.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescent() {#getDescent--}
+```
+public short getDescent()
+```
+
+
+Obtiene la caída.
+
+**Returns:**
+short - El descenso.
+### getLineGap() {#getLineGap--}
+```
+public short getLineGap()
+```
+
+
+Obtiene el espacio entre líneas.
+
+**Returns:**
+short - El interlineado.
+### getMetricDataFormat() {#getMetricDataFormat--}
+```
+public short getMetricDataFormat()
+```
+
+
+Obtiene el formato de los datos de métricas.
+
+**Returns:**
+short - El formato de los datos de métricas.
+### getMinLeftSideBearing() {#getMinLeftSideBearing--}
+```
+public short getMinLeftSideBearing()
+```
+
+
+Obtiene el valor MinLeftSideBearing.
+
+**Returns:**
+short - El valor MinLeftSideBearing.
+### getMinRightSideBearing() {#getMinRightSideBearing--}
+```
+public short getMinRightSideBearing()
+```
+
+
+Obtiene el valor MinRightSideBearing.
+
+**Returns:**
+short - El valor MinRightSideBearing.
+### getNumOfLongHorMetrics() {#getNumOfLongHorMetrics--}
+```
+public int getNumOfLongHorMetrics()
+```
+
+
+Obtiene uint16 numOfLongHorMetrics número de anchos de avance en la tabla de métricas.
+
+**Returns:**
+int - UInt16 numOfLongHorMetrics número de anchos de avance en la tabla de métricas.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - Etiqueta de tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public float getVersion()
+```
+
+
+Obtiene la versión.
+
+**Returns:**
+float - Versión del formato de tabla.
+### getXMaxExtent() {#getXMaxExtent--}
+```
+public short getXMaxExtent()
+```
+
+
+Obtiene el valor XMaxExtent.
+
+**Returns:**
+short - El valor XMaxExtent.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfhmtxtable/_index.md
+++ b/spanish/java/com.aspose.font/ttfhmtxtable/_index.md
@@ -1,0 +1,190 @@
+---
+title: "TtfHmtxTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla hmtx del archivo de fuente TTF."
+type: docs
+weight: 101
+url: /es/java/com.aspose.font/ttfhmtxtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfHmtxTable extends TtfTableBase
+```
+
+Representa la tabla "hmtx" del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalAdvanceWidth()](#getAdditionalAdvanceWidth--) | En la tabla hmtx pueden existir casos en los que el número total de glifos no sea igual a hhea.numberOfHMetrics. |
+| [getClass()](#getClass--) |  |
+| [getHMetrics()](#getHMetrics--) | Obtiene métricas horizontales. |
+| [getLeftSidebearings()](#getLeftSidebearings--) | Obtiene los bearings laterales izquierdos. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalAdvanceWidth() {#getAdditionalAdvanceWidth--}
+```
+public int getAdditionalAdvanceWidth()
+```
+
+
+En la tabla hmtx pueden existir casos en los que el número total de glifos no sea igual a hhea.numberOfHMetrics. Para estos casos la tabla hmtx contiene un arreglo adicional 'leftSideBearing' que corresponde a la propiedad LeftSidebearings. Pero los glifos con índices desde hhea.numOfLongHorMetrics hasta maxp.numGlyphs también tienen anchos. Y estos anchos, de acuerdo con la especificación de la tabla hmtx, tienen los siguientes valores: "Aquí se asume que advanceWidth es el mismo que el advanceWidth de la última entrada anterior".
+
+**Returns:**
+int - Ancho de avance adicional.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHMetrics() {#getHMetrics--}
+```
+public TtfHmtxTable.MetricList getHMetrics()
+```
+
+
+Obtiene métricas horizontales.
+
+**Returns:**
+[MetricList](../../com.aspose.font/metriclist) - Horizontal metrics.
+### getLeftSidebearings() {#getLeftSidebearings--}
+```
+public short[] getLeftSidebearings()
+```
+
+
+Obtiene los bearings laterales izquierdos.
+
+**Returns:**
+short[] - Bearings laterales izquierdos.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - Etiqueta de tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttflocatable/_index.md
+++ b/spanish/java/com.aspose.font/ttflocatable/_index.md
@@ -1,0 +1,157 @@
+---
+title: "TtfLocaTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla loca del archivo de fuente TTF."
+type: docs
+weight: 102
+url: /es/java/com.aspose.font/ttflocatable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfLocaTable extends TtfTableBase
+```
+
+Representa la tabla "loca" del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - Etiqueta de tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfltshtable/_index.md
+++ b/spanish/java/com.aspose.font/ttfltshtable/_index.md
@@ -1,0 +1,195 @@
+---
+title: "TtfLtshTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla Linear Threshold del archivo de fuente TTF."
+type: docs
+weight: 103
+url: /es/java/com.aspose.font/ttfltshtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfLtshTable extends TtfTableBase
+```
+
+Representa la tabla Linear Threshold del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getNumGlyphs()](#getNumGlyphs--) | Obtiene el número de glifos (de "numGlyphs" en la tabla 'maxp'). |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [getVersion()](#getVersion--) | Obtiene la versión de la tabla. |
+| [getYPel(int glyphNum)](#getYPel-int-) | Devuelve la altura de píxel vertical para glyph/zero si el número de glifo es incorrecto. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Obtiene el número de glifos (de "numGlyphs" en la tabla 'maxp').
+
+**Returns:**
+int - El número de glifos (de "numGlyphs" en la tabla 'maxp').
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - La etiqueta de la tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public int getVersion()
+```
+
+
+Obtiene la versión de la tabla.
+
+**Returns:**
+int - La versión de la tabla.
+### getYPel(int glyphNum) {#getYPel-int-}
+```
+public byte getYPel(int glyphNum)
+```
+
+
+Devuelve la altura de píxel vertical para glyph/zero si el número de glifo es incorrecto.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphNum | int | Un número de glifo (índice). |
+
+**Returns:**
+byte - La altura de píxel vertical para glyph/zero si el número de glifo es incorrecto.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfmaxptable/_index.md
+++ b/spanish/java/com.aspose.font/ttfmaxptable/_index.md
@@ -1,0 +1,333 @@
+---
+title: "TtfMaxpTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla maxp del archivo de fuente TTF"
+type: docs
+weight: 104
+url: /es/java/com.aspose.font/ttfmaxptable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfMaxpTable extends TtfTableBase
+```
+
+Representa la tabla "maxp" del archivo de fuente TTF
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxComponentContours()](#getMaxComponentContours--) | Obtiene uint16 maxComponentContours contornos en glifo compuesto. |
+| [getMaxComponentDepth()](#getMaxComponentDepth--) | Obtiene uint16 maxComponentDepth niveles de recursión, establecido en 0 si la fuente tiene solo glifos simples. |
+| [getMaxComponentElements()](#getMaxComponentElements--) | Obtiene uint16 maxComponentElements número de glifos referenciados en el nivel superior. |
+| [getMaxComponentPoints()](#getMaxComponentPoints--) | Obtiene uint16 maxComponentPoints puntos en glifo compuesto. |
+| [getMaxContours()](#getMaxContours--) | Obtiene uint16 maxContours contornos en glifo no compuesto. |
+| [getMaxFunctionDefs()](#getMaxFunctionDefs--) | Obtiene uint16 maxFunctionDefs número de FDEFs. |
+| [getMaxInstructionDefs()](#getMaxInstructionDefs--) | Obtiene uint16 maxInstructionDefs número de IDEFs. |
+| [getMaxPoints()](#getMaxPoints--) | Obtiene uint16 maxPoints puntos en glifo no compuesto. |
+| [getMaxSizeOfInstructions()](#getMaxSizeOfInstructions--) | Obtiene uint16 maxSizeOfInstructions recuento de bytes para instrucciones de glifos. |
+| [getMaxStackElements()](#getMaxStackElements--) | Obtiene uint16 maxStackElements profundidad máxima de la pila. |
+| [getMaxStorage()](#getMaxStorage--) | Obtiene uint16 maxStorage número de ubicaciones del Área de Almacenamiento. |
+| [getMaxTwilightPoints()](#getMaxTwilightPoints--) | Obtiene uint16 maxTwilightPoints puntos usados en la zona Twilight (Z0). |
+| [getMaxZones()](#getMaxZones--) | Obtiene uint16 maxZones establecido en 2. |
+| [getNumGlyphs()](#getNumGlyphs--) | Obtiene uint16 numGlyphs el número de glifos en la fuente. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getTableVersion()](#getTableVersion--) | Obtiene la versión del formato. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [getVersion()](#getVersion--) | Obtiene la versión fija 0x00010000 si (versión 1.0). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxComponentContours() {#getMaxComponentContours--}
+```
+public int getMaxComponentContours()
+```
+
+
+Obtiene uint16 maxComponentContours contornos en glifo compuesto.
+
+**Returns:**
+int - UInt16 maxComponentContours contornos en glifo compuesto.
+### getMaxComponentDepth() {#getMaxComponentDepth--}
+```
+public int getMaxComponentDepth()
+```
+
+
+Obtiene uint16 maxComponentDepth niveles de recursión, establecido en 0 si la fuente tiene solo glifos simples.
+
+**Returns:**
+int - Uint16 maxComponentDepth niveles de recursión, establezca a 0 si la fuente tiene solo glifos simples.
+### getMaxComponentElements() {#getMaxComponentElements--}
+```
+public int getMaxComponentElements()
+```
+
+
+Obtiene uint16 maxComponentElements número de glifos referenciados en el nivel superior.
+
+**Returns:**
+int - UInt16 maxComponentElements número de glifos referenciados en el nivel superior.
+### getMaxComponentPoints() {#getMaxComponentPoints--}
+```
+public int getMaxComponentPoints()
+```
+
+
+Obtiene uint16 maxComponentPoints puntos en glifo compuesto.
+
+**Returns:**
+int - UInt16 maxComponentPoints puntos en glifo compuesto.
+### getMaxContours() {#getMaxContours--}
+```
+public int getMaxContours()
+```
+
+
+Obtiene uint16 maxContours contornos en glifo no compuesto.
+
+**Returns:**
+int - UInt16 maxContours contornos en glifo no compuesto.
+### getMaxFunctionDefs() {#getMaxFunctionDefs--}
+```
+public int getMaxFunctionDefs()
+```
+
+
+Obtiene uint16 maxFunctionDefs número de FDEFs.
+
+**Returns:**
+int - UInt16 maxFunctionDefs número de FDEFs.
+### getMaxInstructionDefs() {#getMaxInstructionDefs--}
+```
+public int getMaxInstructionDefs()
+```
+
+
+Obtiene uint16 maxInstructionDefs número de IDEFs.
+
+**Returns:**
+int - UInt16 maxInstructionDefs número de IDEFs.
+### getMaxPoints() {#getMaxPoints--}
+```
+public int getMaxPoints()
+```
+
+
+Obtiene uint16 maxPoints puntos en glifo no compuesto.
+
+**Returns:**
+int - UInt16 maxPoints puntos en glifo no compuesto.
+### getMaxSizeOfInstructions() {#getMaxSizeOfInstructions--}
+```
+public int getMaxSizeOfInstructions()
+```
+
+
+Obtiene uint16 maxSizeOfInstructions recuento de bytes para instrucciones de glifos.
+
+**Returns:**
+int - UInt16 maxSizeOfInstructions recuento de bytes para instrucciones de glifo.
+### getMaxStackElements() {#getMaxStackElements--}
+```
+public int getMaxStackElements()
+```
+
+
+Obtiene uint16 maxStackElements profundidad máxima de la pila.
+
+**Returns:**
+int - UInt16 maxStackElements profundidad máxima de la pila.
+### getMaxStorage() {#getMaxStorage--}
+```
+public int getMaxStorage()
+```
+
+
+Obtiene uint16 maxStorage número de ubicaciones del Área de Almacenamiento.
+
+**Returns:**
+int - UInt16 maxStorage número de ubicaciones del Área de Almacenamiento.
+### getMaxTwilightPoints() {#getMaxTwilightPoints--}
+```
+public int getMaxTwilightPoints()
+```
+
+
+Obtiene uint16 maxTwilightPoints puntos usados en la zona Twilight (Z0).
+
+**Returns:**
+int - UInt16 maxTwilightPoints puntos usados en la Zona Crepuscular (Z0).
+### getMaxZones() {#getMaxZones--}
+```
+public int getMaxZones()
+```
+
+
+Obtiene uint16 maxZones establecido en 2.
+
+**Returns:**
+int - Uint16 maxZones establecido en 2.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Obtiene uint16 numGlyphs el número de glifos en la fuente.
+
+**Returns:**
+int - UInt16 numGlyphs el número de glifos en la Fuente.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getTableVersion() {#getTableVersion--}
+```
+public Version16Dot16 getTableVersion()
+```
+
+
+Obtiene la versión del formato. Use las propiedades MajorNumber y MinorNUmber del objeto  Version16Dot16  en notación hexadecimal para detectar la versión utilizada.
+
+**Returns:**
+[Version16Dot16](../../com.aspose.font/version16dot16) - Format version.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - Etiqueta de tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public float getVersion()
+```
+
+
+Obtiene la versión fija 0x00010000 si (versión 1.0). Obsoleto, use la propiedad  TableVersion  en su lugar.
+
+**Returns:**
+float - Versión fija 0x00010000 si (versión 1.0).
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfnametable/_index.md
+++ b/spanish/java/com.aspose.font/ttfnametable/_index.md
@@ -1,0 +1,381 @@
+---
+title: "TtfNameTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla de nombres del archivo de fuente TTF."
+type: docs
+weight: 105
+url: /es/java/com.aspose.font/ttfnametable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfNameTable extends TtfTableBase
+```
+
+Representa la tabla "name" del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addMultiLanguageNames(MultiLanguageString mlNames, PlatformId platformId, int platformSpecificId, NameId nameId)](#addMultiLanguageNames-com.aspose.font.MultiLanguageString-com.aspose.font.PlatformId-int-com.aspose.font.NameId-) | Extrae todas las cadenas multilingües del objeto  mlNames  pasado y crea la estructura NameRecord correspondiente para cada cadena extraída usando los parámetros pasados  platformId ,  platformSpecificId  y  nameId . |
+| [addName(NameId nameId, PlatformId platformId, int platformSpecificId, int languageId, String name)](#addName-com.aspose.font.NameId-com.aspose.font.PlatformId-int-int-java.lang.String-) | Agrega una entrada en la tabla. |
+| [deleteRecords(PlatformId platformId, int platformSpecificId)](#deleteRecords-com.aspose.font.PlatformId-int-) | Elimina todos los registros relacionados con la plataforma especificada. |
+| [deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId)](#deleteRecords-com.aspose.font.PlatformId-int-com.aspose.font.NameId-) | Elimina todos los registros relacionados con los parámetros pasados. |
+| [deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId)](#deleteRecords-com.aspose.font.PlatformId-int-com.aspose.font.NameId-int-) | Elimina registro(s) relacionado(s) con los parámetros especificados. |
+| [deleteRecordsByNameId(NameId nameId)](#deleteRecordsByNameId-com.aspose.font.NameId-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllNameRecords()](#getAllNameRecords--) | Devuelve todas las estructuras  NameRecord  de la tabla. |
+| [getClass()](#getClass--) |  |
+| [getMultiLanguageNameById(NameId nameId)](#getMultiLanguageNameById-com.aspose.font.NameId-) | devuelve un nombre por nameId. |
+| [getMultiLanguageNameById(NameId nameId, PlatformId platformId)](#getMultiLanguageNameById-com.aspose.font.NameId-com.aspose.font.PlatformId-) | Devuelve un nombre por nameId usando el identificador de plataforma pasado. |
+| [getMultiLanguageNameById(NameId nameId, PlatformId platformId, int platformSpecificId)](#getMultiLanguageNameById-com.aspose.font.NameId-com.aspose.font.PlatformId-int-) | Devuelve un nombre como objeto del tipo  MultiLanguageString . |
+| [getNameById(NameId nameId)](#getNameById-com.aspose.font.NameId-) | Devuelve un nombre por nameId si se encuentra, null de lo contrario. |
+| [getNameRecordsByNameId(NameId nameId)](#getNameRecordsByNameId-com.aspose.font.NameId-) | Devuelve todas las estructuras  NameRecord  cuyo campo NameId es igual al valor  nameId  pasado. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [updateName(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId, String newName)](#updateName-com.aspose.font.PlatformId-int-com.aspose.font.NameId-int-java.lang.String-) | Actualiza el nombre en registro(s) que están relacionados con la plataforma especificada (combinación de platformId y platformSpecificId), categoría (nameId) y idioma (languageId). |
+| [updateNamesByNameId(NameId nameId, String newName)](#updateNamesByNameId-com.aspose.font.NameId-java.lang.String-) | Selecciona todos los registros que están relacionados con la categoría lógica de cadena, especificada por el parámetro nameId, y actualiza el campo nombre (datos de cadena) en esos registros. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### addMultiLanguageNames(MultiLanguageString mlNames, PlatformId platformId, int platformSpecificId, NameId nameId) {#addMultiLanguageNames-com.aspose.font.MultiLanguageString-com.aspose.font.PlatformId-int-com.aspose.font.NameId-}
+```
+public void addMultiLanguageNames(MultiLanguageString mlNames, PlatformId platformId, int platformSpecificId, NameId nameId)
+```
+
+
+Extrae todas las cadenas multilingües del objeto  mlNames  pasado y crea la estructura NameRecord correspondiente para cada cadena extraída usando los parámetros pasados  platformId ,  platformSpecificId  y  nameId . Valor del campo languageID se extrae del objeto  mlNames  . El nuevo registro recién creado se agrega a la tabla. Si se encuentra un registro que coincide con el recién creado por los campos platformID, platformSpecificID, nameID y langugeId, entonces el registro recién creado no se añadirá y solo se actualizarán los datos de cadena del registro existente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mlNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Cadena multilingüe |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Identificador de plataforma |
+| platformSpecificId | int | Identificador de codificación específico de la plataforma |
+| nameId | [NameId](../../com.aspose.font/nameid) | Identificador de nombre, categoría lógica de cadena, especificado por la enumeración  NameId . |
+
+### addName(NameId nameId, PlatformId platformId, int platformSpecificId, int languageId, String name) {#addName-com.aspose.font.NameId-com.aspose.font.PlatformId-int-int-java.lang.String-}
+```
+public void addName(NameId nameId, PlatformId platformId, int platformSpecificId, int languageId, String name)
+```
+
+
+Agrega una entrada en la tabla. La categoría de datos de cadena a agregar se especifica mediante el parámetro name.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Identificador de nombre, categoría lógica de cadena, especificado por la enumeración [NameId](../../com.aspose.font/nameid). |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Identificador de plataforma. |
+| platformSpecificId | int | Identificador de codificación específica de la plataforma. Por favor, use un valor de una de estas enumeraciones: UnicodePlatformSpecificId, MacPlatformSpecificId, MSPlatformSpecificId. Qué enumeración usar se define por el contexto (parámetro platformId). |
+| languageId | int | Identificador de idioma. Por favor, use un valor de las enumeraciones MSLanguageId o MacLanguageId, según el contexto, definido por el parámetro platformId. |
+| nombre | java.lang.String | Datos reales de cadena. |
+
+### deleteRecords(PlatformId platformId, int platformSpecificId) {#deleteRecords-com.aspose.font.PlatformId-int-}
+```
+public void deleteRecords(PlatformId platformId, int platformSpecificId)
+```
+
+
+Elimina todos los registros relacionados con la plataforma especificada.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Identificador de plataforma |
+| platformSpecificId | int | Identificador de codificación específico de la plataforma |
+
+### deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId) {#deleteRecords-com.aspose.font.PlatformId-int-com.aspose.font.NameId-}
+```
+public void deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId)
+```
+
+
+Elimina todos los registros relacionados con los parámetros pasados.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Identificador de plataforma |
+| platformSpecificId | int | Identificador de codificación específico de la plataforma |
+| nameId | [NameId](../../com.aspose.font/nameid) | Identificador de nombre, categoría lógica de cadena, especificado por la enumeración  NameId . |
+
+### deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId) {#deleteRecords-com.aspose.font.PlatformId-int-com.aspose.font.NameId-int-}
+```
+public void deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId)
+```
+
+
+Elimina registro(s) relacionado(s) con los parámetros especificados.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Identificador de plataforma |
+| platformSpecificId | int | Identificador de codificación específico de la plataforma |
+| nameId | [NameId](../../com.aspose.font/nameid) | Identificador de nombre, categoría lógica de cadena, especificado por la enumeración  NameId . |
+| languageId | int | Identificador de idioma |
+
+### deleteRecordsByNameId(NameId nameId) {#deleteRecordsByNameId-com.aspose.font.NameId-}
+```
+public void deleteRecordsByNameId(NameId nameId)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllNameRecords() {#getAllNameRecords--}
+```
+public NameRecord[] getAllNameRecords()
+```
+
+
+Devuelve todas las estructuras  NameRecord  de la tabla.
+
+**Returns:**
+com.aspose.font.NameRecord[] - Todas las estructuras NameRecord de la tabla.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMultiLanguageNameById(NameId nameId) {#getMultiLanguageNameById-com.aspose.font.NameId-}
+```
+public MultiLanguageString getMultiLanguageNameById(NameId nameId)
+```
+
+
+devuelve un nombre por nameId.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Id de nombre. |
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - name
+### getMultiLanguageNameById(NameId nameId, PlatformId platformId) {#getMultiLanguageNameById-com.aspose.font.NameId-com.aspose.font.PlatformId-}
+```
+public MultiLanguageString getMultiLanguageNameById(NameId nameId, PlatformId platformId)
+```
+
+
+Devuelve un nombre por nameId usando el identificador de plataforma pasado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Id de nombre. |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Id de plataforma. |
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Name.
+### getMultiLanguageNameById(NameId nameId, PlatformId platformId, int platformSpecificId) {#getMultiLanguageNameById-com.aspose.font.NameId-com.aspose.font.PlatformId-int-}
+```
+public MultiLanguageString getMultiLanguageNameById(NameId nameId, PlatformId platformId, int platformSpecificId)
+```
+
+
+Devuelve un nombre como objeto del tipo MultiLanguageString. El método recopila todas las estructuras NameRecord que coinciden con los parámetros pasados nameId, platformId y platformSpecificId y luego construye el objeto resultante basándose en esta lista de estructuras.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Id de nombre. |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Id de plataforma. |
+| platformSpecificId | int | Id específico de la plataforma. |
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Name.
+### getNameById(NameId nameId) {#getNameById-com.aspose.font.NameId-}
+```
+public String getNameById(NameId nameId)
+```
+
+
+Devuelve un nombre por nameId si se encuentra, null de lo contrario.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | identificador de nombre |
+
+**Returns:**
+java.lang.String - name
+### getNameRecordsByNameId(NameId nameId) {#getNameRecordsByNameId-com.aspose.font.NameId-}
+```
+public NameRecord[] getNameRecordsByNameId(NameId nameId)
+```
+
+
+Devuelve todas las estructuras NameRecord cuyo campo NameId es igual al valor nameId pasado. Si no se encuentran registros, se devolverá una matriz vacía.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | identificador de nombre |
+
+**Returns:**
+com.aspose.font.NameRecord[] - Matriz de estructuras NameRecord
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - Etiqueta de tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### updateName(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId, String newName) {#updateName-com.aspose.font.PlatformId-int-com.aspose.font.NameId-int-java.lang.String-}
+```
+public void updateName(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId, String newName)
+```
+
+
+Actualiza el nombre en registro(s) que están relacionados con la plataforma especificada (combinación de platformId y platformSpecificId), categoría (nameId) y idioma (languageId).
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Identificador de plataforma |
+| platformSpecificId | int | Identificador de codificación específico de la plataforma |
+| nameId | [NameId](../../com.aspose.font/nameid) | Identificador de nombre, categoría lógica de cadena, especificado por la enumeración  NameId . |
+| languageId | int | Identificador de idioma |
+| newName | java.lang.String | Nuevo nombre o nuevos datos de cadena |
+
+### updateNamesByNameId(NameId nameId, String newName) {#updateNamesByNameId-com.aspose.font.NameId-java.lang.String-}
+```
+public void updateNamesByNameId(NameId nameId, String newName)
+```
+
+
+Selecciona todos los registros que están relacionados con la categoría lógica de cadena, especificada por el parámetro nameId, y actualiza el campo name (datos de cadena) en esos registros. Los campos relacionados con la plataforma (platformID, Platform-specific encoding ID) y el idioma (Language ID) no se ven afectados por este método. Sólo los datos de cadena del nombre se reemplazan por un nuevo nombre. Use este método con precaución, ya que reemplazará los nombres originales para todas las plataformas e idiomas relacionados con nameId. Puede generar conflictos en casos en los que los nombres originales tenían valores diferentes, porque la operación de reemplazo cambia todos esos valores por uno nuevo único. Y este nuevo valor puede presentar una inconsistencia lógica con algunas plataformas e idiomas. Este método es útil en casos en los que el nombre original tiene una única representación para todas las plataformas e idiomas, por ejemplo, cuando los datos de cadena del nombre están en inglés.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Identificador de nombre, categoría lógica de cadena, especificado por la enumeración  NameId . |
+| newName | java.lang.String | Nuevo nombre o nuevos datos de cadena |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfos2table/_index.md
+++ b/spanish/java/com.aspose.font/ttfos2table/_index.md
@@ -1,0 +1,578 @@
+---
+title: "TtfOs2Table"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla OS/2 del archivo de fuente TTF."
+type: docs
+weight: 106
+url: /es/java/com.aspose.font/ttfos2table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfOs2Table extends TtfTableBase
+```
+
+Representa la tabla "OS/2" del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAchVendId()](#getAchVendId--) | Obtiene el valor de AchVendId. |
+| [getClass()](#getClass--) |  |
+| [getFSSelection()](#getFSSelection--) | Contiene información sobre la naturaleza de los patrones de fuente. |
+| [getFSType()](#getFSType--) | Obtiene el valor de FSType. |
+| [getLicenseFlags()](#getLicenseFlags--) | Obtiene una bandera incrustada (fsType) en la representación del objeto. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getPanose()](#getPanose--) | Esta serie de 10 bytes de números se utiliza para describir las características visuales de una tipografía dada. |
+| [getSCapHeight()](#getSCapHeight--) | Obtiene el valor de SCapHeight. |
+| [getSFamilyClass()](#getSFamilyClass--) | Este parámetro es una clasificación del diseño de la familia tipográfica. |
+| [getSTypoAscender()](#getSTypoAscender--) | Obtiene el valor de STypoAscender. |
+| [getSTypoDescender()](#getSTypoDescender--) | Obtiene el valor de STypoDescender. |
+| [getSTypoLineGap()](#getSTypoLineGap--) | Obtiene el valor de STypoLineGap. |
+| [getSXHeight()](#getSXHeight--) | Obtiene el valor de SXHeight. |
+| [getSupportedTableVersions()](#getSupportedTableVersions--) | Obtiene las versiones compatibles de la tabla OS/2. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [getULCodePageRange()](#getULCodePageRange--) | Obtiene el valor de ULCodePageRange. |
+| [getULUnicodeRange()](#getULUnicodeRange--) | Obtiene el valor de ULUnicodeRange. |
+| [getUSBreakChar()](#getUSBreakChar--) | Obtiene el valor de USBreakChar. |
+| [getUSDefaultChar()](#getUSDefaultChar--) | Obtiene el valor de USDefaultChar. |
+| [getUSFirstCharIndex()](#getUSFirstCharIndex--) | Obtiene el valor de USFirstCharIndex. |
+| [getUSLastCharIndex()](#getUSLastCharIndex--) | Obtiene el valor de USLastCharIndex. |
+| [getUSLowerOpticalPointSize()](#getUSLowerOpticalPointSize--) | Obtiene el valor de USLowerOpticalPointSize. |
+| [getUSMaxContext()](#getUSMaxContext--) | Obtiene el valor de USMaxContext. |
+| [getUSUpperOpticalPointSize()](#getUSUpperOpticalPointSize--) | Obtiene el valor de USUpperOpticalPointSize. |
+| [getUSWeightClass()](#getUSWeightClass--) | Indica el peso visual (grado de oscuridad o grosor de los trazos) de los caracteres en la Fuente. |
+| [getUSWidthClass()](#getUSWidthClass--) | Indica un cambio relativo respecto a la proporción de aspecto normal (relación ancho/alto) según lo especificado por el diseñador de fuentes para los glifos en una Fuente. |
+| [getUSWinAscent()](#getUSWinAscent--) | Obtiene el valor de USWinAscent. |
+| [getUSWinDescent()](#getUSWinDescent--) | Obtiene el valor de USWinDescent. |
+| [getVersion()](#getVersion--) | Obtiene el valor Version. |
+| [getXAvgCharWidth()](#getXAvgCharWidth--) | Obtiene el parámetro Average Character Width. |
+| [getYStrikeoutPosition()](#getYStrikeoutPosition--) | Obtiene el valor YStrikeoutPosition. |
+| [getYStrikeoutSize()](#getYStrikeoutSize--) | Obtiene el valor YStrikeoutSize. |
+| [getYSubscriptXOffset()](#getYSubscriptXOffset--) | Obtiene el valor YSubscriptXOffset. |
+| [getYSubscriptXSize()](#getYSubscriptXSize--) | Obtiene el valor YSubscriptXSize. |
+| [getYSubscriptYOffset()](#getYSubscriptYOffset--) | Obtiene el valor YSubscriptYOffset. |
+| [getYSubscriptYSize()](#getYSubscriptYSize--) | Obtiene el valor YSubscriptYSize. |
+| [getYSuperscriptXOffset()](#getYSuperscriptXOffset--) | Obtiene el valor YSuperscriptXOffset. |
+| [getYSuperscriptXSize()](#getYSuperscriptXSize--) | Obtiene el valor YSuperscriptXSize. |
+| [getYSuperscriptYOffset()](#getYSuperscriptYOffset--) | Obtiene el valor YSuperscriptYOffset. |
+| [getYSuperscriptYSize()](#getYSuperscriptYSize--) | Obtiene el valor YSuperscriptYSize. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAchVendId() {#getAchVendId--}
+```
+public byte[] getAchVendId()
+```
+
+
+Obtiene el valor de AchVendId.
+
+**Returns:**
+byte[] - AchVendId valor.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFSSelection() {#getFSSelection--}
+```
+public int getFSSelection()
+```
+
+
+Contiene información sobre la naturaleza de los patrones de fuente.
+
+> ```
+> 0	bit 1	ITALIC	Font contains Italic characters, otherwise they are upright.
+>  1	 	    UNDERSCORE	Characters are underscored.
+>  2	 	    NEGATIVE	Characters have their foreground and background reversed.
+>  3	 	    OUTLINED	Outline (hollow) characters, otherwise they are solid.
+>  4	 	    STRIKEOUT	Characters are overstruck.
+>  5	bit 0	BOLD	Characters are emboldened.
+>  6	 	    REGULAR	Characters are in the standard weight/style for the font.
+> ```
+
+**Returns:**
+int - La información.
+### getFSType() {#getFSType--}
+```
+public int getFSType()
+```
+
+
+Obtiene el valor de FSType.
+
+--------------------
+
+Indica los derechos de licencia de incrustación de fuentes para la Fuente.
+
+**Returns:**
+int - valor FSType.
+### getLicenseFlags() {#getLicenseFlags--}
+```
+public LicenseFlags getLicenseFlags()
+```
+
+
+Obtiene una bandera incrustada (fsType) en la representación del objeto.
+
+**Returns:**
+[LicenseFlags](../../com.aspose.font/licenseflags) - Embedded flags.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getPanose() {#getPanose--}
+```
+public byte[] getPanose()
+```
+
+
+Esta serie de 10 bytes de números se utiliza para describir las características visuales de un tipo de letra dado. Estas características se utilizan luego para asociar la fuente con otras fuentes de apariencia similar que tienen nombres diferentes.
+
+**Returns:**
+byte[] - Las características visuales de un tipo de letra dado.
+### getSCapHeight() {#getSCapHeight--}
+```
+public short getSCapHeight()
+```
+
+
+Obtiene el valor de SCapHeight.
+
+**Returns:**
+short - SCapHeight valor.
+### getSFamilyClass() {#getSFamilyClass--}
+```
+public short getSFamilyClass()
+```
+
+
+Este parámetro es una clasificación del diseño de la familia tipográfica. La clase de fuente y la subclase de fuente son valores registrados asignados por IBM a cada familia tipográfica. Este parámetro está destinado a usarse para seleccionar una fuente alternativa cuando la fuente solicitada no está disponible.
+
+**Returns:**
+short - Clasificación del diseño de la familia tipográfica.
+### getSTypoAscender() {#getSTypoAscender--}
+```
+public short getSTypoAscender()
+```
+
+
+Obtiene el valor de STypoAscender.
+
+**Returns:**
+short - STypoAscender valor.
+### getSTypoDescender() {#getSTypoDescender--}
+```
+public short getSTypoDescender()
+```
+
+
+Obtiene el valor de STypoDescender.
+
+**Returns:**
+short - STypoDescender valor.
+### getSTypoLineGap() {#getSTypoLineGap--}
+```
+public short getSTypoLineGap()
+```
+
+
+Obtiene el valor de STypoLineGap.
+
+**Returns:**
+short - STypoLineGap valor.
+### getSXHeight() {#getSXHeight--}
+```
+public short getSXHeight()
+```
+
+
+Obtiene el valor de SXHeight.
+
+**Returns:**
+short - SXHeight valor.
+### getSupportedTableVersions() {#getSupportedTableVersions--}
+```
+public int[] getSupportedTableVersions()
+```
+
+
+Obtiene las versiones compatibles de la tabla OS/2.
+
+**Returns:**
+int[] - Versiones compatibles de la tabla OS/2.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - Etiqueta de tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getULCodePageRange() {#getULCodePageRange--}
+```
+public long[] getULCodePageRange()
+```
+
+
+Obtiene el valor de ULCodePageRange.
+
+**Returns:**
+long[] - Valor de ULCodePageRange.
+### getULUnicodeRange() {#getULUnicodeRange--}
+```
+public long[] getULUnicodeRange()
+```
+
+
+Obtiene el valor de ULUnicodeRange.
+
+**Returns:**
+long[] - Valor de ULUnicodeRange.
+### getUSBreakChar() {#getUSBreakChar--}
+```
+public int getUSBreakChar()
+```
+
+
+Obtiene el valor de USBreakChar.
+
+**Returns:**
+int - Valor de USBreakChar.
+### getUSDefaultChar() {#getUSDefaultChar--}
+```
+public int getUSDefaultChar()
+```
+
+
+Obtiene el valor de USDefaultChar.
+
+**Returns:**
+int - Valor de USDefaultChar.
+### getUSFirstCharIndex() {#getUSFirstCharIndex--}
+```
+public int getUSFirstCharIndex()
+```
+
+
+Obtiene el valor de USFirstCharIndex.
+
+**Returns:**
+int - Valor de USFirstCharIndex.
+### getUSLastCharIndex() {#getUSLastCharIndex--}
+```
+public int getUSLastCharIndex()
+```
+
+
+Obtiene el valor de USLastCharIndex.
+
+**Returns:**
+int - Valor de USLastCharIndex.
+### getUSLowerOpticalPointSize() {#getUSLowerOpticalPointSize--}
+```
+public int getUSLowerOpticalPointSize()
+```
+
+
+Obtiene el valor de USLowerOpticalPointSize.
+
+**Returns:**
+int - El valor de USLowerOpticalPointSize.
+### getUSMaxContext() {#getUSMaxContext--}
+```
+public int getUSMaxContext()
+```
+
+
+Obtiene el valor de USMaxContext.
+
+**Returns:**
+int - Valor de UsMaxContext.
+### getUSUpperOpticalPointSize() {#getUSUpperOpticalPointSize--}
+```
+public int getUSUpperOpticalPointSize()
+```
+
+
+Obtiene el valor de USUpperOpticalPointSize.
+
+**Returns:**
+int - El valor de USUpperOpticalPointSize.
+### getUSWeightClass() {#getUSWeightClass--}
+```
+public int getUSWeightClass()
+```
+
+
+Indica el peso visual (grado de oscuridad o grosor de los trazos) de los caracteres en la Fuente.
+
+**Returns:**
+int - El peso visual (grado de negrura o grosor de los trazos) de los caracteres en la Font.
+### getUSWidthClass() {#getUSWidthClass--}
+```
+public int getUSWidthClass()
+```
+
+
+Indica un cambio relativo respecto a la proporción de aspecto normal (relación ancho/alto) según lo especificado por el diseñador de fuentes para los glifos en una Fuente.
+
+**Returns:**
+int - Un cambio relativo respecto a la proporción de aspecto normal (relación ancho/alto) según lo especificado por un diseñador de fuentes para los glifos en una Font.
+### getUSWinAscent() {#getUSWinAscent--}
+```
+public int getUSWinAscent()
+```
+
+
+Obtiene el valor de USWinAscent.
+
+**Returns:**
+int - Valor de USWinAscent.
+### getUSWinDescent() {#getUSWinDescent--}
+```
+public int getUSWinDescent()
+```
+
+
+Obtiene el valor de USWinDescent.
+
+**Returns:**
+int - Valor de USWinDescent.
+### getVersion() {#getVersion--}
+```
+public int getVersion()
+```
+
+
+Obtiene el valor Version.
+
+**Returns:**
+int - Valor de Version.
+### getXAvgCharWidth() {#getXAvgCharWidth--}
+```
+public short getXAvgCharWidth()
+```
+
+
+Obtiene el parámetro Average Character Width.
+
+**Returns:**
+short - El parámetro Average Character Width.
+### getYStrikeoutPosition() {#getYStrikeoutPosition--}
+```
+public short getYStrikeoutPosition()
+```
+
+
+Obtiene el valor YStrikeoutPosition.
+
+**Returns:**
+short - Valor de YStrikeoutPosition.
+### getYStrikeoutSize() {#getYStrikeoutSize--}
+```
+public short getYStrikeoutSize()
+```
+
+
+Obtiene el valor YStrikeoutSize.
+
+**Returns:**
+short - Valor de YStrikeoutSize.
+### getYSubscriptXOffset() {#getYSubscriptXOffset--}
+```
+public short getYSubscriptXOffset()
+```
+
+
+Obtiene el valor YSubscriptXOffset.
+
+**Returns:**
+short - Valor de YSubscriptXOffset.
+### getYSubscriptXSize() {#getYSubscriptXSize--}
+```
+public short getYSubscriptXSize()
+```
+
+
+Obtiene el valor YSubscriptXSize.
+
+**Returns:**
+short - Valor de YSubscriptXSize.
+### getYSubscriptYOffset() {#getYSubscriptYOffset--}
+```
+public short getYSubscriptYOffset()
+```
+
+
+Obtiene el valor YSubscriptYOffset.
+
+**Returns:**
+short - Valor de YSubscriptYOffset.
+### getYSubscriptYSize() {#getYSubscriptYSize--}
+```
+public short getYSubscriptYSize()
+```
+
+
+Obtiene el valor YSubscriptYSize.
+
+**Returns:**
+short - Valor de YSubscriptYSize.
+### getYSuperscriptXOffset() {#getYSuperscriptXOffset--}
+```
+public short getYSuperscriptXOffset()
+```
+
+
+Obtiene el valor YSuperscriptXOffset.
+
+**Returns:**
+short - Valor de YSuperscriptXOffset.
+### getYSuperscriptXSize() {#getYSuperscriptXSize--}
+```
+public short getYSuperscriptXSize()
+```
+
+
+Obtiene el valor YSuperscriptXSize.
+
+**Returns:**
+short - Valor de YSuperscriptXSize.
+### getYSuperscriptYOffset() {#getYSuperscriptYOffset--}
+```
+public short getYSuperscriptYOffset()
+```
+
+
+Obtiene el valor YSuperscriptYOffset.
+
+**Returns:**
+short - Valor de YSuperscriptYOffset.
+### getYSuperscriptYSize() {#getYSuperscriptYSize--}
+```
+public short getYSuperscriptYSize()
+```
+
+
+Obtiene el valor YSuperscriptYSize.
+
+**Returns:**
+corto - valor YSuperscriptYSize.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfposttable/_index.md
+++ b/spanish/java/com.aspose.font/ttfposttable/_index.md
@@ -1,0 +1,326 @@
+---
+title: "TtfPostTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla post del archivo de fuente TTF"
+type: docs
+weight: 107
+url: /es/java/com.aspose.font/ttfposttable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfPostTable extends TtfTableBase
+```
+
+Representa la tabla "post" del archivo de fuente TTF
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIndexesForGlyphName(String glyphName)](#getAllGlyphIndexesForGlyphName-java.lang.String-) | Obtiene una matriz de índices de glifos por nombre de glifo |
+| [getClass()](#getClass--) |  |
+| [getFormat()](#getFormat--) | Obtiene el formato fijo (versión) de esta tabla. |
+| [getGlyphIndex(String glyphName)](#getGlyphIndex-java.lang.String-) | Obtiene el índice de glifo por nombre de glifo. |
+| [getGlyphName(long glyphIndex)](#getGlyphName-long-) | Obtiene el nombre de glifo por índice de glifo. |
+| [getItalicAngle()](#getItalicAngle--) | Obtiene fixed italicAngle ángulo itálico en grados. |
+| [getMaxMemType1()](#getMaxMemType1--) | Obtiene uint32 maxMemType1 Uso máximo de memoria cuando una fuente TrueType se descarga como una fuente Type 1. |
+| [getMaxMemType42()](#getMaxMemType42--) | Obtiene uint32 maxMemType42 Uso máximo de memoria cuando una fuente TrueType se descarga como una fuente Type 42. |
+| [getMinMemType1()](#getMinMemType1--) | Obtiene uint32 minMemType1 Uso mínimo de memoria cuando una fuente TrueType se descarga como una fuente Type 1. |
+| [getMinMemType42()](#getMinMemType42--) | Obtiene uint32 minMemType42 Uso mínimo de memoria cuando una fuente TrueType se descarga como una fuente Type 42. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getTableFormat()](#getTableFormat--) | Obtiene fixed format (versión) de esta tabla. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [getUnderlinePosition()](#getUnderlinePosition--) | Obtiene FWord underlinePosition Posición de subrayado. |
+| [getUnderlineThickness()](#getUnderlineThickness--) | Obtiene FWord underlineThickness Grosor del subrayado. |
+| [hasNoPostScriptNames()](#hasNoPostScriptNames--) | Indica que no se proporciona información de nombre PostScript para los glifos en este archivo de fuente. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Obtiene uint32 isFixedPitch. 0 si la fuente tiene espaciado proporcional, distinto de cero si la Fuente no tiene espaciado proporcional (es decir, monoespaciada). |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIndexesForGlyphName(String glyphName) {#getAllGlyphIndexesForGlyphName-java.lang.String-}
+```
+public long[] getAllGlyphIndexesForGlyphName(String glyphName)
+```
+
+
+Obtiene una matriz de índices de glifos por nombre de glifo
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphName | java.lang.String | Nombre del glifo |
+
+**Returns:**
+long[] - matriz de índices de glifos
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFormat() {#getFormat--}
+```
+public float getFormat()
+```
+
+
+Obtiene el formato fijo (versión) de esta tabla.
+
+**Returns:**
+float - Fixed format (versión) de esta tabla.
+### getGlyphIndex(String glyphName) {#getGlyphIndex-java.lang.String-}
+```
+public long getGlyphIndex(String glyphName)
+```
+
+
+Obtiene el índice de glifo por nombre de glifo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphName | java.lang.String | Nombre del glifo. |
+
+**Returns:**
+long - Índice de glifo. Cuando no se proporciona información de nombre PostScript para los glifos en este archivo de fuente, devuelve el índice 0, que es el glifo indefinido o el glifo \".notdef\".
+### getGlyphName(long glyphIndex) {#getGlyphName-long-}
+```
+public String getGlyphName(long glyphIndex)
+```
+
+
+Obtiene el nombre de glifo por índice de glifo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphIndex | long | Índice de glifo. |
+
+**Returns:**
+java.lang.String - Nombre del glifo. Cuando no se proporciona información de nombre PostScript para los glifos en este archivo de fuente, devuelve null.
+### getItalicAngle() {#getItalicAngle--}
+```
+public float getItalicAngle()
+```
+
+
+Obtiene fixed italicAngle ángulo itálico en grados.
+
+**Returns:**
+float - Fixed italicAngle ángulo itálico en grados.
+### getMaxMemType1() {#getMaxMemType1--}
+```
+public long getMaxMemType1()
+```
+
+
+Obtiene uint32 maxMemType1 Uso máximo de memoria cuando una fuente TrueType se descarga como una fuente Type 1.
+
+**Returns:**
+long - UInt32 maxMemType1 Uso máximo de memoria cuando una fuente TrueType se descarga como una fuente Type 1.
+### getMaxMemType42() {#getMaxMemType42--}
+```
+public long getMaxMemType42()
+```
+
+
+Obtiene uint32 maxMemType42 Uso máximo de memoria cuando una fuente TrueType se descarga como una fuente Type 42.
+
+**Returns:**
+long - UInt32 maxMemType42 Uso máximo de memoria cuando una fuente TrueType se descarga como una fuente Type 42.
+### getMinMemType1() {#getMinMemType1--}
+```
+public long getMinMemType1()
+```
+
+
+Obtiene uint32 minMemType1 Uso mínimo de memoria cuando una fuente TrueType se descarga como una fuente Type 1.
+
+**Returns:**
+long - UInt32 minMemType1 Uso mínimo de memoria cuando una fuente TrueType se descarga como una fuente Type 1.
+### getMinMemType42() {#getMinMemType42--}
+```
+public long getMinMemType42()
+```
+
+
+Obtiene uint32 minMemType42 Uso mínimo de memoria cuando una fuente TrueType se descarga como una fuente Type 42.
+
+**Returns:**
+long - UInt32 minMemType42 Uso mínimo de memoria cuando una fuente TrueType se descarga como una fuente Type 42.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getTableFormat() {#getTableFormat--}
+```
+public Version16Dot16 getTableFormat()
+```
+
+
+Obtiene fixed format (versión) de esta tabla. Use las propiedades MajorNumber y MinorNUmber del objeto Version16Dot16 en notación hexadecimal para detectar la versión utilizada.
+
+**Returns:**
+[Version16Dot16](../../com.aspose.font/version16dot16) - Fixed format (version) of this table.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - Etiqueta de tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getUnderlinePosition() {#getUnderlinePosition--}
+```
+public short getUnderlinePosition()
+```
+
+
+Obtiene FWord underlinePosition Posición de subrayado.
+
+**Returns:**
+short - FWord underlinePosition Posición de subrayado.
+### getUnderlineThickness() {#getUnderlineThickness--}
+```
+public short getUnderlineThickness()
+```
+
+
+Obtiene FWord underlineThickness Grosor del subrayado.
+
+**Returns:**
+short - FWord underlineThickness Grosor del subrayado.
+### hasNoPostScriptNames() {#hasNoPostScriptNames--}
+```
+public boolean hasNoPostScriptNames()
+```
+
+
+Indica que no se proporciona información de nombre PostScript para los glifos en este archivo de fuente.
+
+**Returns:**
+boolean - Verdadero, si no se proporciona información de nombre PostScript para los glifos en este archivo de fuente. Falso, de lo contrario.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public long isFixedPitch()
+```
+
+
+Obtiene uint32 isFixedPitch. 0 si la fuente tiene espaciado proporcional, distinto de cero si la Fuente no tiene espaciado proporcional (es decir, monoespaciada).
+
+**Returns:**
+long - UInt32 isFixedPitch. 0 si la fuente tiene espaciado proporcional, distinto de cero si la Fuente no tiene espaciado proporcional (es decir, monoespaciada).
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfpreptable/_index.md
+++ b/spanish/java/com.aspose.font/ttfpreptable/_index.md
@@ -1,0 +1,168 @@
+---
+title: "TtfPrepTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla prep del archivo de fuente TTF."
+type: docs
+weight: 108
+url: /es/java/com.aspose.font/ttfpreptable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfPrepTable extends TtfTableBase
+```
+
+Representa la tabla "prep" del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getProgram()](#getProgram--) | Conjunto de instrucciones. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getProgram() {#getProgram--}
+```
+public byte[] getProgram()
+```
+
+
+Conjunto de instrucciones.
+
+**Returns:**
+byte[] - Conjunto de instrucciones.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - Etiqueta de tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfstattable/_index.md
+++ b/spanish/java/com.aspose.font/ttfstattable/_index.md
@@ -1,0 +1,267 @@
+---
+title: "TtfStatTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: 
+type: docs
+weight: 109
+url: /es/java/com.aspose.font/ttfstattable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfStatTable extends TtfTableBase
+```
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addAxisRecord(AxisRecord axisRecord)](#addAxisRecord-com.aspose.font.AxisRecord-) | Agrega una estructura de Registro de Eje a la tabla. |
+| [addAxisValueTable(AxisValueTableBase axisValueTable)](#addAxisValueTable-com.aspose.font.AxisValueTableBase-) | Agrega una estructura de Tabla de Valor de Eje a la tabla. |
+| [clearAxisRecords()](#clearAxisRecords--) | Elimina todos los registros de eje de la tabla. |
+| [clearAxisValueTables()](#clearAxisValueTables--) | Elimina todas las tablas de valor de eje de la tabla. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisRecords()](#getAxisRecords--) | Devuelve la matriz de ejes de diseño. |
+| [getAxisValueCount()](#getAxisValueCount--) | Devuelve el número de tablas de valor de eje. |
+| [getAxisValueTables()](#getAxisValueTables--) | Devuelve una matriz de Tablas de Valor de Eje. |
+| [getClass()](#getClass--) |  |
+| [getDesignAxisCount()](#getDesignAxisCount--) | Devuelve el número de registros de eje. |
+| [getElidedFallbackName()](#getElidedFallbackName--) | Especificación: Nombre utilizado como alternativa cuando la proyección de nombres en un modelo de fuente particular produce un nombre de subfamilia que contiene solo elementos elidibles. |
+| [getElidedFallbackNameId()](#getElidedFallbackNameId--) | Especificación: ID de nombre utilizado como alternativa cuando la proyección de nombres en un modelo de fuente particular produce un nombre de subfamilia que contiene solo elementos elidibles. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### addAxisRecord(AxisRecord axisRecord) {#addAxisRecord-com.aspose.font.AxisRecord-}
+```
+public void addAxisRecord(AxisRecord axisRecord)
+```
+
+
+Agrega una estructura de Registro de Eje a la tabla.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| axisRecord | [AxisRecord](../../com.aspose.font/axisrecord) | Estructura AxisRecord |
+
+### addAxisValueTable(AxisValueTableBase axisValueTable) {#addAxisValueTable-com.aspose.font.AxisValueTableBase-}
+```
+public void addAxisValueTable(AxisValueTableBase axisValueTable)
+```
+
+
+Agrega una estructura de Tabla de Valor de Eje a la tabla.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| axisValueTable | [AxisValueTableBase](../../com.aspose.font/axisvaluetablebase) | Estructura de tabla de valor de eje |
+
+### clearAxisRecords() {#clearAxisRecords--}
+```
+public void clearAxisRecords()
+```
+
+
+Elimina todos los registros de eje de la tabla.
+
+### clearAxisValueTables() {#clearAxisValueTables--}
+```
+public void clearAxisValueTables()
+```
+
+
+Elimina todas las tablas de valor de eje de la tabla.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisRecords() {#getAxisRecords--}
+```
+public AxisRecord[] getAxisRecords()
+```
+
+
+Devuelve la matriz de ejes de diseño. La matriz de ejes es una matriz de estructuras del tipo Axis Record. Especificación: el registro de eje proporciona información sobre un único eje de diseño.
+
+**Returns:**
+com.aspose.font.AxisRecord[] - La matriz de ejes de diseño.
+### getAxisValueCount() {#getAxisValueCount--}
+```
+public int getAxisValueCount()
+```
+
+
+Devuelve el número de tablas de valor de eje.
+
+**Returns:**
+int - El número de tablas de valor de eje.
+### getAxisValueTables() {#getAxisValueTables--}
+```
+public AxisValueTableBase[] getAxisValueTables()
+```
+
+
+Devuelve una matriz de Tablas de Valor de Eje. Especificación: Las Tablas de Valor de Eje proporcionan detalles sobre un valor de atributo de estilo específico en algún eje específico de variación de diseño, o una combinación de valores de ejes de variación de diseño, y la relación de esos valores con las etiquetas usadas como elementos en los nombres de subfamilia.
+
+**Returns:**
+com.aspose.font.AxisValueTableBase[] - La matriz de tablas de valores de eje.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDesignAxisCount() {#getDesignAxisCount--}
+```
+public int getDesignAxisCount()
+```
+
+
+Devuelve el número de registros de eje. Especificación: en una fuente con una tabla 'fvar', este valor debe ser mayor o igual que el valor axisCount en la tabla 'fvar'. En todas las fuentes, debe ser mayor que cero si axisValueCount es mayor que cero.
+
+**Returns:**
+int - El número de registros de eje.
+### getElidedFallbackName() {#getElidedFallbackName--}
+```
+public String getElidedFallbackName()
+```
+
+
+Especificación: Nombre utilizado como alternativa cuando la proyección de nombres en un modelo de fuente particular produce un nombre de subfamilia que contiene solo elementos elidibles.
+
+**Returns:**
+java.lang.String - El nombre usado como alternativa cuando la proyección de nombres en un modelo de fuente particular produce un nombre de subfamilia que contiene solo elementos elidibles.
+### getElidedFallbackNameId() {#getElidedFallbackNameId--}
+```
+public int getElidedFallbackNameId()
+```
+
+
+Especificación: ID de nombre utilizado como alternativa cuando la proyección de nombres en un modelo de fuente particular produce un nombre de subfamilia que contiene solo elementos elidibles.
+
+**Returns:**
+int - El ID del nombre.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - Etiqueta de tabla.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttftablebase/_index.md
+++ b/spanish/java/com.aspose.font/ttftablebase/_index.md
@@ -1,0 +1,146 @@
+---
+title: "TtfTableBase"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la definición de tabla TTF."
+type: docs
+weight: 110
+url: /es/java/com.aspose.font/ttftablebase/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TtfTableBase
+```
+
+Representa la definición de tabla TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttftablerepository/_index.md
+++ b/spanish/java/com.aspose.font/ttftablerepository/_index.md
@@ -1,0 +1,333 @@
+---
+title: "TtfTableRepository"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "repositorio de tablas TTF"
+type: docs
+weight: 111
+url: /es/java/com.aspose.font/ttftablerepository/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TtfTableRepository
+```
+
+repositorio de tablas TTF
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCMapTable()](#getCMapTable--) | Obtiene la tabla cmap. |
+| [getCffTable()](#getCffTable--) | Obtiene la tabla cff. |
+| [getClass()](#getClass--) |  |
+| [getCvtTable()](#getCvtTable--) | Obtiene la tabla cvt. |
+| [getFpgmTable()](#getFpgmTable--) | Obtiene la tabla fpgm. |
+| [getGaspTable()](#getGaspTable--) | Obtiene la tabla GASP. |
+| [getGlyfTable()](#getGlyfTable--) | Obtiene la tabla glyf. |
+| [getHeadTable()](#getHeadTable--) | Obtiene la tabla head. |
+| [getHheaTable()](#getHheaTable--) | Obtiene la tabla hhea. |
+| [getHmtxTable()](#getHmtxTable--) | Obtiene la tabla hmtx. |
+| [getLocaTable()](#getLocaTable--) | Obtiene la tabla loca. |
+| [getLtshTable()](#getLtshTable--) | Obtiene la tabla LTSH. |
+| [getMaxpTable()](#getMaxpTable--) | Obtiene la tabla maxp. |
+| [getNameTable()](#getNameTable--) | Obtiene la tabla name. |
+| [getOs2Table()](#getOs2Table--) | Obtiene la tabla OS/2. |
+| [getPostTable()](#getPostTable--) | Obtiene la tabla post. |
+| [getPrepTable()](#getPrepTable--) | Obtiene la tabla prep. |
+| [getStatTable()](#getStatTable--) | Obtiene la tabla STAT. |
+| [getVheaTable()](#getVheaTable--) | Obtiene la tabla vhea. |
+| [getVmtxTable()](#getVmtxTable--) | Obtiene la tabla vmtx. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCMapTable() {#getCMapTable--}
+```
+public TtfCMapTable getCMapTable()
+```
+
+
+Obtiene la tabla cmap.
+
+**Returns:**
+[TtfCMapTable](../../com.aspose.font/ttfcmaptable) - Cmap table.
+### getCffTable() {#getCffTable--}
+```
+public TtfCffTable getCffTable()
+```
+
+
+Obtiene la tabla cff.
+
+**Returns:**
+[TtfCffTable](../../com.aspose.font/ttfcfftable) - Cff table.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCvtTable() {#getCvtTable--}
+```
+public TtfCvtTable getCvtTable()
+```
+
+
+Obtiene la tabla cvt.
+
+**Returns:**
+[TtfCvtTable](../../com.aspose.font/ttfcvttable) - Cvt table.
+### getFpgmTable() {#getFpgmTable--}
+```
+public TtfFpgmTable getFpgmTable()
+```
+
+
+Obtiene la tabla fpgm.
+
+**Returns:**
+[TtfFpgmTable](../../com.aspose.font/ttffpgmtable) - Fpgm table.
+### getGaspTable() {#getGaspTable--}
+```
+public TtfGaspTable getGaspTable()
+```
+
+
+Obtiene la tabla GASP.
+
+**Returns:**
+[TtfGaspTable](../../com.aspose.font/ttfgasptable) - The GASP table.
+### getGlyfTable() {#getGlyfTable--}
+```
+public TtfGlyfTable getGlyfTable()
+```
+
+
+Obtiene la tabla glyf.
+
+**Returns:**
+[TtfGlyfTable](../../com.aspose.font/ttfglyftable) - Glyf table.
+### getHeadTable() {#getHeadTable--}
+```
+public TtfHeadTable getHeadTable()
+```
+
+
+Obtiene la tabla head.
+
+**Returns:**
+[TtfHeadTable](../../com.aspose.font/ttfheadtable) - Head table.
+### getHheaTable() {#getHheaTable--}
+```
+public TtfHheaTable getHheaTable()
+```
+
+
+Obtiene la tabla hhea.
+
+**Returns:**
+[TtfHheaTable](../../com.aspose.font/ttfhheatable) - Hhea table.
+### getHmtxTable() {#getHmtxTable--}
+```
+public TtfHmtxTable getHmtxTable()
+```
+
+
+Obtiene la tabla hmtx.
+
+**Returns:**
+[TtfHmtxTable](../../com.aspose.font/ttfhmtxtable) - Hmtx table.
+### getLocaTable() {#getLocaTable--}
+```
+public TtfLocaTable getLocaTable()
+```
+
+
+Obtiene la tabla loca.
+
+**Returns:**
+[TtfLocaTable](../../com.aspose.font/ttflocatable) - Loca table.
+### getLtshTable() {#getLtshTable--}
+```
+public TtfLtshTable getLtshTable()
+```
+
+
+Obtiene la tabla LTSH.
+
+**Returns:**
+[TtfLtshTable](../../com.aspose.font/ttfltshtable) - The LTSH table.
+### getMaxpTable() {#getMaxpTable--}
+```
+public TtfMaxpTable getMaxpTable()
+```
+
+
+Obtiene la tabla maxp.
+
+**Returns:**
+[TtfMaxpTable](../../com.aspose.font/ttfmaxptable) - Maxp table.
+### getNameTable() {#getNameTable--}
+```
+public TtfNameTable getNameTable()
+```
+
+
+Obtiene la tabla name.
+
+**Returns:**
+[TtfNameTable](../../com.aspose.font/ttfnametable) - Name table.
+### getOs2Table() {#getOs2Table--}
+```
+public TtfOs2Table getOs2Table()
+```
+
+
+Obtiene la tabla OS/2.
+
+**Returns:**
+[TtfOs2Table](../../com.aspose.font/ttfos2table) - OS/2 table.
+### getPostTable() {#getPostTable--}
+```
+public TtfPostTable getPostTable()
+```
+
+
+Obtiene la tabla post.
+
+**Returns:**
+[TtfPostTable](../../com.aspose.font/ttfposttable) - Post table.
+### getPrepTable() {#getPrepTable--}
+```
+public TtfPrepTable getPrepTable()
+```
+
+
+Obtiene la tabla prep.
+
+**Returns:**
+[TtfPrepTable](../../com.aspose.font/ttfpreptable) - Prep table.
+### getStatTable() {#getStatTable--}
+```
+public TtfStatTable getStatTable()
+```
+
+
+Obtiene la tabla STAT.
+
+**Returns:**
+[TtfStatTable](../../com.aspose.font/ttfstattable) - The STAT table.
+### getVheaTable() {#getVheaTable--}
+```
+public TtfVheaTable getVheaTable()
+```
+
+
+Obtiene la tabla vhea.
+
+**Returns:**
+[TtfVheaTable](../../com.aspose.font/ttfvheatable) - Vhea table.
+### getVmtxTable() {#getVmtxTable--}
+```
+public TtfVmtxTable getVmtxTable()
+```
+
+
+Obtiene la tabla vmtx.
+
+**Returns:**
+[TtfVmtxTable](../../com.aspose.font/ttfvmtxtable) - Vmtx table.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfvheatable/_index.md
+++ b/spanish/java/com.aspose.font/ttfvheatable/_index.md
@@ -1,0 +1,300 @@
+---
+title: "TtfVheaTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla hhea del archivo de fuente TTF."
+type: docs
+weight: 112
+url: /es/java/com.aspose.font/ttfvheatable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfVheaTable extends TtfTableBase
+```
+
+Representa la tabla "hhea" del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdvanceHeightMax()](#getAdvanceHeightMax--) | Obtiene AdvanceHeightMax. |
+| [getAscent()](#getAscent--) | Obtiene Ascent. |
+| [getCaretOffset()](#getCaretOffset--) | Obtiene CaretOffset. |
+| [getCaretSlopeRise()](#getCaretSlopeRise--) | Obtiene CaretSlopeRise. |
+| [getCaretSlopeRun()](#getCaretSlopeRun--) | Obtiene CaretSlopeRun. |
+| [getClass()](#getClass--) |  |
+| [getDescent()](#getDescent--) | Obtiene Descent. |
+| [getLineGap()](#getLineGap--) | Obtiene LineGap. |
+| [getMetricDataFormat()](#getMetricDataFormat--) | Obtiene MetricDataFormat. |
+| [getMinBottomSideBearing()](#getMinBottomSideBearing--) | Obtiene MinBottomSideBearing. |
+| [getMinTopSideBearing()](#getMinTopSideBearing--) | Obtiene MinTopSideBearing. |
+| [getNumOfLongVerMetrics()](#getNumOfLongVerMetrics--) | Obtiene MetricDataFormat. |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [getVersion()](#getVersion--) | Obtiene el número de versión de la tabla de encabezado vertical. |
+| [getYMaxExtent()](#getYMaxExtent--) | Obtiene \_yMaxExtent. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdvanceHeightMax() {#getAdvanceHeightMax--}
+```
+public short getAdvanceHeightMax()
+```
+
+
+Obtiene AdvanceHeightMax. La medida máxima de altura de avance en FUnits encontrada en la fuente.
+
+**Returns:**
+short - La AdvanceHeightMax.
+### getAscent() {#getAscent--}
+```
+public short getAscent()
+```
+
+
+Obtiene Ascent. Distancia en FUnits desde la línea central hasta el \_descent de la línea anterior\\u2019s.
+
+**Returns:**
+short - La Ascent.
+### getCaretOffset() {#getCaretOffset--}
+```
+public short getCaretOffset()
+```
+
+
+Obtiene CaretOffset.
+
+**Returns:**
+short - La CaretOffset.
+### getCaretSlopeRise() {#getCaretSlopeRise--}
+```
+public short getCaretSlopeRise()
+```
+
+
+Obtiene CaretSlopeRise.
+
+**Returns:**
+short - La CaretSlopeRise.
+### getCaretSlopeRun() {#getCaretSlopeRun--}
+```
+public short getCaretSlopeRun()
+```
+
+
+Obtiene CaretSlopeRun.
+
+**Returns:**
+short - La CaretSlopeRun.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescent() {#getDescent--}
+```
+public short getDescent()
+```
+
+
+Obtiene Descent. Distancia en FUnits desde la línea central hasta el \_ascent de la siguiente línea\\u2019s.
+
+**Returns:**
+short - La Descent.
+### getLineGap() {#getLineGap--}
+```
+public short getLineGap()
+```
+
+
+Obtiene LineGap. El espacio tipográfico vertical para esta fuente.
+
+**Returns:**
+short - La LineGap.
+### getMetricDataFormat() {#getMetricDataFormat--}
+```
+public short getMetricDataFormat()
+```
+
+
+Obtiene MetricDataFormat.
+
+**Returns:**
+short - La MetricDataFormat.
+### getMinBottomSideBearing() {#getMinBottomSideBearing--}
+```
+public short getMinBottomSideBearing()
+```
+
+
+Obtiene MinBottomSideBearing. La medida mínima de sidebearing inferior encontrada en la fuente, en FUnits.
+
+**Returns:**
+short - La MinBottomSideBearing.
+### getMinTopSideBearing() {#getMinTopSideBearing--}
+```
+public short getMinTopSideBearing()
+```
+
+
+Obtiene MinTopSideBearing. La medida mínima de sidebearing superior encontrada en la fuente, en FUnits.
+
+**Returns:**
+short - El MinTopSideBearing.
+### getNumOfLongVerMetrics() {#getNumOfLongVerMetrics--}
+```
+public int getNumOfLongVerMetrics()
+```
+
+
+Obtiene MetricDataFormat. Número de alturas de avance en la tabla de métricas verticales.
+
+**Returns:**
+int - El MetricDataFormat.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - La etiqueta.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public Version16Dot16 getVersion()
+```
+
+
+Obtiene el número de versión de la tabla de encabezado vertical.
+
+**Returns:**
+[Version16Dot16](../../com.aspose.font/version16dot16) - The Version number of the vertical header table.
+### getYMaxExtent() {#getYMaxExtent--}
+```
+public short getYMaxExtent()
+```
+
+
+Obtiene \_yMaxExtent.
+
+**Returns:**
+short - El \_yMaxExtent.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/ttfvmtxtable/_index.md
+++ b/spanish/java/com.aspose.font/ttfvmtxtable/_index.md
@@ -1,0 +1,179 @@
+---
+title: "TtfVmtxTable"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la tabla vmtx del archivo de fuente TTF."
+type: docs
+weight: 113
+url: /es/java/com.aspose.font/ttfvmtxtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfVmtxTable extends TtfTableBase
+```
+
+Representa la tabla "vmtx" del archivo de fuente TTF.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Obtiene el desplazamiento desde el inicio de sfnt. |
+| [getTag()](#getTag--) | Obtiene la etiqueta de la tabla. |
+| [getTopSideBearings()](#getTopSideBearings--) | Obtiene los Top Side Bearings. |
+| [getTtfTables()](#getTtfTables--) | Referencia al repositorio de tabla TTF. |
+| [getVMetrics()](#getVMetrics--) | Obtiene métricas verticales. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Obtiene el desplazamiento desde el inicio de sfnt.
+
+**Returns:**
+long - Desplazamiento desde el inicio de sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Obtiene la etiqueta de la tabla.
+
+**Returns:**
+java.lang.String - La etiqueta de la tabla.
+### getTopSideBearings() {#getTopSideBearings--}
+```
+public short[] getTopSideBearings()
+```
+
+
+Obtiene los Top Side Bearings. Matriz de top side bearings del glifo.
+
+**Returns:**
+short[] - Los rodamientos superiores.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referencia al repositorio de tabla TTF.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVMetrics() {#getVMetrics--}
+```
+public TtfVmtxTable.LongVerMetric[] getVMetrics()
+```
+
+
+Obtiene métricas verticales.
+
+**Returns:**
+com.aspose.font.TtfVmtxTable.LongVerMetric[] - Las métricas verticales.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/type1encoding/_index.md
+++ b/spanish/java/com.aspose.font/type1encoding/_index.md
@@ -1,0 +1,218 @@
+---
+title: "Type1Encoding"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la codificación de fuente Type1."
+type: docs
+weight: 114
+url: /es/java/com.aspose.font/type1encoding/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFontEncoding](../../com.aspose.font/ifontencoding), [com.aspose.font.ISupportsNameAddressing](../../com.aspose.font/isupportsnameaddressing)
+```
+public class Type1Encoding implements IFontEncoding, ISupportsNameAddressing
+```
+
+Representa la codificación de fuente Type1.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [decodeToGid(long charCode)](#decodeToGid-long-) | Decodifica Gid a unicode. |
+| [decodeToGidParameterized(IEncodingParameters parameters, long charCode)](#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-) | Método de decodificación parametrizado. |
+| [encode(long gid, long charCode)](#encode-long-long-) | Codifica el glifo. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getNameToCharCodeIndex()](#getNameToCharCodeIndex--) | Devuelve el mapa de codificación de nombre a código de carácter. |
+| [gidToUnicode(GlyphId gid)](#gidToUnicode-com.aspose.font.GlyphId-) | Decodifica Gid a Unicode. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [unicodeToGid(long unicode)](#unicodeToGid-long-) | Devuelve GlyphId para Unicode. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### decodeToGid(long charCode) {#decodeToGid-long-}
+```
+public GlyphId decodeToGid(long charCode)
+```
+
+
+Decodifica Gid a unicode. El id del glifo es un número único para un glifo, que depende del tipo de fuente. Por ejemplo: el id de Type1 es un nombre de glifo, instancia de la clase ( GlyphStringId ). El id de TTF es un índice entero, instancia de la clase ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| charCode | long | Código de carácter para obtener el identificador del glifo. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to character code passed.
+### decodeToGidParameterized(IEncodingParameters parameters, long charCode) {#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-}
+```
+public GlyphId decodeToGidParameterized(IEncodingParameters parameters, long charCode)
+```
+
+
+Método de decodificación parametrizado. No compatible con el tipo de fuente Type1.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| parameters | [IEncodingParameters](../../com.aspose.font/iencodingparameters) | No compatible con el tipo de fuente Type1. |
+| charCode | long | No compatible con el tipo de fuente Type1. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Not supported for Type1 Font type.
+### encode(long gid, long charCode) {#encode-long-long-}
+```
+public void encode(long gid, long charCode)
+```
+
+
+Codifica el glifo. Para fuentes TTF el código de carácter es unicode. No compatible con los tipos de fuente Type1.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| gid | long | Id de glifo. |
+| charCode | long | Código de carácter asociado con el id del glifo. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNameToCharCodeIndex() {#getNameToCharCodeIndex--}
+```
+public NameToCodeMap getNameToCharCodeIndex()
+```
+
+
+Devuelve el mapa de codificación de nombre a código de carácter. Nota: El código de carácter no es un unicode. El código de carácter es un índice de carácter en la "tabla" de codificación de la fuente.
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - Name to character code encoding map.
+### gidToUnicode(GlyphId gid) {#gidToUnicode-com.aspose.font.GlyphId-}
+```
+public long gidToUnicode(GlyphId gid)
+```
+
+
+Decodifica Gid a Unicode. El id del glifo es un número único para un glifo, que depende del tipo de fuente. Por ejemplo: el id de Type1 es un nombre de glifo, instancia de la clase ( GlyphStringId ). El id de TTF es un índice entero, instancia de la clase ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| gid | [GlyphId](../../com.aspose.font/glyphid) | Identificador de glifo del símbolo a decodificar. |
+
+**Returns:**
+long - Valor Unicode relacionado con el id de glifo pasado.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unicodeToGid(long unicode) {#unicodeToGid-long-}
+```
+public GlyphId unicodeToGid(long unicode)
+```
+
+
+Devuelve GlyphId para unicode. O notdef si la fuente no contiene un glifo para el unicode. El id del glifo es un número único para un glifo, que depende del tipo de fuente. Por ejemplo: el id de Type1 es un nombre de glifo, instancia de la clase ( GlyphStringId ). El id de TTF es un índice entero, instancia de la clase ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| unicode | long | Unicode para obtener el identificador del glifo. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to unicode passed.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/type1font/_index.md
+++ b/spanish/java/com.aspose.font/type1font/_index.md
@@ -1,0 +1,545 @@
+---
+title: "Type1Font"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la fuente Type1."
+type: docs
+weight: 115
+url: /es/java/com.aspose.font/type1font/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Font](../../com.aspose.font/font)
+```
+public class Type1Font extends Font
+```
+
+Representa la fuente Type1.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Convierte la fuente a otro formato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Devuelve una matriz de todos los identificadores de glifos disponibles en la fuente. |
+| [getClass()](#getClass--) |  |
+| [getEncoding()](#getEncoding--) | Obtiene la codificación de la fuente. |
+| [getFontDefinition()](#getFontDefinition--) | Obtiene la definición de la fuente. |
+| [getFontFamily()](#getFontFamily--) | Obtiene la familia de la fuente. |
+| [getFontName()](#getFontName--) | Obtiene el nombre del estilo de la fuente. |
+| [getFontNames()](#getFontNames--) | Obtiene los nombres de la fuente. |
+| [getFontSaver()](#getFontSaver--) | Obtiene la funcionalidad de guardado de la fuente. |
+| [getFontStyle()](#getFontStyle--) | Obtiene el estilo de la fuente. |
+| [getFontType()](#getFontType--) | Obtiene el tipo de la fuente. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Accesor de glifos de la fuente. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Devuelve el glifo por su identificador. |
+| [getGlyphById(String id)](#getGlyphById-java.lang.String-) | Devuelve el glifo por su identificador. |
+| [getGlyphById(long id)](#getGlyphById-long-) | Devuelve el glifo por su identificador. |
+| [getGlyphIdType()](#getGlyphIdType--) | Especificación del tipo de id de glifo. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Obtiene la representación de glifos para texto. |
+| [getMetrics()](#getMetrics--) | Obtiene las métricas de la fuente. |
+| [getNumGlyphs()](#getNumGlyphs--) | Obtiene el número de glifos en la Fuente. |
+| [getPostscriptNames()](#getPostscriptNames--) | Obtiene los nombres de fuente PostScript. |
+| [getStyle()](#getStyle--) | Obtiene el estilo de la fuente. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Abre una fuente, usando el objeto FontDefinition. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Abre una fuente, usando el tipo de fuente y la matriz de bytes de datos de fuente. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Abre una fuente, usando el tipo de fuente y la fuente de flujo. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Abre una fuente, usando el tipo de fuente y el nombre de archivo de fuente. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Guarda la Fuente en el formato original. |
+| [save(String fileName)](#save-java.lang.String-) | Guarda la Fuente en el formato original. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Guarda la Fuente en el formato especificado. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | El setter de la familia de fuentes no está implementado aún. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | El setter del nombre de la cara de fuente no está implementado aún. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | El setter de estilo no está implementado aún. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public Font convert(FontType fontType)
+```
+
+
+Convierte la fuente a otro formato.
+
+> ```
+> Note: TTF Font type is now supported only.
+> ```
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de formato de fuente al que convertir. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public GlyphId[] getAllGlyphIds()
+```
+
+
+Devuelve una matriz de todos los ids de glifos, disponibles en la Fuente. El id de glifo es un número único para un glifo, que depende del tipo de fuente. El id de glifo de Type1 Font puede ser una instancia de la clase ( GlyphStringId ) o de la clase ( GlyphUInt32Id ).
+
+**Returns:**
+com.aspose.font.GlyphId[]
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncoding() {#getEncoding--}
+```
+public IFontEncoding getEncoding()
+```
+
+
+Obtiene la codificación de la fuente.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public FontDefinition getFontDefinition()
+```
+
+
+Obtiene la definición de la fuente.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public String getFontFamily()
+```
+
+
+Obtiene la familia de la fuente.
+
+**Returns:**
+java.lang.String - Familia de la Fuente.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Obtiene el nombre del estilo de la fuente.
+
+**Returns:**
+java.lang.String - Nombre de la cara de la Fuente.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Obtiene los nombres de la fuente.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Obtiene la funcionalidad de guardado de la fuente.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public int getFontStyle()
+```
+
+
+Obtiene el estilo de la Fuente. Este es un valor calculado y representado en tipo generalizado.
+
+**Returns:**
+int - Estilo de la Fuente. Normalmente, una combinación de valores de bandera constante de la clase FontStyle o 0.
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Obtiene el tipo de Fuente. Devuelve el valor FontType.Type1.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Accesor de glifos de fuente. Recupera glifos e identificadores de glifos.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public Glyph getGlyphById(GlyphId id)
+```
+
+
+Devuelve el glifo por su id de glifo. El id de glifo es un número único para un glifo, que depende del tipo de fuente. El id de glifo de Type1 Font puede ser una instancia de la clase ( GlyphStringId ) o de la clase ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) |  |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph)
+### getGlyphById(String id) {#getGlyphById-java.lang.String-}
+```
+public Glyph getGlyphById(String id)
+```
+
+
+Devuelve el glifo por su identificador.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| id | java.lang.String | Id de glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(long id) {#getGlyphById-long-}
+```
+public Glyph getGlyphById(long id)
+```
+
+
+Devuelve el glifo por su identificador.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| id | long | Id de glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public GlyphIdType getGlyphIdType()
+```
+
+
+Especificación del tipo de id de glifo.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype)
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Obtiene la representación de glifos para texto.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| text | java.lang.String | Texto de entrada. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - matriz de GlyphId.
+### getMetrics() {#getMetrics--}
+```
+public IFontMetrics getMetrics()
+```
+
+
+Obtiene las métricas de la fuente.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Obtiene el número de glifos en la Fuente.
+
+**Returns:**
+int - Número de glifos en la fuente.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Obtiene los nombres de fuente PostScript.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names
+### getStyle() {#getStyle--}
+```
+public String getStyle()
+```
+
+
+Obtiene el estilo de la fuente. Este es un valor de cadena sin procesar proporcionado por el archivo de fuente.
+
+**Returns:**
+java.lang.String - Estilo de la fuente.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Abre una fuente, usando el objeto FontDefinition.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Objeto de definición de fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Abre una fuente, usando el tipo de fuente y la matriz de bytes de datos de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fontData | byte[] | Arreglo de bytes para cargar la fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Abre una fuente, usando el tipo de fuente y la fuente de flujo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Fuente de flujo para la fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Abre una fuente, usando el tipo de fuente y el nombre de archivo de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fileName | java.lang.String | Nombre del archivo de fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Guarda la Fuente en el formato original.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.OutputStream | Flujo para guardar la fuente. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Guarda la Fuente en el formato original.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | java.lang.String | Archivo para guardar la fuente. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Guarda la Fuente en el formato especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.OutputStream | flujo para guardar la fuente |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | formato deseado |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public void setFontFamily(String value)
+```
+
+
+El setter de la familia de fuentes no está implementado aún.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Nueva familia de fuente. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public void setFontName(String value)
+```
+
+
+El setter del nombre de la cara de fuente no está implementado aún.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Nuevo nombre de la cara de fuente. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public void setStyle(String value)
+```
+
+
+El setter Style aún no está implementado. Este es un valor de cadena sin procesar proporcionado por el archivo de Fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Nuevo estilo de fuente. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/type1fontmetrics/_index.md
+++ b/spanish/java/com.aspose.font/type1fontmetrics/_index.md
@@ -1,0 +1,555 @@
+---
+title: "Type1FontMetrics"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa las métricas de la fuente Type1."
+type: docs
+weight: 116
+url: /es/java/com.aspose.font/type1fontmetrics/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.FontMetrics](../../com.aspose.font/fontmetrics)
+```
+public class Type1FontMetrics extends FontMetrics
+```
+
+Representa las métricas de la fuente Type1.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAscender()](#getAscender--) | Obtiene el valor del ascendente. |
+| [getAscender(double fontSize)](#getAscender-double-) | Devuelve el ascender para un tamaño de fuente específico. |
+| [getCapHeight()](#getCapHeight--) | Obtiene el valor de la altura de la mayúscula. |
+| [getClass()](#getClass--) |  |
+| [getDescender()](#getDescender--) | Obtiene el valor del descendente. |
+| [getDescender(double fontSize)](#getDescender-double-) | Devuelve el descender para un tamaño de fuente específico. |
+| [getFontBBox()](#getFontBBox--) | Obtiene el valor de FontBBox. |
+| [getFontMatrix()](#getFontMatrix--) | Obtiene la matriz de transformación de fuente. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Devuelve el Bbox del glifo. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Devuelve el ancho del glifo. |
+| [getItalicAngle()](#getItalicAngle--) | Obtiene el valor del ángulo itálico. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Devuelve el valor de kerning para el par de glifos. |
+| [getLineGap()](#getLineGap--) | Obtiene el valor de LineGap. |
+| [getStdHW()](#getStdHW--) | Obtiene el valor de StdHW. |
+| [getStdVW()](#getStdVW--) | Obtiene el valor de StdVW. |
+| [getTypoAscender()](#getTypoAscender--) | Obtiene el valor de TypoAscender. |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Devuelve el ascendente tipográfico para un tamaño de fuente específico. |
+| [getTypoDescender()](#getTypoDescender--) | Obtiene el valor de TypoDescender. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Devuelve el descendente tipográfico para un tamaño de fuente específico |
+| [getTypoLineGap()](#getTypoLineGap--) | Obtiene el valor de TypoLineGap. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Devuelve el espacio entre líneas para un tamaño de fuente específico. |
+| [getUnderlinePosition()](#getUnderlinePosition--) | Obtiene el valor de la posición del subrayado. |
+| [getUnderlineThickness()](#getUnderlineThickness--) | Obtiene el valor del grosor del subrayado. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Obtiene el valor de UnitsPerEM del subrayado. |
+| [getWeight()](#getWeight--) | Obtiene el peso. |
+| [getXHeight()](#getXHeight--) | Obtiene el valor de XHeight. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Obtiene el valor de IsFixedPitch. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Mide la cadena y devuelve el ancho de la cadena. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAscender(double value)](#setAscender-double-) | Establece el valor de Ascender. |
+| [setDescender(double value)](#setDescender-double-) | Establece el valor de Descender. |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) | Establece el ancho del glifo. |
+| [setTypoAscender(double value)](#setTypoAscender-double-) | Establece el valor de TypoAscender. |
+| [setTypoDescender(double value)](#setTypoDescender-double-) | Establece el valor de TypoDescender. |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAscender() {#getAscender--}
+```
+public double getAscender()
+```
+
+
+Obtiene el valor del ascendente.
+
+**Returns:**
+double - valor de Ascender.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public double getAscender(double fontSize)
+```
+
+
+Devuelve el ascender para un tamaño de fuente específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - valor de Ascender.
+### getCapHeight() {#getCapHeight--}
+```
+public double getCapHeight()
+```
+
+
+Obtiene el valor de la altura de la mayúscula.
+
+**Returns:**
+double - valor de altura de mayúsculas.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescender() {#getDescender--}
+```
+public double getDescender()
+```
+
+
+Obtiene el valor del descendente.
+
+**Returns:**
+double - valor de Descender.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public double getDescender(double fontSize)
+```
+
+
+Devuelve el descender para un tamaño de fuente específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - valor de Descender.
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+Obtiene el valor de FontBBox.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - FontBBox value.
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+Obtiene la matriz de transformación de fuente.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - Font transformation matrix.
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Devuelve el Bbox del glifo. Devuelve FontBBox si el Bbox no estaba definido para el glifo. Puede ser sobrescrito por herederos de codificación de fuente específicos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificador de glifo. |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox.
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Devuelve el ancho del glifo. Puede ser sobrescrito por herederos de codificación de fuente específicos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificador de glifo. |
+
+**Returns:**
+double - Ancho del glifo.
+### getItalicAngle() {#getItalicAngle--}
+```
+public double getItalicAngle()
+```
+
+
+Obtiene el valor del ángulo itálico.
+
+**Returns:**
+double - valor del ángulo itálico.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Devuelve el valor de kerning para el par de glifos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Primer glifo en el par. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Tamaño de fuente. |
+
+**Returns:**
+double - Valor de interletraje.
+### getLineGap() {#getLineGap--}
+```
+public double getLineGap()
+```
+
+
+Obtiene el valor de LineGap.
+
+**Returns:**
+double - Valor de LineGap.
+### getStdHW() {#getStdHW--}
+```
+public double getStdHW()
+```
+
+
+Obtiene el valor de StdHW.
+
+**Returns:**
+double - valor de StdHW.
+### getStdVW() {#getStdVW--}
+```
+public double getStdVW()
+```
+
+
+Obtiene el valor de StdVW.
+
+**Returns:**
+double - valor de StdVW.
+### getTypoAscender() {#getTypoAscender--}
+```
+public double getTypoAscender()
+```
+
+
+Obtiene el valor de TypoAscender.
+
+**Returns:**
+double - Valor de TypoAscender.
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public double getTypoAscender(double fontSize)
+```
+
+
+Devuelve el ascendente tipográfico para un tamaño de fuente específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - Valor del ascendente tipográfico.
+### getTypoDescender() {#getTypoDescender--}
+```
+public double getTypoDescender()
+```
+
+
+Obtiene el valor de TypoDescender.
+
+**Returns:**
+double - Valor de TypoDescender.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public double getTypoDescender(double fontSize)
+```
+
+
+Devuelve el descendente tipográfico para un tamaño de fuente específico
+
+param fontSize Tamaño de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double |  |
+
+**Returns:**
+double - Valor del descendente tipográfico.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public double getTypoLineGap()
+```
+
+
+Obtiene el valor de TypoLineGap.
+
+**Returns:**
+double - Valor de TypoLineGap.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public double getTypoLineGap(double fontSize)
+```
+
+
+Devuelve el espacio entre líneas para un tamaño de fuente específico.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - Valor del espacio de línea.
+### getUnderlinePosition() {#getUnderlinePosition--}
+```
+public double getUnderlinePosition()
+```
+
+
+Obtiene el valor de la posición del subrayado.
+
+**Returns:**
+double - valor de la posición del subrayado.
+### getUnderlineThickness() {#getUnderlineThickness--}
+```
+public double getUnderlineThickness()
+```
+
+
+Obtiene el valor del grosor del subrayado.
+
+**Returns:**
+double - valor del grosor del subrayado.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Obtiene el valor de UnitsPerEM del subrayado.
+
+**Returns:**
+long - valor de UnitsPerEM del subrayado.
+### getWeight() {#getWeight--}
+```
+public String getWeight()
+```
+
+
+Obtiene el peso.
+
+**Returns:**
+java.lang.String - Peso.
+### getXHeight() {#getXHeight--}
+```
+public double getXHeight()
+```
+
+
+Obtiene el valor de XHeight.
+
+**Returns:**
+double - valor de XHeight.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+Obtiene el valor de IsFixedPitch.
+
+**Returns:**
+boolean - Valor de IsFixedPitch.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public double measureString(String unicode, double fontSize)
+```
+
+
+Mide la cadena y devuelve el ancho de la cadena.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| unicode | java.lang.String | Cadena Unicode. |
+| fontSize | double | Tamaño de fuente. |
+
+**Returns:**
+double - Ancho de la cadena.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAscender(double value) {#setAscender-double-}
+```
+public void setAscender(double value)
+```
+
+
+Establece el valor de Ascender.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor del ascendente. |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public void setDescender(double value)
+```
+
+
+Establece el valor de Descender.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor del descendente. |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Establece el ancho del glifo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Identificador de glifo. |
+| valor | double | Nuevo ancho. |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public void setTypoAscender(double value)
+```
+
+
+Establece el valor de TypoAscender.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor de TypoAscender. |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public void setTypoDescender(double value)
+```
+
+
+Establece el valor de TypoDescender.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Valor de TypoDescender. |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public void setUnitsPerEM(long value)
+```
+
+
+Establece el valor de UnitsPerEM.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/type1metricfont/_index.md
+++ b/spanish/java/com.aspose.font/type1metricfont/_index.md
@@ -1,0 +1,574 @@
+---
+title: "Type1MetricFont"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Implementación de fuente métrica Type1."
+type: docs
+weight: 117
+url: /es/java/com.aspose.font/type1metricfont/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Font](../../com.aspose.font/font), [com.aspose.font.Type1Font](../../com.aspose.font/type1font)
+```
+public class Type1MetricFont extends Type1Font
+```
+
+Implementación de fuente tipográfica Type1. Esta fuente type1 se crea solo usando métricas. Las funciones de recuperación de glifos y algunas otras que requieren una fuente real no están permitidas; las funciones no permitidas lanzan la excepción Type1NotSupportedException. Otras propiedades (FontName, Weight, Metrics y Encoding) se obtienen del archivo de métricas.
+
+--------------------
+
+> ```
+> Note: If metrics file defines Encoding as "FontSpecific", user should provide the specific encoding with following way:
+>      string[] zapfDingbatsEncoding = new string[256] {null, null, ... , "space", "a1", ...};
+>      FontEnvironment.Current.FontSpecificEncodings.RegisterEncoding("ZapfDingbats", zapfDingbatsEncoding);
+>  ```
+> 
+>      System::ArrayPtr<System::String> zapfDingbatsEncoding = System::MakeArray<System::String>({nullptr, nullptr, ..., u"space", u"a1", ...});
+>      FontEnvironment::get_Current()->get_FontSpecificEncodings()->RegisterEncoding(u"ZapfDingbats", zapfDingbatsEncoding);
+>  
+> ```
+> ```
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Convierte la fuente a otro formato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Devuelve todos los Ids de glifos, disponibles en el Font. |
+| [getClass()](#getClass--) |  |
+| [getEncoding()](#getEncoding--) | La codificación se define en el archivo de métricas. |
+| [getFontDefinition()](#getFontDefinition--) | Obtiene la definición de la fuente. |
+| [getFontFamily()](#getFontFamily--) | Obtiene la familia de la fuente. |
+| [getFontName()](#getFontName--) | Obtiene el nombre del Font. |
+| [getFontNames()](#getFontNames--) | Obtiene los nombres de la fuente. |
+| [getFontSaver()](#getFontSaver--) | Obtiene la funcionalidad de guardado de la fuente. |
+| [getFontStyle()](#getFontStyle--) | Obtiene el estilo de la fuente. |
+| [getFontType()](#getFontType--) | Obtiene el tipo de la fuente. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Accesor de glifos de la fuente. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Devuelve el glifo por Id de glifo. |
+| [getGlyphById(String id)](#getGlyphById-java.lang.String-) | Devuelve el glifo por Id de glifo. |
+| [getGlyphById(long id)](#getGlyphById-long-) | Devuelve el glifo por su identificador. |
+| [getGlyphIdType()](#getGlyphIdType--) | Especificación del tipo de id de glifo. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Obtiene la representación de glifos para texto. |
+| [getMetrics()](#getMetrics--) | Obtiene las métricas de la fuente. |
+| [getNumGlyphs()](#getNumGlyphs--) | Obtiene el número de glifos en la Fuente. |
+| [getPostscriptNames()](#getPostscriptNames--) | Obtiene los nombres de fuente PostScript. |
+| [getStyle()](#getStyle--) | Obtiene el estilo de la fuente. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Abre una fuente, usando el objeto FontDefinition. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Abre una fuente, usando el tipo de fuente y la matriz de bytes de datos de fuente. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Abre una fuente, usando el tipo de fuente y la fuente de flujo. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Abre una fuente, usando el tipo de fuente y el nombre de archivo de fuente. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Guarda la Fuente en el formato original. |
+| [save(String fileName)](#save-java.lang.String-) | Guarda la Fuente en el formato original. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Guarda la Fuente en el formato especificado. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | El setter de la familia de fuentes no está implementado aún. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | El setter del nombre de la cara de fuente no está implementado aún. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | El setter de estilo no está implementado aún. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public Font convert(FontType fontType)
+```
+
+
+Convierte la fuente a otro formato.
+
+> ```
+> Note: TTF Font type is now supported only.
+> ```
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de formato de fuente al que convertir. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public GlyphId[] getAllGlyphIds()
+```
+
+
+Devuelve todos los Ids de glifos, disponibles en el Font. No compatible con el tipo Type1MetricFont.
+
+**Returns:**
+com.aspose.font.GlyphId[] - Todos los identificadores de glifos, disponibles en el Font.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncoding() {#getEncoding--}
+```
+public IFontEncoding getEncoding()
+```
+
+
+La codificación se define en el archivo de métricas. StandardAdobeEncoding: la codificación se rellena automáticamente.
+
+--------------------
+
+> ```
+> FontSpecific:
+>         user should provide the specific encoding with following way:
+>      string[] zapfDingbatsEncoding = new string[256] {null, null, ... , "space", "a1", ...};
+>      FontEnvironment.Current.FontSpecificEncodings.RegisterEncoding("ZapfDingbats", zapfDingbatsEncoding);
+>  ```
+> 
+>      System::ArrayPtr<System::String> zapfDingbatsEncoding = System::MakeArray<System::String>({nullptr, nullptr, ..., u"space", u"a1", ...});
+>      FontEnvironment::get_Current()->get_FontSpecificEncodings()->RegisterEncoding(u"ZapfDingbats", zapfDingbatsEncoding);
+>  
+> ```
+> ```
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding)
+### getFontDefinition() {#getFontDefinition--}
+```
+public FontDefinition getFontDefinition()
+```
+
+
+Obtiene la definición de la fuente.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public String getFontFamily()
+```
+
+
+Obtiene la familia de la fuente.
+
+**Returns:**
+java.lang.String - Familia de la Fuente.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Obtiene el nombre del Font.
+
+**Returns:**
+java.lang.String - Nombre de fuente.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Obtiene los nombres de la fuente.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Obtiene la funcionalidad de guardado de la fuente.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public int getFontStyle()
+```
+
+
+Obtiene el estilo de la Fuente. Este es un valor calculado y representado en tipo generalizado.
+
+**Returns:**
+int - Obtiene el estilo del Font. Normalmente, una combinación de valores de bandera constantes de la clase FontStyle o 0.
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Obtiene el tipo de Fuente. Devuelve el valor FontType.Type1.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Accesor de glifos de fuente. Recupera glifos e identificadores de glifos.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public Glyph getGlyphById(GlyphId id)
+```
+
+
+Devuelve el glifo por Id de glifo. No compatible con el tipo (@code Type1MetricFont\}.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | Identificador de glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(String id) {#getGlyphById-java.lang.String-}
+```
+public Glyph getGlyphById(String id)
+```
+
+
+Devuelve el glifo por Id de glifo. No compatible con el tipo (@code Type1MetricFont\}.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| id | java.lang.String | Identificador de glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(long id) {#getGlyphById-long-}
+```
+public Glyph getGlyphById(long id)
+```
+
+
+Devuelve el glifo por su identificador.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| id | long | Id de glifo. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public GlyphIdType getGlyphIdType()
+```
+
+
+Especificación del tipo de id de glifo.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype)
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Obtiene la representación de glifos para texto.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| text | java.lang.String | Texto de entrada. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - matriz de GlyphId.
+### getMetrics() {#getMetrics--}
+```
+public IFontMetrics getMetrics()
+```
+
+
+Obtiene las métricas de la fuente.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Obtiene el número de glifos en la Fuente.
+
+**Returns:**
+int - Número de glifos en la fuente.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Obtiene los nombres de fuente PostScript.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names
+### getStyle() {#getStyle--}
+```
+public String getStyle()
+```
+
+
+Obtiene el estilo de la fuente.
+
+**Returns:**
+java.lang.String - Estilo de la fuente.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Abre una fuente, usando el objeto FontDefinition.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Objeto de definición de fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Abre una fuente, usando el tipo de fuente y la matriz de bytes de datos de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fontData | byte[] | Arreglo de bytes para cargar la fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Abre una fuente, usando el tipo de fuente y la fuente de flujo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Fuente de flujo para la fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Abre una fuente, usando el tipo de fuente y el nombre de archivo de fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Tipo de fuente. |
+| fileName | java.lang.String | Nombre del archivo de fuente. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Guarda la Fuente en el formato original.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.OutputStream | Flujo para guardar la fuente. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Guarda la Fuente en el formato original.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | java.lang.String | Archivo para guardar la fuente. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Guarda la Fuente en el formato especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.OutputStream | flujo para guardar la fuente |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | formato deseado |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public void setFontFamily(String value)
+```
+
+
+El setter de la familia de fuentes no está implementado aún.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Nueva familia de fuente. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public void setFontName(String value)
+```
+
+
+El setter del nombre de la cara de fuente no está implementado aún.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Nuevo nombre de la cara de fuente. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public void setStyle(String value)
+```
+
+
+El setter Style aún no está implementado. Este es un valor de cadena sin procesar proporcionado por el archivo de Fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Nuevo estilo de fuente. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/unicodeplatformspecificid/_index.md
+++ b/spanish/java/com.aspose.font/unicodeplatformspecificid/_index.md
@@ -1,0 +1,277 @@
+---
+title: "UnicodePlatformSpecificId"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la enumeración específica de la plataforma Unicode."
+type: docs
+weight: 143
+url: /es/java/com.aspose.font/unicodeplatformspecificid/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum UnicodePlatformSpecificId extends Enum<UnicodePlatformSpecificId>
+```
+
+Representa la enumeración específica de la plataforma Unicode.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [Default](#Default) | Valor 0 Semántica predeterminada (Unicode 1.0). |
+| [ISO10646_1993](#ISO10646-1993) | Valor 2 Semántica ISO 10646 1993 (obsoleta). |
+| [Unicode1_1](#Unicode1-1) | Valor 1 Semántica Unicode 1.1. |
+| [Unicode2_0](#Unicode2-0) | Valor 3 Semántica Unicode 2.0 o posterior. |
+| [Unicode2_0_Full](#Unicode2-0-Full) | Valor 4 Semántica Unicode 2.0 en adelante (se permiten caracteres fuera del BMP), repertorio completo de Unicode. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Default {#Default}
+```
+public static final UnicodePlatformSpecificId Default
+```
+
+
+Valor 0 Semántica predeterminada (Unicode 1.0).
+
+### ISO10646_1993 {#ISO10646-1993}
+```
+public static final UnicodePlatformSpecificId ISO10646_1993
+```
+
+
+Valor 2 Semántica ISO 10646 1993 (obsoleta).
+
+### Unicode1_1 {#Unicode1-1}
+```
+public static final UnicodePlatformSpecificId Unicode1_1
+```
+
+
+Valor 1 Semántica Unicode 1.1.
+
+### Unicode2_0 {#Unicode2-0}
+```
+public static final UnicodePlatformSpecificId Unicode2_0
+```
+
+
+Valor 3 Semántica Unicode 2.0 o posterior. Solo BMP de Unicode.
+
+### Unicode2_0_Full {#Unicode2-0-Full}
+```
+public static final UnicodePlatformSpecificId Unicode2_0_Full
+```
+
+
+Valor 4 Semántica Unicode 2.0 en adelante (se permiten caracteres fuera del BMP), repertorio completo de Unicode.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static UnicodePlatformSpecificId valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[UnicodePlatformSpecificId](../../com.aspose.font/unicodeplatformspecificid)
+### values() {#values--}
+```
+public static UnicodePlatformSpecificId[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.UnicodePlatformSpecificId[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/version16dot16/_index.md
+++ b/spanish/java/com.aspose.font/version16dot16/_index.md
@@ -1,0 +1,227 @@
+---
+title: "Version16Dot16"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa el tipo de dato Version16Dot16"
+type: docs
+weight: 118
+url: /es/java/com.aspose.font/version16dot16/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Cloneable
+```
+public class Version16Dot16 implements Cloneable
+```
+
+Representa el tipo de dato Version16Dot16
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Version16Dot16()](#Version16Dot16--) | Constructor |
+| [Version16Dot16(int majorNumber, int minorNumber)](#Version16Dot16-int-int-) | Constructor |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clone()](#clone--) | Crear una copia del objeto Version16Dot16. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMajorNumber()](#getMajorNumber--) | Obtiene el número de versión mayor. |
+| [getMinorNumber()](#getMinorNumber--) | Obtiene el número de versión menor. |
+| [getRawBytes()](#getRawBytes--) | Obtiene todos los bits sin procesar para el número de versión Version16Dot16 como una matriz de bytes de tamaño 4 bytes. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setMajorNumber(int value)](#setMajorNumber-int-) | Establece el número de versión mayor. |
+| [setMinorNumber(int value)](#setMinorNumber-int-) | Establece el número de versión menor. |
+| [toString()](#toString--) | Devuelve el valor de la versión como una cadena formateada. Por ejemplo "0.5", "1.1", "3.0", etc. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Version16Dot16() {#Version16Dot16--}
+```
+public Version16Dot16()
+```
+
+
+Constructor
+
+### Version16Dot16(int majorNumber, int minorNumber) {#Version16Dot16-int-int-}
+```
+public Version16Dot16(int majorNumber, int minorNumber)
+```
+
+
+Constructor
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| majorNumber | int | Número de versión mayor |
+| minorNumber | int | Número de versión menor |
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Crear una copia del objeto Version16Dot16.
+
+**Returns:**
+java.lang.Object - Objeto del tipo Version16Dot16
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMajorNumber() {#getMajorNumber--}
+```
+public int getMajorNumber()
+```
+
+
+Obtiene el número de versión mayor. El valor tiene sentido solo en notación hexadecimal, por ejemplo la versión 0.5 para 'maxp' en los archivos de fuentes reales son 4 bytes: \{0, 0, 80, 0\}, que tiene la representación hexadecimal 0x00005000. Después de leer esta versión del archivo de fuentes, los números mayor y menor para el objeto Version16Dot16 serán 0 y 20480 respectivamente. Y estos valores en forma hexadecimal son 0x0000 y 0x5000.
+
+**Returns:**
+int - Número de versión mayor.
+### getMinorNumber() {#getMinorNumber--}
+```
+public int getMinorNumber()
+```
+
+
+Obtiene el número de versión menor. El valor tiene sentido solo en notación hexadecimal, por ejemplo la versión 0.5 para 'maxp' en los archivos de fuentes reales son 4 bytes: \{0, 0, 80, 0\}, que tiene la representación hexadecimal 0x00005000. Después de leer esta versión del archivo de fuentes, los números mayor y menor para el objeto Version16Dot16 serán 0 y 20480 respectivamente. Y estos valores en forma hexadecimal son 0x0000 y 0x5000.
+
+**Returns:**
+int - Número de versión menor.
+### getRawBytes() {#getRawBytes--}
+```
+public byte[] getRawBytes()
+```
+
+
+Obtiene todos los bits sin procesar para el número de versión Version16Dot16 como una matriz de bytes de tamaño 4 bytes.
+
+**Returns:**
+byte[] - Todos los bits sin procesar para el número de versión Version16Dot16 como una matriz de bytes de tamaño 4 bytes.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setMajorNumber(int value) {#setMajorNumber-int-}
+```
+public void setMajorNumber(int value)
+```
+
+
+Establece el número de versión mayor. El valor tiene sentido solo en notación hexadecimal, por ejemplo la versión 0.5 para 'maxp' en los archivos de fuentes reales son 4 bytes: \{0, 0, 80, 0\}, que tiene la representación hexadecimal 0x00005000. Después de leer esta versión del archivo de fuentes, los números mayor y menor para el objeto Version16Dot16 serán 0 y 20480 respectivamente. Y estos valores en forma hexadecimal son 0x0000 y 0x5000.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int | Número de versión mayor. |
+
+### setMinorNumber(int value) {#setMinorNumber-int-}
+```
+public void setMinorNumber(int value)
+```
+
+
+Establece el número de versión menor. El valor tiene sentido solo en notación hexadecimal, por ejemplo la versión 0.5 para 'maxp' en los archivos de fuentes reales son 4 bytes: \{0, 0, 80, 0\}, que tiene la representación hexadecimal 0x00005000. Después de leer esta versión del archivo de fuentes, los números mayor y menor para el objeto Version16Dot16 serán 0 y 20480 respectivamente. Y estos valores en forma hexadecimal son 0x0000 y 0x5000.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int | Número de versión menor. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+Devuelve el valor de la versión como una cadena formateada. Por ejemplo "0.5", "1.1", "3.0", etc.
+
+**Returns:**
+java.lang.String - Objeto del tipo String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.font/woffformatexception/_index.md
+++ b/spanish/java/com.aspose.font/woffformatexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "WoffFormatException"
+second_title: "Referencia de API de Aspose.Font para Java"
+description: "Representa la excepción relacionada con el procesamiento de fuentes WOFF."
+type: docs
+weight: 119
+url: /es/java/com.aspose.font/woffformatexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException
+```
+public class WoffFormatException extends IllegalStateException
+```
+
+Representa la excepción relacionada con el procesamiento de fuentes WOFF.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [WoffFormatException()](#WoffFormatException--) | Inicializa un nuevo objeto  WoffFormatException  . |
+| [WoffFormatException(String message)](#WoffFormatException-java.lang.String-) | Inicializa un nuevo objeto  WoffFormatException  . |
+| [WoffFormatException(String message, RuntimeException innerException)](#WoffFormatException-java.lang.String-java.lang.RuntimeException-) | Inicializa un nuevo objeto  WoffFormatException  . |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### WoffFormatException() {#WoffFormatException--}
+```
+public WoffFormatException()
+```
+
+
+Inicializa un nuevo objeto  WoffFormatException  .
+
+### WoffFormatException(String message) {#WoffFormatException-java.lang.String-}
+```
+public WoffFormatException(String message)
+```
+
+
+Inicializa un nuevo objeto  WoffFormatException  .
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+
+### WoffFormatException(String message, RuntimeException innerException) {#WoffFormatException-java.lang.String-java.lang.RuntimeException-}
+```
+public WoffFormatException(String message, RuntimeException innerException)
+```
+
+
+Inicializa un nuevo objeto  WoffFormatException  .
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| mensaje | java.lang.String | Un mensaje que describe el error. |
+| innerException | java.lang.RuntimeException | La excepción que es la causa de la excepción actual. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **Spanish** (`es`) generated by RDA.

- Pages translated: 151/151
- Errors: 0
- Source: `english/java`
- Output: `spanish/java`

🤖 Generated by RDA