### PR TITLE
[auto] Translate JAVA API Reference to Swedish

### DIFF
--- a/swedish/java/_index.md
+++ b/swedish/java/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Aspose.Font för Java"
+type: docs
+weight: 11
+url: /sv/java/
+description: "Aspose.Font för Java API-referenser innehåller exempel, kodsnuttar och API-dokumentation. Den tillhandahåller paket, klasser, gränssnitt och annan API-information."
+is_root: true
+---
+## Packages
+| Paket | Beskrivning |
+| --- | --- |
+| [com.aspose.font](./com.aspose.font) | Den **com.aspose.font** är ett rotpaket för alla klasser som hanterar typsnitt. |
+| [com.aspose.font.textutils](./com.aspose.font.textutils) | Det **com.aspose.font.text.utils**-paketet tillhandahåller klasser och gränssnitt för textbehandling. |

--- a/swedish/java/com.aspose.font.textutils/_index.md
+++ b/swedish/java/com.aspose.font.textutils/_index.md
@@ -1,0 +1,32 @@
+---
+title: "com.aspose.font.textutils"
+second_title: "Aspose.Font för Java API-referens"
+description: "Paketet com.aspose.font.text.utils tillhandahåller klasser och gränssnitt för textbehandling."
+type: docs
+weight: 11
+url: /sv/java/com.aspose.font.textutils/
+---
+
+Det **com.aspose.font.text.utils**-paketet tillhandahåller klasser och gränssnitt för textbehandling.
+
+
+## Klasser
+
+| Klass | Beskrivning |
+| --- | --- |
+| [TextUtilsFactory](../com.aspose.font.textutils/textutilsfactory) | Tillhandahåller funktionalitet för att hämta skapare av texttjänstobjekt |
+
+## Gränssnitt
+
+| Gränssnitt | Beskrivning |
+| --- | --- |
+| [IFontMorseDecoder](../com.aspose.font.textutils/ifontmorsedecoder) | Deklarerar funktionalitet för att avkoda Morse-kod till glyfer i det angivna teckensnittet. |
+| [IFontMorseEncoder](../com.aspose.font.textutils/ifontmorseencoder) | Deklarerar funktionalitet för att koda text med Morse-kod och få resultatet som teckensnittsglyfer. |
+| [IMorseDecoder](../com.aspose.font.textutils/imorsedecoder) | Deklarerar funktionalitet för att avkoda Morse-kod. |
+| [IMorseEncoder](../com.aspose.font.textutils/imorseencoder) | Deklarerar funktionalitet för att koda text med Morse-kod. |
+
+## Enumerationer
+
+| Enum | Beskrivning |
+| --- | --- |
+| [MorseAlphabets](../com.aspose.font.textutils/morsealphabets) | Representerar en uppsättning alfabet som stöds för Morse-kod |

--- a/swedish/java/com.aspose.font.textutils/ifontmorsedecoder/_index.md
+++ b/swedish/java/com.aspose.font.textutils/ifontmorsedecoder/_index.md
@@ -1,0 +1,180 @@
+---
+title: "IFontMorseDecoder"
+second_title: "Aspose.Font för Java API-referens"
+description: "Deklarerar funktionalitet för att avkoda Morse-kod till glyfer i det angivna teckensnittet."
+type: docs
+weight: 11
+url: /sv/java/com.aspose.font.textutils/ifontmorsedecoder/
+---```
+public interface IFontMorseDecoder
+```
+
+Declares functionality to decode Morse code into glyphs of the specified font.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [decode(String morseText, IFont font)](#decode-java.lang.String-com.aspose.font.IFont-) | Deciphers Morse code into glyphs of the specified font. |
+| [decode(String morseText, IFont font, MorseAlphabets alphabet)](#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-) | Deciphers Morse code into glyphs of the specified font. |
+| [decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator)](#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-) | Deciphers Morse code into glyphs of the specified font. |
+| [decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-char-) | Deciphers Morse code into glyphs of the specified font. |
+| [decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)](#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-) | Deciphers Morse code and draws result in PNG-format. |
+| [decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet)](#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-) | Deciphers Morse code and draws result in PNG-format. |
+| [decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator)](#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-) | Deciphers Morse code and draws result in PNG-format. |
+| [decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-char-) | Deciphers Morse code and draws result in PNG-format. |
+### decode(String morseText, IFont font) {#decode-java.lang.String-com.aspose.font.IFont-}
+```
+public abstract GlyphId[] decode(String morseText, IFont font)
+```
+
+
+Deciphers Morse code into glyphs of the specified font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs (glyph identifiers) related to decoded text.
+### decode(String morseText, IFont font, MorseAlphabets alphabet) {#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract GlyphId[] decode(String morseText, IFont font, MorseAlphabets alphabet)
+```
+
+
+Deciphers Morse code into glyphs of the specified font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs (glyph identifiers) related to decoded text.
+### decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator) {#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract GlyphId[] decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Deciphers Morse code into glyphs of the specified font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs (glyph identifiers) related to decoded text.
+### decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#decode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract GlyphId[] decode(String morseText, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Deciphers Morse code into glyphs of the specified font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+| outputSeparator | char | Symbol used to separate words in decoded text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs (glyph identifiers) related to decoded text.
+### decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth) {#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-}
+```
+public abstract InputStream decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)
+```
+
+
+Deciphers Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+
+**Returns:**
+java.io.InputStream - Decoded text in PNG-format as stream of bytes.
+### decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet) {#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract InputStream decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet)
+```
+
+
+Deciphers Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+java.io.InputStream - Decoded text in PNG-format as stream of bytes.
+### decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator) {#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract InputStream decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Deciphers Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.io.InputStream - Decoded text in PNG-format as stream of bytes.
+### decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#decode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract InputStream decode(String morseText, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Deciphers Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to decoded text from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+| outputSeparator | char | Symbol used to separate words in decoded text. |
+
+**Returns:**
+java.io.InputStream - Decoded text in PNG-format as stream of bytes.

--- a/swedish/java/com.aspose.font.textutils/ifontmorseencoder/_index.md
+++ b/swedish/java/com.aspose.font.textutils/ifontmorseencoder/_index.md
@@ -1,0 +1,262 @@
+---
+title: "IFontMorseEncoder"
+second_title: "Aspose.Font för Java API-referens"
+description: "Deklarerar funktionalitet för att koda text med Morse-kod och få resultatet som teckensnittsglyfer."
+type: docs
+weight: 12
+url: /sv/java/com.aspose.font.textutils/ifontmorseencoder/
+---```
+public interface IFontMorseEncoder
+```
+
+Declares functionality to encode text by Morse code and get result as font glyphs.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [encode(String text, IFont font)](#encode-java.lang.String-com.aspose.font.IFont-) | Encodes text in Morse code and returns result as set of glyphs(glyphId). |
+| [encode(String text, IFont font, char inputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-char-) | Encodes text in Morse code and returns result as set of glyphs(glyphId). |
+| [encode(String text, IFont font, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-char-char-) | Encodes text in Morse code and returns result as set of glyphs(glyphId). |
+| [encode(String text, IFont font, MorseAlphabets alphabet)](#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-) | Encodes text by Morse code and returns result as set of glyphs(glyph identifiers). |
+| [encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-) | Encodes text by Morse code and returns result as set of glyphs(glyph identifiers). |
+| [encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-char-) | Encodes text by Morse code and returns result as set of glyphs(glyph identifiers). |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-) | Encodes text in Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-char-) | Encodes text in Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-char-char-) | Encodes text in Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-) | Encodes text by Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-) | Encodes text by Morse code and draws result in PNG-format. |
+| [encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-char-) | Encodes text by Morse code and draws result in PNG-format. |
+### encode(String text, IFont font) {#encode-java.lang.String-com.aspose.font.IFont-}
+```
+public abstract GlyphId[] encode(String text, IFont font)
+```
+
+
+Encodes text in Morse code and returns result as set of glyphs(glyphId). Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, char inputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-char-}
+```
+public abstract GlyphId[] encode(String text, IFont font, char inputSeparator)
+```
+
+
+Encodes text in Morse code and returns result as set of glyphs(glyphId). Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-char-char-}
+```
+public abstract GlyphId[] encode(String text, IFont font, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text in Morse code and returns result as set of glyphs(glyphId). Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, MorseAlphabets alphabet) {#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract GlyphId[] encode(String text, IFont font, MorseAlphabets alphabet)
+```
+
+
+Encodes text by Morse code and returns result as set of glyphs(glyph identifiers).
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract GlyphId[] encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Encodes text by Morse code and returns result as set of glyphs(glyph identifiers).
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract GlyphId[] encode(String text, IFont font, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text by Morse code and returns result as set of glyphs(glyph identifiers).
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyphs(glyphId) related to encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)
+```
+
+
+Encodes text in Morse code and draws result in PNG-format. Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-char-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator)
+```
+
+
+Encodes text in Morse code and draws result in PNG-format. Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-char-char-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text in Morse code and draws result in PNG-format. Heuristic analysis is used to calculate the alphabet of the input text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet)
+```
+
+
+Encodes text by Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Encodes text by Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.
+### encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.IFont-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract InputStream encode(String text, IFont font, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text by Morse code and draws result in PNG-format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| font | [IFont](../../com.aspose.font/ifont) | Font to take glyphs related to symbols dot and dash from. |
+| fontSize | double | Font size. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Type of line spacing. Number of pixels or percent of font height. |
+| lineSpacingValue | int | Value of line spacing. |
+| maxWidth | int | Max width in pixels for image. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.io.InputStream - Text, encoded by Morse code, in PNG-format as stream of bytes.

--- a/swedish/java/com.aspose.font.textutils/imorsedecoder/_index.md
+++ b/swedish/java/com.aspose.font.textutils/imorsedecoder/_index.md
@@ -1,0 +1,86 @@
+---
+title: "IMorseDecoder"
+second_title: "Aspose.Font för Java API-referens"
+description: "Deklarerar funktionalitet för att avkoda Morse-kod."
+type: docs
+weight: 13
+url: /sv/java/com.aspose.font.textutils/imorsedecoder/
+---```
+public interface IMorseDecoder
+```
+
+Declares functionality to decipher Morse code.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [decode(String morseText)](#decode-java.lang.String-) | Deciphers Morse code. |
+| [decode(String morseText, MorseAlphabets alphabet)](#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-) | Deciphers Morse code. |
+| [decode(String morseText, MorseAlphabets alphabet, char inputSeparator)](#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-) | Deciphers Morse code. |
+| [decode(String morseText, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-char-) | Deciphers Morse code. |
+### decode(String morseText) {#decode-java.lang.String-}
+```
+public abstract String decode(String morseText)
+```
+
+
+Deciphers Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+
+**Returns:**
+java.lang.String - Decoded text.
+### decode(String morseText, MorseAlphabets alphabet) {#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract String decode(String morseText, MorseAlphabets alphabet)
+```
+
+
+Deciphers Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+java.lang.String - Decoded text.
+### decode(String morseText, MorseAlphabets alphabet, char inputSeparator) {#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract String decode(String morseText, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Deciphers Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.lang.String - Decoded text.
+### decode(String morseText, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#decode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract String decode(String morseText, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Deciphers Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| morseText | java.lang.String | Text encoded by Morse code, i.e. text like "... --- ..."(SOS). |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in encoded text. |
+| outputSeparator | char | Symbol used to separate words in decoded text. |
+
+**Returns:**
+java.lang.String - Decoded text.

--- a/swedish/java/com.aspose.font.textutils/imorseencoder/_index.md
+++ b/swedish/java/com.aspose.font.textutils/imorseencoder/_index.md
@@ -1,0 +1,121 @@
+---
+title: "IMorseEncoder"
+second_title: "Aspose.Font för Java API-referens"
+description: "Deklarerar funktionalitet för att koda text med Morse-kod."
+type: docs
+weight: 14
+url: /sv/java/com.aspose.font.textutils/imorseencoder/
+---```
+public interface IMorseEncoder
+```
+
+Declares functionality to encode text by Morse code.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [encode(String text)](#encode-java.lang.String-) | Encodes text by Morse code. |
+| [encode(String text, char inputSeparator)](#encode-java.lang.String-char-) | Encodes text by Morse code. |
+| [encode(String text, char inputSeparator, char outputSeparator)](#encode-java.lang.String-char-char-) | Encodes text by Morse code. |
+| [encode(String text, MorseAlphabets alphabet)](#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-) | Encodes text by Morse code. |
+| [encode(String text, MorseAlphabets alphabet, char inputSeparator)](#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-) | Encodes text by Morse code. |
+| [encode(String text, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)](#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-char-) | Encodes text by Morse code. |
+### encode(String text) {#encode-java.lang.String-}
+```
+public abstract String encode(String text)
+```
+
+
+Encodes text by Morse code. Heuristic analysis is used to calculate the alphabet of the input text. The alphabet is selected by the first word.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+
+**Returns:**
+java.lang.String - Encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, char inputSeparator) {#encode-java.lang.String-char-}
+```
+public abstract String encode(String text, char inputSeparator)
+```
+
+
+Encodes text by Morse code. Heuristic analysis is used to calculate the alphabet of the input text. The alphabet is selected by the first word.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+java.lang.String - Encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, char inputSeparator, char outputSeparator) {#encode-java.lang.String-char-char-}
+```
+public abstract String encode(String text, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text by Morse code. Heuristic analysis is used to calculate the alphabet of the input text. The alphabet is selected by the first word.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.lang.String - Encoded text, i.e. "... --- ..." for the input text "SOS".
+### encode(String text, MorseAlphabets alphabet) {#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-}
+```
+public abstract String encode(String text, MorseAlphabets alphabet)
+```
+
+
+Encodes text by Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+
+**Returns:**
+java.lang.String - Encoded text, ie "... --- ..." for the input text "SOS".
+### encode(String text, MorseAlphabets alphabet, char inputSeparator) {#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-}
+```
+public abstract String encode(String text, MorseAlphabets alphabet, char inputSeparator)
+```
+
+
+Encodes text by Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+
+**Returns:**
+java.lang.String - Encoded text, ie "... --- ..." for the input text "SOS".
+### encode(String text, MorseAlphabets alphabet, char inputSeparator, char outputSeparator) {#encode-java.lang.String-com.aspose.font.textutils.MorseAlphabets-char-char-}
+```
+public abstract String encode(String text, MorseAlphabets alphabet, char inputSeparator, char outputSeparator)
+```
+
+
+Encodes text by Morse code.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Text to encode by Morse code. |
+| alphabet | [MorseAlphabets](../../com.aspose.font.textutils/morsealphabets) | Alphabet of Morse code. |
+| inputSeparator | char | Symbol used to separate words in input text. |
+| outputSeparator | char | Symbol used to separate words in encoded text. |
+
+**Returns:**
+java.lang.String - Encoded text, ie "... --- ..." for the input text "SOS".

--- a/swedish/java/com.aspose.font.textutils/morsealphabets/_index.md
+++ b/swedish/java/com.aspose.font.textutils/morsealphabets/_index.md
@@ -1,0 +1,304 @@
+---
+title: "MorseAlphabets"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar en uppsättning alfabet som stöds för Morse-kod"
+type: docs
+weight: 15
+url: /sv/java/com.aspose.font.textutils/morsealphabets/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum MorseAlphabets extends Enum<MorseAlphabets>
+```
+
+Representerar en uppsättning alfabet som stöds för Morse-kod
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [Arabic](#Arabic) | Det arabiska kodalfabetet. |
+| [Cyrillic](#Cyrillic) | Det kyrilliska kodalfabetet. |
+| [Greek](#Greek) | Det grekiska morsekodalfabetet. |
+| [Hebrew](#Hebrew) | Det hebreiska kodalfabetet. |
+| [Kurdish](#Kurdish) | Det kurdiska kodalfabetet. |
+| [Latin](#Latin) | Det latinska morsekodalfabetet. |
+| [Persian](#Persian) | Det persiska (Farsi) kodalfabetet. |
+| [Portuguese](#Portuguese) | Det portugisiska kodalfabetet. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Arabic {#Arabic}
+```
+public static final MorseAlphabets Arabic
+```
+
+
+Det arabiska kodalfabetet.
+
+### Cyrillic {#Cyrillic}
+```
+public static final MorseAlphabets Cyrillic
+```
+
+
+Det kyrilliska kodalfabetet.
+
+### Greek {#Greek}
+```
+public static final MorseAlphabets Greek
+```
+
+
+Det grekiska morsekodalfabetet.
+
+### Hebrew {#Hebrew}
+```
+public static final MorseAlphabets Hebrew
+```
+
+
+Det hebreiska kodalfabetet.
+
+### Kurdish {#Kurdish}
+```
+public static final MorseAlphabets Kurdish
+```
+
+
+Det kurdiska kodalfabetet.
+
+### Latin {#Latin}
+```
+public static final MorseAlphabets Latin
+```
+
+
+Det latinska morsekodalfabetet.
+
+### Persian {#Persian}
+```
+public static final MorseAlphabets Persian
+```
+
+
+Det persiska (Farsi) kodalfabetet.
+
+### Portuguese {#Portuguese}
+```
+public static final MorseAlphabets Portuguese
+```
+
+
+Det portugisiska kodalfabetet.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static MorseAlphabets valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[MorseAlphabets](../../com.aspose.font.textutils/morsealphabets)
+### values() {#values--}
+```
+public static MorseAlphabets[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.textutils.MorseAlphabets[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font.textutils/textutilsfactory/_index.md
+++ b/swedish/java/com.aspose.font.textutils/textutilsfactory/_index.md
@@ -1,0 +1,215 @@
+---
+title: "TextUtilsFactory"
+second_title: "Aspose.Font för Java API-referens"
+description: "Tillhandahåller funktionalitet för att hämta skapare av texttjänstobjekt"
+type: docs
+weight: 10
+url: /sv/java/com.aspose.font.textutils/textutilsfactory/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TextUtilsFactory
+```
+
+Tillhandahåller funktionalitet för att hämta skapare av texttjänstobjekt
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [TextUtilsFactory()](#TextUtilsFactory--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontCharactersMerger(Font primaryFont, Font secondaryFont, FontType outType)](#getFontCharactersMerger-com.aspose.font.Font-com.aspose.font.Font-com.aspose.font.FontType-) |  |
+| [getFontMorseDecoder()](#getFontMorseDecoder--) | Hämtar  IFontMorseDecoder  instansen. |
+| [getFontMorseEncoder()](#getFontMorseEncoder--) | Hämtar  IFontMorseEncoder  instansen. |
+| [getMorseDecoder()](#getMorseDecoder--) | Hämtar  IMorseDecoder  instansen. |
+| [getMorseEncoder()](#getMorseEncoder--) | Hämtar  IMorseEncoder  instansen. |
+| [hashCode()](#hashCode--) |  |
+| [isCffSimpleFontMerging(Font primaryFont, Font secondaryFont, FontType outType)](#isCffSimpleFontMerging-com.aspose.font.Font-com.aspose.font.Font-com.aspose.font.FontType-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TextUtilsFactory() {#TextUtilsFactory--}
+```
+public TextUtilsFactory()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontCharactersMerger(Font primaryFont, Font secondaryFont, FontType outType) {#getFontCharactersMerger-com.aspose.font.Font-com.aspose.font.Font-com.aspose.font.FontType-}
+```
+public FontCharactersMerger getFontCharactersMerger(Font primaryFont, Font secondaryFont, FontType outType)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| primaryFont | [Font](../../com.aspose.font/font) |  |
+| secondaryFont | [Font](../../com.aspose.font/font) |  |
+| outType | [FontType](../../com.aspose.font/fonttype) |  |
+
+**Returns:**
+[FontCharactersMerger](../../com.aspose.font/fontcharactersmerger)
+### getFontMorseDecoder() {#getFontMorseDecoder--}
+```
+public IFontMorseDecoder getFontMorseDecoder()
+```
+
+
+Hämtar  IFontMorseDecoder  instansen.
+
+**Returns:**
+[IFontMorseDecoder](../../com.aspose.font.textutils/ifontmorsedecoder) - The  IFontMorseDecoder  instance.
+### getFontMorseEncoder() {#getFontMorseEncoder--}
+```
+public IFontMorseEncoder getFontMorseEncoder()
+```
+
+
+Hämtar  IFontMorseEncoder  instansen.
+
+**Returns:**
+[IFontMorseEncoder](../../com.aspose.font.textutils/ifontmorseencoder) - The  IFontMorseEncoder  instance.
+### getMorseDecoder() {#getMorseDecoder--}
+```
+public IMorseDecoder getMorseDecoder()
+```
+
+
+Hämtar  IMorseDecoder  instansen.
+
+**Returns:**
+[IMorseDecoder](../../com.aspose.font.textutils/imorsedecoder) - The  IMorseDecoder  instance.
+### getMorseEncoder() {#getMorseEncoder--}
+```
+public IMorseEncoder getMorseEncoder()
+```
+
+
+Hämtar  IMorseEncoder  instansen.
+
+**Returns:**
+[IMorseEncoder](../../com.aspose.font.textutils/imorseencoder) - The  IMorseEncoder  instance.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isCffSimpleFontMerging(Font primaryFont, Font secondaryFont, FontType outType) {#isCffSimpleFontMerging-com.aspose.font.Font-com.aspose.font.Font-com.aspose.font.FontType-}
+```
+public static boolean isCffSimpleFontMerging(Font primaryFont, Font secondaryFont, FontType outType)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| primaryFont | [Font](../../com.aspose.font/font) |  |
+| secondaryFont | [Font](../../com.aspose.font/font) |  |
+| outType | [FontType](../../com.aspose.font/fonttype) |  |
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/_index.md
+++ b/swedish/java/com.aspose.font/_index.md
@@ -1,0 +1,165 @@
+---
+title: "com.aspose.font"
+second_title: "Aspose.Font för Java API-referens"
+description: "Det com.aspose.font är ett rotpaket för alla klasser som hanterar typsnitt."
+type: docs
+weight: 10
+url: /sv/java/com.aspose.font/
+---
+
+Den **com.aspose.font** är ett rotpaket för alla klasser som hanterar typsnitt.
+
+
+## Klasser
+
+| Klass | Beskrivning |
+| --- | --- |
+| [AxisRecord](../com.aspose.font/axisrecord) | Representerar Axis Record-strukturen. |
+| [AxisValue](../com.aspose.font/axisvalue) | Representerar AxisValue-posten. |
+| [AxisValueTableBase](../com.aspose.font/axisvaluetablebase) | Basisklass för Axis Value Table-strukturen. |
+| [AxisValueTableFormat1](../com.aspose.font/axisvaluetableformat1) | Representerar Axis value table-format 1 |
+| [AxisValueTableFormat2](../com.aspose.font/axisvaluetableformat2) | Representerar Axis value table-format 2 |
+| [AxisValueTableFormat3](../com.aspose.font/axisvaluetableformat3) | Representerar Axis value table-format 3 |
+| [AxisValueTableFormat4](../com.aspose.font/axisvaluetableformat4) | Representerar Axis value table-format 4 |
+| [ByteContentStreamSource](../com.aspose.font/bytecontentstreamsource) | Representerar en strömkälla baserad på \_content-strömmen. |
+| [CffEncoding](../com.aspose.font/cffencoding) | Representerar CFF \_font-kodning. |
+| [CffFont](../com.aspose.font/cfffont) | Representerar Compact Font Format (CFF). |
+| [CffFontException](../com.aspose.font/cfffontexception) | Representerar ett vanligt bearbetningsrelaterat undantag för typsnitt i CFF-format. |
+| [CffFontMetrics](../com.aspose.font/cfffontmetrics) | Implementering av CFF-typsnittsmått |
+| [CffFontsSettings](../com.aspose.font/cfffontssettings) | Tillhandahåller inställningar gemensamma för CFF-typsnitt. |
+| [CffParsingException](../com.aspose.font/cffparsingexception) | Representerar parse-undantag för typsnitt i cff-format. |
+| [ClosePath](../com.aspose.font/closepath) | Representerar ClosePath-operationen. |
+| [CompositeGlyph](../com.aspose.font/compositeglyph) | Representerar ett sammansatt teckenglyf. |
+| [CompositeGlyphComponent](../com.aspose.font/compositeglyphcomponent) | Representerar komponent för sammansatt glyf (glyf med placeringsmatris). |
+| [CompositeGlyphComponentList](../com.aspose.font/compositeglyphcomponentlist) | Representerar lista över komponenter för sammansatta glyfer. |
+| [CompressionUtils](../com.aspose.font/compressionutils) | Tillhandahåller hjälpfunktioner för komprimering och dekomprimering. |
+| [CurveTo](../com.aspose.font/curveto) | Representerar CurveTo-operationen. |
+| [EncodingException](../com.aspose.font/encodingexception) | Representerar kodningsundantag. |
+| [FileSystemStreamSource](../com.aspose.font/filesystemstreamsource) | Representerar en strömkälla baserad på filsystemet. |
+| [Font](../com.aspose.font/font) | Representerar basklassen Font. |
+| [FontAgrumentException](../com.aspose.font/fontagrumentexception) | Representerar Font-argumentundantag. |
+| [FontBBox](../com.aspose.font/fontbbox) | representerar teckensnittets begränsningsruta. |
+| [FontCharactersMerger](../com.aspose.font/fontcharactersmerger) | Deklarerar funktionalitet för att slå samman teckensnitt av olika typer. |
+| [FontConversionException](../com.aspose.font/fontconversionexception) | Representerar Font-konverteringsundantag. |
+| [FontCreationException](../com.aspose.font/fontcreationexception) | Representerar Font-skapandeundantag. |
+| [FontDefinition](../com.aspose.font/fontdefinition) | Representerar definition av Font-filuppsättning. |
+| [FontEnvironment](../com.aspose.font/fontenvironment) | Tillhandahåller information om den aktuella miljön och plattformen. |
+| [FontException](../com.aspose.font/fontexception) | Representerar vanligt Font-bearbetningsrelaterat undantag. |
+| [FontFactory](../com.aspose.font/fontfactory) | Innehåller funktionalitet för att öppna teckensnitt av olika typer samt andra metoder för att skapa olika objekt. |
+| [FontFileDefinition](../com.aspose.font/fontfiledefinition) | Representerar definition av Font-fil. |
+| [FontMergeException](../com.aspose.font/fontmergeexception) | Representerar Font-sammanfogningsundantag. |
+| [FontMetrics](../com.aspose.font/fontmetrics) | Representerar teckensnittsmått. |
+| [FontNotSupportedOperationException](../com.aspose.font/fontnotsupportedoperationexception) | Representerar undantag för ej stödjande operation. |
+| [FontSpecificEncodings](../com.aspose.font/fontspecificencodings) | Representerar specifika kodningar för konsumentmedvetna teckensnitt. |
+| [FontStyle](../com.aspose.font/fontstyle) | Teckensnittsstilsuppräkning |
+| [GaspRange](../com.aspose.font/gasprange) | Arrayen av GaspRange-poster tillhandahåller rekommenderade beteenden för olika ppem-storlekar |
+| [Glyph](../com.aspose.font/glyph) | Representerar ett teckensnittsglyf. |
+| [GlyphId](../com.aspose.font/glyphid) | Representerar glyfid, tillgängliga i teckensnittet. |
+| [GlyphIdList](../com.aspose.font/glyphidlist) | Representerar lista över glyfid. |
+| [GlyphOutlineRenderer](../com.aspose.font/glyphoutlinerenderer) | Representerar renderare för glyfkontur. |
+| [GlyphRendererBase](../com.aspose.font/glyphrendererbase) | Representerar basklass för glyfrenderare. |
+| [GlyphStringId](../com.aspose.font/glyphstringid) | Representerar strängglyfid. |
+| [GlyphUInt32Id](../com.aspose.font/glyphuint32id) | Representerar heltalsglyfid. |
+| [HelpersFactory](../com.aspose.font/helpersfactory) | Skapar objekt relaterade till TtfHelpers-namnområdet |
+| [IncorrectFontDataException](../com.aspose.font/incorrectfontdataexception) | Representerar undantag för fall då vissa värden i Font-objektet är ogiltiga. |
+| [License](../com.aspose.font/license) | Tillhandahåller metoder för att licensiera komponenten. |
+| [LicenseFlags](../com.aspose.font/licenseflags) | Representerar en hjälparwrapper för inbäddningsflaggor från 'OS/2'-tabellen (fältet fsType). |
+| [LicenseRestrictionException](../com.aspose.font/licenserestrictionexception) | Representerar undantag som kan kastas vid försök att köra funktionalitet som är begränsad i evalueringsläge. |
+| [LineTo](../com.aspose.font/lineto) | Representerar LineTo-operation. |
+| [MSLanguageId](../com.aspose.font/mslanguageid) | Microsoft-plattformens språk-id-uppräkning. |
+| [MacLanguageId](../com.aspose.font/maclanguageid) | Macintosh-plattformens språk-id-uppräkning. |
+| [Metered](../com.aspose.font/metered) | Tillhandahåller metoder för att ställa in mätad nyckel. |
+| [MoveTo](../com.aspose.font/moveto) | Representerar MoveTo-operation. |
+| [MultiLanguageString](../com.aspose.font/multilanguagestring) | Representerar flerspråkig sträng. |
+| [NameId](../com.aspose.font/nameid) | Representerar NameId-uppräkning. |
+| [NameIndexDataProvider](../com.aspose.font/nameindexdataprovider) | Tillhandahåller inställningar gemensamma för CFF-typsnitt. |
+| [NameRecord](../com.aspose.font/namerecord) | Representerar NameRecord-struktur för 'name'-tabellen |
+| [NameToCodeMap](../com.aspose.font/nametocodemap) | Representerar namn-till-kod-karta. |
+| [PathSegmentCollection](../com.aspose.font/pathsegmentcollection) | Representerar en samling av sökvägssegment. |
+| [RenderingUtils](../com.aspose.font/renderingutils) | Tillhandahåller hjälpfunktioner för rendering. |
+| [SegmentPath](../com.aspose.font/segmentpath) | Representerar renderingsväg. |
+| [StreamSource](../com.aspose.font/streamsource) | Definierar ett sätt att hämta en filström när den behövs. |
+| [StringIndexDataProvider](../com.aspose.font/stringindexdataprovider) | Deklarerar funktionalitet för att komma åt CFF String INDEX-struktur. |
+| [SvgConversionException](../com.aspose.font/svgconversionexception) | Representerar fontkonverteringsundantag för SVG-format. |
+| [TopDictDataProvider](../com.aspose.font/topdictdataprovider) | Deklarerar funktionalitet för att läsa/uppdatera CFF Top DICT-struktur. |
+| [TransformationMatrix](../com.aspose.font/transformationmatrix) | Represents 3x3 matrix | A B 0 |  | C D 0 |  | TX TY 1 | . |
+| [TtcFontFileDefinition](../com.aspose.font/ttcfontfiledefinition) | Representerar fildefinition för TTC-typsnitt. |
+| [TtcFontSource](../com.aspose.font/ttcfontsource) | Representerar TTC-typsnittskälla. |
+| [TtfCMapFormat0Table](../com.aspose.font/ttfcmapformat0table) | Representerar Format0 CMap-undertabell i TTF-typsnittsfilen. |
+| [TtfCMapFormat10Table](../com.aspose.font/ttfcmapformat10table) | Representerar Format10 CMap-undertabell i TTF-typsnittsfilen. |
+| [TtfCMapFormat12Table](../com.aspose.font/ttfcmapformat12table) | Representerar Format8 CMap-undertabell i TTF-typsnittsfilen. |
+| [TtfCMapFormat2Table](../com.aspose.font/ttfcmapformat2table) | Representerar Format2 CMap-undertabell i TTF-typsnittsfilen. |
+| [TtfCMapFormat4Table](../com.aspose.font/ttfcmapformat4table) | Representerar Format4 CMap-undertabell i TTF-typsnittsfilen. |
+| [TtfCMapFormat6Table](../com.aspose.font/ttfcmapformat6table) | Representerar Format6 CMap-undertabell i TTF-typsnittsfilen. |
+| [TtfCMapFormat8Table](../com.aspose.font/ttfcmapformat8table) | Representerar Format8 CMap-undertabell i TTF-typsnittsfilen. |
+| [TtfCMapFormatBaseTable](../com.aspose.font/ttfcmapformatbasetable) | Representerar basklass för CMap-undertabell. |
+| [TtfCMapTable](../com.aspose.font/ttfcmaptable) | Representerar "cmap"-tabell i TTF-typsnittsfilen. |
+| [TtfCMapTable.TtfCMapSubtableDescription](../com.aspose.font/ttfcmaptable.ttfcmapsubtabledescription) | Tillhandahåller kort information om CMap-undertabell. |
+| [TtfCffTable](../com.aspose.font/ttfcfftable) | Representerar "cff"-tabell i TTF-typsnittsfilen. |
+| [TtfCvtTable](../com.aspose.font/ttfcvttable) | Representerar Control Value Table (CVT) i TTF-typsnittsfilen. |
+| [TtfEncoding](../com.aspose.font/ttfencoding) | Representerar TTF-typsnittskodning. |
+| [TtfEncodingParameters](../com.aspose.font/ttfencodingparameters) | Representerar TTF-kodningsparametrar. |
+| [TtfFont](../com.aspose.font/ttffont) | Representerar TrueType-typsnitt (TTF). |
+| [TtfFontMetrics](../com.aspose.font/ttffontmetrics) | Representerar TTF-typsnittsmått. |
+| [TtfFpgmTable](../com.aspose.font/ttffpgmtable) | Representerar "fpgm"-tabell i TTF-typsnittsfilen. |
+| [TtfGaspTable](../com.aspose.font/ttfgasptable) | Representerar "gasp"-tabell i TTF-typsnittsfilen. |
+| [TtfGlyfTable](../com.aspose.font/ttfglyftable) | Representerar "glyf"-tabell i TTF-typsnittsfilen. |
+| [TtfHeadTable](../com.aspose.font/ttfheadtable) | Representerar "head"-tabell i TTF-typsnittsfilen. |
+| [TtfHheaTable](../com.aspose.font/ttfhheatable) | Representerar "hhea"-tabellen i TTF-typsnittsfilen. |
+| [TtfHmtxTable](../com.aspose.font/ttfhmtxtable) | Representerar "hmtx"-tabellen i TTF-typsnittsfilen. |
+| [TtfHmtxTable.LongHorMetric](../com.aspose.font/ttfhmtxtable.longhormetric) | Representerar metrisk post. |
+| [TtfHmtxTable.MetricList](../com.aspose.font/ttfhmtxtable.metriclist) | Representerar lista över metriker |
+| [TtfLocaTable](../com.aspose.font/ttflocatable) | Representerar "loca"-tabellen i TTF-typsnittsfilen. |
+| [TtfLocaTable.OffsetsList](../com.aspose.font/ttflocatable.offsetslist) | Representerar lista över glyf-förskjutningar. |
+| [TtfLtshTable](../com.aspose.font/ttfltshtable) | Representerar Linear Threshold-tabellen i TTF-typsnittsfilen. |
+| [TtfMaxpTable](../com.aspose.font/ttfmaxptable) | Representerar "maxp"-tabellen i TTF-typsnittsfilen |
+| [TtfNameTable](../com.aspose.font/ttfnametable) | Representerar "name"-tabellen i TTF-typsnittsfilen. |
+| [TtfOs2Table](../com.aspose.font/ttfos2table) | Representerar "OS/2"-tabellen i TTF-typsnittsfilen. |
+| [TtfPostTable](../com.aspose.font/ttfposttable) | Representerar "post"-tabellen i TTF-typsnittsfilen |
+| [TtfPrepTable](../com.aspose.font/ttfpreptable) | Representerar "prep"-tabellen i TTF-typsnittsfilen. |
+| [TtfStatTable](../com.aspose.font/ttfstattable) |  |
+| [TtfTableBase](../com.aspose.font/ttftablebase) | Representerar TTF-tabelldefinition. |
+| [TtfTableRepository](../com.aspose.font/ttftablerepository) | arkiv för TTF-tabeller |
+| [TtfVheaTable](../com.aspose.font/ttfvheatable) | Representerar "hhea"-tabellen i TTF-typsnittsfilen. |
+| [TtfVmtxTable](../com.aspose.font/ttfvmtxtable) | Representerar "vmtx"-tabellen i TTF-typsnittsfilen. |
+| [TtfVmtxTable.LongVerMetric](../com.aspose.font/ttfvmtxtable.longvermetric) | Representerar vertikal metrisk post. |
+| [Type1Encoding](../com.aspose.font/type1encoding) | Representerar Type1-typsnitts-kodning. |
+| [Type1Font](../com.aspose.font/type1font) | Representerar Type1-typsnitt. |
+| [Type1FontMetrics](../com.aspose.font/type1fontmetrics) | Representerar Type1-typsnittsmetrik. |
+| [Type1MetricFont](../com.aspose.font/type1metricfont) | Type1-metrisk typsnittsimplementation. |
+| [Version16Dot16](../com.aspose.font/version16dot16) | Representerar Version16Dot16-datatypen |
+| [WoffFormatException](../com.aspose.font/woffformatexception) | Representerar undantag relaterat till WOFF-typsnittshantering. |
+
+## Gränssnitt
+
+| Gränssnitt | Beskrivning |
+| --- | --- |
+| [ICffIndexDataProvider](../com.aspose.font/icffindexdataprovider) | Grundläggande gränssnitt för åtkomst till INDEX-strukturer i CFF-typsnitt. |
+| [IEncodingParameters](../com.aspose.font/iencodingparameters) | Gemensamt gränssnitt för att stödja kodningsparametrar. |
+| [IFont](../com.aspose.font/ifont) | Deklarerar gemensam funktionalitet för alla teckensnittsformat. |
+| [IFontCharactersMerger](../com.aspose.font/ifontcharactersmerger) | Deklarerar hjälparfunktionalitet för att slå samman TrueType-teckensnitt. |
+| [IFontEncoding](../com.aspose.font/ifontencoding) | Definierar ett gränssnitt för teckensnittskodning. |
+| [IFontMetrics](../com.aspose.font/ifontmetrics) | Definierar ett gränssnitt för verktyg för teckensnittsmått. |
+| [IFontSaver](../com.aspose.font/ifontsaver) | Definierar ett gränssnitt för funktionalitet för att spara teckensnitt. |
+| [IGlyphAccessor](../com.aspose.font/iglyphaccessor) | Definierar funktionalitet för att hämta specificerade glyfidentifierare och glyfer. |
+| [IGlyphOutlinePainter](../com.aspose.font/iglyphoutlinepainter) | Definierar ett konturbaserat sätt att rita glyfer. |
+| [IGlyphPainter](../com.aspose.font/iglyphpainter) | Definierar ett sätt att rita glyfer. |
+| [IGlyphRenderer](../com.aspose.font/iglyphrenderer) | Gränssnitt som används för att rendera glyfer. |
+| [IPathSegment](../com.aspose.font/ipathsegment) | Representerar gränssnittet för ett godtyckligt vägsegment. |
+| [ISupportsNameAddressing](../com.aspose.font/isupportsnameaddressing) | Definierar medlemmar som är specifika för kodningar som stöder glyfnamnadsadressering |
+
+## Enumerationer
+
+| Enum | Beskrivning |
+| --- | --- |
+| [CffIndexProviderType](../com.aspose.font/cffindexprovidertype) | Specificerar INDEX-strukturer som stöds av familjen av indexleverantörsgränssnitt. |
+| [CffUpdateStringIndexStrategy](../com.aspose.font/cffupdatestringindexstrategy) | Specificerar hur man lägger till strängar i CFF String INDEX-lagring. |
+| [FontSavingFormats](../com.aspose.font/fontsavingformats) | Specificerar teckensnittstyp. |
+| [FontType](../com.aspose.font/fonttype) | Specificerar teckensnittstyp. |
+| [GlyphIdType](../com.aspose.font/glyphidtype) | Specificerar typer av glyfid. |
+| [GlyphState](../com.aspose.font/glyphstate) | Specificerar glyftillståndet. |
+| [MSPlatformSpecificId](../com.aspose.font/msplatformspecificid) | Representerar Microsoft-plattformens PlatformSpecificId-enumeration. |
+| [MacPlatformSpecificId](../com.aspose.font/macplatformspecificid) | Representerar Macintosh-plattformens PlatformSpecificId-enumeration. |
+| [PlatformId](../com.aspose.font/platformid) | Representerar PlatformId-enumeration. |
+| [RangeGaspBehaviorFlags](../com.aspose.font/rangegaspbehaviorflags) | Flaggor som beskriver önskat rasteriseringsbeteende. |
+| [UnicodePlatformSpecificId](../com.aspose.font/unicodeplatformspecificid) | Representerar unicode-plattformspecifik enumeration. |

--- a/swedish/java/com.aspose.font/axisrecord/_index.md
+++ b/swedish/java/com.aspose.font/axisrecord/_index.md
@@ -1,0 +1,177 @@
+---
+title: "AxisRecord"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Axis Record-strukturen."
+type: docs
+weight: 10
+url: /sv/java/com.aspose.font/axisrecord/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class AxisRecord
+```
+
+Representerar Axis Record-strukturen. Spec: axis-posten ger information om en enskild designaxel.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [AxisRecord(String tag, int axisNameId, int axisOrdering)](#AxisRecord-java.lang.String-int-int-) | Konstruktor |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisNameId()](#getAxisNameId--) | Returnerar fältet axisNameID. |
+| [getAxisOrdering()](#getAxisOrdering--) | Returnerar fältet axisOrdering. |
+| [getClass()](#getClass--) |  |
+| [getTag()](#getTag--) | Returnerar en tagg som identifierar designvariationsaxeln. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisRecord(String tag, int axisNameId, int axisOrdering) {#AxisRecord-java.lang.String-int-int-}
+```
+public AxisRecord(String tag, int axisNameId, int axisOrdering)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| tag | java.lang.String | Tagg, spec: En tagg som identifierar designvariationsaxeln |
+| axisNameId | int | Namnet ID för poster i 'name'-tabellen som tillhandahåller en visningssträng för denna axel |
+| axisOrdering | int | Värdet som applikationer kan använda för att bestämma primär sortering av ansiktsnamn, eller för att ordna etiketter när familje- eller ansiktsnamn komponeras. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisNameId() {#getAxisNameId--}
+```
+public int getAxisNameId()
+```
+
+
+Returnerar fältet axisNameID. Spec: axisNameID-fältet tillhandahåller ett namn-ID som kan användas för att hämta strängar från 'name'-tabellen som kan användas för att referera till axeln i applikationens användargränssnitt.
+
+**Returns:**
+int - axisNameID-fältet.
+### getAxisOrdering() {#getAxisOrdering--}
+```
+public int getAxisOrdering()
+```
+
+
+Returnerar fältet axisOrdering. Spec: Ett värde som applikationer kan använda för att bestämma primär sortering av ansiktsnamn, eller för att ordna etiketter när familje- eller ansiktsnamn komponeras.
+
+**Returns:**
+int - axisOrdering-fältet.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getTag() {#getTag--}
+```
+public String getTag()
+```
+
+
+Returnerar en tagg som identifierar designvariationsaxeln. Spec: Varje axis-poster har en tagg som betecknar axeln. Taggvärden måste följa reglerna för axel-taggar som beskrivs i OpenType Design-Variation Axis Tag Registry.
+
+**Returns:**
+java.lang.String - En tagg som identifierar designvariationsaxeln.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/axisvalue/_index.md
+++ b/swedish/java/com.aspose.font/axisvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: "AxisValue"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar AxisValue-posten."
+type: docs
+weight: 11
+url: /sv/java/com.aspose.font/axisvalue/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class AxisValue
+```
+
+Representerar AxisValue-posten.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [AxisValue(int axisIndex, float value)](#AxisValue-int-float-) | Konstruktor |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisIndex()](#getAxisIndex--) | Hämtar axisIndex-fältet. |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Hämtar ett numeriskt värde för detta attributvärde. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValue(int axisIndex, float value) {#AxisValue-int-float-}
+```
+public AxisValue(int axisIndex, float value)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| axisIndex | int | Nollbaserat index i axis record-arrayen som identifierar den axel som detta värde gäller för. Måste vara mindre än designAxisCount. |
+| värde | float | Det numeriska värdet för detta attributvärde. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisIndex() {#getAxisIndex--}
+```
+public int getAxisIndex()
+```
+
+
+Hämtar axisIndex-fältet. Spec: Nollbaserat index i axis record-arrayen som identifierar den axel som detta värde gäller för. Måste vara mindre än designAxisCount.
+
+**Returns:**
+int - axisIndex-fältet.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public float getValue()
+```
+
+
+Hämtar ett numeriskt värde för detta attributvärde.
+
+**Returns:**
+float - Ett numeriskt värde för detta attributvärde.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/axisvaluetablebase/_index.md
+++ b/swedish/java/com.aspose.font/axisvaluetablebase/_index.md
@@ -1,0 +1,168 @@
+---
+title: "AxisValueTableBase"
+second_title: "Aspose.Font för Java API-referens"
+description: "Basisklass för Axis Value Table-strukturen."
+type: docs
+weight: 12
+url: /sv/java/com.aspose.font/axisvaluetablebase/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class AxisValueTableBase
+```
+
+Basklass för Axis Value Table-strukturen. Spec: Axis Value Tables tillhandahåller detaljer om ett specifikt stilattributvärde på en viss designvariationsaxel, eller en kombination av designvariationsaxelvärden, samt förhållandet mellan dessa värden och etiketter som används som element i underfamiljenamn.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Hämtar fältet för flaggor i axelvärdestabellen. |
+| [getFormat()](#getFormat--) | Hämtar formatidentifierare (versionsnummer). |
+| [getValueName()](#getValueName--) | Hämtar namnet från 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde. |
+| [getValueNameId()](#getValueNameId--) | Hämtar namn-ID för poster i 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Hämtar fältet för flaggor i axelvärdestabellen.
+
+**Returns:**
+int - Fältet för flaggor i axelvärdestabellen.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Hämtar formatidentifierare (versionsnummer).
+
+**Returns:**
+int - Formatidentifieraren (versionsnummer).
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Hämtar namnet från 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde.
+
+**Returns:**
+java.lang.String - Namnet från 'name'-tabellen som tillhandahåller en visningssträng för detta attributvärde.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Hämtar namn-ID för poster i 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde.
+
+**Returns:**
+int - Namn-ID för poster i 'name'-tabellen som tillhandahåller en visningssträng för detta attributvärde.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/axisvaluetableflags/_index.md
+++ b/swedish/java/com.aspose.font/axisvaluetableflags/_index.md
@@ -1,0 +1,259 @@
+---
+title: "TtfStatTable.AxisValueTableFlags"
+second_title: "Aspose.Font för Java API-referens"
+description: "Anger flaggor för axelvärdestabell"
+type: docs
+weight: 10
+url: /sv/java/com.aspose.font/ttfstattable.axisvaluetableflags/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum TtfStatTable.AxisValueTableFlags extends Enum<TtfStatTable.AxisValueTableFlags>
+```
+
+Anger flaggor för axelvärdestabell
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ElidableAxisValueName](#ElidableAxisValueName) | Om den är inställd indikerar den att axelvärdet representerar det "normala" värdet för axeln och kan utelämnas när namnsträngar sammanställs. |
+| [OlderSiblingFontAttribute](#OlderSiblingFontAttribute) | Om den är inställd tillhandahåller denna axelvärdestabell axelvärdesinformation som är tillämplig på andra teckensnitt inom samma teckensnittsfamilj. |
+| [Reserved](#Reserved) | Reserverad för framtida bruk |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ElidableAxisValueName {#ElidableAxisValueName}
+```
+public static final TtfStatTable.AxisValueTableFlags ElidableAxisValueName
+```
+
+
+Om den är inställd indikerar den att axelvärdet representerar det "normala" värdet för axeln och kan utelämnas när namnsträngar sammanställs.
+
+### OlderSiblingFontAttribute {#OlderSiblingFontAttribute}
+```
+public static final TtfStatTable.AxisValueTableFlags OlderSiblingFontAttribute
+```
+
+
+Om den är inställd tillhandahåller denna axelvärdestabell axelvärdesinformation som är tillämplig på andra teckensnitt inom samma teckensnittsfamilj. Detta används om de andra teckensnitten släpptes tidigare och inte innehöll information om värden för vissa axlar. Om nyare versioner av de andra teckensnitten själva inkluderar informationen och finns tillgängliga, ignoreras denna tabell.
+
+### Reserved {#Reserved}
+```
+public static final TtfStatTable.AxisValueTableFlags Reserved
+```
+
+
+Reserverad för framtida bruk
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static TtfStatTable.AxisValueTableFlags valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[AxisValueTableFlags](../../com.aspose.font/axisvaluetableflags)
+### values() {#values--}
+```
+public static TtfStatTable.AxisValueTableFlags[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.TtfStatTable.AxisValueTableFlags[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/axisvaluetableformat1/_index.md
+++ b/swedish/java/com.aspose.font/axisvaluetableformat1/_index.md
@@ -1,0 +1,211 @@
+---
+title: "AxisValueTableFormat1"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Axis value table-format 1"
+type: docs
+weight: 13
+url: /sv/java/com.aspose.font/axisvaluetableformat1/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.AxisValueTableBase](../../com.aspose.font/axisvaluetablebase)
+```
+public class AxisValueTableFormat1 extends AxisValueTableBase
+```
+
+Representerar Axis value table-format 1
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [AxisValueTableFormat1(int flags, int valueNameId, int axisIndex, float value)](#AxisValueTableFormat1-int-int-int-float-) | Konstruktor |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisIndex()](#getAxisIndex--) | Hämtar nollbaserat index i axelpostarrayen som identifierar den designvariationsaxel som axelvärdestabellen gäller för. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Hämtar fältet för flaggor i axelvärdestabellen. |
+| [getFormat()](#getFormat--) | Hämtar formatidentifierare (versionsnummer). |
+| [getValue()](#getValue--) | Det numeriska värdet för detta attributvärde. |
+| [getValueName()](#getValueName--) | Hämtar namnet från 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde. |
+| [getValueNameId()](#getValueNameId--) | Hämtar namn-ID för poster i 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValueTableFormat1(int flags, int valueNameId, int axisIndex, float value) {#AxisValueTableFormat1-int-int-int-float-}
+```
+public AxisValueTableFormat1(int flags, int valueNameId, int axisIndex, float value)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| flaggor | int | Flaggor |
+| valueNameId | int | Namn-ID för poster i 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde |
+| axisIndex | int | Spec: Nollbaserat index i axelpostarrayen som identifierar den designvariationsaxel som axelvärdestabellen gäller för. Måste vara mindre än designAxisCount. |
+| värde | float | Det numeriska värdet för detta attributvärde. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisIndex() {#getAxisIndex--}
+```
+public int getAxisIndex()
+```
+
+
+Hämtar nollbaserat index i axelpostarrayen som identifierar den designvariationsaxel som axelvärdestabellen gäller för.
+
+**Returns:**
+int - Nollbaserat index i axelpostarrayen som identifierar den designvariationsaxel som axelvärdestabellen gäller för.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Hämtar fältet för flaggor i axelvärdestabellen.
+
+**Returns:**
+int - Fältet för flaggor i axelvärdestabellen.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Hämtar formatidentifierare (versionsnummer).
+
+**Returns:**
+int - Formatidentifieraren (versionsnummer).
+### getValue() {#getValue--}
+```
+public float getValue()
+```
+
+
+Det numeriska värdet för detta attributvärde.
+
+**Returns:**
+float - Det numeriska värdet för detta attributvärde.
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Hämtar namnet från 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde.
+
+**Returns:**
+java.lang.String - Namnet från 'name'-tabellen som tillhandahåller en visningssträng för detta attributvärde.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Hämtar namn-ID för poster i 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde.
+
+**Returns:**
+int - Namn-ID för poster i 'name'-tabellen som tillhandahåller en visningssträng för detta attributvärde.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/axisvaluetableformat2/_index.md
+++ b/swedish/java/com.aspose.font/axisvaluetableformat2/_index.md
@@ -1,0 +1,235 @@
+---
+title: "AxisValueTableFormat2"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Axis value table-format 2"
+type: docs
+weight: 14
+url: /sv/java/com.aspose.font/axisvaluetableformat2/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.AxisValueTableBase](../../com.aspose.font/axisvaluetablebase)
+```
+public class AxisValueTableFormat2 extends AxisValueTableBase
+```
+
+Representerar Axis value table-format 2
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [AxisValueTableFormat2(int flags, int valueNameId, int axisIndex, float nominalValue, float rangeMinValue, float rangeMaxValue)](#AxisValueTableFormat2-int-int-int-float-float-float-) | Konstruktor |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisIndex()](#getAxisIndex--) | Hämtar det nollbaserade indexet i axelpostarrayen som identifierar den designvariationsaxel som axelvärdestabellen gäller för. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Hämtar fältet för flaggor i axelvärdestabellen. |
+| [getFormat()](#getFormat--) | Hämtar formatidentifierare (versionsnummer). |
+| [getNominalValue()](#getNominalValue--) | Ett nominellt numeriskt värde |
+| [getRangeMaxValue()](#getRangeMaxValue--) | Det maximala värdet för ett intervall som är associerat med det angivna namn-ID:t. |
+| [getRangeMinValue()](#getRangeMinValue--) | Det minsta värdet för ett intervall som är associerat med det angivna namn-ID:t. |
+| [getValueName()](#getValueName--) | Hämtar namnet från 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde. |
+| [getValueNameId()](#getValueNameId--) | Hämtar namn-ID för poster i 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValueTableFormat2(int flags, int valueNameId, int axisIndex, float nominalValue, float rangeMinValue, float rangeMaxValue) {#AxisValueTableFormat2-int-int-int-float-float-float-}
+```
+public AxisValueTableFormat2(int flags, int valueNameId, int axisIndex, float nominalValue, float rangeMinValue, float rangeMaxValue)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| flaggor | int | Flaggor |
+| valueNameId | int | Namn-ID för poster i 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde |
+| axisIndex | int | Spec: Nollbaserat index i axelpostarrayen som identifierar den designvariationsaxel som axelvärdestabellen gäller för. Måste vara mindre än designAxisCount. |
+| nominalValue | float | Det nominella numeriska värdet för detta attributvärde. |
+| rangeMinValue | float | Det minsta värdet för ett intervall som är associerat med det angivna namn-ID:t. |
+| rangeMaxValue | float | Det maximala värdet för ett intervall som är associerat med det angivna namn-ID:t. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisIndex() {#getAxisIndex--}
+```
+public int getAxisIndex()
+```
+
+
+Hämtar det nollbaserade indexet i axelpostarrayen som identifierar den designvariationsaxel som axelvärdestabellen gäller för.
+
+**Returns:**
+int - Det nollbaserade indexet i axelpostarrayen som identifierar den designvariationsaxeln som axelvärdestabellen gäller för.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Hämtar fältet för flaggor i axelvärdestabellen.
+
+**Returns:**
+int - Fältet för flaggor i axelvärdestabellen.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Hämtar formatidentifierare (versionsnummer).
+
+**Returns:**
+int - Formatidentifieraren (versionsnummer).
+### getNominalValue() {#getNominalValue--}
+```
+public float getNominalValue()
+```
+
+
+Ett nominellt numeriskt värde
+
+**Returns:**
+float - Ett nominellt numeriskt värde
+### getRangeMaxValue() {#getRangeMaxValue--}
+```
+public float getRangeMaxValue()
+```
+
+
+Det maximala värdet för ett intervall som är associerat med det angivna namn-ID:t.
+
+**Returns:**
+float - Det maximala värdet för ett intervall som är associerat med det angivna namn-ID:t.
+### getRangeMinValue() {#getRangeMinValue--}
+```
+public float getRangeMinValue()
+```
+
+
+Det minsta värdet för ett intervall som är associerat med det angivna namn-ID:t.
+
+**Returns:**
+float - Det minsta värdet för ett intervall som är associerat med det angivna namn-ID:t.
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Hämtar namnet från 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde.
+
+**Returns:**
+java.lang.String - Namnet från 'name'-tabellen som tillhandahåller en visningssträng för detta attributvärde.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Hämtar namn-ID för poster i 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde.
+
+**Returns:**
+int - Namn-ID för poster i 'name'-tabellen som tillhandahåller en visningssträng för detta attributvärde.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/axisvaluetableformat3/_index.md
+++ b/swedish/java/com.aspose.font/axisvaluetableformat3/_index.md
@@ -1,0 +1,223 @@
+---
+title: "AxisValueTableFormat3"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Axis value table-format 3"
+type: docs
+weight: 15
+url: /sv/java/com.aspose.font/axisvaluetableformat3/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.AxisValueTableBase](../../com.aspose.font/axisvaluetablebase)
+```
+public class AxisValueTableFormat3 extends AxisValueTableBase
+```
+
+Representerar Axis value table-format 3
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [AxisValueTableFormat3(int flags, int valueNameId, int axisIndex, float value, float linkedValue)](#AxisValueTableFormat3-int-int-int-float-float-) | Konstruktor |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisIndex()](#getAxisIndex--) | Hämtar nollbaserat index i axelpostarrayen som identifierar den designvariationsaxel som axelvärdestabellen gäller för. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Hämtar fältet för flaggor i axelvärdestabellen. |
+| [getFormat()](#getFormat--) | Hämtar formatidentifierare (versionsnummer). |
+| [getLinkedValue()](#getLinkedValue--) | Det numeriska värdet för en stilkopplad mappning från detta värde. |
+| [getValue()](#getValue--) | Det numeriska värdet för detta attributvärde. |
+| [getValueName()](#getValueName--) | Hämtar namnet från 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde. |
+| [getValueNameId()](#getValueNameId--) | Hämtar namn-ID för poster i 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValueTableFormat3(int flags, int valueNameId, int axisIndex, float value, float linkedValue) {#AxisValueTableFormat3-int-int-int-float-float-}
+```
+public AxisValueTableFormat3(int flags, int valueNameId, int axisIndex, float value, float linkedValue)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| flaggor | int | Flaggor |
+| valueNameId | int | Namn-ID för poster i 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde |
+| axisIndex | int | Spec: Nollbaserat index i axelpostarrayen som identifierar den designvariationsaxel som axelvärdestabellen gäller för. Måste vara mindre än designAxisCount. |
+| värde | float | Det numeriska värdet för detta attributvärde. |
+| linkedValue | float | Det numeriska värdet för en stilkopplad mappning från detta värde. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisIndex() {#getAxisIndex--}
+```
+public int getAxisIndex()
+```
+
+
+Hämtar nollbaserat index i axelpostarrayen som identifierar den designvariationsaxel som axelvärdestabellen gäller för.
+
+**Returns:**
+int - Nollbaserat index i axelpostarrayen som identifierar den designvariationsaxel som axelvärdestabellen gäller för.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Hämtar fältet för flaggor i axelvärdestabellen.
+
+**Returns:**
+int - Fältet för flaggor i axelvärdestabellen.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Hämtar formatidentifierare (versionsnummer).
+
+**Returns:**
+int - Formatidentifieraren (versionsnummer).
+### getLinkedValue() {#getLinkedValue--}
+```
+public float getLinkedValue()
+```
+
+
+Det numeriska värdet för en stilkopplad mappning från detta värde.
+
+**Returns:**
+float - Det numeriska värdet för en stilkopplad mappning från detta värde.
+### getValue() {#getValue--}
+```
+public float getValue()
+```
+
+
+Det numeriska värdet för detta attributvärde.
+
+**Returns:**
+float - Det numeriska värdet för detta attributvärde.
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Hämtar namnet från 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde.
+
+**Returns:**
+java.lang.String - Namnet från 'name'-tabellen som tillhandahåller en visningssträng för detta attributvärde.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Hämtar namn-ID för poster i 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde.
+
+**Returns:**
+int - Namn-ID för poster i 'name'-tabellen som tillhandahåller en visningssträng för detta attributvärde.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/axisvaluetableformat4/_index.md
+++ b/swedish/java/com.aspose.font/axisvaluetableformat4/_index.md
@@ -1,0 +1,199 @@
+---
+title: "AxisValueTableFormat4"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Axis value table-format 4"
+type: docs
+weight: 16
+url: /sv/java/com.aspose.font/axisvaluetableformat4/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.AxisValueTableBase](../../com.aspose.font/axisvaluetablebase)
+```
+public class AxisValueTableFormat4 extends AxisValueTableBase
+```
+
+Representerar Axis value table-format 4
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [AxisValueTableFormat4(int flags, int valueNameId, AxisValue[] axisValues)](#AxisValueTableFormat4-int-int-com.aspose.font.AxisValue---) | Konstruktor |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisValues()](#getAxisValues--) | Array av AxisValue-poster som tillhandahåller kombinationen av axelvärden, ett för varje bidragande axel. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Hämtar fältet för flaggor i axelvärdestabellen. |
+| [getFormat()](#getFormat--) | Hämtar formatidentifierare (versionsnummer). |
+| [getValueName()](#getValueName--) | Hämtar namnet från 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde. |
+| [getValueNameId()](#getValueNameId--) | Hämtar namn-ID för poster i 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AxisValueTableFormat4(int flags, int valueNameId, AxisValue[] axisValues) {#AxisValueTableFormat4-int-int-com.aspose.font.AxisValue---}
+```
+public AxisValueTableFormat4(int flags, int valueNameId, AxisValue[] axisValues)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| flaggor | int | Flaggor |
+| valueNameId | int | Namn-ID för poster i 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde |
+| axisValues | [AxisValue\[\]](../../com.aspose.font/axisvalue) | Array av AxisValue-poster som tillhandahåller kombinationen av axelvärden, ett för varje bidragande axel. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisValues() {#getAxisValues--}
+```
+public AxisValue[] getAxisValues()
+```
+
+
+Array av AxisValue-poster som tillhandahåller kombinationen av axelvärden, ett för varje bidragande axel.
+
+**Returns:**
+com.aspose.font.AxisValue[] - Array av AxisValue-poster som tillhandahåller kombinationen av axelvärden, ett för varje bidragande axel.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Hämtar fältet för flaggor i axelvärdestabellen.
+
+**Returns:**
+int - Fältet för flaggor i axelvärdestabellen.
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Hämtar formatidentifierare (versionsnummer).
+
+**Returns:**
+int - Formatidentifieraren (versionsnummer).
+### getValueName() {#getValueName--}
+```
+public String getValueName()
+```
+
+
+Hämtar namnet från 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde.
+
+**Returns:**
+java.lang.String - Namnet från 'name'-tabellen som tillhandahåller en visningssträng för detta attributvärde.
+### getValueNameId() {#getValueNameId--}
+```
+public int getValueNameId()
+```
+
+
+Hämtar namn-ID för poster i 'name'-tabellen som tillhandahåller en displaysträng för detta attributvärde.
+
+**Returns:**
+int - Namn-ID för poster i 'name'-tabellen som tillhandahåller en visningssträng för detta attributvärde.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/bytecontentstreamsource/_index.md
+++ b/swedish/java/com.aspose.font/bytecontentstreamsource/_index.md
@@ -1,0 +1,200 @@
+---
+title: "ByteContentStreamSource"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar en strömkälla baserad på _content stream."
+type: docs
+weight: 17
+url: /sv/java/com.aspose.font/bytecontentstreamsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.StreamSource](../../com.aspose.font/streamsource)
+```
+public class ByteContentStreamSource extends StreamSource
+```
+
+Representerar en strömkälla baserad på \_content-strömmen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ByteContentStreamSource(byte[] fileContent)](#ByteContentStreamSource-byte---) | Initierar ett nytt  ByteContentStreamSource  objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Klonar ByteContentStreamSource-objektet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontStream()](#getFontStream--) | Returnerar Font-filström. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning i källan. |
+| [hashCode()](#hashCode--) |  |
+| [mustCloseAfterUse()](#mustCloseAfterUse--) | Avärvade klasser kan förhindra att strömmen stängs. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOffset(long value)](#setOffset-long-) | Ställer in förskjutning i källan. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ByteContentStreamSource(byte[] fileContent) {#ByteContentStreamSource-byte---}
+```
+public ByteContentStreamSource(byte[] fileContent)
+```
+
+
+Initierar ett nytt  ByteContentStreamSource  objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fileContent | byte[] | Filbyte. |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Klonar ByteContentStreamSource-objektet.
+
+**Returns:**
+java.lang.Object
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontStream() {#getFontStream--}
+```
+public InputStream getFontStream()
+```
+
+
+Returnerar Font-filström. Glöm inte att stänga strömmen efter användning.
+
+**Returns:**
+java.io.InputStream - Font-filström.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning i källan.
+
+**Returns:**
+long - Förskjutning i källan.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### mustCloseAfterUse() {#mustCloseAfterUse--}
+```
+public boolean mustCloseAfterUse()
+```
+
+
+Avärvade klasser kan förhindra att strömmen stängs. Returnerar true om strömkälla vill att strömmen stängs efter användning. Annars returneras false.
+
+**Returns:**
+boolean - True om strömkälla vill att strömmen stängs efter användning, annars false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOffset(long value) {#setOffset-long-}
+```
+public void setOffset(long value)
+```
+
+
+Ställer in förskjutning i källan.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long | Förskjutning i källan. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/cffencoding/_index.md
+++ b/swedish/java/com.aspose.font/cffencoding/_index.md
@@ -1,0 +1,256 @@
+---
+title: "CffEncoding"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar CFF _font-kodning."
+type: docs
+weight: 18
+url: /sv/java/com.aspose.font/cffencoding/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFontEncoding](../../com.aspose.font/ifontencoding), [com.aspose.font.ISupportsNameAddressing](../../com.aspose.font/isupportsnameaddressing)
+```
+public class CffEncoding implements IFontEncoding, ISupportsNameAddressing
+```
+
+Representerar CFF \_font-kodning.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [decodeToGid(long charCode)](#decodeToGid-long-) | Hämtar Gid för angiven charCode. |
+| [decodeToGidParameterized(IEncodingParameters parameters, long charCode)](#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-) | Parametriserad avkodningsmetod. |
+| [encode(long gid, long charCode)](#encode-long-long-) | Kodar tecknet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getNameToCharCodeIndex()](#getNameToCharCodeIndex--) | Returnerar namn‑till‑teckenkod‑kodningskarta. |
+| [getNameToGidIndex()](#getNameToGidIndex--) | Returnerar namn‑till‑teckenkod‑kodningskarta. |
+| [getNameToSidIndex()](#getNameToSidIndex--) | Returnerar namn‑till‑teckenkod‑kodningskarta. |
+| [getSidName(int sid)](#getSidName-int-) | Hämtar namn för den angivna SID. |
+| [gidToUnicode(GlyphId gid)](#gidToUnicode-com.aspose.font.GlyphId-) | Avkodar Gid till unicode. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [unicodeToGid(long unicode)](#unicodeToGid-long-) | Avkodar en unicode och returnerar glyfid. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### decodeToGid(long charCode) {#decodeToGid-long-}
+```
+public GlyphId decodeToGid(long charCode)
+```
+
+
+Hämtar Gid för angiven charCode. Denna metod är avsedd för CFF CIDFonts, där charCode måste vara ett giltigt CID‑värde. Glyph id är ett unikt nummer för en glyf, vilket är \_font‑typberoende. CFF Font glyph id kan vara en instans av klassen ( GlyphStringId ) eller ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| charCode | long | Teckenkod (CID) för att få glyfid. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to CID passed.
+### decodeToGidParameterized(IEncodingParameters parameters, long charCode) {#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-}
+```
+public GlyphId decodeToGidParameterized(IEncodingParameters parameters, long charCode)
+```
+
+
+Parametriserad avkodningsmetod. Stöds inte för CFF Font-typ.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| parameters | [IEncodingParameters](../../com.aspose.font/iencodingparameters) | Implementering av gränssnittet IEncodingParameters. |
+| charCode | long | Teckenkod för att hämta teckenidentifierare för. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to charCode passed.
+### encode(long gid, long charCode) {#encode-long-long-}
+```
+public void encode(long gid, long charCode)
+```
+
+
+Kodar glyfen. Stöds inte för CFF Font-typer.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| gid | long | Glyfid |
+| charCode | long | CharCode associerad med glyfid. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNameToCharCodeIndex() {#getNameToCharCodeIndex--}
+```
+public NameToCodeMap getNameToCharCodeIndex()
+```
+
+
+Returnerar namn‑till‑teckenkod‑kodningskarta. Obs: teckenkod är inte unicode. Teckenkod är ett teckenindex i Font‑kodningens "tabell".
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - Name to character code encoding map.
+### getNameToGidIndex() {#getNameToGidIndex--}
+```
+public NameToCodeMap getNameToGidIndex()
+```
+
+
+Returnerar namn‑till‑teckenkod‑kodningskarta. Obs: teckenkod är inte unicode. Teckenkod är ett teckenindex i Font‑kodningens "tabell".
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - Name to character code encoding map.
+### getNameToSidIndex() {#getNameToSidIndex--}
+```
+public NameToCodeMap getNameToSidIndex()
+```
+
+
+Returnerar namn‑till‑teckenkod‑kodningskarta. Obs: teckenkod är inte unicode. Teckenkod är ett teckenindex i Font‑kodningens "tabell".
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - Name to character code encoding map.
+### getSidName(int sid) {#getSidName-int-}
+```
+public String getSidName(int sid)
+```
+
+
+Hämtar namn för den angivna SID.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| sid | int | String‑identifierare. |
+
+**Returns:**
+java.lang.String - Namn från String‑INDEX om det hittas.
+### gidToUnicode(GlyphId gid) {#gidToUnicode-com.aspose.font.GlyphId-}
+```
+public long gidToUnicode(GlyphId gid)
+```
+
+
+Avkodar Gid till unicode. Glyph id är ett unikt nummer för en glyf, vilket är \_font‑typberoende. CFF Font glyph id kan vara en instans av klassen ( GlyphStringId ) eller ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| gid | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑identifierare för symbol att avkoda. |
+
+**Returns:**
+long – Unicode‑värde relaterat till det angivna glyph‑id.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unicodeToGid(long unicode) {#unicodeToGid-long-}
+```
+public GlyphId unicodeToGid(long unicode)
+```
+
+
+Avkodar en unicode och returnerar glyfid. Glyph id är ett unikt nummer för en glyf, vilket är \_font‑typberoende. CFF Font glyph id kan vara en instans av klassen ( GlyphStringId ) eller ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| unicode | long | Unicode för att få glyph‑identifierare för. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to unicode passed.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/cfffont/_index.md
+++ b/swedish/java/com.aspose.font/cfffont/_index.md
@@ -1,0 +1,604 @@
+---
+title: "CffFont"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Compact Font Format CFF."
+type: docs
+weight: 19
+url: /sv/java/com.aspose.font/cfffont/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Font](../../com.aspose.font/font)
+```
+public class CffFont extends Font
+```
+
+Representerar Compact Font Format (CFF).
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Konverterar Fonten till ett annat format. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Returnerar en array med alla glyfid, tillgängliga i Fonten. |
+| [getClass()](#getClass--) |  |
+| [getCommonFontsSettings()](#getCommonFontsSettings--) | Hämtar inställningar gemensamma för CFF-fonter. |
+| [getEncoding()](#getEncoding--) | Hämtar Font‑kodning. |
+| [getFontDefinition()](#getFontDefinition--) | Hämtar fontdefinition. |
+| [getFontFamily()](#getFontFamily--) | Hämtar Font‑familj. |
+| [getFontName()](#getFontName--) | Hämtar Font‑ansiktsnamn. |
+| [getFontNames()](#getFontNames--) | Hämtar Font‑namn. |
+| [getFontSaver()](#getFontSaver--) | Hämtar Font‑sparfunktionalitet. |
+| [getFontStyle()](#getFontStyle--) | Hämtar Font‑stil. |
+| [getFontType()](#getFontType--) | Hämtar Font‑typ. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Font‑glyf‑åtkomst. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Returnerar glyf efter glyfid. |
+| [getGlyphById(String glyphName)](#getGlyphById-java.lang.String-) | Returnerar glyf efter glyfnamn. |
+| [getGlyphById(long id)](#getGlyphById-long-) | Returnerar glyf efter glyfid. |
+| [getGlyphIdType()](#getGlyphIdType--) | Hämtar specifikation för glyfid‑typ. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Hämtar glyfrepresentation för text. |
+| [getIndexDataProvider(CffIndexProviderType indexType)](#getIndexDataProvider-com.aspose.font.CffIndexProviderType-) | Hämtar leverantör för den specificerade CFF INDEX-strukturtypen. |
+| [getMetrics()](#getMetrics--) | Hämtar Font‑metrik. |
+| [getNumGlyphs()](#getNumGlyphs--) | Hämtar antalet glyfer i Fonten. |
+| [getPostscriptNames()](#getPostscriptNames--) | Hämtar PostScript Font-namn. |
+| [getStyle()](#getStyle--) | Hämtar Font‑stil. |
+| [getTopDictDataProvider()](#getTopDictDataProvider--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isCidKeyedFont()](#isCidKeyedFont--) | Hämtar värde som indikerar att Font är cid-keyed. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Öppnar en font med FontDefinition-objekt. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Öppnar en font med fonttyp och bytearray för fontdata. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Öppnar en font med fonttyp och strömkälla. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Öppnar en font med fonttyp och fontfilnamn. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Sparar Fonten i originalformat. |
+| [save(String fileName)](#save-java.lang.String-) | Sparar Fonten i originalformat. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Sparar Fonten i angivet format. |
+| [setCommonFontsSettings(CffFontsSettings value)](#setCommonFontsSettings-com.aspose.font.CffFontsSettings-) | Anger inställningar gemensamma för CFF-fonter. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Font-familjens inställare är ännu inte implementerad. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Font-ansiktsnamnets inställare är ännu inte implementerad. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Stil-inställaren är ännu inte implementerad. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public Font convert(FontType fontType)
+```
+
+
+Konverterar Fonten till ett annat format. Obs: TTF Font-typ stöds nu endast.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Font-formattyp att konvertera till. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public GlyphId[] getAllGlyphIds()
+```
+
+
+Returnerar en array med alla glyfid, tillgängliga i Font. Glyfid är ett unikt nummer för en glyf, som är beroende av fonttypen. CFF Font glyfid kan vara en instans av klassen ( GlyphStringId ) eller klassen ( GlyphUInt32Id ).
+
+**Returns:**
+com.aspose.font.GlyphId[]
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCommonFontsSettings() {#getCommonFontsSettings--}
+```
+public CffFontsSettings getCommonFontsSettings()
+```
+
+
+Hämtar inställningar gemensamma för CFF-fonter. Dessa inställningar används i olika scenarier och kan ändras för varje enskild font.
+
+**Returns:**
+[CffFontsSettings](../../com.aspose.font/cfffontssettings) - Font definition.
+### getEncoding() {#getEncoding--}
+```
+public IFontEncoding getEncoding()
+```
+
+
+Hämtar Font‑kodning.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public FontDefinition getFontDefinition()
+```
+
+
+Hämtar fontdefinition.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public String getFontFamily()
+```
+
+
+Hämtar Font‑familj.
+
+**Returns:**
+java.lang.String - Font-familj.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Hämtar Font‑ansiktsnamn.
+
+**Returns:**
+java.lang.String - Font face name.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Hämtar Font‑namn.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Hämtar Font‑sparfunktionalitet.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public int getFontStyle()
+```
+
+
+Hämtar Font-stil. Detta är ett värde som beräknas och representeras i en generaliserad typ.
+
+**Returns:**
+int - Font-stil. Vanligtvis en kombination av konstantflaggvärden i FontStyle-klassen eller 0.
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Hämtar Font-typ. Returnerar värdet FontType.CFF.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Typsnittsglyf‑åtkomst. Hämtar glyfer och glyfidenterifierare.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public Glyph getGlyphById(GlyphId id)
+```
+
+
+Returnerar glyf efter glyfid. Glyfid är ett unikt nummer för en glyf, som är beroende av fonttypen. CFF Font glyfid kan vara en instans av klassen ( GlyphStringId ) eller klassen ( GlyphInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | Glyfid. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(String glyphName) {#getGlyphById-java.lang.String-}
+```
+public Glyph getGlyphById(String glyphName)
+```
+
+
+Returnerar glyf efter glyfnamn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphName | java.lang.String | Glyfnamn. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(long id) {#getGlyphById-long-}
+```
+public Glyph getGlyphById(long id)
+```
+
+
+Returnerar glyf efter glyfid.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| id | long | Glyfid. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public GlyphIdType getGlyphIdType()
+```
+
+
+Hämtar specifikation för glyfid‑typ.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype) - Glyph id type specification.
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Hämtar glyfrepresentation för text.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| text | java.lang.String | Indatatext. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - GlyphId‑array.
+### getIndexDataProvider(CffIndexProviderType indexType) {#getIndexDataProvider-com.aspose.font.CffIndexProviderType-}
+```
+public ICffIndexDataProvider getIndexDataProvider(CffIndexProviderType indexType)
+```
+
+
+Hämtar leverantör för den specificerade CFF INDEX-strukturtypen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| indexType | [CffIndexProviderType](../../com.aspose.font/cffindexprovidertype) | Typ av INDEX-struktur. |
+
+**Returns:**
+[ICffIndexDataProvider](../../com.aspose.font/icffindexdataprovider) - Implementation of ( ICffIndexDataProvider ) interface.
+### getMetrics() {#getMetrics--}
+```
+public IFontMetrics getMetrics()
+```
+
+
+Hämtar Font‑metrik.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Hämtar antalet glyfer i Fonten.
+
+**Returns:**
+int - Antal glyfer i typsnittet.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Hämtar PostScript Font-namn.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names.
+### getStyle() {#getStyle--}
+```
+public String getStyle()
+```
+
+
+Hämtar typsnittsstil. Detta är ett rått strängvärde som tillhandahålls av typsnittsfilen.
+
+**Returns:**
+java.lang.String - Typsnittsstil.
+### getTopDictDataProvider() {#getTopDictDataProvider--}
+```
+public TopDictDataProvider getTopDictDataProvider()
+```
+
+
+
+
+**Returns:**
+[TopDictDataProvider](../../com.aspose.font/topdictdataprovider)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isCidKeyedFont() {#isCidKeyedFont--}
+```
+public boolean isCidKeyedFont()
+```
+
+
+Hämtar värde som indikerar att Font är cid-keyed.
+
+**Returns:**
+boolean - Värde som indikerar att Font är cid-keyed.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Öppnar en font med FontDefinition-objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Typsnittsdefinitionsobjekt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Öppnar en font med fonttyp och bytearray för fontdata.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fontData | byte[] | Byte‑array för att läsa in typsnitt från. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Öppnar en font med fonttyp och strömkälla.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Strömkälla för typsnitt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Öppnar en font med fonttyp och fontfilnamn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fileName | java.lang.String | Fontfilnamn. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Sparar Fonten i originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.OutputStream | Ström för att spara teckensnitt. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Sparar Fonten i originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | java.lang.String | Fil för att spara teckensnitt. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Sparar Fonten i angivet format.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.OutputStream | ström för att spara teckensnitt |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | önskat format |
+
+### setCommonFontsSettings(CffFontsSettings value) {#setCommonFontsSettings-com.aspose.font.CffFontsSettings-}
+```
+public void setCommonFontsSettings(CffFontsSettings value)
+```
+
+
+Anger inställningar gemensamma för CFF-fonter.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [CffFontsSettings](../../com.aspose.font/cfffontssettings) | Fontdefinition. |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public void setFontFamily(String value)
+```
+
+
+Font-familjens inställare är ännu inte implementerad.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Ny fontfamilj. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public void setFontName(String value)
+```
+
+
+Font-ansiktsnamnets inställare är ännu inte implementerad.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Nytt teckensnittsansiktsnamn. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public void setStyle(String value)
+```
+
+
+Stil-inställaren är ännu inte implementerad.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Ny fontstil. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/cfffontexception/_index.md
+++ b/swedish/java/com.aspose.font/cfffontexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "CffFontException"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar ett vanligt bearbetningsrelaterat undantag för typsnitt i CFF-format."
+type: docs
+weight: 20
+url: /sv/java/com.aspose.font/cfffontexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class CffFontException extends FontException
+```
+
+Representerar ett vanligt bearbetningsrelaterat undantag för typsnitt i CFF-format.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [CffFontException()](#CffFontException--) | Initierar nytt CffFontException-objekt. |
+| [CffFontException(String message)](#CffFontException-java.lang.String-) | Initierar nytt CffFontException-objekt. |
+| [CffFontException(String message, RuntimeException innerException)](#CffFontException-java.lang.String-java.lang.RuntimeException-) | Initierar nytt CffFontException-objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CffFontException() {#CffFontException--}
+```
+public CffFontException()
+```
+
+
+Initierar nytt CffFontException-objekt.
+
+### CffFontException(String message) {#CffFontException-java.lang.String-}
+```
+public CffFontException(String message)
+```
+
+
+Initierar nytt CffFontException-objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+
+### CffFontException(String message, RuntimeException innerException) {#CffFontException-java.lang.String-java.lang.RuntimeException-}
+```
+public CffFontException(String message, RuntimeException innerException)
+```
+
+
+Initierar nytt CffFontException-objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+| innerException | java.lang.RuntimeException | Undantaget som är orsaken till det aktuella undantaget. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/cfffontmetrics/_index.md
+++ b/swedish/java/com.aspose.font/cfffontmetrics/_index.md
@@ -1,0 +1,483 @@
+---
+title: "CffFontMetrics"
+second_title: "Aspose.Font för Java API-referens"
+description: "Implementering av CFF-typsnittsmått"
+type: docs
+weight: 21
+url: /sv/java/com.aspose.font/cfffontmetrics/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.FontMetrics](../../com.aspose.font/fontmetrics)
+```
+public class CffFontMetrics extends FontMetrics
+```
+
+Implementering av CFF-typsnittsmått
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAscender()](#getAscender--) | Hämtar Ascender‑värdet. |
+| [getAscender(double fontSize)](#getAscender-double-) | Returnerar ascender för en specifik teckenstorlek. |
+| [getClass()](#getClass--) |  |
+| [getDescender()](#getDescender--) | Hämtar Descender‑värdet. |
+| [getDescender(double fontSize)](#getDescender-double-) | Returnerar descender för en specifik teckenstorlek. |
+| [getFontBBox()](#getFontBBox--) | Hämtar FontBBox‑värdet. |
+| [getFontMatrix()](#getFontMatrix--) | Hämtar FontMatrix‑värdet. |
+| [getFontMatrixForGlyph(GlyphId glyphId)](#getFontMatrixForGlyph-com.aspose.font.GlyphId-) | Beräknar transformationsmatris för glyph som anges av id. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Returnerar glyf Bbox. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Returnerar glyfbredd. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Returnerar kerningvärde för glyfparet. |
+| [getLineGap()](#getLineGap--) | Hämtar LineGap-värde. |
+| [getTypoAscender()](#getTypoAscender--) | Hämtar TypoAscender-värde. |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Returnerar typografisk ascender för specifik Font-storlek. |
+| [getTypoDescender()](#getTypoDescender--) | Hämtar TypoDescender-värde. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Returnerar typografisk descender för specifik fontstorlek. |
+| [getTypoLineGap()](#getTypoLineGap--) | Hämtar TypoLineGap-värde. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Returnerar radgap för specifik Font-storlek. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Hämtar UnitsPerEM-värde. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Hämtar IsFixedPitch-värde. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Mäter sträng och returnerar strängbredd. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAscender(double value)](#setAscender-double-) | Ställer in Ascender-värde. |
+| [setDescender(double value)](#setDescender-double-) | Ställer in Descender-värde. |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) |  |
+| [setTypoAscender(double value)](#setTypoAscender-double-) | Ställer in TypoAscender-värde. |
+| [setTypoDescender(double value)](#setTypoDescender-double-) | Ställer in TypoDescender-värde. |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) | Ställer in UnitsPerEM-värde. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAscender() {#getAscender--}
+```
+public double getAscender()
+```
+
+
+Hämtar Ascender‑värdet.
+
+**Returns:**
+double - Ascender-värde.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public double getAscender(double fontSize)
+```
+
+
+Returnerar ascender för en specifik teckenstorlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Ascender-värde.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescender() {#getDescender--}
+```
+public double getDescender()
+```
+
+
+Hämtar Descender‑värdet.
+
+**Returns:**
+double - Descender-värde.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public double getDescender(double fontSize)
+```
+
+
+Returnerar descender för en specifik teckenstorlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Descender-värde.
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+Hämtar FontBBox‑värdet.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - FontBBox value.
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+Hämtar FontMatrix‑värdet.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - FontMatrix value.
+### getFontMatrixForGlyph(GlyphId glyphId) {#getFontMatrixForGlyph-com.aspose.font.GlyphId-}
+```
+public TransformationMatrix getFontMatrixForGlyph(GlyphId glyphId)
+```
+
+
+Beräknar transformationsmatris för glyph som anges av id.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyfidentifierare. |
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - Glyph transformation matrix.
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Returnerar glyf Bbox. Returnerar FontBBox om BBox inte var definierad för glyfen. Kan åsidosättas av specifika teckenkodningsarvtagare.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyfidentifierare. |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox.
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Returnerar glyph‑bredd. Kan åsidosättas av specifika Font‑kodnings‑ärvda klasser.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyfidentifierare. |
+
+**Returns:**
+double - Glyph-bredd.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Returnerar kerningvärde för glyfparet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Första glyph i paret. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Fontstorlek. |
+
+**Returns:**
+double - Kerningvärde.
+### getLineGap() {#getLineGap--}
+```
+public double getLineGap()
+```
+
+
+Hämtar LineGap-värde.
+
+**Returns:**
+double - LineGap-värde.
+### getTypoAscender() {#getTypoAscender--}
+```
+public double getTypoAscender()
+```
+
+
+Hämtar TypoAscender-värde.
+
+**Returns:**
+double - TypoAscender-värde.
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public double getTypoAscender(double fontSize)
+```
+
+
+Returnerar typografisk ascender för specifik Font-storlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Typographic ascender-värde.
+### getTypoDescender() {#getTypoDescender--}
+```
+public double getTypoDescender()
+```
+
+
+Hämtar TypoDescender-värde.
+
+**Returns:**
+double - TypoDescender-värde.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public double getTypoDescender(double fontSize)
+```
+
+
+Returnerar typografisk descender för specifik fontstorlek.
+
+param fontSize teckenstorlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double |  |
+
+**Returns:**
+double - Typographic descender-värde.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public double getTypoLineGap()
+```
+
+
+Hämtar TypoLineGap-värde.
+
+**Returns:**
+double - TypoLineGap-värde.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public double getTypoLineGap(double fontSize)
+```
+
+
+Returnerar radgap för specifik Font-storlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Line gap-värde.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Hämtar UnitsPerEM-värde.
+
+**Returns:**
+long - UnitsPerEM-värde.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+Hämtar IsFixedPitch-värde.
+
+**Returns:**
+boolean - IsFixedPitch-värde.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public double measureString(String unicode, double fontSize)
+```
+
+
+Mäter sträng och returnerar strängbredd.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| unicode | java.lang.String | Unicode-sträng. |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Strängbredd.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAscender(double value) {#setAscender-double-}
+```
+public void setAscender(double value)
+```
+
+
+Ställer in Ascender-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | Ascender-värde. |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public void setDescender(double value)
+```
+
+
+Ställer in Descender-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | Descender-värde. |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Ställer in glyfbredd.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) |  |
+| värde | double |  |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public void setTypoAscender(double value)
+```
+
+
+Ställer in TypoAscender-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | TypoAscender-värde. |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public void setTypoDescender(double value)
+```
+
+
+Ställer in TypoDescender-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | TypoDescender-värde. |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public void setUnitsPerEM(long value)
+```
+
+
+Ställer in UnitsPerEM-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long | UnitsPerEM-värde. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/cfffontssettings/_index.md
+++ b/swedish/java/com.aspose.font/cfffontssettings/_index.md
@@ -1,0 +1,162 @@
+---
+title: "CffFontsSettings"
+second_title: "Aspose.Font för Java API-referens"
+description: "Tillhandahåller inställningar gemensamma för CFF-typsnitt."
+type: docs
+weight: 22
+url: /sv/java/com.aspose.font/cfffontssettings/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class CffFontsSettings
+```
+
+Tillhandahåller inställningar gemensamma för CFF-typsnitt.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [CffFontsSettings()](#CffFontsSettings--) | Konstruktor |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getUpdateStringsStrategy()](#getUpdateStringsStrategy--) | Hämtar strategin för att uppdatera strängar i CFF String INDEX‑strukturen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUpdateStringStrategy(CffUpdateStringIndexStrategy updateStringsStrategy)](#setUpdateStringStrategy-com.aspose.font.CffUpdateStringIndexStrategy-) | Specificerar strategin för att uppdatera strängar i CFF String INDEX‑strukturen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CffFontsSettings() {#CffFontsSettings--}
+```
+public CffFontsSettings()
+```
+
+
+Konstruktor
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUpdateStringsStrategy() {#getUpdateStringsStrategy--}
+```
+public CffUpdateStringIndexStrategy getUpdateStringsStrategy()
+```
+
+
+Hämtar strategin för att uppdatera strängar i CFF String INDEX‑strukturen. Alternativet AddStringAsIs används som standard.
+
+**Returns:**
+[CffUpdateStringIndexStrategy](../../com.aspose.font/cffupdatestringindexstrategy)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUpdateStringStrategy(CffUpdateStringIndexStrategy updateStringsStrategy) {#setUpdateStringStrategy-com.aspose.font.CffUpdateStringIndexStrategy-}
+```
+public void setUpdateStringStrategy(CffUpdateStringIndexStrategy updateStringsStrategy)
+```
+
+
+Specificerar strategin för att uppdatera strängar i CFF String INDEX‑strukturen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| updateStringsStrategy | [CffUpdateStringIndexStrategy](../../com.aspose.font/cffupdatestringindexstrategy) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/cffindexprovidertype/_index.md
+++ b/swedish/java/com.aspose.font/cffindexprovidertype/_index.md
@@ -1,0 +1,250 @@
+---
+title: "CffIndexProviderType"
+second_title: "Aspose.Font för Java API-referens"
+description: "Specificerar INDEX-strukturer som stöds av familjen av indexleverantörsgränssnitt."
+type: docs
+weight: 133
+url: /sv/java/com.aspose.font/cffindexprovidertype/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum CffIndexProviderType extends Enum<CffIndexProviderType>
+```
+
+Specificerar INDEX-strukturer som stöds av familjen av indexleverantörsgränssnitt.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [NameIndex](#NameIndex) | Name INDEX |
+| [StringIndex](#StringIndex) | String INDEX |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NameIndex {#NameIndex}
+```
+public static final CffIndexProviderType NameIndex
+```
+
+
+Name INDEX
+
+### StringIndex {#StringIndex}
+```
+public static final CffIndexProviderType StringIndex
+```
+
+
+String INDEX
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static CffIndexProviderType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[CffIndexProviderType](../../com.aspose.font/cffindexprovidertype)
+### values() {#values--}
+```
+public static CffIndexProviderType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.CffIndexProviderType[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/cffparsingexception/_index.md
+++ b/swedish/java/com.aspose.font/cffparsingexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "CffParsingException"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar parse-undantag för typsnitt i cff-format."
+type: docs
+weight: 23
+url: /sv/java/com.aspose.font/cffparsingexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception), [com.aspose.font.CffFontException](../../com.aspose.font/cfffontexception)
+```
+public class CffParsingException extends CffFontException
+```
+
+Representerar parse‑undantag för teckensnitt i cff-format. Undantaget kan kastas vid fel under teckensnittsparsningsprocessen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [CffParsingException()](#CffParsingException--) | Initierar ett nytt  CffParsingException  -objekt. |
+| [CffParsingException(String message)](#CffParsingException-java.lang.String-) | Initierar ett nytt  CffParsingException  -objekt. |
+| [CffParsingException(String message, RuntimeException innerException)](#CffParsingException-java.lang.String-java.lang.RuntimeException-) | Initierar ett nytt  CffParsingException  -objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CffParsingException() {#CffParsingException--}
+```
+public CffParsingException()
+```
+
+
+Initierar ett nytt  CffParsingException  -objekt.
+
+### CffParsingException(String message) {#CffParsingException-java.lang.String-}
+```
+public CffParsingException(String message)
+```
+
+
+Initierar ett nytt  CffParsingException  -objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+
+### CffParsingException(String message, RuntimeException innerException) {#CffParsingException-java.lang.String-java.lang.RuntimeException-}
+```
+public CffParsingException(String message, RuntimeException innerException)
+```
+
+
+Initierar ett nytt  CffParsingException  -objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+| innerException | java.lang.RuntimeException | Undantaget som är orsaken till det aktuella undantaget. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/cffupdatestringindexstrategy/_index.md
+++ b/swedish/java/com.aspose.font/cffupdatestringindexstrategy/_index.md
@@ -1,0 +1,250 @@
+---
+title: "CffUpdateStringIndexStrategy"
+second_title: "Aspose.Font för Java API-referens"
+description: "Specificerar hur man lägger till strängar i CFF String INDEX-lagring."
+type: docs
+weight: 134
+url: /sv/java/com.aspose.font/cffupdatestringindexstrategy/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum CffUpdateStringIndexStrategy extends Enum<CffUpdateStringIndexStrategy>
+```
+
+Anger hur man lägger till strängar i CFF String INDEX-lagring. När vi försöker lägga till en sträng i CFF String INDEX kan det uppstå en situation där denna sträng redan finns i String INDEX. Genom att använda alternativet SearchForDuplicates kan vi tvinga en sökning i String INDEX för att upptäcka om strängen redan finns eller inte. Detta tillvägagångssätt sparar utrymme i String INDEX-strukturen, men kräver mer tid för att lägga till strängen.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [AddStringAsIs](#AddStringAsIs) | Anger att inga kontroller för dubbletter ska utföras när en sträng läggs till. |
+| [SearchForDuplicates](#SearchForDuplicates) | Anger att sökningen efter den sträng som ska läggas till ska utföras i String INDEX-strukturen för att undvika att lägga till dubbletter. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AddStringAsIs {#AddStringAsIs}
+```
+public static final CffUpdateStringIndexStrategy AddStringAsIs
+```
+
+
+Anger att inga kontroller för dubbletter ska utföras när en sträng läggs till. Detta tillvägagångssätt är snabbare, men kan leda till ineffektiv minnesanvändning för String INDEX.
+
+### SearchForDuplicates {#SearchForDuplicates}
+```
+public static final CffUpdateStringIndexStrategy SearchForDuplicates
+```
+
+
+Anger att sökningen efter den sträng som ska läggas till ska utföras i String INDEX-strukturen för att undvika att lägga till dubbletter.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static CffUpdateStringIndexStrategy valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[CffUpdateStringIndexStrategy](../../com.aspose.font/cffupdatestringindexstrategy)
+### values() {#values--}
+```
+public static CffUpdateStringIndexStrategy[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.CffUpdateStringIndexStrategy[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/closepath/_index.md
+++ b/swedish/java/com.aspose.font/closepath/_index.md
@@ -1,0 +1,200 @@
+---
+title: "ClosePath"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar ClosePath-operationen."
+type: docs
+weight: 24
+url: /sv/java/com.aspose.font/closepath/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IPathSegment](../../com.aspose.font/ipathsegment)
+```
+public class ClosePath implements IPathSegment
+```
+
+Representerar ClosePath-operationen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clone()](#clone--) | Skapar ett nytt objekt som är en kopia av den aktuella instansen. |
+| [copy()](#copy--) | Skapar en kopia av segmentobjektet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getX()](#getX--) | Hämtar koordinat x. |
+| [getY()](#getY--) | Hämtar koordinat y. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [shift(double dx, double dy)](#shift-double-double-) | Utför förskjutning med x- och y-koordinater. |
+| [toString()](#toString--) |  |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Transformerar koordinater med transformationsmatrisen. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Skapar ett nytt objekt som är en kopia av den aktuella instansen.
+
+**Returns:**
+java.lang.Object - Ett nytt objekt som är en kopia av denna instans.
+### copy() {#copy--}
+```
+public IPathSegment copy()
+```
+
+
+Skapar en kopia av segmentobjektet.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getX() {#getX--}
+```
+public double getX()
+```
+
+
+Hämtar koordinat x.
+
+**Returns:**
+double - Koordinat x.
+### getY() {#getY--}
+```
+public double getY()
+```
+
+
+Hämtar koordinat y.
+
+**Returns:**
+double - Koordinat y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public void shift(double dx, double dy)
+```
+
+
+Utför förskjutning med x- och y-koordinater.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| dx | double | Värde dx. |
+| dy | double | Värde dy. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public void transform(TransformationMatrix matrix)
+```
+
+
+Transformerar koordinater med transformationsmatrisen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Transformationsmatris för transformation. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/compositeglyph/_index.md
+++ b/swedish/java/com.aspose.font/compositeglyph/_index.md
@@ -1,0 +1,245 @@
+---
+title: "CompositeGlyph"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar ett sammansatt teckenglyf."
+type: docs
+weight: 25
+url: /sv/java/com.aspose.font/compositeglyph/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Glyph](../../com.aspose.font/glyph)
+```
+public class CompositeGlyph extends Glyph
+```
+
+Representerar ett sammansatt teckenglyf.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clone()](#clone--) | Returnerar en kopia av glyph. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getComponents()](#getComponents--) | Hämtar komponentlista. |
+| [getGlyphBBox()](#getGlyphBBox--) | Hämtar glyph BBox. |
+| [getLeftSidebearingX()](#getLeftSidebearingX--) | Hämtar tecknets sidobäring x-koordinat. |
+| [getLeftSidebearingY()](#getLeftSidebearingY--) | Hämtar tecknets sidobäring y-koordinat. |
+| [getPath()](#getPath--) | Hämtar tecknets bana. |
+| [getSourceResolution()](#getSourceResolution--) | Hämtar upplösning för källkommandosatsen. |
+| [getState()](#getState--) | Hämtar tecknets tillstånd. |
+| [getWidthVectorX()](#getWidthVectorX--) | Hämtar tecknets breddvektor. |
+| [getWidthVectorY()](#getWidthVectorY--) | Hämtar tecknets breddvektor. |
+| [hashCode()](#hashCode--) |  |
+| [isEmpty()](#isEmpty--) | Sant om tecknet inte innehåller ritinstruktioner. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Returnerar en kopia av glyph.
+
+**Returns:**
+java.lang.Object - Kopia av Glyph
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getComponents() {#getComponents--}
+```
+public CompositeGlyphComponentList getComponents()
+```
+
+
+Hämtar komponentlista.
+
+**Returns:**
+[CompositeGlyphComponentList](../../com.aspose.font/compositeglyphcomponentlist) - Components list.
+### getGlyphBBox() {#getGlyphBBox--}
+```
+public FontBBox getGlyphBBox()
+```
+
+
+Hämtar glyph BBox.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox
+### getLeftSidebearingX() {#getLeftSidebearingX--}
+```
+public double getLeftSidebearingX()
+```
+
+
+Hämtar tecknets sidobäring x-koordinat.
+
+**Returns:**
+double - Tecknets sidobäring x-koordinat.
+### getLeftSidebearingY() {#getLeftSidebearingY--}
+```
+public double getLeftSidebearingY()
+```
+
+
+Hämtar tecknets sidobäring y-koordinat.
+
+**Returns:**
+double - Tecknets sidobäring y-koordinat.
+### getPath() {#getPath--}
+```
+public SegmentPath getPath()
+```
+
+
+Hämtar tecknets bana.
+
+**Returns:**
+[SegmentPath](../../com.aspose.font/segmentpath) - Glyph path.
+### getSourceResolution() {#getSourceResolution--}
+```
+public int getSourceResolution()
+```
+
+
+Hämtar upplösning för källkommandosatsen.
+
+**Returns:**
+int - Upplösning för källkommandosatsen.
+### getState() {#getState--}
+```
+public GlyphState getState()
+```
+
+
+Hämtar tecknets tillstånd.
+
+**Returns:**
+[GlyphState](../../com.aspose.font/glyphstate) - Glyph state.
+### getWidthVectorX() {#getWidthVectorX--}
+```
+public double getWidthVectorX()
+```
+
+
+Hämtar tecknets breddvektor. Koordinat x.
+
+**Returns:**
+double - Tecknets breddvektor. Koordinat x.
+### getWidthVectorY() {#getWidthVectorY--}
+```
+public double getWidthVectorY()
+```
+
+
+Hämtar tecknets breddvektor. Koordinat y.
+
+**Returns:**
+double - Tecknets breddvektor. Koordinat y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+Sant om tecknet inte innehåller ritinstruktioner.
+
+**Returns:**
+boolean - Sant om tecknet inte innehåller ritinstruktioner.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/compositeglyphcomponent/_index.md
+++ b/swedish/java/com.aspose.font/compositeglyphcomponent/_index.md
@@ -1,0 +1,146 @@
+---
+title: "CompositeGlyphComponent"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar sammansatt glyfkomponent med placeringsmatris."
+type: docs
+weight: 26
+url: /sv/java/com.aspose.font/compositeglyphcomponent/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class CompositeGlyphComponent
+```
+
+Representerar komponent för sammansatt glyf (glyf med placeringsmatris).
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGlyph()](#getGlyph--) | Hämtar komponentglyfen. |
+| [getMatrix()](#getMatrix--) | Hämtar komponentens transformationsmatris. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyph() {#getGlyph--}
+```
+public Glyph getGlyph()
+```
+
+
+Hämtar komponentglyfen.
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - The component glyph.
+### getMatrix() {#getMatrix--}
+```
+public TransformationMatrix getMatrix()
+```
+
+
+Hämtar komponentens transformationsmatris.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - The component transformation matrix.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/compositeglyphcomponentlist/_index.md
+++ b/swedish/java/com.aspose.font/compositeglyphcomponentlist/_index.md
@@ -1,0 +1,565 @@
+---
+title: "CompositeGlyphComponentList"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar lista över komponenter för sammansatta glyfer."
+type: docs
+weight: 27
+url: /sv/java/com.aspose.font/compositeglyphcomponentlist/
+---
+**Inheritance:**
+java.lang.Object, java.util.AbstractCollection, java.util.AbstractList, java.util.ArrayList
+```
+public class CompositeGlyphComponentList extends ArrayList<CompositeGlyphComponent>
+```
+
+Representerar lista över komponenter för sammansatta glyfer.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>toArray(T[] arg0)](#-T-toArray-T---) |  |
+| [add(E arg0)](#add-E-) |  |
+| [add(int arg0, E arg1)](#add-int-E-) |  |
+| [addAll(int arg0, Collection<? extends E> arg1)](#addAll-int-java.util.Collection---extends-E--) |  |
+| [addAll(Collection<? extends E> arg0)](#addAll-java.util.Collection---extends-E--) |  |
+| [clear()](#clear--) |  |
+| [clone()](#clone--) |  |
+| [contains(Object arg0)](#contains-java.lang.Object-) |  |
+| [containsAll(Collection<?> arg0)](#containsAll-java.util.Collection----) |  |
+| [ensureCapacity(int arg0)](#ensureCapacity-int-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [forEach(Consumer<? super E> arg0)](#forEach-java.util.function.Consumer---super-E--) |  |
+| [get(int arg0)](#get-int-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object arg0)](#indexOf-java.lang.Object-) |  |
+| [isEmpty()](#isEmpty--) |  |
+| [iterator()](#iterator--) |  |
+| [lastIndexOf(Object arg0)](#lastIndexOf-java.lang.Object-) |  |
+| [listIterator()](#listIterator--) |  |
+| [listIterator(int arg0)](#listIterator-int-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(int arg0)](#remove-int-) |  |
+| [remove(Object arg0)](#remove-java.lang.Object-) |  |
+| [removeAll(Collection<?> arg0)](#removeAll-java.util.Collection----) |  |
+| [removeIf(Predicate<? super E> arg0)](#removeIf-java.util.function.Predicate---super-E--) |  |
+| [replaceAll(UnaryOperator<E> arg0)](#replaceAll-java.util.function.UnaryOperator-E--) |  |
+| [retainAll(Collection<?> arg0)](#retainAll-java.util.Collection----) |  |
+| [set(int arg0, E arg1)](#set-int-E-) |  |
+| [size()](#size--) |  |
+| [sort(Comparator<? super E> arg0)](#sort-java.util.Comparator---super-E--) |  |
+| [spliterator()](#spliterator--) |  |
+| [subList(int arg0, int arg1)](#subList-int-int-) |  |
+| [toArray()](#toArray--) |  |
+| [toString()](#toString--) |  |
+| [trimToSize()](#trimToSize--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>toArray(T[] arg0) {#-T-toArray-T---}
+```
+public T[] <T>toArray(T[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | T[] |  |
+
+**Returns:**
+T[]
+### add(E arg0) {#add-E-}
+```
+public boolean add(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+boolean
+### add(int arg0, E arg1) {#add-int-E-}
+```
+public void add(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+### addAll(int arg0, Collection<? extends E> arg1) {#addAll-int-java.util.Collection---extends-E--}
+```
+public boolean addAll(int arg0, Collection<? extends E> arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### addAll(Collection<? extends E> arg0) {#addAll-java.util.Collection---extends-E--}
+```
+public boolean addAll(Collection<? extends E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### contains(Object arg0) {#contains-java.lang.Object-}
+```
+public boolean contains(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### containsAll(Collection<?> arg0) {#containsAll-java.util.Collection----}
+```
+public boolean containsAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### ensureCapacity(int arg0) {#ensureCapacity-int-}
+```
+public void ensureCapacity(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### forEach(Consumer<? super E> arg0) {#forEach-java.util.function.Consumer---super-E--}
+```
+public void forEach(Consumer<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.function.Consumer<? super E> |  |
+
+### get(int arg0) {#get-int-}
+```
+public E get(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object arg0) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public Iterator<E> iterator()
+```
+
+
+
+
+**Returns:**
+java.util.Iterator<E>
+### lastIndexOf(Object arg0) {#lastIndexOf-java.lang.Object-}
+```
+public int lastIndexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### listIterator() {#listIterator--}
+```
+public ListIterator<E> listIterator()
+```
+
+
+
+
+**Returns:**
+java.util.ListIterator<E>
+### listIterator(int arg0) {#listIterator-int-}
+```
+public ListIterator<E> listIterator(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+java.util.ListIterator<E>
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(int arg0) {#remove-int-}
+```
+public E remove(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### remove(Object arg0) {#remove-java.lang.Object-}
+```
+public boolean remove(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### removeAll(Collection<?> arg0) {#removeAll-java.util.Collection----}
+```
+public boolean removeAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### removeIf(Predicate<? super E> arg0) {#removeIf-java.util.function.Predicate---super-E--}
+```
+public boolean removeIf(Predicate<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.function.Predicate<? super E> |  |
+
+**Returns:**
+boolean
+### replaceAll(UnaryOperator<E> arg0) {#replaceAll-java.util.function.UnaryOperator-E--}
+```
+public void replaceAll(UnaryOperator<E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.function.UnaryOperator<E> |  |
+
+### retainAll(Collection<?> arg0) {#retainAll-java.util.Collection----}
+```
+public boolean retainAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### set(int arg0, E arg1) {#set-int-E-}
+```
+public E set(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+**Returns:**
+E
+### size() {#size--}
+```
+public int size()
+```
+
+
+
+
+**Returns:**
+int
+### sort(Comparator<? super E> arg0) {#sort-java.util.Comparator---super-E--}
+```
+public void sort(Comparator<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.Comparator<? super E> |  |
+
+### spliterator() {#spliterator--}
+```
+public Spliterator<E> spliterator()
+```
+
+
+
+
+**Returns:**
+java.util.Spliterator<E>
+### subList(int arg0, int arg1) {#subList-int-int-}
+```
+public List<E> subList(int arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | int |  |
+
+**Returns:**
+java.util.List<E>
+### toArray() {#toArray--}
+```
+public Object[] toArray()
+```
+
+
+
+
+**Returns:**
+java.lang.Object[]
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### trimToSize() {#trimToSize--}
+```
+public void trimToSize()
+```
+
+
+
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/compressionutils/_index.md
+++ b/swedish/java/com.aspose.font/compressionutils/_index.md
@@ -1,0 +1,168 @@
+---
+title: "CompressionUtils"
+second_title: "Aspose.Font för Java API-referens"
+description: "Tillhandahåller hjälpfunktioner för komprimering och dekomprimering."
+type: docs
+weight: 28
+url: /sv/java/com.aspose.font/compressionutils/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class CompressionUtils
+```
+
+Tillhandahåller hjälpfunktioner för komprimering och dekomprimering.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [CompressionUtils()](#CompressionUtils--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [decodeByBrotli(byte[] input)](#decodeByBrotli-byte---) | Dekomprimerar den givna Brotli-komprimerade byte array. |
+| [encodeByBrotli(byte[] buff, int buffLength)](#encodeByBrotli-byte---int-) | Komprimerar den givna byte array med Brotli-algoritmen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CompressionUtils() {#CompressionUtils--}
+```
+public CompressionUtils()
+```
+
+
+### decodeByBrotli(byte[] input) {#decodeByBrotli-byte---}
+```
+public static byte[] decodeByBrotli(byte[] input)
+```
+
+
+Dekomprimerar den givna Brotli-komprimerade byte array.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| inmatning | byte[] | Den komprimerade datan. |
+
+**Returns:**
+byte[] - Den dekomprimerade byte arrayen.
+### encodeByBrotli(byte[] buff, int buffLength) {#encodeByBrotli-byte---int-}
+```
+public static byte[] encodeByBrotli(byte[] buff, int buffLength)
+```
+
+
+Komprimerar den givna byte array med Brotli-algoritmen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| buff | byte[] | Inmatningsbufferten att komprimera. |
+| buffLength | int | Längden på datan som ska komprimeras. |
+
+**Returns:**
+byte[] - Den komprimerade byte arrayen.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/curveto/_index.md
+++ b/swedish/java/com.aspose.font/curveto/_index.md
@@ -1,0 +1,244 @@
+---
+title: "CurveTo"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar CurveTo-operationen."
+type: docs
+weight: 29
+url: /sv/java/com.aspose.font/curveto/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IPathSegment](../../com.aspose.font/ipathsegment)
+```
+public class CurveTo implements IPathSegment
+```
+
+Representerar CurveTo-operationen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clone()](#clone--) | Skapar ett nytt objekt som är en kopia av den aktuella instansen. |
+| [copy()](#copy--) | Skapar en kopia av segmentobjektet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getX1()](#getX1--) | Hämtar koordinat x1. |
+| [getX2()](#getX2--) | Hämtar koordinat x2. |
+| [getX3()](#getX3--) | Hämtar koordinat x3. |
+| [getY1()](#getY1--) | Hämtar koordinat y1. |
+| [getY2()](#getY2--) | Hämtar koordinat y2. |
+| [getY3()](#getY3--) | Hämtar koordinat y3. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [shift(double dx, double dy)](#shift-double-double-) | Utför förskjutning med x- och y-koordinater. |
+| [toString()](#toString--) |  |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Transformerar koordinater med transformationsmatrisen. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Skapar ett nytt objekt som är en kopia av den aktuella instansen.
+
+**Returns:**
+java.lang.Object - Ett nytt objekt som är en kopia av denna instans.
+### copy() {#copy--}
+```
+public IPathSegment copy()
+```
+
+
+Skapar en kopia av segmentobjektet.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getX1() {#getX1--}
+```
+public double getX1()
+```
+
+
+Hämtar koordinat x1.
+
+**Returns:**
+double - Koordinat x1.
+### getX2() {#getX2--}
+```
+public double getX2()
+```
+
+
+Hämtar koordinat x2.
+
+**Returns:**
+double - Koordinat x2.
+### getX3() {#getX3--}
+```
+public double getX3()
+```
+
+
+Hämtar koordinat x3.
+
+**Returns:**
+double - Koordinat x3.
+### getY1() {#getY1--}
+```
+public double getY1()
+```
+
+
+Hämtar koordinat y1.
+
+**Returns:**
+double - Koordinat y1.
+### getY2() {#getY2--}
+```
+public double getY2()
+```
+
+
+Hämtar koordinat y2.
+
+**Returns:**
+double - Koordinat y2.
+### getY3() {#getY3--}
+```
+public double getY3()
+```
+
+
+Hämtar koordinat y3.
+
+**Returns:**
+double - Koordinat y3.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public void shift(double dx, double dy)
+```
+
+
+Utför förskjutning med x- och y-koordinater.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| dx | double | Värde dx. |
+| dy | double | Värde dy. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public void transform(TransformationMatrix matrix)
+```
+
+
+Transformerar koordinater med transformationsmatrisen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Transformationsmatris. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/encodingexception/_index.md
+++ b/swedish/java/com.aspose.font/encodingexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "EncodingException"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar kodningsundantag."
+type: docs
+weight: 30
+url: /sv/java/com.aspose.font/encodingexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class EncodingException extends FontException
+```
+
+Representerar kodningsundantag. Undantaget kan kastas vid problem med kodning/avkodning av text.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [EncodingException()](#EncodingException--) | Initierar ett nytt  EncodingException  -objekt. |
+| [EncodingException(String message)](#EncodingException-java.lang.String-) | Initierar ett nytt  EncodingException  -objekt. |
+| [EncodingException(String message, RuntimeException innerException)](#EncodingException-java.lang.String-java.lang.RuntimeException-) | Initierar ett nytt  EncodingException  -objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EncodingException() {#EncodingException--}
+```
+public EncodingException()
+```
+
+
+Initierar ett nytt  EncodingException  -objekt.
+
+### EncodingException(String message) {#EncodingException-java.lang.String-}
+```
+public EncodingException(String message)
+```
+
+
+Initierar ett nytt  EncodingException  -objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+
+### EncodingException(String message, RuntimeException innerException) {#EncodingException-java.lang.String-java.lang.RuntimeException-}
+```
+public EncodingException(String message, RuntimeException innerException)
+```
+
+
+Initierar ett nytt  EncodingException  -objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+| innerException | java.lang.RuntimeException | Undantaget som är orsaken till det aktuella undantaget. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/filesystemstreamsource/_index.md
+++ b/swedish/java/com.aspose.font/filesystemstreamsource/_index.md
@@ -1,0 +1,225 @@
+---
+title: "FileSystemStreamSource"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar en strömkälla baserad på filsystemet."
+type: docs
+weight: 31
+url: /sv/java/com.aspose.font/filesystemstreamsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.StreamSource](../../com.aspose.font/streamsource)
+```
+public class FileSystemStreamSource extends StreamSource
+```
+
+Representerar en strömkälla baserad på filsystemet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FileSystemStreamSource(String fileName)](#FileSystemStreamSource-java.lang.String-) | Initierar ett nytt FileSystemStreamSource‑objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Klonar FileSystemStreamSource‑objektet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileName()](#getFileName--) | Hämtar filnamn. |
+| [getFontStream()](#getFontStream--) | Returnerar Font-filström. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning i källan. |
+| [hashCode()](#hashCode--) |  |
+| [mustCloseAfterUse()](#mustCloseAfterUse--) | Avärvade klasser kan förhindra att strömmen stängs. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFileName(String value)](#setFileName-java.lang.String-) | Ställer in filnamn. |
+| [setOffset(long value)](#setOffset-long-) | Ställer in förskjutning i källan. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileSystemStreamSource(String fileName) {#FileSystemStreamSource-java.lang.String-}
+```
+public FileSystemStreamSource(String fileName)
+```
+
+
+Initierar ett nytt FileSystemStreamSource‑objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | java.lang.String | Filnamn. |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Klonar FileSystemStreamSource‑objektet.
+
+**Returns:**
+java.lang.Object - Kopia av FileSystemStreamSource‑objekt.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Hämtar filnamn.
+
+**Returns:**
+java.lang.String - Filnamn.
+### getFontStream() {#getFontStream--}
+```
+public InputStream getFontStream()
+```
+
+
+Returnerar Font-filström. Glöm inte att stänga strömmen efter användning.
+
+**Returns:**
+java.io.InputStream - Font-filström.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning i källan.
+
+**Returns:**
+long - Förskjutning i källan.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### mustCloseAfterUse() {#mustCloseAfterUse--}
+```
+public boolean mustCloseAfterUse()
+```
+
+
+Avärvade klasser kan förhindra att strömmen stängs. Returnerar true om strömkälla vill att strömmen stängs efter användning. Annars returneras false.
+
+**Returns:**
+boolean - True om strömkälla vill att strömmen stängs efter användning, annars false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFileName(String value) {#setFileName-java.lang.String-}
+```
+public void setFileName(String value)
+```
+
+
+Ställer in filnamn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Filnamn. |
+
+### setOffset(long value) {#setOffset-long-}
+```
+public void setOffset(long value)
+```
+
+
+Ställer in förskjutning i källan.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long | Förskjutning i källan. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/font/_index.md
+++ b/swedish/java/com.aspose.font/font/_index.md
@@ -1,0 +1,526 @@
+---
+title: "Font"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar basklassen Font."
+type: docs
+weight: 32
+url: /sv/java/com.aspose.font/font/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFont](../../com.aspose.font/ifont), [com.aspose.font.IGlyphAccessor](../../com.aspose.font/iglyphaccessor), [com.aspose.font.IFontSaver](../../com.aspose.font/ifontsaver)
+```
+public abstract class Font implements IFont, IGlyphAccessor, IFontSaver
+```
+
+Representerar basklassen Font.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Konverterar Fonten till ett annat format. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Returnerar alla glyph ids, tillgängliga i Font. |
+| [getClass()](#getClass--) |  |
+| [getEncoding()](#getEncoding--) | Hämtar Font‑kodning. |
+| [getFontDefinition()](#getFontDefinition--) | Hämtar Font‑definition. |
+| [getFontFamily()](#getFontFamily--) | Hämtar Font‑familj. |
+| [getFontName()](#getFontName--) | Hämtar Font‑ansiktsnamn. |
+| [getFontNames()](#getFontNames--) | Hämtar Font‑namn. |
+| [getFontSaver()](#getFontSaver--) | Hämtar Font‑sparfunktionalitet. |
+| [getFontStyle()](#getFontStyle--) | Hämtar Font‑stil. |
+| [getFontType()](#getFontType--) | Hämtar Font‑typ. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Font‑glyf‑åtkomst. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Returnerar glyf efter glyfid. |
+| [getGlyphIdType()](#getGlyphIdType--) | Specifikation av glyph-id-typ. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Hämtar glyfrepresentation för text. |
+| [getMetrics()](#getMetrics--) | Hämtar Font‑metrik. |
+| [getNumGlyphs()](#getNumGlyphs--) | Hämtar antalet glyfer i Fonten. |
+| [getPostscriptNames()](#getPostscriptNames--) | Hämtar postscript-teckensnittsnamn. |
+| [getStyle()](#getStyle--) | Hämtar Font‑stil. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Öppnar en font med FontDefinition-objekt. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Öppnar en font med fonttyp och bytearray för fontdata. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Öppnar en font med fonttyp och strömkälla. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Öppnar en font med fonttyp och fontfilnamn. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Sparar Fonten i originalformat. |
+| [save(String fileName)](#save-java.lang.String-) | Sparar Fonten i originalformat. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Sparar Fonten i angivet format. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Ställer in Font-familj. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Ställer in Font face name. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Ställer in Font-stil. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public abstract Font convert(FontType fontType)
+```
+
+
+Konverterar Fonten till ett annat format.
+
+--------------------
+
+> ```
+> Note: TTF Font type is now supported only.
+> ```
+
+fontType Font-formattyp att konvertera till.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) |  |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public abstract GlyphId[] getAllGlyphIds()
+```
+
+
+Returnerar alla glyph ids, tillgängliga i Font. Glyph id är ett unikt nummer för en glyf, som är beroende av teckensnittstypen. Till exempel: Type1:s id är ett glyfnamn, en instans av klassen ( GlyphStringId ). TTF:s id är ett int-index, en instans av klassen ( GlyphInt32Id ).
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyph-identifierare.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncoding() {#getEncoding--}
+```
+public abstract IFontEncoding getEncoding()
+```
+
+
+Hämtar Font‑kodning.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public abstract FontDefinition getFontDefinition()
+```
+
+
+Hämtar Font‑definition.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public abstract String getFontFamily()
+```
+
+
+Hämtar Font‑familj.
+
+**Returns:**
+java.lang.String - Font-familj.
+### getFontName() {#getFontName--}
+```
+public abstract String getFontName()
+```
+
+
+Hämtar Font‑ansiktsnamn.
+
+**Returns:**
+java.lang.String - Font face name.
+### getFontNames() {#getFontNames--}
+```
+public abstract MultiLanguageString getFontNames()
+```
+
+
+Hämtar Font‑namn.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Hämtar Font‑sparfunktionalitet.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public abstract int getFontStyle()
+```
+
+
+Hämtar Font-stil. Detta är ett värde som beräknas och representeras i en generaliserad typ.
+
+**Returns:**
+int - Font-stil. Vanligtvis en kombination av konstantflaggvärden i FontStyle-klassen eller 0.
+### getFontType() {#getFontType--}
+```
+public abstract FontType getFontType()
+```
+
+
+Hämtar Font‑typ.
+
+--------------------
+
+> ```
+> Type1, TrueType etc.
+> ```
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Typsnittsglyf‑åtkomst. Hämtar glyfer och glyfidenterifierare.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public abstract Glyph getGlyphById(GlyphId id)
+```
+
+
+Returnerar glyf efter glyph Id. Glyph id är ett unikt nummer för en glyf, som är beroende av teckensnittstypen. GlyphId - härlett objekt. Till exempel: Type1:s id är ett glyfnamn, en instans av klassen ( GlyphStringId ). TTF:s id är ett int-index, en instans av klassen ( GlyphInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | Glyfid. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public abstract GlyphIdType getGlyphIdType()
+```
+
+
+Specifikation av glyph id-typ. För konsumenter som behöver känna till den faktiska typen för 'bytes[]'.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype) - Id type specification
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Hämtar glyfrepresentation för text.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| text | java.lang.String | Indatatext. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - GlyphId‑array.
+### getMetrics() {#getMetrics--}
+```
+public abstract IFontMetrics getMetrics()
+```
+
+
+Hämtar Font‑metrik.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public abstract int getNumGlyphs()
+```
+
+
+Hämtar antalet glyfer i Fonten.
+
+**Returns:**
+int - Antal glyfer i typsnittet.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public abstract MultiLanguageString getPostscriptNames()
+```
+
+
+Hämtar postscript-teckensnittsnamn.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript font names.
+### getStyle() {#getStyle--}
+```
+public abstract String getStyle()
+```
+
+
+Hämtar typsnittsstil. Detta är ett rått strängvärde som tillhandahålls av typsnittsfilen.
+
+**Returns:**
+java.lang.String - Typsnittsstil.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Öppnar en font med FontDefinition-objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Typsnittsdefinitionsobjekt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Öppnar en font med fonttyp och bytearray för fontdata.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fontData | byte[] | Byte‑array för att läsa in typsnitt från. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Öppnar en font med fonttyp och strömkälla.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Strömkälla för typsnitt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Öppnar en font med fonttyp och fontfilnamn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fileName | java.lang.String | Fontfilnamn. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Sparar Fonten i originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.OutputStream | Ström för att spara teckensnitt. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Sparar Fonten i originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | java.lang.String | Fil för att spara teckensnitt. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Sparar Fonten i angivet format.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.OutputStream | ström för att spara teckensnitt |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | önskat format |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public abstract void setFontFamily(String value)
+```
+
+
+Ställer in Font-familj.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Ny fontfamilj. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public abstract void setFontName(String value)
+```
+
+
+Ställer in Font face name.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Nytt teckensnittsansiktsnamn. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public abstract void setStyle(String value)
+```
+
+
+Ställer in fontstil. Detta är ett rått strängvärde som tillhandahålls av fontfilen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Ny fontstil. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fontagrumentexception/_index.md
+++ b/swedish/java/com.aspose.font/fontagrumentexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontAgrumentException"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Font-argumentundantag."
+type: docs
+weight: 33
+url: /sv/java/com.aspose.font/fontagrumentexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontAgrumentException extends FontException
+```
+
+Representerar Font‑argument‑undantag. Undantaget kan kastas vid felaktig argumentanvändning.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FontAgrumentException()](#FontAgrumentException--) | Initierar ett nytt  FontAgrumentException ‑objekt. |
+| [FontAgrumentException(String message)](#FontAgrumentException-java.lang.String-) | Initierar ett nytt  FontAgrumentException ‑objekt. |
+| [FontAgrumentException(String message, RuntimeException innerException)](#FontAgrumentException-java.lang.String-java.lang.RuntimeException-) | Initierar ett nytt  FontAgrumentException ‑objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontAgrumentException() {#FontAgrumentException--}
+```
+public FontAgrumentException()
+```
+
+
+Initierar ett nytt  FontAgrumentException ‑objekt.
+
+### FontAgrumentException(String message) {#FontAgrumentException-java.lang.String-}
+```
+public FontAgrumentException(String message)
+```
+
+
+Initierar ett nytt  FontAgrumentException ‑objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+
+### FontAgrumentException(String message, RuntimeException innerException) {#FontAgrumentException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontAgrumentException(String message, RuntimeException innerException)
+```
+
+
+Initierar ett nytt  FontAgrumentException ‑objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+| innerException | java.lang.RuntimeException | Undantaget som är orsaken till det aktuella undantaget. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fontbbox/_index.md
+++ b/swedish/java/com.aspose.font/fontbbox/_index.md
@@ -1,0 +1,168 @@
+---
+title: "FontBBox"
+second_title: "Aspose.Font för Java API-referens"
+description: "representerar teckensnittets begränsningsruta."
+type: docs
+weight: 34
+url: /sv/java/com.aspose.font/fontbbox/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontBBox
+```
+
+representerar teckensnittets begränsningsruta.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getXMax()](#getXMax--) | Hämtar XMax-värdet. |
+| [getXMin()](#getXMin--) | Hämtar XMin‑värdet. |
+| [getYMax()](#getYMax--) | Hämtar YMax‑värdet. |
+| [getYMin()](#getYMin--) | Hämtar YMin‑värdet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getXMax() {#getXMax--}
+```
+public double getXMax()
+```
+
+
+Hämtar XMax-värdet.
+
+**Returns:**
+double – XMax‑värdet.
+### getXMin() {#getXMin--}
+```
+public double getXMin()
+```
+
+
+Hämtar XMin‑värdet.
+
+**Returns:**
+double – XMin‑värdet.
+### getYMax() {#getYMax--}
+```
+public double getYMax()
+```
+
+
+Hämtar YMax‑värdet.
+
+**Returns:**
+double – YMax‑värdet.
+### getYMin() {#getYMin--}
+```
+public double getYMin()
+```
+
+
+Hämtar YMin‑värdet.
+
+**Returns:**
+double – YMin‑värdet.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fontcharactersmerger/_index.md
+++ b/swedish/java/com.aspose.font/fontcharactersmerger/_index.md
@@ -1,0 +1,200 @@
+---
+title: "FontCharactersMerger"
+second_title: "Aspose.Font för Java API-referens"
+description: "Deklarerar funktionalitet för att slå samman teckensnitt av olika typer."
+type: docs
+weight: 35
+url: /sv/java/com.aspose.font/fontcharactersmerger/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class FontCharactersMerger
+```
+
+Deklarerar funktionalitet för att slå ihop teckensnitt av olika typer. Ett teckensnittspar behövs för sammanslagningsoperationen. Ett teckensnitt i detta par betraktas som primärt. Det innebär att många egenskaper relaterade till det slutliga sammanslagna teckensnittet, såsom metriker, kodningsstruktur och andra, tas från detta primära teckensnitt. Det andra teckensnittet i paret (sekundärt) tillhandahåller endast glyfer för det slutliga sammanslagna teckensnittet.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPrimaryFont()](#getPrimaryFont--) | Hämtar primärt teckensnitt. |
+| [getSecondaryFont()](#getSecondaryFont--) | Hämtar sekundärt teckensnitt. |
+| [hashCode()](#hashCode--) |  |
+| [mergeFonts(GlyphId[] primaryFontGlyphs, GlyphId[] secondaryFontGlyphs, String newFontName)](#mergeFonts-com.aspose.font.GlyphId---com.aspose.font.GlyphId---java.lang.String-) | Slår samman teckensnitt baserat på de överförda glyflistorna. |
+| [mergeFonts(int[] primaryFontCharCodes, int[] secondaryFontCharCodes, String newFontName)](#mergeFonts-int---int---java.lang.String-) | Slår samman teckensnitt baserat på de överförda teckenkodlistorna. |
+| [mergeFonts(Map<Integer,GlyphId> primaryFontDict, Map<Integer,GlyphId> secondaryFontDict, String newFontName)](#mergeFonts-java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.lang.String-) | Denna metodversion är avsedd för fall där du vill ange teckenkoder för glyfer i det resulterande teckensnittet explicit. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPrimaryFont() {#getPrimaryFont--}
+```
+public abstract Font getPrimaryFont()
+```
+
+
+Hämtar primärt teckensnitt.
+
+**Returns:**
+[Font](../../com.aspose.font/font) - The primary font.
+### getSecondaryFont() {#getSecondaryFont--}
+```
+public abstract Font getSecondaryFont()
+```
+
+
+Hämtar sekundärt teckensnitt.
+
+**Returns:**
+[Font](../../com.aspose.font/font) - The secondary font.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### mergeFonts(GlyphId[] primaryFontGlyphs, GlyphId[] secondaryFontGlyphs, String newFontName) {#mergeFonts-com.aspose.font.GlyphId---com.aspose.font.GlyphId---java.lang.String-}
+```
+public abstract Font mergeFonts(GlyphId[] primaryFontGlyphs, GlyphId[] secondaryFontGlyphs, String newFontName)
+```
+
+
+Slår samman teckensnitt baserat på de överförda glyflistorna. Söker efter en teckenkod för varje överförd glyf och lägger till den hittade teckenkoden med motsvarande glyf i det nya resulterande teckensnittet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| primaryFontGlyphs | [GlyphId\[\]](../../com.aspose.font/glyphid) | Lista över glyfer att ta från primärt teckensnitt. |
+| secondaryFontGlyphs | [GlyphId\[\]](../../com.aspose.font/glyphid) | Lista över glyfer att ta från sekundärt teckensnitt. |
+| newFontName | java.lang.String | Önskat namn för det resulterande teckensnittet. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Merged font
+### mergeFonts(int[] primaryFontCharCodes, int[] secondaryFontCharCodes, String newFontName) {#mergeFonts-int---int---java.lang.String-}
+```
+public abstract Font mergeFonts(int[] primaryFontCharCodes, int[] secondaryFontCharCodes, String newFontName)
+```
+
+
+Slår samman teckensnitt baserat på de överförda teckenkodlistorna. För att skapa det önskade resulterande teckensnittet, skicka bara symbolkoder från de ursprungliga teckensnitten du vill inkludera i det resulterande teckensnittet. Glyfer relaterade till de överförda koderna kommer att hittas automatiskt. Till exempel, om du vill inkludera glyfer relaterade till bokstäverna A och B från det första teckensnittet och glyfer relaterade till bokstäverna C och D från det andra teckensnittet, anropa bara den här metoden så här: `mergeFonts(new uint[] { 'A', 'B' }, new uint[] { 'C', 'D' }, "NewFont")`
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| primaryFontCharCodes | int[] | Koder att ta från det primära teckensnittet. |
+| secondaryFontCharCodes | int[] | Koder att ta från det sekundära teckensnittet. |
+| newFontName | java.lang.String | Önskat namn för det resulterande teckensnittet. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Merged font.
+### mergeFonts(Map<Integer,GlyphId> primaryFontDict, Map<Integer,GlyphId> secondaryFontDict, String newFontName) {#mergeFonts-java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.lang.String-}
+```
+public abstract Font mergeFonts(Map<Integer,GlyphId> primaryFontDict, Map<Integer,GlyphId> secondaryFontDict, String newFontName)
+```
+
+
+Denna metodversion är avsedd för fall där du vill ange teckenkoder för glyfer i det resulterande teckensnittet explicit. Det är inte ett krav att koden för den glyf du angav finns i det ursprungliga teckensnittet. Syftet med den överförda koden är att den ska associeras med motsvarande glyfid i det resulterande teckensnittet. Därför är regeln för att bearbeta varje par som skickas via ordboksparametern [kod, glyfid] att endast glyfid hämtas från det ursprungliga teckensnittet och sedan länkas till den motsvarande koden i det resulterande teckensnittet. Detta kan vara användbart när vissa koder från det första teckensnittet krockar med samma koder från det andra teckensnittet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| primaryFontDict | java.util.Map<java.lang.Integer,com.aspose.font.GlyphId> | Ordbok med par [symbolkod, glyfid] från det primära teckensnittet. |
+| secondaryFontDict | java.util.Map<java.lang.Integer,com.aspose.font.GlyphId> | Ordbok med par [symbolkod, glyfid] från det sekundära teckensnittet. |
+| newFontName | java.lang.String | Önskat namn för det resulterande teckensnittet. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Merged font.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fontconversionexception/_index.md
+++ b/swedish/java/com.aspose.font/fontconversionexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontConversionException"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Font-konverteringsundantag."
+type: docs
+weight: 36
+url: /sv/java/com.aspose.font/fontconversionexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontConversionException extends FontException
+```
+
+Representerar Font‑konverteringsundantag. Undantaget kan kastas vid fel under fontkonverteringsprocessen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FontConversionException()](#FontConversionException--) | Initierar nytt  FontConversionException  objekt. |
+| [FontConversionException(String message)](#FontConversionException-java.lang.String-) | Initierar nytt  FontConversionException  objekt. |
+| [FontConversionException(String message, RuntimeException innerException)](#FontConversionException-java.lang.String-java.lang.RuntimeException-) | Initierar nytt  FontConversionException  objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontConversionException() {#FontConversionException--}
+```
+public FontConversionException()
+```
+
+
+Initierar nytt  FontConversionException  objekt.
+
+### FontConversionException(String message) {#FontConversionException-java.lang.String-}
+```
+public FontConversionException(String message)
+```
+
+
+Initierar nytt  FontConversionException  objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+
+### FontConversionException(String message, RuntimeException innerException) {#FontConversionException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontConversionException(String message, RuntimeException innerException)
+```
+
+
+Initierar nytt  FontConversionException  objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+| innerException | java.lang.RuntimeException | Undantaget som är orsaken till det aktuella undantaget. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fontcreationexception/_index.md
+++ b/swedish/java/com.aspose.font/fontcreationexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontCreationException"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Font-skapandeundantag."
+type: docs
+weight: 37
+url: /sv/java/com.aspose.font/fontcreationexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontCreationException extends FontException
+```
+
+Representerar Font‑skapandeundantag. Undantaget kan kastas vid fel under font‑skapandeprocessen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FontCreationException()](#FontCreationException--) | Initierar ett nytt FontCreationException‑objekt. |
+| [FontCreationException(String message)](#FontCreationException-java.lang.String-) | Initierar ett nytt FontCreationException‑objekt. |
+| [FontCreationException(String message, RuntimeException innerException)](#FontCreationException-java.lang.String-java.lang.RuntimeException-) | Initierar ett nytt FontCreationException‑objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontCreationException() {#FontCreationException--}
+```
+public FontCreationException()
+```
+
+
+Initierar ett nytt FontCreationException‑objekt.
+
+### FontCreationException(String message) {#FontCreationException-java.lang.String-}
+```
+public FontCreationException(String message)
+```
+
+
+Initierar ett nytt FontCreationException‑objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+
+### FontCreationException(String message, RuntimeException innerException) {#FontCreationException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontCreationException(String message, RuntimeException innerException)
+```
+
+
+Initierar ett nytt FontCreationException‑objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+| innerException | java.lang.RuntimeException | Undantaget som är orsaken till det aktuella undantaget. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fontdefinition/_index.md
+++ b/swedish/java/com.aspose.font/fontdefinition/_index.md
@@ -1,0 +1,390 @@
+---
+title: "FontDefinition"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar definition av Font-filuppsättning."
+type: docs
+weight: 38
+url: /sv/java/com.aspose.font/fontdefinition/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontDefinition
+```
+
+Representerar definition av teckensnittfiluppsättning. Denna klass innehåller fält som inte är relaterade till teckensnittets interna data. Dessa fält beskriver teckensnittets placering och annan data som behövs för att ladda teckensnitt från någon teckensnittskälla (fil, minne, etc).
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FontDefinition(FontType fontType, String fileExtension, StreamSource streamSource)](#FontDefinition-com.aspose.font.FontType-java.lang.String-com.aspose.font.StreamSource-) | Skapar en enkel-fils teckensnittsdefinition. |
+| [FontDefinition(FontType fontType, StreamSource streamSource)](#FontDefinition-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Skapar en enkel-fils teckensnittsdefinition. |
+| [FontDefinition(String fontName, FontType fontType, String fileExtension, StreamSource streamSource)](#FontDefinition-java.lang.String-com.aspose.font.FontType-java.lang.String-com.aspose.font.StreamSource-) | Skapar en enkel-fils teckensnittsdefinition. |
+| [FontDefinition(FontType fontType, FontFileDefinition fileDefinition)](#FontDefinition-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-) | Skapar en enkel-fils teckensnittsdefinition. |
+| [FontDefinition(String fontName, FontType fontType, FontFileDefinition fileDefinition)](#FontDefinition-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-) | Skapar en enkel-fils teckensnittsdefinition. |
+| [FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition fileDefinition)](#FontDefinition-java.lang.String-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-) | Skapar en enkel-fils teckensnittsdefinition. |
+| [FontDefinition(FontType fontType, FontFileDefinition[] fileDefinitions)](#FontDefinition-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---) | Skapar en flermodulig teckensnittsdefinition. |
+| [FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition[] fileDefinitions)](#FontDefinition-java.lang.String-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---) | Skapar en flermodulig teckensnittsdefinition. |
+| [FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition fileDefinition)](#FontDefinition-com.aspose.font.MultiLanguageString-com.aspose.font.MultiLanguageString-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-) | Skapar en flermodulig teckensnittsdefinition. |
+| [FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition[] fileDefinitions)](#FontDefinition-com.aspose.font.MultiLanguageString-com.aspose.font.MultiLanguageString-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---) | Skapar en flermodulig teckensnittsdefinition. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileDefinitions()](#getFileDefinitions--) | Hämtar samling av fildefinitioner. |
+| [getFontName()](#getFontName--) | Returnerar teckensnittets namn. |
+| [getFontNames()](#getFontNames--) | Hämtar teckensnittens namn som en  MultiLanguageString . |
+| [getFontType()](#getFontType--) | Hämtar Font‑typ. |
+| [getPostscriptName()](#getPostscriptName--) | Hämtar postscript-teckensnittets namn. |
+| [getPostscriptNames()](#getPostscriptNames--) | Hämtar postscript-teckensnittens namn som en  MultiLanguageString . |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(StreamSource source, FontType fontType)](#open-com.aspose.font.StreamSource-com.aspose.font.FontType-) | Returnerar FontDefinition för teckensnittets strömkälla och teckensnittstyp. |
+| [open(String fileName, FontType fontType)](#open-java.lang.String-com.aspose.font.FontType-) | Returnerar FontDefinition för teckensnittfil och teckensnittstyp. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontDefinition(FontType fontType, String fileExtension, StreamSource streamSource) {#FontDefinition-com.aspose.font.FontType-java.lang.String-com.aspose.font.StreamSource-}
+```
+public FontDefinition(FontType fontType, String fileExtension, StreamSource streamSource)
+```
+
+
+Skapar en enkel-fils teckensnittsdefinition.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fileExtension | java.lang.String | Teckensnittfilens filändelse. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Teckensnittets strömkälla. |
+
+### FontDefinition(FontType fontType, StreamSource streamSource) {#FontDefinition-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public FontDefinition(FontType fontType, StreamSource streamSource)
+```
+
+
+Skapar en enkel-fils teckensnittsdefinition.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Teckensnittets strömkälla. |
+
+### FontDefinition(String fontName, FontType fontType, String fileExtension, StreamSource streamSource) {#FontDefinition-java.lang.String-com.aspose.font.FontType-java.lang.String-com.aspose.font.StreamSource-}
+```
+public FontDefinition(String fontName, FontType fontType, String fileExtension, StreamSource streamSource)
+```
+
+
+Skapar en enkel-fils teckensnittsdefinition.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontName | java.lang.String | Teckensnittsnamn. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fileExtension | java.lang.String | Teckensnittfilens filändelse. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Teckensnittets strömkälla. |
+
+### FontDefinition(FontType fontType, FontFileDefinition fileDefinition) {#FontDefinition-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-}
+```
+public FontDefinition(FontType fontType, FontFileDefinition fileDefinition)
+```
+
+
+Skapar en enkel-fils teckensnittsdefinition.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fileDefinition | [FontFileDefinition](../../com.aspose.font/fontfiledefinition) | FontFileDefinition. |
+
+### FontDefinition(String fontName, FontType fontType, FontFileDefinition fileDefinition) {#FontDefinition-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-}
+```
+public FontDefinition(String fontName, FontType fontType, FontFileDefinition fileDefinition)
+```
+
+
+Skapar en enkel-fils teckensnittsdefinition.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontName | java.lang.String | Teckensnittsnamn. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fileDefinition | [FontFileDefinition](../../com.aspose.font/fontfiledefinition) | FontFileDefinition. |
+
+### FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition fileDefinition) {#FontDefinition-java.lang.String-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-}
+```
+public FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition fileDefinition)
+```
+
+
+Skapar en enkel-fils teckensnittsdefinition.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontName | java.lang.String | Teckensnittsnamn. |
+| postscriptName | java.lang.String | Postscript-teckensnittets namn. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fileDefinition | [FontFileDefinition](../../com.aspose.font/fontfiledefinition) | FontFileDefinition. |
+
+### FontDefinition(FontType fontType, FontFileDefinition[] fileDefinitions) {#FontDefinition-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---}
+```
+public FontDefinition(FontType fontType, FontFileDefinition[] fileDefinitions)
+```
+
+
+Skapar en flermodulig teckensnittsdefinition.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fileDefinitions | [FontFileDefinition\[\]](../../com.aspose.font/fontfiledefinition) | Array av FontFileDefinition-objekt. |
+
+### FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition[] fileDefinitions) {#FontDefinition-java.lang.String-java.lang.String-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---}
+```
+public FontDefinition(String fontName, String postscriptName, FontType fontType, FontFileDefinition[] fileDefinitions)
+```
+
+
+Skapar en flermodulig teckensnittsdefinition.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontName | java.lang.String | Teckensnittsnamn. |
+| postscriptName | java.lang.String | Postscript-teckensnittets namn. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fileDefinitions | [FontFileDefinition\[\]](../../com.aspose.font/fontfiledefinition) | Array av FontFileDefinition-objekt. |
+
+### FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition fileDefinition) {#FontDefinition-com.aspose.font.MultiLanguageString-com.aspose.font.MultiLanguageString-com.aspose.font.FontType-com.aspose.font.FontFileDefinition-}
+```
+public FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition fileDefinition)
+```
+
+
+Skapar en flermodulig teckensnittsdefinition.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Teckensnittsnamn. |
+| postscriptNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Postscript-teckensnittsnamn. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fileDefinition | [FontFileDefinition](../../com.aspose.font/fontfiledefinition) | FontFileDefinition. |
+
+### FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition[] fileDefinitions) {#FontDefinition-com.aspose.font.MultiLanguageString-com.aspose.font.MultiLanguageString-com.aspose.font.FontType-com.aspose.font.FontFileDefinition---}
+```
+public FontDefinition(MultiLanguageString fontNames, MultiLanguageString postscriptNames, FontType fontType, FontFileDefinition[] fileDefinitions)
+```
+
+
+Skapar en flermodulig teckensnittsdefinition.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Teckensnittsnamn. |
+| postscriptNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Postscript-teckensnittsnamn. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fileDefinitions | [FontFileDefinition\[\]](../../com.aspose.font/fontfiledefinition) | Array av FontFileDefinition-objekt. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileDefinitions() {#getFileDefinitions--}
+```
+public FontFileDefinition[] getFileDefinitions()
+```
+
+
+Hämtar samling av fildefinitioner.
+
+**Returns:**
+com.aspose.font.FontFileDefinition[] - Samling av fildefinitioner.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Returnerar teckensnittets namn.
+
+**Returns:**
+java.lang.String - Teckensnittsnamn.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Hämtar teckensnittens namn som en  MultiLanguageString .
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names as a  MultiLanguageString .
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Hämtar Font‑typ.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getPostscriptName() {#getPostscriptName--}
+```
+public String getPostscriptName()
+```
+
+
+Hämtar postscript-teckensnittets namn.
+
+**Returns:**
+java.lang.String - Postscript-teckensnittets namn.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Hämtar postscript-teckensnittens namn som en  MultiLanguageString .
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names as a  MultiLanguageString .
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(StreamSource source, FontType fontType) {#open-com.aspose.font.StreamSource-com.aspose.font.FontType-}
+```
+public static FontDefinition open(StreamSource source, FontType fontType)
+```
+
+
+Returnerar FontDefinition för teckensnittets strömkälla och teckensnittstyp.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| source | [StreamSource](../../com.aspose.font/streamsource) | Teckensnittets strömkälla. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - FontDefinition.
+### open(String fileName, FontType fontType) {#open-java.lang.String-com.aspose.font.FontType-}
+```
+public static FontDefinition open(String fileName, FontType fontType)
+```
+
+
+Returnerar FontDefinition för teckensnittfil och teckensnittstyp.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | java.lang.String | Fontfilnamn. |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - FontDefinition.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fontenvironment/_index.md
+++ b/swedish/java/com.aspose.font/fontenvironment/_index.md
@@ -1,0 +1,193 @@
+---
+title: "FontEnvironment"
+second_title: "Aspose.Font för Java API-referens"
+description: "Tillhandahåller information om den aktuella miljön och plattformen."
+type: docs
+weight: 39
+url: /sv/java/com.aspose.font/fontenvironment/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontEnvironment
+```
+
+Tillhandahåller information om den aktuella miljön och plattformen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCffCommonFontsSettings()](#getCffCommonFontsSettings--) | Inställningar gemensamma för CFF-teckensnitt. |
+| [getClass()](#getClass--) |  |
+| [getCurrent()](#getCurrent--) | Hämtar aktuell miljö. |
+| [getCurrentPlatformId()](#getCurrentPlatformId--) | Hämtar aktuellt plattforms-ID. |
+| [getFontSpecificEncodings()](#getFontSpecificEncodings--) | Lagrar specifika kodningar för konsumentmedvetna teckensnitt. |
+| [getStrictness()](#getStrictness--) | Vissa teckensnitt kan innehålla oväntade data, ospecificerade funktioner eller kan vara grovt beskurna. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setStrictness(FontEnvironment.ParsingStrictness value)](#setStrictness-com.aspose.font.FontEnvironment.ParsingStrictness-) | Vissa teckensnitt kan innehålla oväntade data, ospecificerade funktioner eller kan vara grovt beskurna. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCffCommonFontsSettings() {#getCffCommonFontsSettings--}
+```
+public static CffFontsSettings getCffCommonFontsSettings()
+```
+
+
+Inställningar gemensamma för CFF-teckensnitt.
+
+**Returns:**
+[CffFontsSettings](../../com.aspose.font/cfffontssettings)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCurrent() {#getCurrent--}
+```
+public static FontEnvironment getCurrent()
+```
+
+
+Hämtar aktuell miljö.
+
+**Returns:**
+[FontEnvironment](../../com.aspose.font/fontenvironment) - Current environment.
+### getCurrentPlatformId() {#getCurrentPlatformId--}
+```
+public int getCurrentPlatformId()
+```
+
+
+Hämtar aktuellt plattforms-ID.
+
+**Returns:**
+int - Aktuellt plattforms-ID.
+### getFontSpecificEncodings() {#getFontSpecificEncodings--}
+```
+public FontSpecificEncodings getFontSpecificEncodings()
+```
+
+
+Lagrar specifika kodningar för konsumentmedvetna teckensnitt. Till exempel använder PDF specifika kodningar för Adobe Symbol och ZapfDingbats.
+
+**Returns:**
+[FontSpecificEncodings](../../com.aspose.font/fontspecificencodings) - Specific encodings for consumer-aware Fonts.
+### getStrictness() {#getStrictness--}
+```
+public FontEnvironment.ParsingStrictness getStrictness()
+```
+
+
+Vissa teckensnitt kan innehålla oväntade data, ospecificerade funktioner eller kan vara grovt beskurna. En tolerant inställning rekommenderas för konsumenter som vill öppna vilket teckensnitt som helst oavsett eventuell otillräcklighet. Teckensnittens interna strukturer garanteras inte att vara konsekventa. En strikt inställning rekommenderas för konsumenter som vill öppna mestadels giltiga och solida teckensnitt.
+
+**Returns:**
+[ParsingStrictness](../../com.aspose.font/parsingstrictness) - Strictness.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setStrictness(FontEnvironment.ParsingStrictness value) {#setStrictness-com.aspose.font.FontEnvironment.ParsingStrictness-}
+```
+public void setStrictness(FontEnvironment.ParsingStrictness value)
+```
+
+
+Vissa teckensnitt kan innehålla oväntade data, ospecificerade funktioner eller kan vara grovt beskurna. En tolerant inställning rekommenderas för konsumenter som vill öppna vilket teckensnitt som helst oavsett eventuell otillräcklighet. Teckensnittens interna strukturer garanteras inte att vara konsekventa. En strikt inställning rekommenderas för konsumenter som vill öppna mestadels giltiga och solida teckensnitt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ParsingStrictness](../../com.aspose.font/parsingstrictness) | Strikthet. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fontexception/_index.md
+++ b/swedish/java/com.aspose.font/fontexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontException"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar vanligt Font-bearbetningsrelaterat undantag."
+type: docs
+weight: 40
+url: /sv/java/com.aspose.font/fontexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException
+```
+public class FontException extends IllegalStateException
+```
+
+Representerar vanligt Font-bearbetningsrelaterat undantag.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FontException()](#FontException--) | Initierar nytt  FontException  objekt. |
+| [FontException(String message)](#FontException-java.lang.String-) | Initierar nytt  FontException  objekt. |
+| [FontException(String message, RuntimeException innerException)](#FontException-java.lang.String-java.lang.RuntimeException-) | Initierar nytt  FontException  objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontException() {#FontException--}
+```
+public FontException()
+```
+
+
+Initierar nytt  FontException  objekt.
+
+### FontException(String message) {#FontException-java.lang.String-}
+```
+public FontException(String message)
+```
+
+
+Initierar nytt  FontException  objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+
+### FontException(String message, RuntimeException innerException) {#FontException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontException(String message, RuntimeException innerException)
+```
+
+
+Initierar nytt  FontException  objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+| innerException | java.lang.RuntimeException | Undantaget som är orsaken till det aktuella undantaget. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fontfactory/_index.md
+++ b/swedish/java/com.aspose.font/fontfactory/_index.md
@@ -1,0 +1,204 @@
+---
+title: "FontFactory"
+second_title: "Aspose.Font för Java API-referens"
+description: "Innehåller funktionalitet för att öppna typsnitt av olika typer och andra metoder för att skapa olika objekt."
+type: docs
+weight: 41
+url: /sv/java/com.aspose.font/fontfactory/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontFactory
+```
+
+Innehåller funktionalitet för att öppna teckensnitt av olika typer samt andra metoder för att skapa olika objekt.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FontFactory()](#FontFactory--) | Konstruktor |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Öppnar en font med FontDefinition-objekt. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Öppnar en font med fonttyp och bytearray för fontdata. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Öppnar en font med fonttyp och strömkälla. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Öppnar en font med fonttyp och fontfilnamn. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontFactory() {#FontFactory--}
+```
+public FontFactory()
+```
+
+
+Konstruktor
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public Font open(FontDefinition fontDefinition)
+```
+
+
+Öppnar en font med FontDefinition-objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Typsnittsdefinitionsobjekt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public Font open(FontType fontType, byte[] fontData)
+```
+
+
+Öppnar en font med fonttyp och bytearray för fontdata.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fontData | byte[] | Byte‑array för att läsa in typsnitt från. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Öppnar en font med fonttyp och strömkälla.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Strömkälla för typsnitt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public Font open(FontType fontType, String fileName)
+```
+
+
+Öppnar en font med fonttyp och fontfilnamn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fileName | java.lang.String | Fontfilnamn. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fontfiledefinition/_index.md
+++ b/swedish/java/com.aspose.font/fontfiledefinition/_index.md
@@ -1,0 +1,231 @@
+---
+title: "FontFileDefinition"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar definition av Font-fil."
+type: docs
+weight: 42
+url: /sv/java/com.aspose.font/fontfiledefinition/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontFileDefinition
+```
+
+Representerar definition av Font-fil.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FontFileDefinition(StreamSource streamSource)](#FontFileDefinition-com.aspose.font.StreamSource-) | Skapar en fildefinition som endast använder filinnehåll. |
+| [FontFileDefinition(String fileExtension, StreamSource streamSource)](#FontFileDefinition-java.lang.String-com.aspose.font.StreamSource-) | Skapar en fildefinition som endast använder filinnehåll. |
+| [FontFileDefinition(String fileExtension, StreamSource streamSource, long offset)](#FontFileDefinition-java.lang.String-com.aspose.font.StreamSource-long-) | Skapar en fildefinition som endast använder filinnehåll. |
+| [FontFileDefinition(File fontFile)](#FontFileDefinition-java.io.File-) | Skapar en fildefinition med teckensnittfil (representerad av File) och filinnehåll. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileExtension()](#getFileExtension--) | Hämtar filändelse. |
+| [getFileName()](#getFileName--) | Hämtar filnamn. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning i strömmen. |
+| [getStreamSource()](#getStreamSource--) | Hämtar strömkällan. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontFileDefinition(StreamSource streamSource) {#FontFileDefinition-com.aspose.font.StreamSource-}
+```
+public FontFileDefinition(StreamSource streamSource)
+```
+
+
+Skapar en fildefinition som endast använder filinnehåll.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Teckensnittets strömkälla. |
+
+### FontFileDefinition(String fileExtension, StreamSource streamSource) {#FontFileDefinition-java.lang.String-com.aspose.font.StreamSource-}
+```
+public FontFileDefinition(String fileExtension, StreamSource streamSource)
+```
+
+
+Skapar en fildefinition som endast använder filinnehåll.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fileExtension | java.lang.String | Teckensnittfilens filändelse. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Teckensnittets strömkälla. |
+
+### FontFileDefinition(String fileExtension, StreamSource streamSource, long offset) {#FontFileDefinition-java.lang.String-com.aspose.font.StreamSource-long-}
+```
+public FontFileDefinition(String fileExtension, StreamSource streamSource, long offset)
+```
+
+
+Skapar en fildefinition som endast använder filinnehåll.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fileExtension | java.lang.String | Teckensnittfilens filändelse. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Teckensnittets strömkälla. |
+| förskjutning | long | Förskjutning till teckensnittsdata i strömkällan. |
+
+### FontFileDefinition(File fontFile) {#FontFileDefinition-java.io.File-}
+```
+public FontFileDefinition(File fontFile)
+```
+
+
+Skapar en fildefinition med teckensnittfil (representerad av File) och filinnehåll.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontFile | java.io.File | Filobjekt. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileExtension() {#getFileExtension--}
+```
+public String getFileExtension()
+```
+
+
+Hämtar filändelse.
+
+**Returns:**
+java.lang.String - Filändelse.
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Hämtar filnamn.
+
+**Returns:**
+java.lang.String - Filnamn.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning i strömmen.
+
+**Returns:**
+long - Förskjutning i strömmen.
+### getStreamSource() {#getStreamSource--}
+```
+public StreamSource getStreamSource()
+```
+
+
+Hämtar strömkällan.
+
+**Returns:**
+[StreamSource](../../com.aspose.font/streamsource) - The stream source.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fontmergeexception/_index.md
+++ b/swedish/java/com.aspose.font/fontmergeexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontMergeException"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Font-sammanfogningsundantag."
+type: docs
+weight: 43
+url: /sv/java/com.aspose.font/fontmergeexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontMergeException extends FontException
+```
+
+Representerar ett Font‑merge‑undantag. Undantaget kan kastas vid fel under sammanslagning av teckensnitt.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FontMergeException()](#FontMergeException--) | Initierar ett nytt  FontMergeException  object. |
+| [FontMergeException(String message)](#FontMergeException-java.lang.String-) | Initierar ett nytt  FontMergeException  object. |
+| [FontMergeException(String message, RuntimeException innerException)](#FontMergeException-java.lang.String-java.lang.RuntimeException-) | Initierar ett nytt  FontMergeException  object. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontMergeException() {#FontMergeException--}
+```
+public FontMergeException()
+```
+
+
+Initierar ett nytt  FontMergeException  object.
+
+### FontMergeException(String message) {#FontMergeException-java.lang.String-}
+```
+public FontMergeException(String message)
+```
+
+
+Initierar ett nytt  FontMergeException  object.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+
+### FontMergeException(String message, RuntimeException innerException) {#FontMergeException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontMergeException(String message, RuntimeException innerException)
+```
+
+
+Initierar ett nytt  FontMergeException  object.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+| innerException | java.lang.RuntimeException | Undantaget som är orsaken till det aktuella undantaget. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fontmetrics/_index.md
+++ b/swedish/java/com.aspose.font/fontmetrics/_index.md
@@ -1,0 +1,470 @@
+---
+title: "FontMetrics"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar teckensnittsmått."
+type: docs
+weight: 44
+url: /sv/java/com.aspose.font/fontmetrics/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFontMetrics](../../com.aspose.font/ifontmetrics)
+```
+public abstract class FontMetrics implements IFontMetrics
+```
+
+Representerar teckensnittsmått.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAscender()](#getAscender--) | Hämtar Ascender‑värdet. |
+| [getAscender(double fontSize)](#getAscender-double-) | Returnerar ascender för en specifik teckenstorlek. |
+| [getClass()](#getClass--) |  |
+| [getDescender()](#getDescender--) | Hämtar Descender‑värdet. |
+| [getDescender(double fontSize)](#getDescender-double-) | Returnerar descender för en specifik teckenstorlek. |
+| [getFontBBox()](#getFontBBox--) | Hämtar FontBBox‑värdet. |
+| [getFontMatrix()](#getFontMatrix--) | Hämtar FontMatrix‑värdet. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Returnerar glyf Bbox. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Returnerar glyfbredd. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Returnerar kerningvärde för glyfparet. |
+| [getLineGap()](#getLineGap--) | Hämtar LineGap-värde. |
+| [getTypoAscender()](#getTypoAscender--) | Hämtar TypoAscender-värde. |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Returnerar typografisk ascender för specifik Font-storlek. |
+| [getTypoDescender()](#getTypoDescender--) | Hämtar TypoDescender-värde. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Returnerar typografisk descender för specifik fontstorlek. |
+| [getTypoLineGap()](#getTypoLineGap--) | Hämtar TypoLineGap-värde. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Returnerar radgap för specifik Font-storlek. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Hämtar UnitsPerEM-värde. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Hämtar IsFixedPitch-värde. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Mäter sträng och returnerar strängbredd. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAscender(double value)](#setAscender-double-) | Ställer in Ascender-värde. |
+| [setDescender(double value)](#setDescender-double-) | Ställer in Descender-värde. |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) | Ställer in glyfbredd. |
+| [setTypoAscender(double value)](#setTypoAscender-double-) | Ställer in TypoAscender-värde. |
+| [setTypoDescender(double value)](#setTypoDescender-double-) | Ställer in TypoDescender-värde. |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) | Ställer in UnitsPerEM-värde. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAscender() {#getAscender--}
+```
+public double getAscender()
+```
+
+
+Hämtar Ascender‑värdet.
+
+**Returns:**
+double - Ascender-värde.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public double getAscender(double fontSize)
+```
+
+
+Returnerar ascender för en specifik teckenstorlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Ascender-värde.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescender() {#getDescender--}
+```
+public double getDescender()
+```
+
+
+Hämtar Descender‑värdet.
+
+**Returns:**
+double - Descender-värde.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public double getDescender(double fontSize)
+```
+
+
+Returnerar descender för en specifik teckenstorlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Descender-värde.
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+Hämtar FontBBox‑värdet.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - FontBBox value.
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+Hämtar FontMatrix‑värdet.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - FontMatrix value.
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Returnerar glyf Bbox. Returnerar FontBBox om BBox inte var definierad för glyfen. Kan åsidosättas av specifika teckenkodningsarvtagare.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyfidentifierare. |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox.
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Returnerar glyphbredd. Kan åsidosättas av specifika teckenkodningsarvingar.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyfidentifierare. |
+
+**Returns:**
+double - Glyph-bredd.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Returnerar kerningvärde för glyfparet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Första glyph i paret. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Fontstorlek. |
+
+**Returns:**
+double - Kerningvärde.
+### getLineGap() {#getLineGap--}
+```
+public double getLineGap()
+```
+
+
+Hämtar LineGap-värde.
+
+**Returns:**
+double - LineGap-värde.
+### getTypoAscender() {#getTypoAscender--}
+```
+public double getTypoAscender()
+```
+
+
+Hämtar TypoAscender-värde.
+
+**Returns:**
+double - TypoAscender-värde.
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public double getTypoAscender(double fontSize)
+```
+
+
+Returnerar typografisk ascender för specifik Font-storlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Typographic ascender-värde.
+### getTypoDescender() {#getTypoDescender--}
+```
+public double getTypoDescender()
+```
+
+
+Hämtar TypoDescender-värde.
+
+**Returns:**
+double - TypoDescender-värde.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public double getTypoDescender(double fontSize)
+```
+
+
+Returnerar typografisk descender för specifik fontstorlek.
+
+param fontSize teckenstorlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double |  |
+
+**Returns:**
+double - Typographic descender-värde.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public double getTypoLineGap()
+```
+
+
+Hämtar TypoLineGap-värde.
+
+**Returns:**
+double - TypoLineGap-värde.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public double getTypoLineGap(double fontSize)
+```
+
+
+Returnerar radgap för specifik Font-storlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Line gap-värde.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Hämtar UnitsPerEM-värde.
+
+**Returns:**
+long - UnitsPerEM-värde.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+Hämtar IsFixedPitch-värde.
+
+**Returns:**
+boolean - IsFixedPitch-värde.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public abstract double measureString(String unicode, double fontSize)
+```
+
+
+Mäter sträng och returnerar strängbredd.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| unicode | java.lang.String | Unicode-sträng. |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Strängbredd.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAscender(double value) {#setAscender-double-}
+```
+public void setAscender(double value)
+```
+
+
+Ställer in Ascender-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | Ascender-värde. |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public void setDescender(double value)
+```
+
+
+Ställer in Descender-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | Descender-värde. |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public abstract void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Ställer in glyfbredd.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyfidentifierare. |
+| värde | double | Ny bredd. |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public void setTypoAscender(double value)
+```
+
+
+Ställer in TypoAscender-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | TypoAscender-värde. |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public void setTypoDescender(double value)
+```
+
+
+Ställer in TypoDescender-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | TypoDescender-värde. |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public void setUnitsPerEM(long value)
+```
+
+
+Ställer in UnitsPerEM-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long | UnitsPerEM-värde. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fontnotsupportedoperationexception/_index.md
+++ b/swedish/java/com.aspose.font/fontnotsupportedoperationexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "FontNotSupportedOperationException"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar undantag för ej stödjande operation."
+type: docs
+weight: 45
+url: /sv/java/com.aspose.font/fontnotsupportedoperationexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class FontNotSupportedOperationException extends FontException
+```
+
+Representerar ett undantag för en operation som inte stöds. Undantaget kan kastas om en viss operation inte stöds för en viss typsnittstyp.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FontNotSupportedOperationException()](#FontNotSupportedOperationException--) | Initierar ett nytt FontNotSupportedOperationException-objekt. |
+| [FontNotSupportedOperationException(String message)](#FontNotSupportedOperationException-java.lang.String-) | Initierar ett nytt FontNotSupportedOperationException-objekt. |
+| [FontNotSupportedOperationException(String message, RuntimeException innerException)](#FontNotSupportedOperationException-java.lang.String-java.lang.RuntimeException-) | Initierar ett nytt FontNotSupportedOperationException-objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontNotSupportedOperationException() {#FontNotSupportedOperationException--}
+```
+public FontNotSupportedOperationException()
+```
+
+
+Initierar ett nytt FontNotSupportedOperationException-objekt.
+
+### FontNotSupportedOperationException(String message) {#FontNotSupportedOperationException-java.lang.String-}
+```
+public FontNotSupportedOperationException(String message)
+```
+
+
+Initierar ett nytt FontNotSupportedOperationException-objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+
+### FontNotSupportedOperationException(String message, RuntimeException innerException) {#FontNotSupportedOperationException-java.lang.String-java.lang.RuntimeException-}
+```
+public FontNotSupportedOperationException(String message, RuntimeException innerException)
+```
+
+
+Initierar ett nytt FontNotSupportedOperationException-objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+| innerException | java.lang.RuntimeException | Undantaget som är orsaken till det aktuella undantaget. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fontsavingformats/_index.md
+++ b/swedish/java/com.aspose.font/fontsavingformats/_index.md
@@ -1,0 +1,277 @@
+---
+title: "FontSavingFormats"
+second_title: "Aspose.Font för Java API-referens"
+description: "Specificerar teckensnittstyp."
+type: docs
+weight: 135
+url: /sv/java/com.aspose.font/fontsavingformats/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum FontSavingFormats extends Enum<FontSavingFormats>
+```
+
+Specificerar teckensnittstyp.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [OTF](#OTF) | OpenType‑teckensnitt. |
+| [SVG](#SVG) | SVG(Scalable Vector Graphics) teckensnittformat |
+| [TTF](#TTF) | TTF (TrueType) teckensnittformat. |
+| [WOFF](#WOFF) | WOFF(Web Open Font Format). |
+| [WOFF2](#WOFF2) | WOFF filformat 2.0 |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OTF {#OTF}
+```
+public static final FontSavingFormats OTF
+```
+
+
+OpenType‑teckensnitt. OpenType‑teckensnittformatet är en utökning av TrueType‑teckensnittformatet och lägger till stöd för PostScript‑teckensnittsdata.
+
+### SVG {#SVG}
+```
+public static final FontSavingFormats SVG
+```
+
+
+SVG(Scalable Vector Graphics) teckensnittformat
+
+### TTF {#TTF}
+```
+public static final FontSavingFormats TTF
+```
+
+
+TTF (TrueType) teckensnittformat.
+
+### WOFF {#WOFF}
+```
+public static final FontSavingFormats WOFF
+```
+
+
+WOFF(Web Open Font Format).
+
+### WOFF2 {#WOFF2}
+```
+public static final FontSavingFormats WOFF2
+```
+
+
+WOFF filformat 2.0
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static FontSavingFormats valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[FontSavingFormats](../../com.aspose.font/fontsavingformats)
+### values() {#values--}
+```
+public static FontSavingFormats[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.FontSavingFormats[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fontspecificencodings/_index.md
+++ b/swedish/java/com.aspose.font/fontspecificencodings/_index.md
@@ -1,0 +1,139 @@
+---
+title: "FontSpecificEncodings"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar specifika kodningar för konsumentmedvetna teckensnitt."
+type: docs
+weight: 46
+url: /sv/java/com.aspose.font/fontspecificencodings/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontSpecificEncodings
+```
+
+Representerar specifika kodningar för konsumentmedvetna teckensnitt.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [registerEncoding(String fontName, String[] encoding)](#registerEncoding-java.lang.String-java.lang.String---) | Registrera kodning för konsumentmedvetna teckensnitt. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### registerEncoding(String fontName, String[] encoding) {#registerEncoding-java.lang.String-java.lang.String---}
+```
+public void registerEncoding(String fontName, String[] encoding)
+```
+
+
+Registrera kodning för konsumentmedvetna teckensnitt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontName | java.lang.String | Teckensnittsnamn. |
+| kodning | java.lang.String[] | Kodning. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fontstyle/_index.md
+++ b/swedish/java/com.aspose.font/fontstyle/_index.md
@@ -1,0 +1,155 @@
+---
+title: "FontStyle"
+second_title: "Aspose.Font för Java API-referens"
+description: "Teckensnittsstilsuppräkning"
+type: docs
+weight: 47
+url: /sv/java/com.aspose.font/fontstyle/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class FontStyle
+```
+
+Teckensnittsstilsuppräkning
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [Bold](#Bold) | Anger den feta Font-stilen. |
+| [Italic](#Italic) | Anger den kursiva Font-stilen. |
+| [Regular](#Regular) | Anger den vanliga Font-stilen. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Bold {#Bold}
+```
+public static final int Bold
+```
+
+
+Anger den feta Font-stilen.
+
+### Italic {#Italic}
+```
+public static final int Italic
+```
+
+
+Anger den kursiva Font-stilen.
+
+### Regular {#Regular}
+```
+public static final int Regular
+```
+
+
+Anger den vanliga Font-stilen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/fonttype/_index.md
+++ b/swedish/java/com.aspose.font/fonttype/_index.md
@@ -1,0 +1,268 @@
+---
+title: "FontType"
+second_title: "Aspose.Font för Java API-referens"
+description: "Specificerar teckensnittstyp."
+type: docs
+weight: 136
+url: /sv/java/com.aspose.font/fonttype/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum FontType extends Enum<FontType>
+```
+
+Specificerar teckensnittstyp.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CFF](#CFF) | CFF (Compact font format) teckensnittstyp. |
+| [OTF](#OTF) | OpenType‑teckensnitt. |
+| [TTF](#TTF) | TTF (TrueType) teckensnittstyp och relaterat. |
+| [Type1](#Type1) | Type1‑teckensnittstyp. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CFF {#CFF}
+```
+public static final FontType CFF
+```
+
+
+CFF (Compact font format) teckensnittstyp.
+
+### OTF {#OTF}
+```
+public static final FontType OTF
+```
+
+
+OpenType‑teckensnitt. OpenType‑teckensnittformatet är en utökning av TrueType‑teckensnittformatet och lägger till stöd för PostScript‑teckensnittsdata.
+
+### TTF {#TTF}
+```
+public static final FontType TTF
+```
+
+
+TTF (TrueType) teckensnittstyp och relaterat.
+
+### Type1 {#Type1}
+```
+public static final FontType Type1
+```
+
+
+Type1‑teckensnittstyp.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static FontType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype)
+### values() {#values--}
+```
+public static FontType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.FontType[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/gasprange/_index.md
+++ b/swedish/java/com.aspose.font/gasprange/_index.md
@@ -1,0 +1,163 @@
+---
+title: "GaspRange"
+second_title: "Aspose.Font för Java API-referens"
+description: "Arrayen av GaspRange-poster tillhandahåller rekommenderade beteenden för olika ppem-storlekar"
+type: docs
+weight: 48
+url: /sv/java/com.aspose.font/gasprange/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class GaspRange
+```
+
+Arrayen av GaspRange-poster tillhandahåller rekommenderade beteenden för olika ppem-storlekar
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [GaspRange(int rangeMaxPPEM, AsFoEnumSet<RangeGaspBehaviorFlags> rangeGaspBehaviorFlags)](#GaspRange-int-com.aspose.font.util.AsFoEnumSet-com.aspose.font.RangeGaspBehaviorFlags--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getRangeGaspBehaviorFlags()](#getRangeGaspBehaviorFlags--) | Hämtar flaggorna som beskriver önskat rasteriseringsbeteende. |
+| [getRangeMaxPPEM()](#getRangeMaxPPEM--) | Hämtar det övre gränsvärdet för intervallet, i PPEM. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GaspRange(int rangeMaxPPEM, AsFoEnumSet<RangeGaspBehaviorFlags> rangeGaspBehaviorFlags) {#GaspRange-int-com.aspose.font.util.AsFoEnumSet-com.aspose.font.RangeGaspBehaviorFlags--}
+```
+public GaspRange(int rangeMaxPPEM, AsFoEnumSet<RangeGaspBehaviorFlags> rangeGaspBehaviorFlags)
+```
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| rangeMaxPPEM | int |  |
+| rangeGaspBehaviorFlags | com.aspose.font.util.AsFoEnumSet<com.aspose.font.RangeGaspBehaviorFlags> |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getRangeGaspBehaviorFlags() {#getRangeGaspBehaviorFlags--}
+```
+public AsFoEnumSet<RangeGaspBehaviorFlags> getRangeGaspBehaviorFlags()
+```
+
+
+Hämtar flaggorna som beskriver önskat rasteriseringsbeteende.
+
+**Returns:**
+[AsFoEnumSet](../../com.aspose.font.util/asfoenumset) - The flags describing desired rasterizer behavior.
+### getRangeMaxPPEM() {#getRangeMaxPPEM--}
+```
+public int getRangeMaxPPEM()
+```
+
+
+Hämtar det övre gränsvärdet för intervallet, i PPEM.
+
+**Returns:**
+int - Det övre gränsvärdet för intervallet, i PPEM.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/glyph/_index.md
+++ b/swedish/java/com.aspose.font/glyph/_index.md
@@ -1,0 +1,237 @@
+---
+title: "Glyph"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar ett teckensnittsglyf."
+type: docs
+weight: 49
+url: /sv/java/com.aspose.font/glyph/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Cloneable
+```
+public class Glyph implements Cloneable
+```
+
+Representerar ett teckensnittsglyf.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clone()](#clone--) | Returnerar en kopia av glyph. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGlyphBBox()](#getGlyphBBox--) | Hämtar glyph BBox. |
+| [getLeftSidebearingX()](#getLeftSidebearingX--) | Hämtar tecknets sidobäring x-koordinat. |
+| [getLeftSidebearingY()](#getLeftSidebearingY--) | Hämtar tecknets sidobäring y-koordinat. |
+| [getPath()](#getPath--) | Hämtar tecknets bana. |
+| [getSourceResolution()](#getSourceResolution--) | Hämtar upplösning för källkommandosatsen. |
+| [getState()](#getState--) | Hämtar tecknets tillstånd. |
+| [getWidthVectorX()](#getWidthVectorX--) | Hämtar tecknets breddvektor. |
+| [getWidthVectorY()](#getWidthVectorY--) | Hämtar tecknets breddvektor. |
+| [hashCode()](#hashCode--) |  |
+| [isEmpty()](#isEmpty--) | Sant om tecknet inte innehåller ritinstruktioner. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Returnerar en kopia av glyph.
+
+**Returns:**
+java.lang.Object - Kopia av tecken.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphBBox() {#getGlyphBBox--}
+```
+public FontBBox getGlyphBBox()
+```
+
+
+Hämtar glyph BBox.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox
+### getLeftSidebearingX() {#getLeftSidebearingX--}
+```
+public double getLeftSidebearingX()
+```
+
+
+Hämtar tecknets sidobäring x-koordinat.
+
+**Returns:**
+double - Tecknets sidobäring x-koordinat.
+### getLeftSidebearingY() {#getLeftSidebearingY--}
+```
+public double getLeftSidebearingY()
+```
+
+
+Hämtar tecknets sidobäring y-koordinat.
+
+**Returns:**
+double - Tecknets sidobäring y-koordinat.
+### getPath() {#getPath--}
+```
+public SegmentPath getPath()
+```
+
+
+Hämtar tecknets bana.
+
+**Returns:**
+[SegmentPath](../../com.aspose.font/segmentpath) - Glyph path.
+### getSourceResolution() {#getSourceResolution--}
+```
+public int getSourceResolution()
+```
+
+
+Hämtar upplösning för källkommandosatsen.
+
+**Returns:**
+int - Upplösning för källkommandosatsen.
+### getState() {#getState--}
+```
+public GlyphState getState()
+```
+
+
+Hämtar tecknets tillstånd.
+
+**Returns:**
+[GlyphState](../../com.aspose.font/glyphstate) - Glyph state.
+### getWidthVectorX() {#getWidthVectorX--}
+```
+public double getWidthVectorX()
+```
+
+
+Hämtar tecknets breddvektor. Koordinat x.
+
+**Returns:**
+double - Tecknets breddvektor. Koordinat x.
+### getWidthVectorY() {#getWidthVectorY--}
+```
+public double getWidthVectorY()
+```
+
+
+Hämtar tecknets breddvektor. Koordinat y.
+
+**Returns:**
+double - Tecknets breddvektor. Koordinat y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+Sant om tecknet inte innehåller ritinstruktioner.
+
+**Returns:**
+boolean - Sant om tecknet inte innehåller ritinstruktioner.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/glyphid/_index.md
+++ b/swedish/java/com.aspose.font/glyphid/_index.md
@@ -1,0 +1,180 @@
+---
+title: "GlyphId"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar glyph‑id:n som finns i teckensnittet."
+type: docs
+weight: 50
+url: /sv/java/com.aspose.font/glyphid/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class GlyphId
+```
+
+Representerar glyph‑id:n som finns i teckensnittet. Ett glyph‑id är ett unikt nummer för ett glyph, vilket beror på teckensnittstypen. Till exempel: Type1:s id är ett glyph‑namn, en instans av klassen ( GlyphStringId ) class. TTF:s id är ett heltalsindex, en instans av klassen ( GlyphUInt32Id ) class.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Returnerar sant om två glyph-id:n inte är lika. |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) | Returnerar hashkod för objektet. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(GlyphId obj1, Object obj2)](#op-Equality-com.aspose.font.GlyphId-java.lang.Object-) | Returnerar sant om två glyph-id:n är lika. |
+| [op_Inequality(GlyphId obj1, Object obj2)](#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-) | Returnerar sant om två glyph-id:n inte är lika. |
+| [toGlyphStringId()](#toGlyphStringId--) | Virtuell kastning till GlyphStringId. |
+| [toGlyphUInt32Id()](#toGlyphUInt32Id--) | Virtuell kastning till GlyphUInt32Id. |
+| [toString()](#toString--) | Returnerar strängrepresentation av glyph‑id‑t. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Returnerar sant om två glyph-id:n inte är lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj | java.lang.Object | Glyph‑identifierare att jämföra med. |
+
+**Returns:**
+boolean - Jämförelseresultat.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public abstract int hashCode()
+```
+
+
+Returnerar hashkod för objektet.
+
+**Returns:**
+int - Hashkod för objektet.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(GlyphId obj1, Object obj2) {#op-Equality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Equality(GlyphId obj1, Object obj2)
+```
+
+
+Returnerar sant om två glyph-id:n är lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Första glyph-identifierare att jämföra. |
+| obj2 | java.lang.Object | Andra glyph-identifierare att jämföra. |
+
+**Returns:**
+boolean - Jämförelseresultat.
+### op_Inequality(GlyphId obj1, Object obj2) {#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Inequality(GlyphId obj1, Object obj2)
+```
+
+
+Returnerar sant om två glyph-id:n inte är lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Första glyph-identifierare att jämföra. |
+| obj2 | java.lang.Object | Andra glyph-identifierare att jämföra. |
+
+**Returns:**
+boolean - Jämförelseresultat.
+### toGlyphStringId() {#toGlyphStringId--}
+```
+public GlyphStringId toGlyphStringId()
+```
+
+
+Virtuell cast till GlyphStringId. GlyphStringId återdefinierar för att returnera en instans.
+
+**Returns:**
+[GlyphStringId](../../com.aspose.font/glyphstringid) - null
+### toGlyphUInt32Id() {#toGlyphUInt32Id--}
+```
+public GlyphUInt32Id toGlyphUInt32Id()
+```
+
+
+Virtuell kastning till GlyphUInt32Id. GlyphUInt32Id åsidosätter för att returnera en instans.
+
+**Returns:**
+[GlyphUInt32Id](../../com.aspose.font/glyphuint32id) - null
+### toString() {#toString--}
+```
+public abstract String toString()
+```
+
+
+Returnerar strängrepresentation av glyph‑id‑t.
+
+**Returns:**
+java.lang.String – glyfidentifierare
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/glyphidlist/_index.md
+++ b/swedish/java/com.aspose.font/glyphidlist/_index.md
@@ -1,0 +1,613 @@
+---
+title: "GlyphIdList"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar lista över glyfid."
+type: docs
+weight: 51
+url: /sv/java/com.aspose.font/glyphidlist/
+---
+**Inheritance:**
+java.lang.Object, java.util.AbstractCollection, java.util.AbstractList, java.util.ArrayList
+```
+public class GlyphIdList extends ArrayList<GlyphId>
+```
+
+Representerar lista över glyfid.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>toArray(T[] arg0)](#-T-toArray-T---) |  |
+| [add(E arg0)](#add-E-) |  |
+| [add(GlyphId glyphId)](#add-com.aspose.font.GlyphId-) | Lägger till glyph‑id i listan. |
+| [add(int arg0, E arg1)](#add-int-E-) |  |
+| [addAll(int arg0, Collection<? extends E> arg1)](#addAll-int-java.util.Collection---extends-E--) |  |
+| [addAll(Collection<? extends E> arg0)](#addAll-java.util.Collection---extends-E--) |  |
+| [clear()](#clear--) | Rensar listan. |
+| [clone()](#clone--) |  |
+| [contains(GlyphId glyphId)](#contains-com.aspose.font.GlyphId-) | Returnerar true om glyph‑id finns i listan. |
+| [contains(Object arg0)](#contains-java.lang.Object-) |  |
+| [containsAll(Collection<?> arg0)](#containsAll-java.util.Collection----) |  |
+| [ensureCapacity(int arg0)](#ensureCapacity-int-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [forEach(Consumer<? super E> arg0)](#forEach-java.util.function.Consumer---super-E--) |  |
+| [get(int index)](#get-int-) | Returnerar glyph‑id enligt indexet. |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object arg0)](#indexOf-java.lang.Object-) |  |
+| [isEmpty()](#isEmpty--) |  |
+| [iterator()](#iterator--) |  |
+| [lastIndexOf(Object arg0)](#lastIndexOf-java.lang.Object-) |  |
+| [listIterator()](#listIterator--) |  |
+| [listIterator(int arg0)](#listIterator-int-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(GlyphId glyphId)](#remove-com.aspose.font.GlyphId-) | Tar bort glyph‑id från listan. |
+| [remove(int arg0)](#remove-int-) |  |
+| [remove(Object arg0)](#remove-java.lang.Object-) |  |
+| [removeAll(Collection<?> arg0)](#removeAll-java.util.Collection----) |  |
+| [removeIf(Predicate<? super E> arg0)](#removeIf-java.util.function.Predicate---super-E--) |  |
+| [replaceAll(UnaryOperator<E> arg0)](#replaceAll-java.util.function.UnaryOperator-E--) |  |
+| [retainAll(Collection<?> arg0)](#retainAll-java.util.Collection----) |  |
+| [set(int arg0, E arg1)](#set-int-E-) |  |
+| [size()](#size--) |  |
+| [sort(Comparator<? super E> arg0)](#sort-java.util.Comparator---super-E--) |  |
+| [spliterator()](#spliterator--) |  |
+| [subList(int arg0, int arg1)](#subList-int-int-) |  |
+| [toArray()](#toArray--) |  |
+| [toString()](#toString--) |  |
+| [trimToSize()](#trimToSize--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>toArray(T[] arg0) {#-T-toArray-T---}
+```
+public T[] <T>toArray(T[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | T[] |  |
+
+**Returns:**
+T[]
+### add(E arg0) {#add-E-}
+```
+public boolean add(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+boolean
+### add(GlyphId glyphId) {#add-com.aspose.font.GlyphId-}
+```
+public boolean add(GlyphId glyphId)
+```
+
+
+Lägger till glyph‑id i listan.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | glyph identifierare |
+
+**Returns:**
+boolean
+### add(int arg0, E arg1) {#add-int-E-}
+```
+public void add(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+### addAll(int arg0, Collection<? extends E> arg1) {#addAll-int-java.util.Collection---extends-E--}
+```
+public boolean addAll(int arg0, Collection<? extends E> arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### addAll(Collection<? extends E> arg0) {#addAll-java.util.Collection---extends-E--}
+```
+public boolean addAll(Collection<? extends E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rensar listan.
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### contains(GlyphId glyphId) {#contains-com.aspose.font.GlyphId-}
+```
+public boolean contains(GlyphId glyphId)
+```
+
+
+Returnerar true om glyph‑id finns i listan.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | glyph identifierare |
+
+**Returns:**
+boolean - true om glyph‑id finns i listan, annars false
+### contains(Object arg0) {#contains-java.lang.Object-}
+```
+public boolean contains(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### containsAll(Collection<?> arg0) {#containsAll-java.util.Collection----}
+```
+public boolean containsAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### ensureCapacity(int arg0) {#ensureCapacity-int-}
+```
+public void ensureCapacity(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### forEach(Consumer<? super E> arg0) {#forEach-java.util.function.Consumer---super-E--}
+```
+public void forEach(Consumer<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.function.Consumer<? super E> |  |
+
+### get(int index) {#get-int-}
+```
+public GlyphId get(int index)
+```
+
+
+Returnerar glyph‑id enligt indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för glyph i listan |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object arg0) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public Iterator<E> iterator()
+```
+
+
+
+
+**Returns:**
+java.util.Iterator<E>
+### lastIndexOf(Object arg0) {#lastIndexOf-java.lang.Object-}
+```
+public int lastIndexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### listIterator() {#listIterator--}
+```
+public ListIterator<E> listIterator()
+```
+
+
+
+
+**Returns:**
+java.util.ListIterator<E>
+### listIterator(int arg0) {#listIterator-int-}
+```
+public ListIterator<E> listIterator(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+java.util.ListIterator<E>
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(GlyphId glyphId) {#remove-com.aspose.font.GlyphId-}
+```
+public boolean remove(GlyphId glyphId)
+```
+
+
+Tar bort glyph‑id från listan.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | glyph identifierare |
+
+**Returns:**
+boolean - true om objektet har tagits bort framgångsrikt; annars false
+### remove(int arg0) {#remove-int-}
+```
+public E remove(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### remove(Object arg0) {#remove-java.lang.Object-}
+```
+public boolean remove(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### removeAll(Collection<?> arg0) {#removeAll-java.util.Collection----}
+```
+public boolean removeAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### removeIf(Predicate<? super E> arg0) {#removeIf-java.util.function.Predicate---super-E--}
+```
+public boolean removeIf(Predicate<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.function.Predicate<? super E> |  |
+
+**Returns:**
+boolean
+### replaceAll(UnaryOperator<E> arg0) {#replaceAll-java.util.function.UnaryOperator-E--}
+```
+public void replaceAll(UnaryOperator<E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.function.UnaryOperator<E> |  |
+
+### retainAll(Collection<?> arg0) {#retainAll-java.util.Collection----}
+```
+public boolean retainAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### set(int arg0, E arg1) {#set-int-E-}
+```
+public E set(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+**Returns:**
+E
+### size() {#size--}
+```
+public int size()
+```
+
+
+
+
+**Returns:**
+int
+### sort(Comparator<? super E> arg0) {#sort-java.util.Comparator---super-E--}
+```
+public void sort(Comparator<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.Comparator<? super E> |  |
+
+### spliterator() {#spliterator--}
+```
+public Spliterator<E> spliterator()
+```
+
+
+
+
+**Returns:**
+java.util.Spliterator<E>
+### subList(int arg0, int arg1) {#subList-int-int-}
+```
+public List<E> subList(int arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | int |  |
+
+**Returns:**
+java.util.List<E>
+### toArray() {#toArray--}
+```
+public Object[] toArray()
+```
+
+
+
+
+**Returns:**
+java.lang.Object[]
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### trimToSize() {#trimToSize--}
+```
+public void trimToSize()
+```
+
+
+
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/glyphidtype/_index.md
+++ b/swedish/java/com.aspose.font/glyphidtype/_index.md
@@ -1,0 +1,250 @@
+---
+title: "GlyphIdType"
+second_title: "Aspose.Font för Java API-referens"
+description: "Specificerar typer av glyfid."
+type: docs
+weight: 137
+url: /sv/java/com.aspose.font/glyphidtype/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum GlyphIdType extends Enum<GlyphIdType>
+```
+
+Specificerar typer av glyfid.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ASCIIStringName](#ASCIIStringName) | ASCII-sträng för glyfnamn. |
+| [Int32Index](#Int32Index) | Heltalsindex för glyf. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ASCIIStringName {#ASCIIStringName}
+```
+public static final GlyphIdType ASCIIStringName
+```
+
+
+ASCII-sträng för glyfnamn.
+
+### Int32Index {#Int32Index}
+```
+public static final GlyphIdType Int32Index
+```
+
+
+Heltalsindex för glyf.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static GlyphIdType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype)
+### values() {#values--}
+```
+public static GlyphIdType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.GlyphIdType[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/glyphoutlinerenderer/_index.md
+++ b/swedish/java/com.aspose.font/glyphoutlinerenderer/_index.md
@@ -1,0 +1,238 @@
+---
+title: "GlyphOutlineRenderer"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar renderare för glyfkontur."
+type: docs
+weight: 52
+url: /sv/java/com.aspose.font/glyphoutlinerenderer/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.GlyphRendererBase](../../com.aspose.font/glyphrendererbase)
+```
+public class GlyphOutlineRenderer extends GlyphRendererBase
+```
+
+Representerar renderare för glyfkontur.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [GlyphOutlineRenderer(IGlyphOutlinePainter painter)](#GlyphOutlineRenderer-com.aspose.font.IGlyphOutlinePainter-) | Initierar ett nytt  GlyphOutlineRenderer  objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [renderGlyph(IFont font, GlyphId glyphId)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-) | Renderar glyf. |
+| [renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renderar glyf, ett mål med den här överlagrade versionen - att användas med cache för glyfer. |
+| [renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-) | Renderar glyf. |
+| [renderGlyph(IFont font, long glyphIndex)](#renderGlyph-com.aspose.font.IFont-long-) | Renderar glyf |
+| [renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-) | Renderar glyf. |
+| [renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renderar glyf med en oberoende glyfväg. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlyphOutlineRenderer(IGlyphOutlinePainter painter) {#GlyphOutlineRenderer-com.aspose.font.IGlyphOutlinePainter-}
+```
+public GlyphOutlineRenderer(IGlyphOutlinePainter painter)
+```
+
+
+Initierar ett nytt  GlyphOutlineRenderer  objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| painter | [IGlyphOutlinePainter](../../com.aspose.font/iglyphoutlinepainter) | Glyph-målare. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### renderGlyph(IFont font, GlyphId glyphId) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId)
+```
+
+
+Renderar glyf.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Typsnittet som innehåller glyfen. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Fysiskt glyfindex i typsnittet. Observera att detta inte är en Unicode. |
+
+### renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderar glyf, ett mål med den här överlagrade versionen - att användas med cache för glyfer.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Typsnittet som innehåller glyfen. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Fysiskt glyfindex i typsnittet. Observera att detta inte är en Unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glyf att rendera. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matris som tillämpas på glyfkoordinater. |
+
+### renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderar glyf.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Typsnittet som innehåller glyfen. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Fysiskt glyfindex i typsnittet. Observera att detta inte är en Unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matris som tillämpas på glyfkoordinater. |
+
+### renderGlyph(IFont font, long glyphIndex) {#renderGlyph-com.aspose.font.IFont-long-}
+```
+public void renderGlyph(IFont font, long glyphIndex)
+```
+
+
+Renderar glyf
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Typsnittet som innehåller glyfen. |
+| glyphIndex | long | Fysiskt glyfindex i typsnittet. Observera att detta inte är en Unicode. |
+
+### renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderar glyf.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Typsnittet som innehåller glyfen. |
+| glyphIndex | long | Fysiskt glyfindex i typsnittet. Observera att detta inte är en Unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matris som tillämpas på glyfkoordinater. |
+
+### renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public void renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Ritar tecknet med en oberoende teckenväg. RenderGlyph()-funktionfamiljen ändrar teckenvägen vid rendering. Detta leder till att tecknet måste laddas om igen. Funktionen använder en kopia av teckenvägen och ändrar inte den ursprungliga teckenvägen, så samma tecken kan återanvändas flera gånger. Denna version av funktionen är avsedd för användning med en cache av tecken.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Typsnittet som innehåller glyfen. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Fysiskt glyfindex i typsnittet. Observera att detta inte är en Unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glyf att rendera. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matris som tillämpas på glyfkoordinater. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/glyphrendererbase/_index.md
+++ b/swedish/java/com.aspose.font/glyphrendererbase/_index.md
@@ -1,0 +1,223 @@
+---
+title: "GlyphRendererBase"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar basklass för glyfrenderare."
+type: docs
+weight: 53
+url: /sv/java/com.aspose.font/glyphrendererbase/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IGlyphRenderer](../../com.aspose.font/iglyphrenderer)
+```
+public abstract class GlyphRendererBase implements IGlyphRenderer
+```
+
+Representerar basklass för glyfrenderare.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [renderGlyph(IFont font, GlyphId glyphId)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-) | Renderar glyf. |
+| [renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renderar glyf, ett mål med den här överlagrade versionen - att användas med cache för glyfer. |
+| [renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-) | Renderar glyf. |
+| [renderGlyph(IFont font, long glyphIndex)](#renderGlyph-com.aspose.font.IFont-long-) | Renderar glyf |
+| [renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-) | Renderar glyf. |
+| [renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renderar glyf med en oberoende glyfväg. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### renderGlyph(IFont font, GlyphId glyphId) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId)
+```
+
+
+Renderar glyf.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Typsnittet som innehåller glyfen. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Fysiskt glyfindex i typsnittet. Observera att detta inte är en Unicode. |
+
+### renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderar glyf, ett mål med den här överlagrade versionen - att användas med cache för glyfer.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Typsnittet som innehåller glyfen. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Fysiskt glyfindex i typsnittet. Observera att detta inte är en Unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glyf att rendera. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matris som tillämpas på glyfkoordinater. |
+
+### renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderar glyf.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Typsnittet som innehåller glyfen. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Fysiskt glyfindex i typsnittet. Observera att detta inte är en Unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matris som tillämpas på glyfkoordinater. |
+
+### renderGlyph(IFont font, long glyphIndex) {#renderGlyph-com.aspose.font.IFont-long-}
+```
+public void renderGlyph(IFont font, long glyphIndex)
+```
+
+
+Renderar glyf
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Typsnittet som innehåller glyfen. |
+| glyphIndex | long | Fysiskt glyfindex i typsnittet. Observera att detta inte är en Unicode. |
+
+### renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-}
+```
+public void renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renderar glyf.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Typsnittet som innehåller glyfen. |
+| glyphIndex | long | Fysiskt glyfindex i typsnittet. Observera att detta inte är en Unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matris som tillämpas på glyfkoordinater. |
+
+### renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public void renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Ritar tecknet med en oberoende teckenväg. RenderGlyph()-funktionfamiljen ändrar teckenvägen vid rendering. Detta leder till att tecknet måste laddas om igen. Funktionen använder en kopia av teckenvägen och ändrar inte den ursprungliga teckenvägen, så samma tecken kan återanvändas flera gånger. Denna version av funktionen är avsedd för användning med en cache av tecken.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | Typsnittet som innehåller glyfen. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Fysiskt glyfindex i typsnittet. Observera att detta inte är en Unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glyf att rendera. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matris som tillämpas på glyfkoordinater. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/glyphstate/_index.md
+++ b/swedish/java/com.aspose.font/glyphstate/_index.md
@@ -1,0 +1,250 @@
+---
+title: "GlyphState"
+second_title: "Aspose.Font för Java API-referens"
+description: "Specificerar glyftillståndet."
+type: docs
+weight: 138
+url: /sv/java/com.aspose.font/glyphstate/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum GlyphState extends Enum<GlyphState>
+```
+
+Specificerar glyftillståndet.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ParsedWithErrors](#ParsedWithErrors) | Glyph tolkades med fel. |
+| [Success](#Success) | Glyph tolkades framgångsrikt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ParsedWithErrors {#ParsedWithErrors}
+```
+public static final GlyphState ParsedWithErrors
+```
+
+
+Glyph tolkades med fel.
+
+### Success {#Success}
+```
+public static final GlyphState Success
+```
+
+
+Glyph tolkades framgångsrikt.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static GlyphState valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[GlyphState](../../com.aspose.font/glyphstate)
+### values() {#values--}
+```
+public static GlyphState[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.GlyphState[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/glyphstringid/_index.md
+++ b/swedish/java/com.aspose.font/glyphstringid/_index.md
@@ -1,0 +1,234 @@
+---
+title: "GlyphStringId"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar strängglyfid."
+type: docs
+weight: 54
+url: /sv/java/com.aspose.font/glyphstringid/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.GlyphId](../../com.aspose.font/glyphid)
+```
+public class GlyphStringId extends GlyphId
+```
+
+Representerar strängglyfid.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [GlyphStringId(String value)](#GlyphStringId-java.lang.String-) | Initierar nytt  GlyphStringID  objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Returnerar sant om sträng-ID:n är lika. |
+| [getClass()](#getClass--) |  |
+| [getNotDefId()](#getNotDefId--) | Hämtar odefinierat glyph-id. |
+| [getValue()](#getValue--) | Hämtar strängvärde. |
+| [hashCode()](#hashCode--) | GetHashCode-implementation. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(GlyphId obj1, Object obj2)](#op-Equality-com.aspose.font.GlyphId-java.lang.Object-) | Returnerar sant om två glyph-id:n är lika. |
+| [op_Inequality(GlyphId obj1, Object obj2)](#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-) | Returnerar sant om två glyph-id:n inte är lika. |
+| [setValue(String value)](#setValue-java.lang.String-) | Sätter strängvärde. |
+| [toGlyphStringId()](#toGlyphStringId--) | Kasta GlyphId till GlyphStringId |
+| [toGlyphUInt32Id()](#toGlyphUInt32Id--) | Virtuell kastning till GlyphUInt32Id. |
+| [toString()](#toString--) | Returnerar strängvärde för glyph-id:t. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlyphStringId(String value) {#GlyphStringId-java.lang.String-}
+```
+public GlyphStringId(String value)
+```
+
+
+Initierar nytt  GlyphStringID  objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Glyfidentifierare. |
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Returnerar sant om sträng-ID:n är lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj | java.lang.Object | Glyph-strängidentifierare att jämföra med. |
+
+**Returns:**
+boolean - Jämförelseresultat
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNotDefId() {#getNotDefId--}
+```
+public static GlyphStringId getNotDefId()
+```
+
+
+Hämtar odefinierat glyph-id.
+
+**Returns:**
+[GlyphStringId](../../com.aspose.font/glyphstringid) - Not defined glyph id.
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Hämtar strängvärde.
+
+**Returns:**
+java.lang.String - Strängvärde.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+GetHashCode-implementation.
+
+**Returns:**
+int - Hashkod för objektet.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(GlyphId obj1, Object obj2) {#op-Equality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Equality(GlyphId obj1, Object obj2)
+```
+
+
+Returnerar sant om två glyph-id:n är lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Första glyph-identifierare att jämföra. |
+| obj2 | java.lang.Object | Andra glyph-identifierare att jämföra. |
+
+**Returns:**
+boolean - Jämförelseresultat.
+### op_Inequality(GlyphId obj1, Object obj2) {#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Inequality(GlyphId obj1, Object obj2)
+```
+
+
+Returnerar sant om två glyph-id:n inte är lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Första glyph-identifierare att jämföra. |
+| obj2 | java.lang.Object | Andra glyph-identifierare att jämföra. |
+
+**Returns:**
+boolean - Jämförelseresultat.
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Sätter strängvärde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Strängvärde. |
+
+### toGlyphStringId() {#toGlyphStringId--}
+```
+public GlyphStringId toGlyphStringId()
+```
+
+
+Kasta GlyphId till GlyphStringId
+
+**Returns:**
+[GlyphStringId](../../com.aspose.font/glyphstringid) - this
+### toGlyphUInt32Id() {#toGlyphUInt32Id--}
+```
+public GlyphUInt32Id toGlyphUInt32Id()
+```
+
+
+Virtuell kastning till GlyphUInt32Id. GlyphUInt32Id åsidosätter för att returnera en instans.
+
+**Returns:**
+[GlyphUInt32Id](../../com.aspose.font/glyphuint32id) - null
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+Returnerar strängvärde för glyph-id:t.
+
+**Returns:**
+java.lang.String - Glyph-identifierare.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/glyphuint32id/_index.md
+++ b/swedish/java/com.aspose.font/glyphuint32id/_index.md
@@ -1,0 +1,268 @@
+---
+title: "GlyphUInt32Id"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar heltalsglyfid."
+type: docs
+weight: 55
+url: /sv/java/com.aspose.font/glyphuint32id/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.GlyphId](../../com.aspose.font/glyphid)
+```
+public class GlyphUInt32Id extends GlyphId
+```
+
+Representerar heltalsglyfid.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [GlyphUInt32Id(long value)](#GlyphUInt32Id-long-) | Initierar ett nytt  GlyphUInt32Id  objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Returnerar true om Id:n är lika. |
+| [getClass()](#getClass--) |  |
+| [getNotDefId()](#getNotDefId--) | Hämtar odefinierat glyph-id. |
+| [getValue()](#getValue--) | Hämtar int‑värdet för ID:t. |
+| [hashCode()](#hashCode--) | GetHashCode-implementation. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(GlyphId obj1, Object obj2)](#op-Equality-com.aspose.font.GlyphId-java.lang.Object-) | Returnerar sant om två glyph-id:n är lika. |
+| [op_Equality(GlyphUInt32Id obj1, Object obj2)](#op-Equality-com.aspose.font.GlyphUInt32Id-java.lang.Object-) | Implementering av likhetsoperator. |
+| [op_Inequality(GlyphId obj1, Object obj2)](#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-) | Returnerar sant om två glyph-id:n inte är lika. |
+| [op_Inequality(GlyphUInt32Id obj1, Object obj2)](#op-Inequality-com.aspose.font.GlyphUInt32Id-java.lang.Object-) | Implementering av ojämlikhetsoperator. |
+| [setValue(long value)](#setValue-long-) | Sätter int‑värdet för ID:t. |
+| [toGlyphStringId()](#toGlyphStringId--) | Virtuell kastning till GlyphStringId. |
+| [toGlyphUInt32Id()](#toGlyphUInt32Id--) | Kasta GlyphId till GlyphUInt32Id |
+| [toString()](#toString--) | Hämtar strängrepresentationen av heltalsvärdet. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlyphUInt32Id(long value) {#GlyphUInt32Id-long-}
+```
+public GlyphUInt32Id(long value)
+```
+
+
+Initierar ett nytt  GlyphUInt32Id  objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long | Glyfidentifierare. |
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Returnerar true om Id:n är lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj | java.lang.Object | glyph identifierare att jämföra med |
+
+**Returns:**
+boolean - jämförelsresultat
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNotDefId() {#getNotDefId--}
+```
+public static GlyphUInt32Id getNotDefId()
+```
+
+
+Hämtar odefinierat glyph-id.
+
+**Returns:**
+[GlyphUInt32Id](../../com.aspose.font/glyphuint32id) - Not defined glyph id.
+### getValue() {#getValue--}
+```
+public long getValue()
+```
+
+
+Hämtar int‑värdet för ID:t.
+
+**Returns:**
+long - Int‑värdet för ID:t.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+GetHashCode-implementation.
+
+**Returns:**
+int - hashkod för objektet
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(GlyphId obj1, Object obj2) {#op-Equality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Equality(GlyphId obj1, Object obj2)
+```
+
+
+Returnerar sant om två glyph-id:n är lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Första glyph-identifierare att jämföra. |
+| obj2 | java.lang.Object | Andra glyph-identifierare att jämföra. |
+
+**Returns:**
+boolean - Jämförelseresultat.
+### op_Equality(GlyphUInt32Id obj1, Object obj2) {#op-Equality-com.aspose.font.GlyphUInt32Id-java.lang.Object-}
+```
+public static boolean op_Equality(GlyphUInt32Id obj1, Object obj2)
+```
+
+
+Implementering av likhetsoperator.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj1 | [GlyphUInt32Id](../../com.aspose.font/glyphuint32id) | första glyph‑identifieraren att jämföra |
+| obj2 | java.lang.Object | andra glyph‑identifieraren att jämföra |
+
+**Returns:**
+boolean - jämförelsresultat
+### op_Inequality(GlyphId obj1, Object obj2) {#op-Inequality-com.aspose.font.GlyphId-java.lang.Object-}
+```
+public static boolean op_Inequality(GlyphId obj1, Object obj2)
+```
+
+
+Returnerar sant om två glyph-id:n inte är lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj1 | [GlyphId](../../com.aspose.font/glyphid) | Första glyph-identifierare att jämföra. |
+| obj2 | java.lang.Object | Andra glyph-identifierare att jämföra. |
+
+**Returns:**
+boolean - Jämförelseresultat.
+### op_Inequality(GlyphUInt32Id obj1, Object obj2) {#op-Inequality-com.aspose.font.GlyphUInt32Id-java.lang.Object-}
+```
+public static boolean op_Inequality(GlyphUInt32Id obj1, Object obj2)
+```
+
+
+Implementering av ojämlikhetsoperator.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj1 | [GlyphUInt32Id](../../com.aspose.font/glyphuint32id) | första glyph‑identifieraren att jämföra |
+| obj2 | java.lang.Object | andra glyph‑identifieraren att jämföra |
+
+**Returns:**
+boolean - jämförelsresultat
+### setValue(long value) {#setValue-long-}
+```
+public void setValue(long value)
+```
+
+
+Sätter int‑värdet för ID:t.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long | Int‑värde för ID:t. |
+
+### toGlyphStringId() {#toGlyphStringId--}
+```
+public GlyphStringId toGlyphStringId()
+```
+
+
+Virtuell cast till GlyphStringId. GlyphStringId återdefinierar för att returnera en instans.
+
+**Returns:**
+[GlyphStringId](../../com.aspose.font/glyphstringid) - null
+### toGlyphUInt32Id() {#toGlyphUInt32Id--}
+```
+public GlyphUInt32Id toGlyphUInt32Id()
+```
+
+
+Kasta GlyphId till GlyphUInt32Id
+
+**Returns:**
+[GlyphUInt32Id](../../com.aspose.font/glyphuint32id) - this
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+Hämtar strängrepresentationen av heltalsvärdet.
+
+**Returns:**
+java.lang.String – glyfidentifierare
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/helpersfactory/_index.md
+++ b/swedish/java/com.aspose.font/helpersfactory/_index.md
@@ -1,0 +1,141 @@
+---
+title: "HelpersFactory"
+second_title: "Aspose.Font för Java API-referens"
+description: "Skapar objekt relaterade till TtfHelpers-namnområdet"
+type: docs
+weight: 56
+url: /sv/java/com.aspose.font/helpersfactory/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class HelpersFactory
+```
+
+Skapar objekt relaterade till TtfHelpers-namnområdet
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontCharactersMerger(TtfFont font1, TtfFont font2)](#getFontCharactersMerger-com.aspose.font.TtfFont-com.aspose.font.TtfFont-) | Skapar en IFontCharactersMerger‑instans |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontCharactersMerger(TtfFont font1, TtfFont font2) {#getFontCharactersMerger-com.aspose.font.TtfFont-com.aspose.font.TtfFont-}
+```
+public static IFontCharactersMerger getFontCharactersMerger(TtfFont font1, TtfFont font2)
+```
+
+
+Skapar en IFontCharactersMerger‑instans
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font1 | [TtfFont](../../com.aspose.font/ttffont) | Första teckensnittet att slå ihop, detta teckensnitt kommer att betraktas som primärt teckensnitt |
+| font2 | [TtfFont](../../com.aspose.font/ttffont) | Andra teckensnittet att slå ihop |
+
+**Returns:**
+[IFontCharactersMerger](../../com.aspose.font/ifontcharactersmerger) -  IFontCharactersMerger  instance
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/icffindexdataprovider/_index.md
+++ b/swedish/java/com.aspose.font/icffindexdataprovider/_index.md
@@ -1,0 +1,38 @@
+---
+title: "ICffIndexDataProvider"
+second_title: "Aspose.Font för Java API-referens"
+description: "Grundläggande gränssnitt för åtkomst till INDEX-strukturer i CFF-typsnitt."
+type: docs
+weight: 120
+url: /sv/java/com.aspose.font/icffindexdataprovider/
+---```
+public interface ICffIndexDataProvider
+```
+
+Basic interface for accessing INDEX structures of CFF fonts.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getCount()](#getCount--) | The number of objects in the CFF INDEX structure. |
+| [getRawBytes()](#getRawBytes--) | Gets all the bytes of the CFF INDEX structure. |
+### getCount() {#getCount--}
+```
+public abstract int getCount()
+```
+
+
+The number of objects in the CFF INDEX structure.
+
+**Returns:**
+int
+### getRawBytes() {#getRawBytes--}
+```
+public abstract byte[] getRawBytes()
+```
+
+
+Gets all the bytes of the CFF INDEX structure.
+
+**Returns:**
+byte[] - Bytes of the CFF INDEX structure

--- a/swedish/java/com.aspose.font/iencodingparameters/_index.md
+++ b/swedish/java/com.aspose.font/iencodingparameters/_index.md
@@ -1,0 +1,12 @@
+---
+title: "IEncodingParameters"
+second_title: "Aspose.Font för Java API-referens"
+description: "Gemensamt gränssnitt för att stödja kodningsparametrar."
+type: docs
+weight: 121
+url: /sv/java/com.aspose.font/iencodingparameters/
+---```
+public interface IEncodingParameters
+```
+
+Common interface to support encoding parameters. Some font types can have multiple encoding algorithms/maps. So, this interface should be used to create concrete font encoding parameters.

--- a/swedish/java/com.aspose.font/ifont/_index.md
+++ b/swedish/java/com.aspose.font/ifont/_index.md
@@ -1,0 +1,223 @@
+---
+title: "IFont"
+second_title: "Aspose.Font för Java API-referens"
+description: "Deklarerar gemensam funktionalitet för alla teckensnittsformat."
+type: docs
+weight: 122
+url: /sv/java/com.aspose.font/ifont/
+---```
+public interface IFont
+```
+
+Declares common functionality for all font formats. Implemented by Font classes.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Converts the Font into another format. |
+| [getEncoding()](#getEncoding--) | Gets Font encoding. |
+| [getFontDefinition()](#getFontDefinition--) | Gets Font definition. |
+| [getFontFamily()](#getFontFamily--) | Gets Font family. |
+| [getFontName()](#getFontName--) | Gets Font face name. |
+| [getFontNames()](#getFontNames--) | Gets Font names. |
+| [getFontSaver()](#getFontSaver--) | Gets Font save functionality. |
+| [getFontStyle()](#getFontStyle--) | Gets Font style. |
+| [getFontType()](#getFontType--) | Gets Font type. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Gets Font glyph accessor. |
+| [getMetrics()](#getMetrics--) | Gets Font metrics. |
+| [getNumGlyphs()](#getNumGlyphs--) | Gets number of glyphs in the Font. |
+| [getPostscriptNames()](#getPostscriptNames--) | Gets postscript Font names. |
+| [getStyle()](#getStyle--) | Gets Font style. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Sets Font family. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Sets Font face name. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Sets Font style. |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public abstract Font convert(FontType fontType)
+```
+
+
+Converts the Font into another format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | type to convert to font into |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - font converted into format specified
+### getEncoding() {#getEncoding--}
+```
+public abstract IFontEncoding getEncoding()
+```
+
+
+Gets Font encoding.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public abstract FontDefinition getFontDefinition()
+```
+
+
+Gets Font definition.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public abstract String getFontFamily()
+```
+
+
+Gets Font family.
+
+**Returns:**
+java.lang.String - Font family.
+### getFontName() {#getFontName--}
+```
+public abstract String getFontName()
+```
+
+
+Gets Font face name.
+
+**Returns:**
+java.lang.String - Font face name.
+### getFontNames() {#getFontNames--}
+```
+public abstract MultiLanguageString getFontNames()
+```
+
+
+Gets Font names.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public abstract IFontSaver getFontSaver()
+```
+
+
+Gets Font save functionality.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public abstract int getFontStyle()
+```
+
+
+Gets Font style. This is a value computed and represented in generalized type.
+
+**Returns:**
+int - Font style. Usually, a combination of FontStyle class constant flag values or 0.
+### getFontType() {#getFontType--}
+```
+public abstract FontType getFontType()
+```
+
+
+Gets Font type.
+
+--------------------
+
+> ```
+> Type1, TrueType etc.
+> ```
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public abstract IGlyphAccessor getGlyphAccessor()
+```
+
+
+Gets Font glyph accessor. Retrieves glyphs and glyph identifiers.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getMetrics() {#getMetrics--}
+```
+public abstract IFontMetrics getMetrics()
+```
+
+
+Gets Font metrics.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public abstract int getNumGlyphs()
+```
+
+
+Gets number of glyphs in the Font.
+
+**Returns:**
+int - Number of glyphs in the Font..
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public abstract MultiLanguageString getPostscriptNames()
+```
+
+
+Gets postscript Font names.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names.
+### getStyle() {#getStyle--}
+```
+public abstract String getStyle()
+```
+
+
+Gets Font style. This is a raw string value provided by Font file.
+
+**Returns:**
+java.lang.String - Font style.
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public abstract void setFontFamily(String value)
+```
+
+
+Sets Font family.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | java.lang.String | New Font family. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public abstract void setFontName(String value)
+```
+
+
+Sets Font face name.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | java.lang.String | New Font face name. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public abstract void setStyle(String value)
+```
+
+
+Sets Font style. This is a raw string value provided by Font file.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | java.lang.String | New Font style. |
+

--- a/swedish/java/com.aspose.font/ifontcharactersmerger/_index.md
+++ b/swedish/java/com.aspose.font/ifontcharactersmerger/_index.md
@@ -1,0 +1,70 @@
+---
+title: "IFontCharactersMerger"
+second_title: "Aspose.Font för Java API-referens"
+description: "Deklarerar hjälparfunktionalitet för att slå samman TrueType-teckensnitt."
+type: docs
+weight: 123
+url: /sv/java/com.aspose.font/ifontcharactersmerger/
+---```
+public interface IFontCharactersMerger
+```
+
+Declares helpers functionality to merge TrueType fonts. Font which is passed by parameter font1 considered as primary. It means that many characteristics, related to final merged font, such as metrics, encoding structure and others, will be taken from this primary font.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [mergeFonts(GlyphId[] font1Glyphs, GlyphId[] font2Glyphs, String newFontName)](#mergeFonts-com.aspose.font.GlyphId---com.aspose.font.GlyphId---java.lang.String-) | Merges fonts based on glyphs lists passed. |
+| [mergeFonts(int[] font1CharCodes, int[] font2CharCodes, String newFontName)](#mergeFonts-int---int---java.lang.String-) | Merges fonts based on character codes lists passed. |
+| [mergeFonts(Map<Integer,GlyphId> font1Dict, Map<Integer,GlyphId> font2Dict, String newFontName)](#mergeFonts-java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.lang.String-) | This method version designed for cases when you want to set character codes for glyphs in resultant font explicitly. |
+### mergeFonts(GlyphId[] font1Glyphs, GlyphId[] font2Glyphs, String newFontName) {#mergeFonts-com.aspose.font.GlyphId---com.aspose.font.GlyphId---java.lang.String-}
+```
+public abstract TtfFont mergeFonts(GlyphId[] font1Glyphs, GlyphId[] font2Glyphs, String newFontName)
+```
+
+
+Merges fonts based on glyphs lists passed. Searches for a character code for every glyph passed and add found character code with correspondent glyph into resultant new font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font1Glyphs | [GlyphId\[\]](../../com.aspose.font/glyphid) | List of glyphs from first font |
+| font2Glyphs | [GlyphId\[\]](../../com.aspose.font/glyphid) | List of glyphs from second font |
+| newFontName | java.lang.String | Desired name for resultant font |
+
+**Returns:**
+[TtfFont](../../com.aspose.font/ttffont) - Merged font
+### mergeFonts(int[] font1CharCodes, int[] font2CharCodes, String newFontName) {#mergeFonts-int---int---java.lang.String-}
+```
+public abstract TtfFont mergeFonts(int[] font1CharCodes, int[] font2CharCodes, String newFontName)
+```
+
+
+Merges fonts based on character codes lists passed. To create desired resultant font just pass symbol codes from original fonts you want to include into resultant font. Glyphs related to codes passed will be found automatically. For example, if you want to include into resultant font glyphs related to letters A and B from first font and glyphs, related to letters C and D from second font, just call this method like this:  MergeFonts(new uint[] \{ 'A', 'B' \}, new uint[] \{ 'C', 'D' \}, "NewFont") 
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font1CharCodes | int[] | Codes to take from first font |
+| font2CharCodes | int[] | Codes to take from second font |
+| newFontName | java.lang.String | Desired name for resultant font |
+
+**Returns:**
+[TtfFont](../../com.aspose.font/ttffont) - Merged font
+### mergeFonts(Map<Integer,GlyphId> font1Dict, Map<Integer,GlyphId> font2Dict, String newFontName) {#mergeFonts-java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.util.Map-java.lang.Integer-com.aspose.font.GlyphId--java.lang.String-}
+```
+public abstract TtfFont mergeFonts(Map<Integer,GlyphId> font1Dict, Map<Integer,GlyphId> font2Dict, String newFontName)
+```
+
+
+This method version designed for cases when you want to set character codes for glyphs in resultant font explicitly. It's not mandatory that code for glyph you provided is included in original font. The sense of code passed is that it will be associated with correspondent glyph identifier in resultant font. So, rule to process every pair passed by dictionary parameter[code, glyph ideitifier] is that only glyph identifer will be taken from original font and then it will be linked with correspondent code in resultant font. It can be helpful when some codes from first font conflict with same codes from second font.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font1Dict | java.util.Map<java.lang.Integer,com.aspose.font.GlyphId> | Dictionary with pairs [symbol code, glyph identifier] from first font |
+| font2Dict | java.util.Map<java.lang.Integer,com.aspose.font.GlyphId> | Dictionary with pairs [symbol code, glyph identifier] from second font |
+| newFontName | java.lang.String | Desired name for resultant font |
+
+**Returns:**
+[TtfFont](../../com.aspose.font/ttffont) - Merged font

--- a/swedish/java/com.aspose.font/ifontencoding/_index.md
+++ b/swedish/java/com.aspose.font/ifontencoding/_index.md
@@ -1,0 +1,96 @@
+---
+title: "IFontEncoding"
+second_title: "Aspose.Font för Java API-referens"
+description: "Definierar ett gränssnitt för teckensnittskodning."
+type: docs
+weight: 124
+url: /sv/java/com.aspose.font/ifontencoding/
+---```
+public interface IFontEncoding
+```
+
+Defines an interface for Font encoding.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [decodeToGid(long charCode)](#decodeToGid-long-) | Decodes a character code and returns glyph id. |
+| [decodeToGidParameterized(IEncodingParameters parameters, long charCode)](#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-) | Parameterized decode method. |
+| [encode(long gid, long charCode)](#encode-long-long-) | Encodes the glyph. |
+| [gidToUnicode(GlyphId gid)](#gidToUnicode-com.aspose.font.GlyphId-) | Decodes Gid to unicode. |
+| [unicodeToGid(long unicode)](#unicodeToGid-long-) | Decodes a unicode and returns glyph id. |
+### decodeToGid(long charCode) {#decodeToGid-long-}
+```
+public abstract GlyphId decodeToGid(long charCode)
+```
+
+
+Decodes a character code and returns glyph id. Glyph id is a unique number for a glyph, which is font type dependent. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| charCode | long | Character code to get glyph identifier for. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to charCode passed.
+### decodeToGidParameterized(IEncodingParameters parameters, long charCode) {#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-}
+```
+public abstract GlyphId decodeToGidParameterized(IEncodingParameters parameters, long charCode)
+```
+
+
+Parameterized decode method. Some font types can have multiple encoding algorithms/maps. So,  IEncodingParameters  interface is used to create concrete font encoding parameters.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| parameters | [IEncodingParameters](../../com.aspose.font/iencodingparameters) | Implementation of  IEncodingParameters  interface. |
+| charCode | long | Character code to get glyph identifier for. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to char code passed.
+### encode(long gid, long charCode) {#encode-long-long-}
+```
+public abstract void encode(long gid, long charCode)
+```
+
+
+Encodes the glyph. For TTF Fonts the charCode is unicode.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| gid | long | Glyph id. |
+| charCode | long | Character code associated with the glyph id. |
+
+### gidToUnicode(GlyphId gid) {#gidToUnicode-com.aspose.font.GlyphId-}
+```
+public abstract long gidToUnicode(GlyphId gid)
+```
+
+
+Decodes Gid to unicode. Glyph id is a unique number for a glyph, which is font type dependent. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| gid | [GlyphId](../../com.aspose.font/glyphid) | Glyph identifier of symbol to decode. |
+
+**Returns:**
+long - Unicode value related to glyph id passed.
+### unicodeToGid(long unicode) {#unicodeToGid-long-}
+```
+public abstract GlyphId unicodeToGid(long unicode)
+```
+
+
+Decodes a unicode and returns glyph id. Glyph id is a unique number for a glyph, which is font type dependent. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| unicode | long | Unicode to get glyph identifier for. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to unicode passed.

--- a/swedish/java/com.aspose.font/ifontmetrics/_index.md
+++ b/swedish/java/com.aspose.font/ifontmetrics/_index.md
@@ -1,0 +1,357 @@
+---
+title: "IFontMetrics"
+second_title: "Aspose.Font för Java API-referens"
+description: "Definierar ett gränssnitt för verktyg för teckensnittsmått."
+type: docs
+weight: 125
+url: /sv/java/com.aspose.font/ifontmetrics/
+---```
+public interface IFontMetrics
+```
+
+Defines an interface for Font metrics tools.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getAscender()](#getAscender--) | Gets ascender value of the Font in font units. |
+| [getAscender(double fontSize)](#getAscender-double-) | Returns ascender for specific Font size. |
+| [getDescender()](#getDescender--) | Gets descender value of the Font in font units. |
+| [getDescender(double fontSize)](#getDescender-double-) | Returns descender for specific Font size. |
+| [getFontBBox()](#getFontBBox--) | Gets Font bounding box. |
+| [getFontMatrix()](#getFontMatrix--) | Gets Font transformation matrix. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Returns glyph BBox. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Returns glyph width. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Returns kerning value for the glyph pair. |
+| [getLineGap()](#getLineGap--) | Gets LineGap value of the Font in Font units. |
+| [getTypoAscender()](#getTypoAscender--) | Gets typographic ascender value of the Font in font units |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Returns typographic ascender for specific Font size. |
+| [getTypoDescender()](#getTypoDescender--) | Gets typographic descender value of the Font in Font units. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Returns typographic descender for specific Font size. |
+| [getTypoLineGap()](#getTypoLineGap--) | Gets typographic LineGap value of the Font in Font units. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Returns line gap for specific Font size. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Gets Gets units per em. |
+| [isFixedPitch()](#isFixedPitch--) | True, if the Font is monospaced. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Measures string and returns string width. |
+| [setAscender(double value)](#setAscender-double-) |  |
+| [setDescender(double value)](#setDescender-double-) |  |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) | Specifies glyph width. |
+| [setTypoAscender(double value)](#setTypoAscender-double-) |  |
+| [setTypoDescender(double value)](#setTypoDescender-double-) |  |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) |  |
+### getAscender() {#getAscender--}
+```
+public abstract double getAscender()
+```
+
+
+Gets ascender value of the Font in font units.
+
+**Returns:**
+double - Ascender value of the Font in font units.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public abstract double getAscender(double fontSize)
+```
+
+
+Returns ascender for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Ascender value.
+### getDescender() {#getDescender--}
+```
+public abstract double getDescender()
+```
+
+
+Gets descender value of the Font in font units.
+
+**Returns:**
+double - Descender value of the Font in font units.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public abstract double getDescender(double fontSize)
+```
+
+
+Returns descender for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Descender value.
+### getFontBBox() {#getFontBBox--}
+```
+public abstract FontBBox getFontBBox()
+```
+
+
+Gets Font bounding box.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Font bounding box.
+### getFontMatrix() {#getFontMatrix--}
+```
+public abstract TransformationMatrix getFontMatrix()
+```
+
+
+Gets Font transformation matrix.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - Font transformation matrix.
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public abstract FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Returns glyph BBox.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | glyph identifier |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - glyph BBox
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public abstract double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Returns glyph width.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph identifier. |
+
+**Returns:**
+double - Glyph width.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public abstract double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Returns kerning value for the glyph pair.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | First glyph in pair. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Font size. |
+
+**Returns:**
+double - Kerning value.
+### getLineGap() {#getLineGap--}
+```
+public abstract double getLineGap()
+```
+
+
+Gets LineGap value of the Font in Font units.
+
+**Returns:**
+double - LineGap value of the Font in Font units.
+### getTypoAscender() {#getTypoAscender--}
+```
+public abstract double getTypoAscender()
+```
+
+
+Gets typographic ascender value of the Font in font units
+
+**Returns:**
+double - Typographic ascender value of the Font in font units
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public abstract double getTypoAscender(double fontSize)
+```
+
+
+Returns typographic ascender for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Typographic ascender value.
+### getTypoDescender() {#getTypoDescender--}
+```
+public abstract double getTypoDescender()
+```
+
+
+Gets typographic descender value of the Font in Font units.
+
+**Returns:**
+double - Typographic descender value of the Font in Font units.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public abstract double getTypoDescender(double fontSize)
+```
+
+
+Returns typographic descender for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Typographic descender value.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public abstract double getTypoLineGap()
+```
+
+
+Gets typographic LineGap value of the Font in Font units.
+
+**Returns:**
+double - Typographic LineGap value of the Font in Font units.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public abstract double getTypoLineGap(double fontSize)
+```
+
+
+Returns line gap for specific Font size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - Line gap value.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public abstract long getUnitsPerEM()
+```
+
+
+Gets Gets units per em.
+
+**Returns:**
+long - Units per em.
+### isFixedPitch() {#isFixedPitch--}
+```
+public abstract boolean isFixedPitch()
+```
+
+
+True, if the Font is monospaced.
+
+**Returns:**
+boolean - True, if the Font is monospaced.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public abstract double measureString(String unicode, double fontSize)
+```
+
+
+Measures string and returns string width.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| unicode | java.lang.String | Unicode string. |
+| fontSize | double | Font size. |
+
+**Returns:**
+double - String width.
+### setAscender(double value) {#setAscender-double-}
+```
+public abstract void setAscender(double value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | double |  |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public abstract void setDescender(double value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | double |  |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public abstract void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Specifies glyph width.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph identifier. |
+| value | double | Glyph width value. |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public abstract void setTypoAscender(double value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | double |  |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public abstract void setTypoDescender(double value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | double |  |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public abstract void setUnitsPerEM(long value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | long |  |
+

--- a/swedish/java/com.aspose.font/ifontsaver/_index.md
+++ b/swedish/java/com.aspose.font/ifontsaver/_index.md
@@ -1,0 +1,59 @@
+---
+title: "IFontSaver"
+second_title: "Aspose.Font för Java API-referens"
+description: "Definierar ett gränssnitt för funktionalitet för att spara teckensnitt."
+type: docs
+weight: 126
+url: /sv/java/com.aspose.font/ifontsaver/
+---```
+public interface IFontSaver
+```
+
+Defines an interface for Font save functionality.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Saves the Font into original format. |
+| [save(String fileName)](#save-java.lang.String-) | Saves the Font into original format. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Saves the Font into format specified. |
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public abstract void save(OutputStream stream)
+```
+
+
+Saves the Font into original format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| stream | java.io.OutputStream | stream to save font |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public abstract void save(String fileName)
+```
+
+
+Saves the Font into original format.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| fileName | java.lang.String | file to save font |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public abstract void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Saves the Font into format specified.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| stream | java.io.OutputStream | stream to save font |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | desired format |
+

--- a/swedish/java/com.aspose.font/iglyphaccessor/_index.md
+++ b/swedish/java/com.aspose.font/iglyphaccessor/_index.md
@@ -1,0 +1,70 @@
+---
+title: "IGlyphAccessor"
+second_title: "Aspose.Font för Java API-referens"
+description: "Definierar funktionalitet för att hämta specificerade glyfidentifierare och glyfer."
+type: docs
+weight: 127
+url: /sv/java/com.aspose.font/iglyphaccessor/
+---```
+public interface IGlyphAccessor
+```
+
+Defines functionality to retrieve specified glyph identifiers and glyphs.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Returns all glyph ids, available in the Font. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Returns glyph by glyph id. |
+| [getGlyphIdType()](#getGlyphIdType--) | Glyph id type specification. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Get glyphs representation for text. |
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public abstract GlyphId[] getAllGlyphIds()
+```
+
+
+Returns all glyph ids, available in the Font. Glyph id is a unique number for a glyph, which is font type dependent. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyph identifiers.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public abstract Glyph getGlyphById(GlyphId id)
+```
+
+
+Returns glyph by glyph id. Glyph id is a unique number for a glyph, which is font type dependent. GlyphId - derived object. For example: Type1's id is a glyph name, instance of ( GlyphStringId ) class. TTF's id is an int index, instance of ( GlyphUInt32Id ) class.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | glyph ID. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public abstract GlyphIdType getGlyphIdType()
+```
+
+
+Glyph id type specification.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype) - Id type specification.
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public abstract GlyphId[] getGlyphsForText(String text)
+```
+
+
+Get glyphs representation for text.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| text | java.lang.String | Input text. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - GlyphId array.

--- a/swedish/java/com.aspose.font/iglyphoutlinepainter/_index.md
+++ b/swedish/java/com.aspose.font/iglyphoutlinepainter/_index.md
@@ -1,0 +1,70 @@
+---
+title: "IGlyphOutlinePainter"
+second_title: "Aspose.Font för Java API-referens"
+description: "Definierar ett konturbaserat sätt att rita glyfer."
+type: docs
+weight: 128
+url: /sv/java/com.aspose.font/iglyphoutlinepainter/
+---
+**All Implemented Interfaces:**
+[com.aspose.font.IGlyphPainter](../../com.aspose.font/iglyphpainter)
+```
+public interface IGlyphOutlinePainter extends IGlyphPainter
+```
+
+Definierar ett konturbaserat sätt att rita glyfer.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [closePath()](#closePath--) | Bearbetar ClosePath-operation. |
+| [curveTo(CurveTo curveTo)](#curveTo-com.aspose.font.CurveTo-) | Bearbetar CurveTo-operation. |
+| [lineTo(LineTo lineTo)](#lineTo-com.aspose.font.LineTo-) | Bearbetar LineTo-operation. |
+| [moveTo(MoveTo moveTo)](#moveTo-com.aspose.font.MoveTo-) | Bearbetar MoveTo-operationen. |
+### closePath() {#closePath--}
+```
+public abstract void closePath()
+```
+
+
+Bearbetar ClosePath-operation.
+
+### curveTo(CurveTo curveTo) {#curveTo-com.aspose.font.CurveTo-}
+```
+public abstract void curveTo(CurveTo curveTo)
+```
+
+
+Bearbetar CurveTo-operation.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| curveTo | [CurveTo](../../com.aspose.font/curveto) | CurveTo-referens |
+
+### lineTo(LineTo lineTo) {#lineTo-com.aspose.font.LineTo-}
+```
+public abstract void lineTo(LineTo lineTo)
+```
+
+
+Bearbetar LineTo-operation.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| lineTo | [LineTo](../../com.aspose.font/lineto) | LineTo-referens |
+
+### moveTo(MoveTo moveTo) {#moveTo-com.aspose.font.MoveTo-}
+```
+public abstract void moveTo(MoveTo moveTo)
+```
+
+
+Bearbetar MoveTo-operationen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| moveTo | [MoveTo](../../com.aspose.font/moveto) | MoveTo-referens |
+

--- a/swedish/java/com.aspose.font/iglyphpainter/_index.md
+++ b/swedish/java/com.aspose.font/iglyphpainter/_index.md
@@ -1,0 +1,12 @@
+---
+title: "IGlyphPainter"
+second_title: "Aspose.Font för Java API-referens"
+description: "Definierar ett sätt att rita glyfer."
+type: docs
+weight: 129
+url: /sv/java/com.aspose.font/iglyphpainter/
+---```
+public interface IGlyphPainter
+```
+
+Defines a way to draw glyphs.

--- a/swedish/java/com.aspose.font/iglyphrenderer/_index.md
+++ b/swedish/java/com.aspose.font/iglyphrenderer/_index.md
@@ -1,0 +1,112 @@
+---
+title: "IGlyphRenderer"
+second_title: "Aspose.Font för Java API-referens"
+description: "Gränssnitt som används för att rendera glyfer."
+type: docs
+weight: 130
+url: /sv/java/com.aspose.font/iglyphrenderer/
+---```
+public interface IGlyphRenderer
+```
+
+Interface used to render glyphs.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [renderGlyph(IFont font, GlyphId glyphId)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-) | Renders glyph. |
+| [renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renders glyph, an objective of this overloaded version - to be used with cache for glyphs. |
+| [renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-) | Renders glyph. |
+| [renderGlyph(IFont font, long glyphIndex)](#renderGlyph-com.aspose.font.IFont-long-) | Renders glyph. |
+| [renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)](#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-) | Renders glyph. |
+| [renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)](#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-) | Renders glyph using independent glyph path. |
+### renderGlyph(IFont font, GlyphId glyphId) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-}
+```
+public abstract void renderGlyph(IFont font, GlyphId glyphId)
+```
+
+
+Renders glyph.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physical glyph index inside font. Note that this is not a unicode. |
+
+### renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public abstract void renderGlyph(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renders glyph, an objective of this overloaded version - to be used with cache for glyphs.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physical glyph index inside font. Note that this is not a unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glyph to render. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix that is applied to glyph coordinates. |
+
+### renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.TransformationMatrix-}
+```
+public abstract void renderGlyph(IFont font, GlyphId glyphId, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renders glyph.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physical glyph index inside font. Note that this is not a unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix that is applied to glyph coordinates. |
+
+### renderGlyph(IFont font, long glyphIndex) {#renderGlyph-com.aspose.font.IFont-long-}
+```
+public abstract void renderGlyph(IFont font, long glyphIndex)
+```
+
+
+Renders glyph.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphIndex | long | Physical glyph index inside font. Note that this is not a unicode. |
+
+### renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix) {#renderGlyph-com.aspose.font.IFont-long-com.aspose.font.TransformationMatrix-}
+```
+public abstract void renderGlyph(IFont font, long glyphIndex, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renders glyph.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphIndex | long | Physical glyph index inside font. Note that this is not a unicode. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix that is applied to glyph coordinates. |
+
+### renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix) {#renderIndependentGlyphPath-com.aspose.font.IFont-com.aspose.font.GlyphId-com.aspose.font.Glyph-com.aspose.font.TransformationMatrix-}
+```
+public abstract void renderIndependentGlyphPath(IFont font, GlyphId glyphId, Glyph glyph, TransformationMatrix glyphPlacementMatrix)
+```
+
+
+Renders glyph using independent glyph path. RenderGlyph() function family changes glyph path on rendering. It then leads to necessity reload this glyph again. This function uses copy of glyph path and doesn't changes original glyph path, so the same glyph could be reused multiple times. This version of function is intended for use with cache of glyphs.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| font | [IFont](../../com.aspose.font/ifont) | The font that contains the glyph. |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Physical glyph index inside font. Note that this is not a unicode. |
+| glyph | [Glyph](../../com.aspose.font/glyph) | Glyph to render. |
+| glyphPlacementMatrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Matrix that is applied to glyph coordinates. |
+

--- a/swedish/java/com.aspose.font/incorrectfontdataexception/_index.md
+++ b/swedish/java/com.aspose.font/incorrectfontdataexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "IncorrectFontDataException"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar undantag för fall då vissa värden i Font-objektet är ogiltiga."
+type: docs
+weight: 57
+url: /sv/java/com.aspose.font/incorrectfontdataexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class IncorrectFontDataException extends FontException
+```
+
+Representerar undantag för fall då vissa värden i Font-objektet är ogiltiga.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [IncorrectFontDataException()](#IncorrectFontDataException--) | Initierar ett nytt  FontAgrumentException ‑objekt. |
+| [IncorrectFontDataException(String message)](#IncorrectFontDataException-java.lang.String-) | Initierar ett nytt  FontAgrumentException ‑objekt. |
+| [IncorrectFontDataException(String message, RuntimeException innerException)](#IncorrectFontDataException-java.lang.String-java.lang.RuntimeException-) | Initierar ett nytt  FontAgrumentException ‑objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IncorrectFontDataException() {#IncorrectFontDataException--}
+```
+public IncorrectFontDataException()
+```
+
+
+Initierar ett nytt  FontAgrumentException ‑objekt.
+
+### IncorrectFontDataException(String message) {#IncorrectFontDataException-java.lang.String-}
+```
+public IncorrectFontDataException(String message)
+```
+
+
+Initierar ett nytt  FontAgrumentException ‑objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+
+### IncorrectFontDataException(String message, RuntimeException innerException) {#IncorrectFontDataException-java.lang.String-java.lang.RuntimeException-}
+```
+public IncorrectFontDataException(String message, RuntimeException innerException)
+```
+
+
+Initierar ett nytt  FontAgrumentException ‑objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+| innerException | java.lang.RuntimeException | Undantaget som är orsaken till det aktuella undantaget. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ipathsegment/_index.md
+++ b/swedish/java/com.aspose.font/ipathsegment/_index.md
@@ -1,0 +1,59 @@
+---
+title: "IPathSegment"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar gränssnittet för ett godtyckligt vägsegment."
+type: docs
+weight: 131
+url: /sv/java/com.aspose.font/ipathsegment/
+---
+**All Implemented Interfaces:**
+java.lang.Cloneable
+```
+public interface IPathSegment extends Cloneable
+```
+
+Representerar gränssnittet för ett godtyckligt vägsegment.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [copy()](#copy--) | Skapar en kopia av segmentobjektet. |
+| [shift(double dx, double dy)](#shift-double-double-) | Utför förskjutning med x- och y-koordinater. |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Transformerar koordinater med transformationsmatrisen. |
+### copy() {#copy--}
+```
+public abstract IPathSegment copy()
+```
+
+
+Skapar en kopia av segmentobjektet.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public abstract void shift(double dx, double dy)
+```
+
+
+Utför förskjutning med x- och y-koordinater.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| dx | double | Värde dx. |
+| dy | double | Värde dy. |
+
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public abstract void transform(TransformationMatrix matrix)
+```
+
+
+Transformerar koordinater med transformationsmatrisen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Transformationsmatris. |
+

--- a/swedish/java/com.aspose.font/isupportsnameaddressing/_index.md
+++ b/swedish/java/com.aspose.font/isupportsnameaddressing/_index.md
@@ -1,0 +1,27 @@
+---
+title: "ISupportsNameAddressing"
+second_title: "Aspose.Font för Java API-referens"
+description: "Definierar medlemmar som är specifika för kodningar som stöder glyfnamnadsadressering"
+type: docs
+weight: 132
+url: /sv/java/com.aspose.font/isupportsnameaddressing/
+---```
+public interface ISupportsNameAddressing
+```
+
+Defines members that are specific to encodings that support glyph name addressing
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getNameToCharCodeIndex()](#getNameToCharCodeIndex--) | Returns name to code map object. |
+### getNameToCharCodeIndex() {#getNameToCharCodeIndex--}
+```
+public abstract NameToCodeMap getNameToCharCodeIndex()
+```
+
+
+Returns name to code map object.
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - name to code map object.

--- a/swedish/java/com.aspose.font/license/_index.md
+++ b/swedish/java/com.aspose.font/license/_index.md
@@ -1,0 +1,193 @@
+---
+title: "Licens"
+second_title: "Aspose.Font för Java API-referens"
+description: "Tillhandahåller metoder för att licensiera komponenten."
+type: docs
+weight: 58
+url: /sv/java/com.aspose.font/license/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class License
+```
+
+Tillhandahåller metoder för att licensiera komponenten.
+
+I det här exemplet kommer ett försök att hitta en licensfil med namnet MyLicense.lic i mappen som innehåller komponenten, i mappen som innehåller den anropande samlingen, i mappen för startsamlingen och sedan i de inbäddade resurserna för den anropande samlingen.
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [License()](#License--) | Initierar en ny instans av denna klass. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLicense(InputStream stream)](#setLicense-java.io.InputStream-) | Licensierar komponenten. |
+| [setLicense(String licenseName)](#setLicense-java.lang.String-) | Licensierar komponenten. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### License() {#License--}
+```
+public License()
+```
+
+
+Initierar en ny instans av denna klass.
+
+I det här exemplet kommer ett försök att hitta en licensfil med namnet MyLicense.lic i mappen som innehåller komponenten, i mappen som innehåller den anropande samlingen, i mappen för startsamlingen och sedan i de inbäddade resurserna för den anropande samlingen.
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLicense(InputStream stream) {#setLicense-java.io.InputStream-}
+```
+public void setLicense(InputStream stream)
+```
+
+
+Licensierar komponenten.
+
+En ström som innehåller licensen.
+
+Använd den här metoden för att läsa in en licens från en ström.
+
+License license = new License();
+license.setLicense(myStream);
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.InputStream | license Stream |
+
+### setLicense(String licenseName) {#setLicense-java.lang.String-}
+```
+public void setLicense(String licenseName)
+```
+
+
+Licensierar komponenten.
+
+Försöker hitta licensen på följande platser:
+
+1. Explicit sökväg.
+
+2. Mappen för komponentens jar-fil.
+
+I det här exemplet kommer ett försök att hitta en licensfil med namnet MyLicense.lic i mappen som innehåller komponenten, i mappen som innehåller den anropande samlingen, i mappen för startsamlingen och sedan i de inbäddade resurserna för den anropande samlingen.
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| licenseName | java.lang.String | Kan vara ett fullständigt eller kort filnamn eller namn på en inbäddad resurs. Använd en tom sträng för att växla till utvärderingsläge. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/licenseflags/_index.md
+++ b/swedish/java/com.aspose.font/licenseflags/_index.md
@@ -1,0 +1,223 @@
+---
+title: "Licensflaggor"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar ett hjälparomslag för inbäddningsflaggor från OS/2-tabellfältet fsType."
+type: docs
+weight: 59
+url: /sv/java/com.aspose.font/licenseflags/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class LicenseFlags
+```
+
+Representerar en hjälparwrapper för inbäddningsflaggor från 'OS/2'-tabellen (fältet fsType).
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFSType()](#getFSType--) | Hämtar rått fsType-värde från OS/2-tabellen eller 0 om detta fält inte finns i tabellen. |
+| [hashCode()](#hashCode--) |  |
+| [isBitmapOnlyEmbedding()](#isBitmapOnlyEmbedding--) | Detekterar om fsType tillåter BitmapOnly-inbäddning. |
+| [isEditableEmbedding()](#isEditableEmbedding--) | Detekterar om fsType tillåter Editable-inbäddning. |
+| [isFSTypeAbsent()](#isFSTypeAbsent--) | Returnerar true om fsType-flaggan saknas i 'OS/2'-tabellen. |
+| [isInstallableEmbedding()](#isInstallableEmbedding--) | Detekterar om fsType är Installable-inbäddning. |
+| [isNoSubsettingEmbedding()](#isNoSubsettingEmbedding--) | Detekterar om fsType tillåter NoSubsetting-inbäddning. |
+| [isPreviewAndPrintEmbedding()](#isPreviewAndPrintEmbedding--) | Detekterar om fsType tillåter Preview and Print-inbäddning. |
+| [isReservedType()](#isReservedType--) | Detekterar om reserverad bit (bit 0) är satt för fsType. |
+| [isRestrictedLicenseEmbedding()](#isRestrictedLicenseEmbedding--) | Detekterar om fsType är Restricted License-inbäddning. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFSType() {#getFSType--}
+```
+public int getFSType()
+```
+
+
+Hämtar rått fsType-värde från OS/2-tabellen eller 0 om detta fält inte finns i tabellen.
+
+**Returns:**
+int - Rått fsType-värde från OS/2-tabellen eller 0 om detta fält inte finns i tabellen.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isBitmapOnlyEmbedding() {#isBitmapOnlyEmbedding--}
+```
+public boolean isBitmapOnlyEmbedding()
+```
+
+
+Detekterar om fsType tillåter BitmapOnly-inbäddning.
+
+**Returns:**
+boolean - Detekterar om fsType tillåter BitmapOnly-inbäddning.
+### isEditableEmbedding() {#isEditableEmbedding--}
+```
+public boolean isEditableEmbedding()
+```
+
+
+Detekterar om fsType tillåter Editable-inbäddning.
+
+**Returns:**
+boolean - Detekterar om fsType tillåter redigerbar inbäddning.
+### isFSTypeAbsent() {#isFSTypeAbsent--}
+```
+public boolean isFSTypeAbsent()
+```
+
+
+Returnerar true om fsType-flaggan saknas i 'OS/2'-tabellen.
+
+**Returns:**
+boolean - Sant om fsType-flaggan saknas i 'OS/2'-tabellen.
+### isInstallableEmbedding() {#isInstallableEmbedding--}
+```
+public boolean isInstallableEmbedding()
+```
+
+
+Detekterar om fsType är Installable-inbäddning.
+
+**Returns:**
+boolean - Detekterar om fsType är installerbar inbäddning.
+### isNoSubsettingEmbedding() {#isNoSubsettingEmbedding--}
+```
+public boolean isNoSubsettingEmbedding()
+```
+
+
+Detekterar om fsType tillåter NoSubsetting-inbäddning.
+
+**Returns:**
+boolean - Detekterar om fsType tillåter inbäddning utan delmängdsindelning.
+### isPreviewAndPrintEmbedding() {#isPreviewAndPrintEmbedding--}
+```
+public boolean isPreviewAndPrintEmbedding()
+```
+
+
+Detekterar om fsType tillåter Preview and Print-inbäddning.
+
+**Returns:**
+boolean - Detekterar om fsType tillåter förhandsgranskning och utskriftsinbäddning.
+### isReservedType() {#isReservedType--}
+```
+public boolean isReservedType()
+```
+
+
+Detekterar om reserverad bit (bit 0) är satt för fsType.
+
+**Returns:**
+boolean - Detekterar om reserverad bit (bit 0) är satt för fsType.
+### isRestrictedLicenseEmbedding() {#isRestrictedLicenseEmbedding--}
+```
+public boolean isRestrictedLicenseEmbedding()
+```
+
+
+Detekterar om fsType är Restricted License-inbäddning.
+
+**Returns:**
+boolean - Detekterar om fsType är inbäddning med begränsad licens.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/licenserestrictionexception/_index.md
+++ b/swedish/java/com.aspose.font/licenserestrictionexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "LicenseRestrictionException"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar undantag som kan kastas vid försök att köra funktionalitet som är begränsad i evalueringsläge."
+type: docs
+weight: 60
+url: /sv/java/com.aspose.font/licenserestrictionexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class LicenseRestrictionException extends FontException
+```
+
+Representerar undantag som kan kastas vid försök att köra funktionalitet som är begränsad i evalueringsläge.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [LicenseRestrictionException()](#LicenseRestrictionException--) | Initierar ett nytt FontCreationException‑objekt. |
+| [LicenseRestrictionException(String message)](#LicenseRestrictionException-java.lang.String-) | Initierar ett nytt FontCreationException‑objekt. |
+| [LicenseRestrictionException(String message, RuntimeException innerException)](#LicenseRestrictionException-java.lang.String-java.lang.RuntimeException-) | Initierar ett nytt FontCreationException‑objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LicenseRestrictionException() {#LicenseRestrictionException--}
+```
+public LicenseRestrictionException()
+```
+
+
+Initierar ett nytt FontCreationException‑objekt.
+
+### LicenseRestrictionException(String message) {#LicenseRestrictionException-java.lang.String-}
+```
+public LicenseRestrictionException(String message)
+```
+
+
+Initierar ett nytt FontCreationException‑objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+
+### LicenseRestrictionException(String message, RuntimeException innerException) {#LicenseRestrictionException-java.lang.String-java.lang.RuntimeException-}
+```
+public LicenseRestrictionException(String message, RuntimeException innerException)
+```
+
+
+Initierar ett nytt FontCreationException‑objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+| innerException | java.lang.RuntimeException | Undantaget som är orsaken till det aktuella undantaget. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/linespacingtype/_index.md
+++ b/swedish/java/com.aspose.font/linespacingtype/_index.md
@@ -1,0 +1,250 @@
+---
+title: "RenderingUtils.LineSpacingType"
+second_title: "Aspose.Font för Java API-referens"
+description: "Radavståndstyp."
+type: docs
+weight: 10
+url: /sv/java/com.aspose.font/renderingutils.linespacingtype/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum RenderingUtils.LineSpacingType extends Enum<RenderingUtils.LineSpacingType>
+```
+
+Radavståndstyp. Antal pixlar eller procent av teckensnittshöjd.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [PercentOfFontHeight](#PercentOfFontHeight) | Värdet för radavstånd är angivet i procent av teckensnittshöjd. |
+| [Pixels](#Pixels) | Värdet för radavstånd är angivet i pixlar. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PercentOfFontHeight {#PercentOfFontHeight}
+```
+public static final RenderingUtils.LineSpacingType PercentOfFontHeight
+```
+
+
+Värdet för radavstånd är angivet i procent av teckensnittshöjd.
+
+### Pixels {#Pixels}
+```
+public static final RenderingUtils.LineSpacingType Pixels
+```
+
+
+Värdet för radavstånd är angivet i pixlar.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static RenderingUtils.LineSpacingType valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[LineSpacingType](../../com.aspose.font/linespacingtype)
+### values() {#values--}
+```
+public static RenderingUtils.LineSpacingType[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.RenderingUtils.LineSpacingType[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/lineto/_index.md
+++ b/swedish/java/com.aspose.font/lineto/_index.md
@@ -1,0 +1,200 @@
+---
+title: "LineTo"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar LineTo-operation."
+type: docs
+weight: 61
+url: /sv/java/com.aspose.font/lineto/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IPathSegment](../../com.aspose.font/ipathsegment)
+```
+public class LineTo implements IPathSegment
+```
+
+Representerar LineTo-operation.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clone()](#clone--) | Skapar ett nytt objekt som är en kopia av den aktuella instansen. |
+| [copy()](#copy--) | Skapar en kopia av segmentobjektet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getX()](#getX--) | Hämtar koordinat x. |
+| [getY()](#getY--) | Hämtar koordinat y. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [shift(double dx, double dy)](#shift-double-double-) | Utför förskjutning med x- och y-koordinater. |
+| [toString()](#toString--) |  |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Transformerar koordinater med transformationsmatrisen. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Skapar ett nytt objekt som är en kopia av den aktuella instansen.
+
+**Returns:**
+java.lang.Object - Ett nytt objekt som är en kopia av denna instans.
+### copy() {#copy--}
+```
+public IPathSegment copy()
+```
+
+
+Skapar en kopia av segmentobjektet.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getX() {#getX--}
+```
+public double getX()
+```
+
+
+Hämtar koordinat x.
+
+**Returns:**
+double - Koordinat x.
+### getY() {#getY--}
+```
+public double getY()
+```
+
+
+Hämtar koordinat y.
+
+**Returns:**
+double - Koordinat y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public void shift(double dx, double dy)
+```
+
+
+Utför förskjutning med x- och y-koordinater.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| dx | double | Värde dx. |
+| dy | double | Värde dy. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public void transform(TransformationMatrix matrix)
+```
+
+
+Transformerar koordinater med transformationsmatrisen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Transformationsmatris. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/longhormetric/_index.md
+++ b/swedish/java/com.aspose.font/longhormetric/_index.md
@@ -1,0 +1,185 @@
+---
+title: "TtfHmtxTable.LongHorMetric"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar metrisk post."
+type: docs
+weight: 10
+url: /sv/java/com.aspose.font/ttfhmtxtable.longhormetric/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static class TtfHmtxTable.LongHorMetric
+```
+
+Representerar metrisk post.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [LongHorMetric()](#LongHorMetric--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clone()](#clone--) |  |
+| [equals(TtfHmtxTable.LongHorMetric obj1, TtfHmtxTable.LongHorMetric obj2)](#equals-com.aspose.font.TtfHmtxTable.LongHorMetric-com.aspose.font.TtfHmtxTable.LongHorMetric-) |  |
+| [equals(Object obj)](#equals-java.lang.Object-) |  |
+| [getAdvanceWidth()](#getAdvanceWidth--) | Hämtar förskjutningsbreddvärde. |
+| [getClass()](#getClass--) |  |
+| [getLeftSideBearing()](#getLeftSideBearing--) | Hämtar värde för vänster sidbäring. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LongHorMetric() {#LongHorMetric--}
+```
+public LongHorMetric()
+```
+
+
+### clone() {#clone--}
+```
+public TtfHmtxTable.LongHorMetric clone()
+```
+
+
+
+
+**Returns:**
+[LongHorMetric](../../com.aspose.font/longhormetric)
+### equals(TtfHmtxTable.LongHorMetric obj1, TtfHmtxTable.LongHorMetric obj2) {#equals-com.aspose.font.TtfHmtxTable.LongHorMetric-com.aspose.font.TtfHmtxTable.LongHorMetric-}
+```
+public static boolean equals(TtfHmtxTable.LongHorMetric obj1, TtfHmtxTable.LongHorMetric obj2)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj1 | [LongHorMetric](../../com.aspose.font/longhormetric) |  |
+| obj2 | [LongHorMetric](../../com.aspose.font/longhormetric) |  |
+
+**Returns:**
+boolean
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdvanceWidth() {#getAdvanceWidth--}
+```
+public int getAdvanceWidth()
+```
+
+
+Hämtar förskjutningsbreddvärde.
+
+**Returns:**
+int - Avancerad breddvärde.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLeftSideBearing() {#getLeftSideBearing--}
+```
+public short getLeftSideBearing()
+```
+
+
+Hämtar värde för vänster sidbäring.
+
+**Returns:**
+short - Värde för vänster sidbäring.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/longvermetric/_index.md
+++ b/swedish/java/com.aspose.font/longvermetric/_index.md
@@ -1,0 +1,185 @@
+---
+title: "TtfVmtxTable.LongVerMetric"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar vertikal metrisk post."
+type: docs
+weight: 10
+url: /sv/java/com.aspose.font/ttfvmtxtable.longvermetric/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static class TtfVmtxTable.LongVerMetric
+```
+
+Representerar vertikal metrisk post.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [LongVerMetric()](#LongVerMetric--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clone()](#clone--) |  |
+| [equals(TtfVmtxTable.LongVerMetric obj1, TtfVmtxTable.LongVerMetric obj2)](#equals-com.aspose.font.TtfVmtxTable.LongVerMetric-com.aspose.font.TtfVmtxTable.LongVerMetric-) |  |
+| [equals(Object obj)](#equals-java.lang.Object-) |  |
+| [getAdvanceHeight()](#getAdvanceHeight--) | Hämtar förskjutningshöjdvärdet. |
+| [getClass()](#getClass--) |  |
+| [getTopSideBearing()](#getTopSideBearing--) | Hämtar top side bearing‑värdet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LongVerMetric() {#LongVerMetric--}
+```
+public LongVerMetric()
+```
+
+
+### clone() {#clone--}
+```
+public TtfVmtxTable.LongVerMetric clone()
+```
+
+
+
+
+**Returns:**
+[LongVerMetric](../../com.aspose.font/longvermetric)
+### equals(TtfVmtxTable.LongVerMetric obj1, TtfVmtxTable.LongVerMetric obj2) {#equals-com.aspose.font.TtfVmtxTable.LongVerMetric-com.aspose.font.TtfVmtxTable.LongVerMetric-}
+```
+public static boolean equals(TtfVmtxTable.LongVerMetric obj1, TtfVmtxTable.LongVerMetric obj2)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj1 | [LongVerMetric](../../com.aspose.font/longvermetric) |  |
+| obj2 | [LongVerMetric](../../com.aspose.font/longvermetric) |  |
+
+**Returns:**
+boolean
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdvanceHeight() {#getAdvanceHeight--}
+```
+public int getAdvanceHeight()
+```
+
+
+Hämtar förskjutningshöjdvärdet.
+
+**Returns:**
+int - Förskjutningshöjdvärdet.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getTopSideBearing() {#getTopSideBearing--}
+```
+public short getTopSideBearing()
+```
+
+
+Hämtar top side bearing‑värdet.
+
+**Returns:**
+short - Top side bearing‑värdet.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/maclanguageid/_index.md
+++ b/swedish/java/com.aspose.font/maclanguageid/_index.md
@@ -1,0 +1,1201 @@
+---
+title: "MacLanguageId"
+second_title: "Aspose.Font för Java API-referens"
+description: "Macintosh-plattformens språk-id-uppräkning."
+type: docs
+weight: 63
+url: /sv/java/com.aspose.font/maclanguageid/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class MacLanguageId
+```
+
+Macintosh-plattformens språk-id-uppräkning.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [Afrikaans](#Afrikaans) | Afrikaans LanguageId‑värde |
+| [Albanian](#Albanian) | Albanian LanguageId‑värde |
+| [Amharic](#Amharic) | Amharic LanguageId‑värde |
+| [Arabic](#Arabic) | Arabic LanguageId‑värde |
+| [Armenian](#Armenian) | Armenian LanguageId‑värde |
+| [Assamese](#Assamese) | Assamese LanguageId‑värde |
+| [Aymara](#Aymara) | Aymara LanguageId värde |
+| [Azerbaijani_Arabic](#Azerbaijani-Arabic) | Azerbajdzjanska (arabiskt skript) LanguageId värde |
+| [Azerbaijani_Cyrillic](#Azerbaijani-Cyrillic) | Azerbajdzjanska (kyrilliskt skript) LanguageId värde |
+| [Azerbaijani_Roman](#Azerbaijani-Roman) | Azerbajdzjanska (romerskt skript) LanguageId värde |
+| [Basque](#Basque) | Baskiska LanguageId värde |
+| [Bengali](#Bengali) | Bengali LanguageId värde |
+| [Breton](#Breton) | Bretonska LanguageId värde |
+| [Bulgarian](#Bulgarian) | Bulgariska LanguageId värde |
+| [Burmese](#Burmese) | Burmesiska LanguageId värde |
+| [Byelorussian](#Byelorussian) | Belarusiska LanguageId värde |
+| [Catalan](#Catalan) | Katalanska LanguageId värde |
+| [Chinese_Simplified](#Chinese-Simplified) | Kinesiska (förenklad) LanguageId värde |
+| [Chinese_Traditional](#Chinese-Traditional) | Kinesiska (traditionell) LanguageId värde |
+| [Croatian](#Croatian) | Kroatiska LanguageId värde |
+| [Czech](#Czech) | Tjeckiska LanguageId värde |
+| [Danish](#Danish) | Danska LanguageId värde |
+| [Dutch](#Dutch) | Nederländska LanguageId värde |
+| [Dzongkha](#Dzongkha) | Dzongkha LanguageId värde |
+| [English](#English) | Engelska LanguageId värde |
+| [Esperanto](#Esperanto) | Esperanto LanguageId värde |
+| [Estonian](#Estonian) | Estniska LanguageId värde |
+| [Faroese](#Faroese) | Färöiska LanguageId värde |
+| [Farsi_Persian](#Farsi-Persian) | Farsi/persiska LanguageId värde |
+| [Finnish](#Finnish) | Finska LanguageId värde |
+| [Flemish](#Flemish) | Flamländska LanguageId värde |
+| [French](#French) | Franska LanguageId värde |
+| [Galician](#Galician) | Galiciska LanguageId värde |
+| [Galla](#Galla) | Galla LanguageId värde |
+| [Georgian](#Georgian) | Georgiska LanguageId värde |
+| [German](#German) | Tyska LanguageId värde |
+| [Greek](#Greek) | Grekiska LanguageId värde |
+| [Greek_Polytonic](#Greek-Polytonic) | Grekiska (polytonisk) LanguageId värde |
+| [Greenlandic](#Greenlandic) | Grönländska LanguageId värde |
+| [Guarani](#Guarani) | Guaraní LanguageId värde |
+| [Gujarati](#Gujarati) | Gujarati LanguageId värde |
+| [Hebrew](#Hebrew) | Hebreiska LanguageId värde |
+| [Hindi](#Hindi) | Hindi LanguageId värde |
+| [Hungarian](#Hungarian) | Ungerska LanguageId värde |
+| [Icelandic](#Icelandic) | Isländska LanguageId värde |
+| [Indonesian](#Indonesian) | Indonesiska LanguageId värde |
+| [Inuktitut](#Inuktitut) | Inuktitut LanguageId värde |
+| [Irish_Gaelic](#Irish-Gaelic) | Irländsk gaeliska LanguageId värde |
+| [Irish_Gaelic_WDA](#Irish-Gaelic-WDA) | Irländsk gaeliska (med prick ovanför) LanguageId värde |
+| [Italian](#Italian) | Italienska LanguageId värde |
+| [Japanese](#Japanese) | Japanska LanguageId värde |
+| [Javanese](#Javanese) | Javanska (romerskt skriftsystem) LanguageId värde |
+| [Kannada](#Kannada) | Kannada LanguageId värde |
+| [Kashmiri](#Kashmiri) | Kashmiri LanguageId värde |
+| [Kazakh](#Kazakh) | Kazakiska LanguageId värde |
+| [Khmer](#Khmer) | Khmer LanguageId värde |
+| [Kinyarwanda_Ruanda](#Kinyarwanda-Ruanda) | Kinyarwanda/Ruanda LanguageId värde |
+| [Kirghiz](#Kirghiz) | Kirghiz LanguageId värde |
+| [Korean](#Korean) | Koreanska LanguageId värde |
+| [Kurdish](#Kurdish) | Kurdiska LanguageId värde |
+| [Lao](#Lao) | Laotiska LanguageId värde |
+| [Latin](#Latin) | Latin LanguageId värde |
+| [Latvian](#Latvian) | Lettiska LanguageId värde |
+| [Lithuanian](#Lithuanian) | Litauiska LanguageId värde |
+| [Macedonian](#Macedonian) | Makedonska LanguageId värde |
+| [Malagasy](#Malagasy) | Malagassiska LanguageId värde |
+| [Malay_Arabic](#Malay-Arabic) | Malajiska (arabiskt skript) LanguageId värde |
+| [Malay_Roman](#Malay-Roman) | Malajiska (romerskt skript) LanguageId värde |
+| [Malayalam](#Malayalam) | Malayalam LanguageId värde |
+| [Maltese](#Maltese) | Maltesiska LanguageId värde |
+| [Manx_Gaelic](#Manx-Gaelic) | Manx-gaeliska LanguageId värde |
+| [Marathi](#Marathi) | Marathi LanguageId värde |
+| [Moldavian](#Moldavian) | Moldaviska LanguageId värde |
+| [Mongolian_Cyrillic](#Mongolian-Cyrillic) | Mongoliska (kyrilliskt skript) LanguageId värde |
+| [Mongolian_Mongolian](#Mongolian-Mongolian) | Mongoliska (mongoliskt skript) LanguageId värde |
+| [Nepali](#Nepali) | Nepali LanguageId värde |
+| [Norwegian](#Norwegian) | Norska LanguageId värde |
+| [Nyanja_Chewa](#Nyanja-Chewa) | Nyanja/Chewa LanguageId värde |
+| [Oriya](#Oriya) | Oriya LanguageId värde |
+| [Pashto](#Pashto) | Pashto LanguageId värde |
+| [Polish](#Polish) | Polska LanguageId värde |
+| [Portuguese](#Portuguese) | Portugisiska LanguageId värde |
+| [Punjabi](#Punjabi) | Punjabi LanguageId värde |
+| [Quechua](#Quechua) | Quechua LanguageId värde |
+| [Romanian](#Romanian) | Rumänska LanguageId värde |
+| [Rundi](#Rundi) | Rundi LanguageId värde |
+| [Russian](#Russian) | Ryska LanguageId värde |
+| [Sami](#Sami) | Samiska LanguageId värde |
+| [Sanskrit](#Sanskrit) | Sanskrit LanguageId värde |
+| [Scottish_Gaelic](#Scottish-Gaelic) | Skotsk gaeliska LanguageId värde |
+| [Serbian](#Serbian) | Serbiska LanguLanguageIdageID värde |
+| [Sindhi](#Sindhi) | Sindhi LanguageId värde |
+| [Sinhalese](#Sinhalese) | Singalesiska LanguageId värde |
+| [Slovak](#Slovak) | Slovakiska LanguageId värde |
+| [Slovenian](#Slovenian) | Slovenska LanguageId värde |
+| [Somali](#Somali) | Somaliska LanguageId värde |
+| [Spanish](#Spanish) | Spanska LanguageId värde |
+| [Sundanese](#Sundanese) | Sundanesiska (romanskt skript) LanguageId värde |
+| [Swahili](#Swahili) | Swahili LanguageId värde |
+| [Swedish](#Swedish) | Svenska LanguageId värde |
+| [Tagalog](#Tagalog) | Tagalog LanguageId värde |
+| [Tajiki](#Tajiki) | Tadzjikiska LanguageId värde |
+| [Tamil](#Tamil) | Tamil LanguagLanguageIdeID värde |
+| [Tatar](#Tatar) | Tatariska LanguageId värde |
+| [Telugu](#Telugu) | Telugu LanguageId värde |
+| [Thai](#Thai) | Thailändska LanguageId värde |
+| [Tibetan](#Tibetan) | Tibetanska LanguageId-värde |
+| [Tigrinya](#Tigrinya) | Tigrinska LanguageId-värde |
+| [Tongan](#Tongan) | Tonganska LanguageId-värde |
+| [Turkish](#Turkish) | Turkiska LanguageId-värde |
+| [Turkmen](#Turkmen) | Turkmenska LanguageId-värde |
+| [Uighur](#Uighur) | Uiguriska LanguageId-värde |
+| [Ukrainian](#Ukrainian) | Ukrainska LanguageId-värde |
+| [Urdu](#Urdu) | Urdu LanguageId-värde |
+| [Uzbek](#Uzbek) | Uzbekiska LanguageId-värde |
+| [Vietnamese](#Vietnamese) | Vietnamesiska LanguageId-värde |
+| [Welsh](#Welsh) | Walesiska LanguageId-värde |
+| [Yiddish](#Yiddish) | Jiddisch LanguageId-värde |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getId()](#getId--) | Hämta heltalsvärdet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Afrikaans {#Afrikaans}
+```
+public static final MacLanguageId Afrikaans
+```
+
+
+Afrikaans LanguageId‑värde
+
+### Albanian {#Albanian}
+```
+public static final MacLanguageId Albanian
+```
+
+
+Albanian LanguageId‑värde
+
+### Amharic {#Amharic}
+```
+public static final MacLanguageId Amharic
+```
+
+
+Amharic LanguageId‑värde
+
+### Arabic {#Arabic}
+```
+public static final MacLanguageId Arabic
+```
+
+
+Arabic LanguageId‑värde
+
+### Armenian {#Armenian}
+```
+public static final MacLanguageId Armenian
+```
+
+
+Armenian LanguageId‑värde
+
+### Assamese {#Assamese}
+```
+public static final MacLanguageId Assamese
+```
+
+
+Assamese LanguageId‑värde
+
+### Aymara {#Aymara}
+```
+public static final MacLanguageId Aymara
+```
+
+
+Aymara LanguageId värde
+
+### Azerbaijani_Arabic {#Azerbaijani-Arabic}
+```
+public static final MacLanguageId Azerbaijani_Arabic
+```
+
+
+Azerbajdzjanska (arabiskt skript) LanguageId värde
+
+### Azerbaijani_Cyrillic {#Azerbaijani-Cyrillic}
+```
+public static final MacLanguageId Azerbaijani_Cyrillic
+```
+
+
+Azerbajdzjanska (kyrilliskt skript) LanguageId värde
+
+### Azerbaijani_Roman {#Azerbaijani-Roman}
+```
+public static final MacLanguageId Azerbaijani_Roman
+```
+
+
+Azerbajdzjanska (romerskt skript) LanguageId värde
+
+### Basque {#Basque}
+```
+public static final MacLanguageId Basque
+```
+
+
+Baskiska LanguageId värde
+
+### Bengali {#Bengali}
+```
+public static final MacLanguageId Bengali
+```
+
+
+Bengali LanguageId värde
+
+### Breton {#Breton}
+```
+public static final MacLanguageId Breton
+```
+
+
+Bretonska LanguageId värde
+
+### Bulgarian {#Bulgarian}
+```
+public static final MacLanguageId Bulgarian
+```
+
+
+Bulgariska LanguageId värde
+
+### Burmese {#Burmese}
+```
+public static final MacLanguageId Burmese
+```
+
+
+Burmesiska LanguageId värde
+
+### Byelorussian {#Byelorussian}
+```
+public static final MacLanguageId Byelorussian
+```
+
+
+Belarusiska LanguageId värde
+
+### Catalan {#Catalan}
+```
+public static final MacLanguageId Catalan
+```
+
+
+Katalanska LanguageId värde
+
+### Chinese_Simplified {#Chinese-Simplified}
+```
+public static final MacLanguageId Chinese_Simplified
+```
+
+
+Kinesiska (förenklad) LanguageId värde
+
+### Chinese_Traditional {#Chinese-Traditional}
+```
+public static final MacLanguageId Chinese_Traditional
+```
+
+
+Kinesiska (traditionell) LanguageId värde
+
+### Croatian {#Croatian}
+```
+public static final MacLanguageId Croatian
+```
+
+
+Kroatiska LanguageId värde
+
+### Czech {#Czech}
+```
+public static final MacLanguageId Czech
+```
+
+
+Tjeckiska LanguageId värde
+
+### Danish {#Danish}
+```
+public static final MacLanguageId Danish
+```
+
+
+Danska LanguageId värde
+
+### Dutch {#Dutch}
+```
+public static final MacLanguageId Dutch
+```
+
+
+Nederländska LanguageId värde
+
+### Dzongkha {#Dzongkha}
+```
+public static final MacLanguageId Dzongkha
+```
+
+
+Dzongkha LanguageId värde
+
+### English {#English}
+```
+public static final MacLanguageId English
+```
+
+
+Engelska LanguageId värde
+
+### Esperanto {#Esperanto}
+```
+public static final MacLanguageId Esperanto
+```
+
+
+Esperanto LanguageId värde
+
+### Estonian {#Estonian}
+```
+public static final MacLanguageId Estonian
+```
+
+
+Estniska LanguageId värde
+
+### Faroese {#Faroese}
+```
+public static final MacLanguageId Faroese
+```
+
+
+Färöiska LanguageId värde
+
+### Farsi_Persian {#Farsi-Persian}
+```
+public static final MacLanguageId Farsi_Persian
+```
+
+
+Farsi/persiska LanguageId värde
+
+### Finnish {#Finnish}
+```
+public static final MacLanguageId Finnish
+```
+
+
+Finska LanguageId värde
+
+### Flemish {#Flemish}
+```
+public static final MacLanguageId Flemish
+```
+
+
+Flamländska LanguageId värde
+
+### French {#French}
+```
+public static final MacLanguageId French
+```
+
+
+Franska LanguageId värde
+
+### Galician {#Galician}
+```
+public static final MacLanguageId Galician
+```
+
+
+Galiciska LanguageId värde
+
+### Galla {#Galla}
+```
+public static final MacLanguageId Galla
+```
+
+
+Galla LanguageId värde
+
+### Georgian {#Georgian}
+```
+public static final MacLanguageId Georgian
+```
+
+
+Georgiska LanguageId värde
+
+### German {#German}
+```
+public static final MacLanguageId German
+```
+
+
+Tyska LanguageId värde
+
+### Greek {#Greek}
+```
+public static final MacLanguageId Greek
+```
+
+
+Grekiska LanguageId värde
+
+### Greek_Polytonic {#Greek-Polytonic}
+```
+public static final MacLanguageId Greek_Polytonic
+```
+
+
+Grekiska (polytonisk) LanguageId värde
+
+### Greenlandic {#Greenlandic}
+```
+public static final MacLanguageId Greenlandic
+```
+
+
+Grönländska LanguageId värde
+
+### Guarani {#Guarani}
+```
+public static final MacLanguageId Guarani
+```
+
+
+Guaraní LanguageId värde
+
+### Gujarati {#Gujarati}
+```
+public static final MacLanguageId Gujarati
+```
+
+
+Gujarati LanguageId värde
+
+### Hebrew {#Hebrew}
+```
+public static final MacLanguageId Hebrew
+```
+
+
+Hebreiska LanguageId värde
+
+### Hindi {#Hindi}
+```
+public static final MacLanguageId Hindi
+```
+
+
+Hindi LanguageId värde
+
+### Hungarian {#Hungarian}
+```
+public static final MacLanguageId Hungarian
+```
+
+
+Ungerska LanguageId värde
+
+### Icelandic {#Icelandic}
+```
+public static final MacLanguageId Icelandic
+```
+
+
+Isländska LanguageId värde
+
+### Indonesian {#Indonesian}
+```
+public static final MacLanguageId Indonesian
+```
+
+
+Indonesiska LanguageId värde
+
+### Inuktitut {#Inuktitut}
+```
+public static final MacLanguageId Inuktitut
+```
+
+
+Inuktitut LanguageId värde
+
+### Irish_Gaelic {#Irish-Gaelic}
+```
+public static final MacLanguageId Irish_Gaelic
+```
+
+
+Irländsk gaeliska LanguageId värde
+
+### Irish_Gaelic_WDA {#Irish-Gaelic-WDA}
+```
+public static final MacLanguageId Irish_Gaelic_WDA
+```
+
+
+Irländsk gaeliska (med prick ovanför) LanguageId värde
+
+### Italian {#Italian}
+```
+public static final MacLanguageId Italian
+```
+
+
+Italienska LanguageId värde
+
+### Japanese {#Japanese}
+```
+public static final MacLanguageId Japanese
+```
+
+
+Japanska LanguageId värde
+
+### Javanese {#Javanese}
+```
+public static final MacLanguageId Javanese
+```
+
+
+Javanska (romerskt skriftsystem) LanguageId värde
+
+### Kannada {#Kannada}
+```
+public static final MacLanguageId Kannada
+```
+
+
+Kannada LanguageId värde
+
+### Kashmiri {#Kashmiri}
+```
+public static final MacLanguageId Kashmiri
+```
+
+
+Kashmiri LanguageId värde
+
+### Kazakh {#Kazakh}
+```
+public static final MacLanguageId Kazakh
+```
+
+
+Kazakiska LanguageId värde
+
+### Khmer {#Khmer}
+```
+public static final MacLanguageId Khmer
+```
+
+
+Khmer LanguageId värde
+
+### Kinyarwanda_Ruanda {#Kinyarwanda-Ruanda}
+```
+public static final MacLanguageId Kinyarwanda_Ruanda
+```
+
+
+Kinyarwanda/Ruanda LanguageId värde
+
+### Kirghiz {#Kirghiz}
+```
+public static final MacLanguageId Kirghiz
+```
+
+
+Kirghiz LanguageId värde
+
+### Korean {#Korean}
+```
+public static final MacLanguageId Korean
+```
+
+
+Koreanska LanguageId värde
+
+### Kurdish {#Kurdish}
+```
+public static final MacLanguageId Kurdish
+```
+
+
+Kurdiska LanguageId värde
+
+### Lao {#Lao}
+```
+public static final MacLanguageId Lao
+```
+
+
+Laotiska LanguageId värde
+
+### Latin {#Latin}
+```
+public static final MacLanguageId Latin
+```
+
+
+Latin LanguageId värde
+
+### Latvian {#Latvian}
+```
+public static final MacLanguageId Latvian
+```
+
+
+Lettiska LanguageId värde
+
+### Lithuanian {#Lithuanian}
+```
+public static final MacLanguageId Lithuanian
+```
+
+
+Litauiska LanguageId värde
+
+### Macedonian {#Macedonian}
+```
+public static final MacLanguageId Macedonian
+```
+
+
+Makedonska LanguageId värde
+
+### Malagasy {#Malagasy}
+```
+public static final MacLanguageId Malagasy
+```
+
+
+Malagassiska LanguageId värde
+
+### Malay_Arabic {#Malay-Arabic}
+```
+public static final MacLanguageId Malay_Arabic
+```
+
+
+Malajiska (arabiskt skript) LanguageId värde
+
+### Malay_Roman {#Malay-Roman}
+```
+public static final MacLanguageId Malay_Roman
+```
+
+
+Malajiska (romerskt skript) LanguageId värde
+
+### Malayalam {#Malayalam}
+```
+public static final MacLanguageId Malayalam
+```
+
+
+Malayalam LanguageId värde
+
+### Maltese {#Maltese}
+```
+public static final MacLanguageId Maltese
+```
+
+
+Maltesiska LanguageId värde
+
+### Manx_Gaelic {#Manx-Gaelic}
+```
+public static final MacLanguageId Manx_Gaelic
+```
+
+
+Manx-gaeliska LanguageId värde
+
+### Marathi {#Marathi}
+```
+public static final MacLanguageId Marathi
+```
+
+
+Marathi LanguageId värde
+
+### Moldavian {#Moldavian}
+```
+public static final MacLanguageId Moldavian
+```
+
+
+Moldaviska LanguageId värde
+
+### Mongolian_Cyrillic {#Mongolian-Cyrillic}
+```
+public static final MacLanguageId Mongolian_Cyrillic
+```
+
+
+Mongoliska (kyrilliskt skript) LanguageId värde
+
+### Mongolian_Mongolian {#Mongolian-Mongolian}
+```
+public static final MacLanguageId Mongolian_Mongolian
+```
+
+
+Mongoliska (mongoliskt skript) LanguageId värde
+
+### Nepali {#Nepali}
+```
+public static final MacLanguageId Nepali
+```
+
+
+Nepali LanguageId värde
+
+### Norwegian {#Norwegian}
+```
+public static final MacLanguageId Norwegian
+```
+
+
+Norska LanguageId värde
+
+### Nyanja_Chewa {#Nyanja-Chewa}
+```
+public static final MacLanguageId Nyanja_Chewa
+```
+
+
+Nyanja/Chewa LanguageId värde
+
+### Oriya {#Oriya}
+```
+public static final MacLanguageId Oriya
+```
+
+
+Oriya LanguageId värde
+
+### Pashto {#Pashto}
+```
+public static final MacLanguageId Pashto
+```
+
+
+Pashto LanguageId värde
+
+### Polish {#Polish}
+```
+public static final MacLanguageId Polish
+```
+
+
+Polska LanguageId värde
+
+### Portuguese {#Portuguese}
+```
+public static final MacLanguageId Portuguese
+```
+
+
+Portugisiska LanguageId värde
+
+### Punjabi {#Punjabi}
+```
+public static final MacLanguageId Punjabi
+```
+
+
+Punjabi LanguageId värde
+
+### Quechua {#Quechua}
+```
+public static final MacLanguageId Quechua
+```
+
+
+Quechua LanguageId värde
+
+### Romanian {#Romanian}
+```
+public static final MacLanguageId Romanian
+```
+
+
+Rumänska LanguageId värde
+
+### Rundi {#Rundi}
+```
+public static final MacLanguageId Rundi
+```
+
+
+Rundi LanguageId värde
+
+### Russian {#Russian}
+```
+public static final MacLanguageId Russian
+```
+
+
+Ryska LanguageId värde
+
+### Sami {#Sami}
+```
+public static final MacLanguageId Sami
+```
+
+
+Samiska LanguageId värde
+
+### Sanskrit {#Sanskrit}
+```
+public static final MacLanguageId Sanskrit
+```
+
+
+Sanskrit LanguageId värde
+
+### Scottish_Gaelic {#Scottish-Gaelic}
+```
+public static final MacLanguageId Scottish_Gaelic
+```
+
+
+Skotsk gaeliska LanguageId värde
+
+### Serbian {#Serbian}
+```
+public static final MacLanguageId Serbian
+```
+
+
+Serbiska LanguLanguageIdageID värde
+
+### Sindhi {#Sindhi}
+```
+public static final MacLanguageId Sindhi
+```
+
+
+Sindhi LanguageId värde
+
+### Sinhalese {#Sinhalese}
+```
+public static final MacLanguageId Sinhalese
+```
+
+
+Singalesiska LanguageId värde
+
+### Slovak {#Slovak}
+```
+public static final MacLanguageId Slovak
+```
+
+
+Slovakiska LanguageId värde
+
+### Slovenian {#Slovenian}
+```
+public static final MacLanguageId Slovenian
+```
+
+
+Slovenska LanguageId värde
+
+### Somali {#Somali}
+```
+public static final MacLanguageId Somali
+```
+
+
+Somaliska LanguageId värde
+
+### Spanish {#Spanish}
+```
+public static final MacLanguageId Spanish
+```
+
+
+Spanska LanguageId värde
+
+### Sundanese {#Sundanese}
+```
+public static final MacLanguageId Sundanese
+```
+
+
+Sundanesiska (romanskt skript) LanguageId värde
+
+### Swahili {#Swahili}
+```
+public static final MacLanguageId Swahili
+```
+
+
+Swahili LanguageId värde
+
+### Swedish {#Swedish}
+```
+public static final MacLanguageId Swedish
+```
+
+
+Svenska LanguageId värde
+
+### Tagalog {#Tagalog}
+```
+public static final MacLanguageId Tagalog
+```
+
+
+Tagalog LanguageId värde
+
+### Tajiki {#Tajiki}
+```
+public static final MacLanguageId Tajiki
+```
+
+
+Tadzjikiska LanguageId värde
+
+### Tamil {#Tamil}
+```
+public static final MacLanguageId Tamil
+```
+
+
+Tamil LanguagLanguageIdeID värde
+
+### Tatar {#Tatar}
+```
+public static final MacLanguageId Tatar
+```
+
+
+Tatariska LanguageId värde
+
+### Telugu {#Telugu}
+```
+public static final MacLanguageId Telugu
+```
+
+
+Telugu LanguageId värde
+
+### Thai {#Thai}
+```
+public static final MacLanguageId Thai
+```
+
+
+Thailändska LanguageId värde
+
+### Tibetan {#Tibetan}
+```
+public static final MacLanguageId Tibetan
+```
+
+
+Tibetanska LanguageId-värde
+
+### Tigrinya {#Tigrinya}
+```
+public static final MacLanguageId Tigrinya
+```
+
+
+Tigrinska LanguageId-värde
+
+### Tongan {#Tongan}
+```
+public static final MacLanguageId Tongan
+```
+
+
+Tonganska LanguageId-värde
+
+### Turkish {#Turkish}
+```
+public static final MacLanguageId Turkish
+```
+
+
+Turkiska LanguageId-värde
+
+### Turkmen {#Turkmen}
+```
+public static final MacLanguageId Turkmen
+```
+
+
+Turkmenska LanguageId-värde
+
+### Uighur {#Uighur}
+```
+public static final MacLanguageId Uighur
+```
+
+
+Uiguriska LanguageId-värde
+
+### Ukrainian {#Ukrainian}
+```
+public static final MacLanguageId Ukrainian
+```
+
+
+Ukrainska LanguageId-värde
+
+### Urdu {#Urdu}
+```
+public static final MacLanguageId Urdu
+```
+
+
+Urdu LanguageId-värde
+
+### Uzbek {#Uzbek}
+```
+public static final MacLanguageId Uzbek
+```
+
+
+Uzbekiska LanguageId-värde
+
+### Vietnamese {#Vietnamese}
+```
+public static final MacLanguageId Vietnamese
+```
+
+
+Vietnamesiska LanguageId-värde
+
+### Welsh {#Welsh}
+```
+public static final MacLanguageId Welsh
+```
+
+
+Walesiska LanguageId-värde
+
+### Yiddish {#Yiddish}
+```
+public static final MacLanguageId Yiddish
+```
+
+
+Jiddisch LanguageId-värde
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getId() {#getId--}
+```
+public int getId()
+```
+
+
+Hämta heltalsvärdet.
+
+**Returns:**
+int - Heltalsvärdet.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/macplatformspecificid/_index.md
+++ b/swedish/java/com.aspose.font/macplatformspecificid/_index.md
@@ -1,0 +1,529 @@
+---
+title: "MacPlatformSpecificId"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Macintosh-plattformens PlatformSpecificId-enumeration."
+type: docs
+weight: 140
+url: /sv/java/com.aspose.font/macplatformspecificid/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum MacPlatformSpecificId extends Enum<MacPlatformSpecificId>
+```
+
+Representerar Macintosh-plattformens PlatformSpecificId-enumeration.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [Arabic](#Arabic) | Arabiskt plattformspecifikt värde. |
+| [Armenian](#Armenian) | Armeniskt plattformspecifikt värde. |
+| [Bengali](#Bengali) | Bengaliskt plattformspecifikt värde. |
+| [Burmese](#Burmese) | Burmesiskt plattformspecifikt värde. |
+| [Devanagari](#Devanagari) | Devanagari plattformspecifikt värde. |
+| [Geez](#Geez) | Geez plattformspecifikt värde. |
+| [Georgian](#Georgian) | Georgiskt plattformspecifikt värde. |
+| [Greek](#Greek) | Grekiskt plattformspecifikt värde. |
+| [Gujarati](#Gujarati) | Gujarati plattformspecifikt värde. |
+| [Gurmukhi](#Gurmukhi) | Gurmukhi plattformspecifikt värde. |
+| [Hebrew](#Hebrew) | Hebreiskt plattformspecifikt värde. |
+| [Japanese](#Japanese) | Japanskt plattformsspecifikt värde. |
+| [Kannada](#Kannada) | Kannada plattformspecifikt värde. |
+| [Khmer](#Khmer) | Khmer plattformspecifikt värde. |
+| [Korean](#Korean) | Koreanskt plattformsspecifikt värde. |
+| [Laotian](#Laotian) | Laotiskt plattformspecifikt värde. |
+| [Malayalam](#Malayalam) | Malayalam plattformspecifikt värde. |
+| [Mongolian](#Mongolian) | Mongoliskt plattformspecifikt värde. |
+| [Oriya](#Oriya) | Oriya plattformspecifikt värde. |
+| [RSymbol](#RSymbol) | RSymbol plattformsspecifikt värde. |
+| [Roman](#Roman) | Romerskt plattformsspecifikt värde. |
+| [Russian](#Russian) | Ryskt plattformsspecifikt värde. |
+| [Simplified_Chinese](#Simplified-Chinese) | Förenklad kinesisk plattformspecifikt värde. |
+| [Sindhi](#Sindhi) | Sindhi-plattformspecifikt värde. |
+| [Sinhalese](#Sinhalese) | Singalesisk plattformspecifikt värde. |
+| [Slavic](#Slavic) | Slavisk plattformspecifikt värde. |
+| [Tamil](#Tamil) | Tamil plattformspecifikt värde. |
+| [Telugu](#Telugu) | Telugu plattformspecifikt värde. |
+| [Thai](#Thai) | Thailändskt plattformspecifikt värde. |
+| [Tibetan](#Tibetan) | Tibetiskt plattformspecifikt värde. |
+| [Traditional_Chinese](#Traditional-Chinese) | Traditionellt kinesiskt plattformspecifikt värde. |
+| [Uninterpreted](#Uninterpreted) | Otolkat plattformspecifikt värde. |
+| [Vietnamese](#Vietnamese) | Vietnamesiskt plattformspecifikt värde. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Arabic {#Arabic}
+```
+public static final MacPlatformSpecificId Arabic
+```
+
+
+Arabiskt plattformspecifikt värde.
+
+### Armenian {#Armenian}
+```
+public static final MacPlatformSpecificId Armenian
+```
+
+
+Armeniskt plattformspecifikt värde.
+
+### Bengali {#Bengali}
+```
+public static final MacPlatformSpecificId Bengali
+```
+
+
+Bengaliskt plattformspecifikt värde.
+
+### Burmese {#Burmese}
+```
+public static final MacPlatformSpecificId Burmese
+```
+
+
+Burmesiskt plattformspecifikt värde.
+
+### Devanagari {#Devanagari}
+```
+public static final MacPlatformSpecificId Devanagari
+```
+
+
+Devanagari plattformspecifikt värde.
+
+### Geez {#Geez}
+```
+public static final MacPlatformSpecificId Geez
+```
+
+
+Geez plattformspecifikt värde.
+
+### Georgian {#Georgian}
+```
+public static final MacPlatformSpecificId Georgian
+```
+
+
+Georgiskt plattformspecifikt värde.
+
+### Greek {#Greek}
+```
+public static final MacPlatformSpecificId Greek
+```
+
+
+Grekiskt plattformspecifikt värde.
+
+### Gujarati {#Gujarati}
+```
+public static final MacPlatformSpecificId Gujarati
+```
+
+
+Gujarati plattformspecifikt värde.
+
+### Gurmukhi {#Gurmukhi}
+```
+public static final MacPlatformSpecificId Gurmukhi
+```
+
+
+Gurmukhi plattformspecifikt värde.
+
+### Hebrew {#Hebrew}
+```
+public static final MacPlatformSpecificId Hebrew
+```
+
+
+Hebreiskt plattformspecifikt värde.
+
+### Japanese {#Japanese}
+```
+public static final MacPlatformSpecificId Japanese
+```
+
+
+Japanskt plattformsspecifikt värde.
+
+### Kannada {#Kannada}
+```
+public static final MacPlatformSpecificId Kannada
+```
+
+
+Kannada plattformspecifikt värde.
+
+### Khmer {#Khmer}
+```
+public static final MacPlatformSpecificId Khmer
+```
+
+
+Khmer plattformspecifikt värde.
+
+### Korean {#Korean}
+```
+public static final MacPlatformSpecificId Korean
+```
+
+
+Koreanskt plattformsspecifikt värde.
+
+### Laotian {#Laotian}
+```
+public static final MacPlatformSpecificId Laotian
+```
+
+
+Laotiskt plattformspecifikt värde.
+
+### Malayalam {#Malayalam}
+```
+public static final MacPlatformSpecificId Malayalam
+```
+
+
+Malayalam plattformspecifikt värde.
+
+### Mongolian {#Mongolian}
+```
+public static final MacPlatformSpecificId Mongolian
+```
+
+
+Mongoliskt plattformspecifikt värde.
+
+### Oriya {#Oriya}
+```
+public static final MacPlatformSpecificId Oriya
+```
+
+
+Oriya plattformspecifikt värde.
+
+### RSymbol {#RSymbol}
+```
+public static final MacPlatformSpecificId RSymbol
+```
+
+
+RSymbol plattformsspecifikt värde.
+
+### Roman {#Roman}
+```
+public static final MacPlatformSpecificId Roman
+```
+
+
+Romerskt plattformsspecifikt värde.
+
+### Russian {#Russian}
+```
+public static final MacPlatformSpecificId Russian
+```
+
+
+Ryskt plattformsspecifikt värde.
+
+### Simplified_Chinese {#Simplified-Chinese}
+```
+public static final MacPlatformSpecificId Simplified_Chinese
+```
+
+
+Förenklad kinesisk plattformspecifikt värde.
+
+### Sindhi {#Sindhi}
+```
+public static final MacPlatformSpecificId Sindhi
+```
+
+
+Sindhi-plattformspecifikt värde.
+
+### Sinhalese {#Sinhalese}
+```
+public static final MacPlatformSpecificId Sinhalese
+```
+
+
+Singalesisk plattformspecifikt värde.
+
+### Slavic {#Slavic}
+```
+public static final MacPlatformSpecificId Slavic
+```
+
+
+Slavisk plattformspecifikt värde.
+
+### Tamil {#Tamil}
+```
+public static final MacPlatformSpecificId Tamil
+```
+
+
+Tamil plattformspecifikt värde.
+
+### Telugu {#Telugu}
+```
+public static final MacPlatformSpecificId Telugu
+```
+
+
+Telugu plattformspecifikt värde.
+
+### Thai {#Thai}
+```
+public static final MacPlatformSpecificId Thai
+```
+
+
+Thailändskt plattformspecifikt värde.
+
+### Tibetan {#Tibetan}
+```
+public static final MacPlatformSpecificId Tibetan
+```
+
+
+Tibetiskt plattformspecifikt värde.
+
+### Traditional_Chinese {#Traditional-Chinese}
+```
+public static final MacPlatformSpecificId Traditional_Chinese
+```
+
+
+Traditionellt kinesiskt plattformspecifikt värde.
+
+### Uninterpreted {#Uninterpreted}
+```
+public static final MacPlatformSpecificId Uninterpreted
+```
+
+
+Otolkat plattformspecifikt värde.
+
+### Vietnamese {#Vietnamese}
+```
+public static final MacPlatformSpecificId Vietnamese
+```
+
+
+Vietnamesiskt plattformspecifikt värde.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static MacPlatformSpecificId valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[MacPlatformSpecificId](../../com.aspose.font/macplatformspecificid)
+### values() {#values--}
+```
+public static MacPlatformSpecificId[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.MacPlatformSpecificId[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/metered/_index.md
+++ b/swedish/java/com.aspose.font/metered/_index.md
@@ -1,0 +1,185 @@
+---
+title: "Måttad"
+second_title: "Aspose.Font för Java API-referens"
+description: "Tillhandahåller metoder för att ställa in mätad nyckel."
+type: docs
+weight: 64
+url: /sv/java/com.aspose.font/metered/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class Metered
+```
+
+Tillhandahåller metoder för att ställa in mätad nyckel.
+
+--------------------
+
+I det här exemplet kommer ett försök att ställa in mättad offentlig och privat nyckel att göras.
+
+```
+The component jar file:
+  
+ 	Metered metered = new Metered();
+ 	matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Metered()](#Metered--) | Initierar en ny instans av denna klass. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getConsumptionCredit()](#getConsumptionCredit--) | Hämtar konsumtionskredit |
+| [getConsumptionQuantity()](#getConsumptionQuantity--) | Hämtar konsumtionsfilens storlek |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setMeteredKey(String publicKey, String privateKey)](#setMeteredKey-java.lang.String-java.lang.String-) | Ställer in mättad offentlig och privat nyckel |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Metered() {#Metered--}
+```
+public Metered()
+```
+
+
+Initierar en ny instans av denna klass.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConsumptionCredit() {#getConsumptionCredit--}
+```
+public static double getConsumptionCredit()
+```
+
+
+Hämtar konsumtionskredit
+
+**Returns:**
+double - konsumtionskvantitet
+### getConsumptionQuantity() {#getConsumptionQuantity--}
+```
+public static double getConsumptionQuantity()
+```
+
+
+Hämtar konsumtionsfilens storlek
+
+**Returns:**
+double - konsumtionskvantitet
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setMeteredKey(String publicKey, String privateKey) {#setMeteredKey-java.lang.String-java.lang.String-}
+```
+public void setMeteredKey(String publicKey, String privateKey)
+```
+
+
+Ställer in mättad offentlig och privat nyckel
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| publicKey | java.lang.String | offentlig nyckel |
+| privateKey | java.lang.String | privat nyckel |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/metriclist/_index.md
+++ b/swedish/java/com.aspose.font/metriclist/_index.md
@@ -1,0 +1,162 @@
+---
+title: "TtfHmtxTable.MetricList"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar lista över metriker"
+type: docs
+weight: 11
+url: /sv/java/com.aspose.font/ttfhmtxtable.metriclist/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static class TtfHmtxTable.MetricList
+```
+
+Representerar lista över metriker
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int glyphIndex)](#get-int-) | Hämtar mått efter glyfindex. |
+| [getClass()](#getClass--) |  |
+| [getRawList()](#getRawList--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [size()](#size--) | Hämtar antal mått. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int glyphIndex) {#get-int-}
+```
+public TtfHmtxTable.LongHorMetric get(int glyphIndex)
+```
+
+
+Hämtar mått efter glyfindex.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphIndex | int | Glyfindex för att hämta mått för. |
+
+**Returns:**
+[LongHorMetric](../../com.aspose.font/longhormetric) - Metrics record.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getRawList() {#getRawList--}
+```
+public System.Collections.Generic.List<TtfHmtxTable.LongHorMetric> getRawList()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List<com.aspose.font.TtfHmtxTable.LongHorMetric>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+Hämtar antal mått.
+
+**Returns:**
+int - Antal mått.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/moveto/_index.md
+++ b/swedish/java/com.aspose.font/moveto/_index.md
@@ -1,0 +1,200 @@
+---
+title: "MoveTo"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar MoveTo-operation."
+type: docs
+weight: 65
+url: /sv/java/com.aspose.font/moveto/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IPathSegment](../../com.aspose.font/ipathsegment)
+```
+public class MoveTo implements IPathSegment
+```
+
+Representerar MoveTo-operation.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clone()](#clone--) | Skapar ett nytt objekt som är en kopia av den aktuella instansen. |
+| [copy()](#copy--) | Skapar en kopia av segmentobjektet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getX()](#getX--) | Hämtar koordinat x. |
+| [getY()](#getY--) | Hämtar koordinat y. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [shift(double dx, double dy)](#shift-double-double-) | Utför förskjutning med x- och y-koordinater. |
+| [toString()](#toString--) |  |
+| [transform(TransformationMatrix matrix)](#transform-com.aspose.font.TransformationMatrix-) | Transformerar koordinater med transformationsmatrisen. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Skapar ett nytt objekt som är en kopia av den aktuella instansen.
+
+**Returns:**
+java.lang.Object - Ett nytt objekt som är en kopia av denna instans.
+### copy() {#copy--}
+```
+public IPathSegment copy()
+```
+
+
+Skapar en kopia av segmentobjektet.
+
+**Returns:**
+[IPathSegment](../../com.aspose.font/ipathsegment) - Copy of the segment object.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getX() {#getX--}
+```
+public double getX()
+```
+
+
+Hämtar koordinat x.
+
+**Returns:**
+double - Koordinat x.
+### getY() {#getY--}
+```
+public double getY()
+```
+
+
+Hämtar koordinat y.
+
+**Returns:**
+double - Koordinat y.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### shift(double dx, double dy) {#shift-double-double-}
+```
+public void shift(double dx, double dy)
+```
+
+
+Utför förskjutning med x- och y-koordinater.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| dx | double | Värde dx. |
+| dy | double | Värde dy. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(TransformationMatrix matrix) {#transform-com.aspose.font.TransformationMatrix-}
+```
+public void transform(TransformationMatrix matrix)
+```
+
+
+Transformerar koordinater med transformationsmatrisen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Transformationsmatris. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/mslanguageid/_index.md
+++ b/swedish/java/com.aspose.font/mslanguageid/_index.md
@@ -1,0 +1,1984 @@
+---
+title: "MSLanguageId"
+second_title: "Aspose.Font för Java API-referens"
+description: "Microsoft-plattformens språk-id-uppräkning."
+type: docs
+weight: 62
+url: /sv/java/com.aspose.font/mslanguageid/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class MSLanguageId
+```
+
+Microsoft-plattformens språk-id-uppräkning.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [Afrikaans](#Afrikaans) | Afrikaans (Region: Sydafrika, SA) LanguageId-värde |
+| [Albanian](#Albanian) | Albanska (Region: Albanien, SQI) LanguageId värde |
+| [Alsatian](#Alsatian) | Alsatiska (Region: Frankrike) LanguageId värde |
+| [Amharic](#Amharic) | Amhariska (Region: Etiopien) LanguageId värde |
+| [Arabic_Algeria](#Arabic-Algeria) | Arabiska (Region: Algeriet) LanguageId värde |
+| [Arabic_Bahrain](#Arabic-Bahrain) | Arabiska (Region: Bahrain) LanguageId värde |
+| [Arabic_Egypt](#Arabic-Egypt) | Arabiska (Region: Egypten) LanguageId värde |
+| [Arabic_Iraq](#Arabic-Iraq) | Arabiska (Region: Irak) LanguageId värde |
+| [Arabic_Jordan](#Arabic-Jordan) | Arabiska (Region: Jordanien) LanguageId värde |
+| [Arabic_Kuwait](#Arabic-Kuwait) | Arabiska (Region: Kuwait) LanguageId värde |
+| [Arabic_Lebanon](#Arabic-Lebanon) | Arabiska (Region: Libanon) LanguageId värde |
+| [Arabic_Libya](#Arabic-Libya) | Arabiska (Region: Libyen) LanguageId värde |
+| [Arabic_Morocco](#Arabic-Morocco) | Arabiska (Region: Marocko) LanguageId värde |
+| [Arabic_Oman](#Arabic-Oman) | Arabiska (Region: Oman) LanguageId värde |
+| [Arabic_Qatar](#Arabic-Qatar) | Arabiska (Region: Qatar) LanguageId värde |
+| [Arabic_Saudi_Arabia](#Arabic-Saudi-Arabia) | Arabiska (Region: Saudiarabien) LanguageId värde |
+| [Arabic_Syria](#Arabic-Syria) | Arabiska (Region: Syrien) LanguageId värde |
+| [Arabic_Tunisia](#Arabic-Tunisia) | Arabiska (Region: Tunisien) LanguageId värde |
+| [Arabic_U_A_E](#Arabic-U-A-E) | Arabiska (Region: Förenade Arabemiraten) |
+| [Arabic_Yemen](#Arabic-Yemen) | Arabiska (Region: Jemen) LanguageId värde |
+| [Armenian](#Armenian) | Armeniska (Region: Armenien) LanguageId värde |
+| [Assamese](#Assamese) | Assamesiska (Region: Indien) LanguageId värde |
+| [Azeri_Cyrillic](#Azeri-Cyrillic) | Azeri (Kyrillisk, Region: Azerbajdzjan) LanguageId värde |
+| [Azeri_Latin](#Azeri-Latin) | Azeri (Latinsk, Region: Azerbajdzjan) LanguageId värde |
+| [Bashkir](#Bashkir) | Bashkiriska (Region: Ryssland) LanguageId värde |
+| [Basque](#Basque) | Baskiska (Region: Baskien, EUQ) LanguageId värde |
+| [Belarusian](#Belarusian) | Belarusiska (Region: Belarus, BEL) LanguageId-värde |
+| [Bengali_Bangladesh](#Bengali-Bangladesh) | Bengali (Region: Bangladesh) LanguageId-värde |
+| [Bengali_India](#Bengali-India) | Bengali (Region: India) LanguageId-värde |
+| [Bosnian_Cyrillic](#Bosnian-Cyrillic) | Bosniska (Kyrilliska, Region: Bosnien och Hercegovina) LanguageId-värde |
+| [Bosnian_Latin](#Bosnian-Latin) | Bosniska (Latinska, Region: Bosnien och Hercegovina) LanguageId-värde |
+| [Breton](#Breton) | Bretonska (Region: Frankrike) LanguageId-värde |
+| [Bulgarian](#Bulgarian) | Bulgariska (Region: Bulgarien, BGR) LanguageId-värde |
+| [Catalan](#Catalan) | Katalanska (Region: Katalonien, CAT) LanguageId-värde |
+| [Chinese_Hong_Kong](#Chinese-Hong-Kong) | Kinesiska (Region: Hongkong S.A.R.) |
+| [Chinese_Macao](#Chinese-Macao) | Kinesiska (Region: Macao S.A.R.) |
+| [Chinese_PRC](#Chinese-PRC) | Kinesiska (Region: Folkrepubliken Kina) LanguageId-värde |
+| [Chinese_Singapore](#Chinese-Singapore) | Kinesiska (Region: Singapore) LanguageId-värde |
+| [Chinese_Taiwan](#Chinese-Taiwan) | Kinesiska (Region: Taiwan) LanguageId-värde |
+| [Corsican](#Corsican) | Korsikanska (Region: Frankrike) LanguageId-värde |
+| [Croatian](#Croatian) | Kroatiska (Region: Kroatien, SHL) LanguageId-värde |
+| [Croatian_Latin](#Croatian-Latin) | Kroatiska (Latinska, Region: Bosnien och Hercegovina) LanguageId-värde |
+| [Czech](#Czech) | Tjeckiska (Region: Tjeckien, CSY) LanguageId-värde |
+| [Danish](#Danish) | Danska (Region: Danmark, DAN) LanguageId-värde |
+| [Dari](#Dari) | Dari (Region: Afghanistan) LanguageId-värde |
+| [Divehi](#Divehi) | Divehi (Region: Maldiverna) LanguageId-värde |
+| [Dutch_Belgium](#Dutch-Belgium) | Nederländska (Flemiska, Region: Belgien, NLB) LanguageId-värde |
+| [Dutch_Netherlands](#Dutch-Netherlands) | Nederländska (Standard, Region: Nederländerna, NLD) LanguageId-värde |
+| [English_Australia](#English-Australia) | Engelska (Australisk, Region: Australien, ENA) LanguageId-värde |
+| [English_Belize](#English-Belize) | Engelska (Region: Belize) LanguageId-värde |
+| [English_Canada](#English-Canada) | Engelska (Kanadisk, Region: Kanada, ENC) LanguageId-värde |
+| [English_Caribbean](#English-Caribbean) | Engelska (Region: Caribbean) LanguageId värde |
+| [English_India](#English-India) | Engelska (Region: Indien) LanguageId värde |
+| [English_Ireland](#English-Ireland) | Engelska (Region: Irland, ENI) LanguageId värde |
+| [English_Jamaica](#English-Jamaica) | Engelska (Region: Jamaica) LanguageId värde |
+| [English_Malaysia](#English-Malaysia) | Engelska (Region: Malaysia) LanguageId värde |
+| [English_New_Zealand](#English-New-Zealand) | Engelska (Region: Nya Zeeland, ENZ) LanguageId värde |
+| [English_ROP](#English-ROP) | Engelska (Region: Filippinernas republiken, ROP) LanguageId värde |
+| [English_Singapore](#English-Singapore) | Engelska (Region: Singapore) LanguageId värde |
+| [English_South_Africa](#English-South-Africa) | Engelska (Region: Sydafrika, SA) LanguageId värde |
+| [English_TT](#English-TT) | Engelska (Region: Trinidad och Tobago, TT) LanguageId värde |
+| [English_United_Kingdom](#English-United-Kingdom) | Engelska (Brittiska, Region: Storbritannien, ENG) LanguageId värde |
+| [English_United_States](#English-United-States) | Engelska (Amerikanska, Region: USA, ENU) LanguageId värde |
+| [English_Zimbabwe](#English-Zimbabwe) | Engelska (Region: Zimbabwe) LanguageId värde |
+| [Estonian](#Estonian) | Estniska (Region: Estland, ETI) LanguageId värde |
+| [Faroese](#Faroese) | Färöiska (Region: Färöarna) LanguageId värde |
+| [Filipino](#Filipino) | Filippinska (Region: Filippinerna) LanguageId värde |
+| [Finnish](#Finnish) | Finska (Region: Finland, FIN) LanguageId värde |
+| [French_Belgium](#French-Belgium) | Franska (Belgiska, Region: Belgien, FRB) LanguageId värde |
+| [French_Canada](#French-Canada) | Franska (Kanadensiska, Region: Kanada, FRC) LanguageId värde |
+| [French_France](#French-France) | Franska (Standard, Region: Frankrike, FRA) LanguageId värde |
+| [French_Luxembourg](#French-Luxembourg) | Franska (Region: Luxemburg, FRL) LanguageId värde |
+| [French_MC](#French-MC) | Franska (Region: Monacos furstendöme, MC) LanguageId värde |
+| [French_Switzerland](#French-Switzerland) | Franska (Schweiziska, Region: Schweiz, FRS) LanguageId värde |
+| [Frisian](#Frisian) | Frisiska (Region: Nederländerna, NLD) LanguageId värde |
+| [Galician](#Galician) | Galiciska (Region: Galicien) LanguageId värde |
+| [Georgian](#Georgian) | Georgiska (Region: Georgien) LanguageId värde |
+| [German_Austria](#German-Austria) | Tyska (Österrikisk, Region: Österrike, DEA) LanguageId värde |
+| [German_Germany](#German-Germany) | Tyska (Standard, Region: Tyskland, DEU) LanguageId värde |
+| [German_Liechtenstein](#German-Liechtenstein) | Tyska (Region: Liechtenstein, DEC) LanguageId värde |
+| [German_Luxembourg](#German-Luxembourg) | Tyska (Region: Luxemburg, DEL) LanguageId värde |
+| [German_Switzerland](#German-Switzerland) | Tyska (Schweizisk, Region: Schweiz, DES) LanguageId värde |
+| [Greek](#Greek) | Grekiska (Region: Grekland, ELL) LanguageId värde |
+| [Greenlandic](#Greenlandic) | Grönländska (Region: Grönland) LanguageId värde |
+| [Gujarati](#Gujarati) | Gujarati (Region: Indien) LanguageId värde |
+| [Hausa](#Hausa) | Hausa (Latin, Region: Nigeria) LanguageId värde |
+| [Hebrew](#Hebrew) | Hebreiska (Region: Israel) LanguageId värde |
+| [Hindi](#Hindi) | Hindi (Region: Indien) LanguageId värde |
+| [Hungarian](#Hungarian) | Ungerska (Region: Ungern, HUN) LanguageId värde |
+| [Icelandic](#Icelandic) | Isländska (Region: Island, ISL) LanguageId värde |
+| [Igbo](#Igbo) | Igbo (Region: Nigeria) LanguageId värde |
+| [Indonesian](#Indonesian) | Indonesiska (Region: Indonesien) LanguageId värde |
+| [Inuktitut](#Inuktitut) | Inuktitut (Region: Kanada) LanguageId värde |
+| [Inuktitut_Latin](#Inuktitut-Latin) | Inuktitut (Latin, Region: Kanada) LanguageId värde |
+| [Irish](#Irish) | Irländska (Region: Irland) LanguageId värde |
+| [Italian_Italy](#Italian-Italy) | Italienska (Standard, Region: Italien, ITA) LanguageId värde |
+| [Italian_Switzerland](#Italian-Switzerland) | Italienska (Schweizisk, Region: Schweiz, ITS) LanguageId värde |
+| [Japanese](#Japanese) | Japanska (Region: Japan) LanguageId värde |
+| [Kannada](#Kannada) | Kannada (Region: Indien) LanguageId värde |
+| [Kazakh](#Kazakh) | Kazakiska (Region: Kazakstan) LanguageId värde |
+| [Khmer](#Khmer) | Khmer (Region: Kambodja) LanguageId värde |
+| [Kiche](#Kiche) | K\\u2019iche (Region: Guatemala) LanguageId värde |
+| [Kinyarwanda](#Kinyarwanda) | Kinyarwanda (Region: Rwanda) LanguageId värde |
+| [Kiswahili](#Kiswahili) | Kiswahili (Region: Kenya) LanguageId värde |
+| [Konkani](#Konkani) | Konkani (Region: India) LanguageId värde |
+| [Korean](#Korean) | Korean (Region: Korea) LanguageId värde |
+| [Kyrgyz](#Kyrgyz) | Kyrgyz (Region: Kyrgyzstan) LanguageId värde |
+| [Lao](#Lao) | Lao (Region: Lao P.D.R.) |
+| [Latvian](#Latvian) | Latvian (Region: Latvia, LVI) LanguageId värde |
+| [Lithuanian](#Lithuanian) | Lithuanian (Region: Lithuania, LTH) LanguageId värde |
+| [Lower_Sorbian](#Lower-Sorbian) | Lower Sorbian (Region: Germany) LanguageId värde |
+| [Luxembourgish](#Luxembourgish) | Luxembourgish (Region: Luxembourg) LanguageId värde |
+| [Macedonian](#Macedonian) | Macedonian (Region: North Macedonia) LanguageId värde |
+| [Malay_Brunei_Darussalam](#Malay-Brunei-Darussalam) | Malay (Region: Brunei Darussalam) LanguageId värde |
+| [Malay_Malaysia](#Malay-Malaysia) | Malay (Region: Malaysia) LanguageId värde |
+| [Malayalam](#Malayalam) | Malayalam (Region: India) LanguageId värde |
+| [Maltese](#Maltese) | Maltese (Region: Malta) LanguageId värde |
+| [Maori](#Maori) | Maori (Region: New Zealand) LanguageId värde |
+| [Mapudungun](#Mapudungun) | Mapudungun (Region: Chile) LanguageId värde |
+| [Marathi](#Marathi) | Marathi (Region: India) LanguageId värde |
+| [Mohawk](#Mohawk) | Mohawk (Region: Mohawk) LanguageId värde |
+| [Mongolian_Cyrillic](#Mongolian-Cyrillic) | Mongolian (Cyrillic, Region: Mongolia) LanguageId värde |
+| [Mongolian_Traditional](#Mongolian-Traditional) | Mongolian (Traditional, Region: People\\u2019s Republic of China) LanguageId värde |
+| [Nepali](#Nepali) | Nepali (Region: Nepal) LanguageId värde |
+| [Norwegian_Bokmal](#Norwegian-Bokmal) | Norwegian (Bokmal, Region: Norway, NOR) LanguageId värde |
+| [Norwegian_Nynorsk](#Norwegian-Nynorsk) | Norwegian (Nynorsk, Region: Norway, NON) LanguageId värde |
+| [Occitan](#Occitan) | Occitan (Region: France) LanguageId‑värde |
+| [Odia](#Odia) | Odia (tidigare Oriya, Region: India) LanguageId‑värde |
+| [Pashto](#Pashto) | Pashto (Region: Afghanistan) LanguageId‑värde |
+| [Polish](#Polish) | Polska (Region: Poland, PLK) LanguageId‑värde |
+| [Portuguese_Brazil](#Portuguese-Brazil) | Portugisiska (brasiliansk, Region: Brazil, PTB) LanguageId‑värde |
+| [Portuguese_Portugal](#Portuguese-Portugal) | Portugisiska (standard, Region: Portugal, PTG) LanguageId‑värde |
+| [Punjabi](#Punjabi) | Punjabi (Region: India) LanguageId‑värde |
+| [Quechua_Bolivia](#Quechua-Bolivia) | Quechua (Region: Bolivia) LanguageId‑värde |
+| [Quechua_Ecuador](#Quechua-Ecuador) | Quechua (Region: Ecuador) LanguageId‑värde |
+| [Quechua_Peru](#Quechua-Peru) | Quechua (Region: Peru) LanguageId‑värde |
+| [Romanian](#Romanian) | Rumänska (Region: Romania, ROM) LanguageId‑värde |
+| [Romansh](#Romansh) | Rätoromanska (Region: Switzerland) LanguageId‑värde |
+| [Russian](#Russian) | Ryska (Region: Russia, RUS) LanguageId‑värde |
+| [Sami_Inari](#Sami-Inari) | Sami (Inari, Region: Finland) LanguageId‑värde |
+| [Sami_Lule_Norway](#Sami-Lule-Norway) | Sami (Lule, Region: Norway) LanguageId‑värde |
+| [Sami_Lule_Sweden](#Sami-Lule-Sweden) | Sami (Lule, Region: Sweden) LanguageId‑värde |
+| [Sami_Northern_Finland](#Sami-Northern-Finland) | Sami (nordlig, Region: Finland) LanguageId‑värde |
+| [Sami_Northern_Norway](#Sami-Northern-Norway) | Sami (nordlig, Region: Norway) LanguageId‑värde |
+| [Sami_Northern_Sweden](#Sami-Northern-Sweden) | Sami (nordlig, Region: Sweden) LanguageId‑värde |
+| [Sami_Skolt](#Sami-Skolt) | Sami (Skolt, Region: Finland) LanguageId‑värde |
+| [Sami_Southern_Norway](#Sami-Southern-Norway) | Sami (södra, Region: Norway) LanguageId‑värde |
+| [Sami_Southern_Sweden](#Sami-Southern-Sweden) | Sami (södra, Region: Sweden) LanguageId‑värde |
+| [Sanskrit](#Sanskrit) | Sanskrit (Region: India) LanguageId‑värde |
+| [Serbian_Cyrillic_BIH](#Serbian-Cyrillic-BIH) | Serbiska (kyrillisk, Region: Bosnia and Herzegovina) LanguageId‑värde |
+| [Serbian_Cyrillic_Serbia](#Serbian-Cyrillic-Serbia) | Serbiska (kyrillisk, Region: Serbia) LanguageId‑värde |
+| [Serbian_Latin_BIH](#Serbian-Latin-BIH) | Serbiska (Latin, Region: Bosnien och Herzegovina) LanguageId värde |
+| [Serbian_Latin_Serbia](#Serbian-Latin-Serbia) | Serbiska (Latin, Region: Serbien) LanguageId värde |
+| [Sesotho_Sa_Leboa](#Sesotho-Sa-Leboa) | Sesotho sa Leboa (Nordliga Sotho, Region: Sydafrika, SA) LanguageId värde |
+| [Setswana](#Setswana) | Setswana (Region: Sydafrika, SA) LanguageId värde |
+| [Sinhala](#Sinhala) | Sinhala (Region: Sri Lanka) LanguageId värde |
+| [Slovak](#Slovak) | Slovakiska (Region: Slovakien, SKY) LanguageId värde |
+| [Slovenian](#Slovenian) | Slovenska (Region: Slovenien, SLV) LanguageId värde |
+| [Spanish_Argentina](#Spanish-Argentina) | Spanska (Region: Argentina) LanguageId värde |
+| [Spanish_Bolivia](#Spanish-Bolivia) | Spanska (Region: Bolivia) LanguageId värde |
+| [Spanish_Chile](#Spanish-Chile) | Spanska (Region: Chile) LanguageId värde |
+| [Spanish_Colombia](#Spanish-Colombia) | Spanska (Region: Colombia) LanguageId värde |
+| [Spanish_Costa_Rica](#Spanish-Costa-Rica) | Spanska (Region: Costa Rica) LanguageId värde |
+| [Spanish_Dominican_Republic](#Spanish-Dominican-Republic) | Spanska (Region: Dominikanska republiken) LanguageId värde |
+| [Spanish_Ecuador](#Spanish-Ecuador) | Spanska (Region: Ecuador) LanguageId värde |
+| [Spanish_El_Salvador](#Spanish-El-Salvador) | Spanska (Region: El Salvador) LanguageId värde |
+| [Spanish_Guatemala](#Spanish-Guatemala) | Spanska (Region: Guatemala) LanguageId värde |
+| [Spanish_Honduras](#Spanish-Honduras) | Spanska (Region: Honduras) LanguageId värde |
+| [Spanish_Mexico](#Spanish-Mexico) | Spanska (Mexikansk, Region: Mexiko, ESM) LanguageId värde |
+| [Spanish_Modern_Sort](#Spanish-Modern-Sort) | Spanska (Modern sortering, Region: Spanien, ESN) LanguageId värde |
+| [Spanish_Nicaragua](#Spanish-Nicaragua) | Spanska (Region: Nicaragua) LanguageId värde |
+| [Spanish_Panama](#Spanish-Panama) | Spanska (Region: Panama) LanguageId värde |
+| [Spanish_Paraguay](#Spanish-Paraguay) | Spanska (Region: Paraguay) LanguageId värde |
+| [Spanish_Peru](#Spanish-Peru) | Spanska (Region: Peru) LanguageId värde |
+| [Spanish_Puerto_Rico](#Spanish-Puerto-Rico) | Spanska (Region: Puerto Rico) LanguageId värde |
+| [Spanish_Traditional_Sort](#Spanish-Traditional-Sort) | Spanska (Traditionell sortering, Region: Spanien, ESP) LanguageId värde |
+| [Spanish_United_States](#Spanish-United-States) | Spanska (Region: USA) LanguageId värde |
+| [Spanish_Uruguay](#Spanish-Uruguay) | Spanska (Region: Uruguay) LanguageId värde |
+| [Spanish_Venezuela](#Spanish-Venezuela) | Spanska (Region: Venezuela) LanguageId värde |
+| [Swedish_Finland](#Swedish-Finland) | Svenska (Region: Finland) LanguageId värde |
+| [Swedish_Sweden](#Swedish-Sweden) | Svenska (Region: Sverige, SVE) LanguageId värde |
+| [Syriac](#Syriac) | Syriska (Region: Syrien) LanguageId värde |
+| [Tajik](#Tajik) | Tadzjikiska (Cyrillisk, Region: Tadzjikistan) LanguageId värde |
+| [Tamazight](#Tamazight) | Tamazight (Latin, Region: Algeriet) LanguageId värde |
+| [Tamil](#Tamil) | Tamil (Region: Indien) LanguageId värde |
+| [Tatar](#Tatar) | Tatar (Region: Ryssland) LanguageId värde |
+| [Telugu](#Telugu) | Telugu (Region: Indien) LanguageId värde |
+| [Thai](#Thai) | Thailändska (Region: Thailand) LanguageId värde |
+| [Tibetan](#Tibetan) | Tibetanska (Region: PRC) LanguageId värde |
+| [Turkish](#Turkish) | Turkiska (Region: Turkiet, TRK) LanguageId värde |
+| [Turkmen](#Turkmen) | Turkmeniska (Region: Turkmenistan) LanguageId värde |
+| [Uighur](#Uighur) | Uiguriska (Region: PRC) LanguageId värde |
+| [Ukrainian](#Ukrainian) | Ukrainska (Region: Ukraina, UKR) LanguageId värde |
+| [Upper_Sorbian](#Upper-Sorbian) | Övre sorbiska (Region: Tyskland) LanguageId värde |
+| [Urdu](#Urdu) | Urdu (Region: Islamiska republiken Pakistan) LanguageId värde |
+| [Uzbek_Cyrillic](#Uzbek-Cyrillic) | Uzbekiska (Cyrillisk, Region: Uzbekistan) LanguageId värde |
+| [Uzbek_Latin](#Uzbek-Latin) | Uzbekiska (Latin, Region: Uzbekistan) LanguageId värde |
+| [Vietnamese](#Vietnamese) | Vietnamesiska (Region: Vietnam) LanguageId värde |
+| [Welsh](#Welsh) | Walesiska (Region: Storbritannien) LanguageId värde |
+| [Wolof](#Wolof) | Wolof (Region: Senegal) LanguageId värde |
+| [Yakut](#Yakut) | Jakutiska (Region: Ryssland) LanguageId värde |
+| [Yi](#Yi) | Yi (Region: PRC) LanguageId-värde |
+| [Yoruba](#Yoruba) | Yoruba (Region: Nigeria) LanguageId-värde |
+| [isiXhosa](#isiXhosa) | isiXhosa (Region: Sydafrika, SA) LanguageId-värde |
+| [isiZulu](#isiZulu) | isiZulu (Region: Sydafrika, SA) LanguageId-värde |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getId()](#getId--) | Hämta heltalsvärdet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Afrikaans {#Afrikaans}
+```
+public static final MSLanguageId Afrikaans
+```
+
+
+Afrikaans (Region: Sydafrika, SA) LanguageId-värde
+
+### Albanian {#Albanian}
+```
+public static final MSLanguageId Albanian
+```
+
+
+Albanska (Region: Albanien, SQI) LanguageId värde
+
+### Alsatian {#Alsatian}
+```
+public static final MSLanguageId Alsatian
+```
+
+
+Alsatiska (Region: Frankrike) LanguageId värde
+
+### Amharic {#Amharic}
+```
+public static final MSLanguageId Amharic
+```
+
+
+Amhariska (Region: Etiopien) LanguageId värde
+
+### Arabic_Algeria {#Arabic-Algeria}
+```
+public static final MSLanguageId Arabic_Algeria
+```
+
+
+Arabiska (Region: Algeriet) LanguageId värde
+
+### Arabic_Bahrain {#Arabic-Bahrain}
+```
+public static final MSLanguageId Arabic_Bahrain
+```
+
+
+Arabiska (Region: Bahrain) LanguageId värde
+
+### Arabic_Egypt {#Arabic-Egypt}
+```
+public static final MSLanguageId Arabic_Egypt
+```
+
+
+Arabiska (Region: Egypten) LanguageId värde
+
+### Arabic_Iraq {#Arabic-Iraq}
+```
+public static final MSLanguageId Arabic_Iraq
+```
+
+
+Arabiska (Region: Irak) LanguageId värde
+
+### Arabic_Jordan {#Arabic-Jordan}
+```
+public static final MSLanguageId Arabic_Jordan
+```
+
+
+Arabiska (Region: Jordanien) LanguageId värde
+
+### Arabic_Kuwait {#Arabic-Kuwait}
+```
+public static final MSLanguageId Arabic_Kuwait
+```
+
+
+Arabiska (Region: Kuwait) LanguageId värde
+
+### Arabic_Lebanon {#Arabic-Lebanon}
+```
+public static final MSLanguageId Arabic_Lebanon
+```
+
+
+Arabiska (Region: Libanon) LanguageId värde
+
+### Arabic_Libya {#Arabic-Libya}
+```
+public static final MSLanguageId Arabic_Libya
+```
+
+
+Arabiska (Region: Libyen) LanguageId värde
+
+### Arabic_Morocco {#Arabic-Morocco}
+```
+public static final MSLanguageId Arabic_Morocco
+```
+
+
+Arabiska (Region: Marocko) LanguageId värde
+
+### Arabic_Oman {#Arabic-Oman}
+```
+public static final MSLanguageId Arabic_Oman
+```
+
+
+Arabiska (Region: Oman) LanguageId värde
+
+### Arabic_Qatar {#Arabic-Qatar}
+```
+public static final MSLanguageId Arabic_Qatar
+```
+
+
+Arabiska (Region: Qatar) LanguageId värde
+
+### Arabic_Saudi_Arabia {#Arabic-Saudi-Arabia}
+```
+public static final MSLanguageId Arabic_Saudi_Arabia
+```
+
+
+Arabiska (Region: Saudiarabien) LanguageId värde
+
+### Arabic_Syria {#Arabic-Syria}
+```
+public static final MSLanguageId Arabic_Syria
+```
+
+
+Arabiska (Region: Syrien) LanguageId värde
+
+### Arabic_Tunisia {#Arabic-Tunisia}
+```
+public static final MSLanguageId Arabic_Tunisia
+```
+
+
+Arabiska (Region: Tunisien) LanguageId värde
+
+### Arabic_U_A_E {#Arabic-U-A-E}
+```
+public static final MSLanguageId Arabic_U_A_E
+```
+
+
+Arabiska (Region: F.A.E.) LanguageId-värde
+
+### Arabic_Yemen {#Arabic-Yemen}
+```
+public static final MSLanguageId Arabic_Yemen
+```
+
+
+Arabiska (Region: Jemen) LanguageId värde
+
+### Armenian {#Armenian}
+```
+public static final MSLanguageId Armenian
+```
+
+
+Armeniska (Region: Armenien) LanguageId värde
+
+### Assamese {#Assamese}
+```
+public static final MSLanguageId Assamese
+```
+
+
+Assamesiska (Region: Indien) LanguageId värde
+
+### Azeri_Cyrillic {#Azeri-Cyrillic}
+```
+public static final MSLanguageId Azeri_Cyrillic
+```
+
+
+Azeri (Kyrillisk, Region: Azerbajdzjan) LanguageId värde
+
+### Azeri_Latin {#Azeri-Latin}
+```
+public static final MSLanguageId Azeri_Latin
+```
+
+
+Azeri (Latinsk, Region: Azerbajdzjan) LanguageId värde
+
+### Bashkir {#Bashkir}
+```
+public static final MSLanguageId Bashkir
+```
+
+
+Bashkiriska (Region: Ryssland) LanguageId värde
+
+### Basque {#Basque}
+```
+public static final MSLanguageId Basque
+```
+
+
+Baskiska (Region: Baskien, EUQ) LanguageId värde
+
+### Belarusian {#Belarusian}
+```
+public static final MSLanguageId Belarusian
+```
+
+
+Belarusiska (Region: Belarus, BEL) LanguageId-värde
+
+### Bengali_Bangladesh {#Bengali-Bangladesh}
+```
+public static final MSLanguageId Bengali_Bangladesh
+```
+
+
+Bengali (Region: Bangladesh) LanguageId-värde
+
+### Bengali_India {#Bengali-India}
+```
+public static final MSLanguageId Bengali_India
+```
+
+
+Bengali (Region: India) LanguageId-värde
+
+### Bosnian_Cyrillic {#Bosnian-Cyrillic}
+```
+public static final MSLanguageId Bosnian_Cyrillic
+```
+
+
+Bosniska (Kyrilliska, Region: Bosnien och Hercegovina) LanguageId-värde
+
+### Bosnian_Latin {#Bosnian-Latin}
+```
+public static final MSLanguageId Bosnian_Latin
+```
+
+
+Bosniska (Latinska, Region: Bosnien och Hercegovina) LanguageId-värde
+
+### Breton {#Breton}
+```
+public static final MSLanguageId Breton
+```
+
+
+Bretonska (Region: Frankrike) LanguageId-värde
+
+### Bulgarian {#Bulgarian}
+```
+public static final MSLanguageId Bulgarian
+```
+
+
+Bulgariska (Region: Bulgarien, BGR) LanguageId-värde
+
+### Catalan {#Catalan}
+```
+public static final MSLanguageId Catalan
+```
+
+
+Katalanska (Region: Katalonien, CAT) LanguageId-värde
+
+### Chinese_Hong_Kong {#Chinese-Hong-Kong}
+```
+public static final MSLanguageId Chinese_Hong_Kong
+```
+
+
+Kinesiska (Region: Hongkong S.A.R.) LanguageId-värde
+
+### Chinese_Macao {#Chinese-Macao}
+```
+public static final MSLanguageId Chinese_Macao
+```
+
+
+Kinesiska (Region: Macao S.A.R.) LanguageId-värde
+
+### Chinese_PRC {#Chinese-PRC}
+```
+public static final MSLanguageId Chinese_PRC
+```
+
+
+Kinesiska (Region: Folkrepubliken Kina) LanguageId-värde
+
+### Chinese_Singapore {#Chinese-Singapore}
+```
+public static final MSLanguageId Chinese_Singapore
+```
+
+
+Kinesiska (Region: Singapore) LanguageId-värde
+
+### Chinese_Taiwan {#Chinese-Taiwan}
+```
+public static final MSLanguageId Chinese_Taiwan
+```
+
+
+Kinesiska (Region: Taiwan) LanguageId-värde
+
+### Corsican {#Corsican}
+```
+public static final MSLanguageId Corsican
+```
+
+
+Korsikanska (Region: Frankrike) LanguageId-värde
+
+### Croatian {#Croatian}
+```
+public static final MSLanguageId Croatian
+```
+
+
+Kroatiska (Region: Kroatien, SHL) LanguageId-värde
+
+### Croatian_Latin {#Croatian-Latin}
+```
+public static final MSLanguageId Croatian_Latin
+```
+
+
+Kroatiska (Latinska, Region: Bosnien och Hercegovina) LanguageId-värde
+
+### Czech {#Czech}
+```
+public static final MSLanguageId Czech
+```
+
+
+Tjeckiska (Region: Tjeckien, CSY) LanguageId-värde
+
+### Danish {#Danish}
+```
+public static final MSLanguageId Danish
+```
+
+
+Danska (Region: Danmark, DAN) LanguageId-värde
+
+### Dari {#Dari}
+```
+public static final MSLanguageId Dari
+```
+
+
+Dari (Region: Afghanistan) LanguageId-värde
+
+### Divehi {#Divehi}
+```
+public static final MSLanguageId Divehi
+```
+
+
+Divehi (Region: Maldiverna) LanguageId-värde
+
+### Dutch_Belgium {#Dutch-Belgium}
+```
+public static final MSLanguageId Dutch_Belgium
+```
+
+
+Nederländska (Flemiska, Region: Belgien, NLB) LanguageId-värde
+
+### Dutch_Netherlands {#Dutch-Netherlands}
+```
+public static final MSLanguageId Dutch_Netherlands
+```
+
+
+Nederländska (Standard, Region: Nederländerna, NLD) LanguageId-värde
+
+### English_Australia {#English-Australia}
+```
+public static final MSLanguageId English_Australia
+```
+
+
+Engelska (Australisk, Region: Australien, ENA) LanguageId-värde
+
+### English_Belize {#English-Belize}
+```
+public static final MSLanguageId English_Belize
+```
+
+
+Engelska (Region: Belize) LanguageId-värde
+
+### English_Canada {#English-Canada}
+```
+public static final MSLanguageId English_Canada
+```
+
+
+Engelska (Kanadisk, Region: Kanada, ENC) LanguageId-värde
+
+### English_Caribbean {#English-Caribbean}
+```
+public static final MSLanguageId English_Caribbean
+```
+
+
+Engelska (Region: Caribbean) LanguageId värde
+
+### English_India {#English-India}
+```
+public static final MSLanguageId English_India
+```
+
+
+Engelska (Region: Indien) LanguageId värde
+
+### English_Ireland {#English-Ireland}
+```
+public static final MSLanguageId English_Ireland
+```
+
+
+Engelska (Region: Irland, ENI) LanguageId värde
+
+### English_Jamaica {#English-Jamaica}
+```
+public static final MSLanguageId English_Jamaica
+```
+
+
+Engelska (Region: Jamaica) LanguageId värde
+
+### English_Malaysia {#English-Malaysia}
+```
+public static final MSLanguageId English_Malaysia
+```
+
+
+Engelska (Region: Malaysia) LanguageId värde
+
+### English_New_Zealand {#English-New-Zealand}
+```
+public static final MSLanguageId English_New_Zealand
+```
+
+
+Engelska (Region: Nya Zeeland, ENZ) LanguageId värde
+
+### English_ROP {#English-ROP}
+```
+public static final MSLanguageId English_ROP
+```
+
+
+Engelska (Region: Filippinernas republiken, ROP) LanguageId värde
+
+### English_Singapore {#English-Singapore}
+```
+public static final MSLanguageId English_Singapore
+```
+
+
+Engelska (Region: Singapore) LanguageId värde
+
+### English_South_Africa {#English-South-Africa}
+```
+public static final MSLanguageId English_South_Africa
+```
+
+
+Engelska (Region: Sydafrika, SA) LanguageId värde
+
+### English_TT {#English-TT}
+```
+public static final MSLanguageId English_TT
+```
+
+
+Engelska (Region: Trinidad och Tobago, TT) LanguageId värde
+
+### English_United_Kingdom {#English-United-Kingdom}
+```
+public static final MSLanguageId English_United_Kingdom
+```
+
+
+Engelska (Brittiska, Region: Storbritannien, ENG) LanguageId värde
+
+### English_United_States {#English-United-States}
+```
+public static final MSLanguageId English_United_States
+```
+
+
+Engelska (Amerikanska, Region: USA, ENU) LanguageId värde
+
+### English_Zimbabwe {#English-Zimbabwe}
+```
+public static final MSLanguageId English_Zimbabwe
+```
+
+
+Engelska (Region: Zimbabwe) LanguageId värde
+
+### Estonian {#Estonian}
+```
+public static final MSLanguageId Estonian
+```
+
+
+Estniska (Region: Estland, ETI) LanguageId värde
+
+### Faroese {#Faroese}
+```
+public static final MSLanguageId Faroese
+```
+
+
+Färöiska (Region: Färöarna) LanguageId värde
+
+### Filipino {#Filipino}
+```
+public static final MSLanguageId Filipino
+```
+
+
+Filippinska (Region: Filippinerna) LanguageId värde
+
+### Finnish {#Finnish}
+```
+public static final MSLanguageId Finnish
+```
+
+
+Finska (Region: Finland, FIN) LanguageId värde
+
+### French_Belgium {#French-Belgium}
+```
+public static final MSLanguageId French_Belgium
+```
+
+
+Franska (Belgiska, Region: Belgien, FRB) LanguageId värde
+
+### French_Canada {#French-Canada}
+```
+public static final MSLanguageId French_Canada
+```
+
+
+Franska (Kanadensiska, Region: Kanada, FRC) LanguageId värde
+
+### French_France {#French-France}
+```
+public static final MSLanguageId French_France
+```
+
+
+Franska (Standard, Region: Frankrike, FRA) LanguageId värde
+
+### French_Luxembourg {#French-Luxembourg}
+```
+public static final MSLanguageId French_Luxembourg
+```
+
+
+Franska (Region: Luxemburg, FRL) LanguageId värde
+
+### French_MC {#French-MC}
+```
+public static final MSLanguageId French_MC
+```
+
+
+Franska (Region: Monacos furstendöme, MC) LanguageId värde
+
+### French_Switzerland {#French-Switzerland}
+```
+public static final MSLanguageId French_Switzerland
+```
+
+
+Franska (Schweiziska, Region: Schweiz, FRS) LanguageId värde
+
+### Frisian {#Frisian}
+```
+public static final MSLanguageId Frisian
+```
+
+
+Frisiska (Region: Nederländerna, NLD) LanguageId värde
+
+### Galician {#Galician}
+```
+public static final MSLanguageId Galician
+```
+
+
+Galiciska (Region: Galicien) LanguageId värde
+
+### Georgian {#Georgian}
+```
+public static final MSLanguageId Georgian
+```
+
+
+Georgiska (Region: Georgien) LanguageId värde
+
+### German_Austria {#German-Austria}
+```
+public static final MSLanguageId German_Austria
+```
+
+
+Tyska (Österrikisk, Region: Österrike, DEA) LanguageId värde
+
+### German_Germany {#German-Germany}
+```
+public static final MSLanguageId German_Germany
+```
+
+
+Tyska (Standard, Region: Tyskland, DEU) LanguageId värde
+
+### German_Liechtenstein {#German-Liechtenstein}
+```
+public static final MSLanguageId German_Liechtenstein
+```
+
+
+Tyska (Region: Liechtenstein, DEC) LanguageId värde
+
+### German_Luxembourg {#German-Luxembourg}
+```
+public static final MSLanguageId German_Luxembourg
+```
+
+
+Tyska (Region: Luxemburg, DEL) LanguageId värde
+
+### German_Switzerland {#German-Switzerland}
+```
+public static final MSLanguageId German_Switzerland
+```
+
+
+Tyska (Schweizisk, Region: Schweiz, DES) LanguageId värde
+
+### Greek {#Greek}
+```
+public static final MSLanguageId Greek
+```
+
+
+Grekiska (Region: Grekland, ELL) LanguageId värde
+
+### Greenlandic {#Greenlandic}
+```
+public static final MSLanguageId Greenlandic
+```
+
+
+Grönländska (Region: Grönland) LanguageId värde
+
+### Gujarati {#Gujarati}
+```
+public static final MSLanguageId Gujarati
+```
+
+
+Gujarati (Region: Indien) LanguageId värde
+
+### Hausa {#Hausa}
+```
+public static final MSLanguageId Hausa
+```
+
+
+Hausa (Latin, Region: Nigeria) LanguageId värde
+
+### Hebrew {#Hebrew}
+```
+public static final MSLanguageId Hebrew
+```
+
+
+Hebreiska (Region: Israel) LanguageId värde
+
+### Hindi {#Hindi}
+```
+public static final MSLanguageId Hindi
+```
+
+
+Hindi (Region: Indien) LanguageId värde
+
+### Hungarian {#Hungarian}
+```
+public static final MSLanguageId Hungarian
+```
+
+
+Ungerska (Region: Ungern, HUN) LanguageId värde
+
+### Icelandic {#Icelandic}
+```
+public static final MSLanguageId Icelandic
+```
+
+
+Isländska (Region: Island, ISL) LanguageId värde
+
+### Igbo {#Igbo}
+```
+public static final MSLanguageId Igbo
+```
+
+
+Igbo (Region: Nigeria) LanguageId värde
+
+### Indonesian {#Indonesian}
+```
+public static final MSLanguageId Indonesian
+```
+
+
+Indonesiska (Region: Indonesien) LanguageId värde
+
+### Inuktitut {#Inuktitut}
+```
+public static final MSLanguageId Inuktitut
+```
+
+
+Inuktitut (Region: Kanada) LanguageId värde
+
+### Inuktitut_Latin {#Inuktitut-Latin}
+```
+public static final MSLanguageId Inuktitut_Latin
+```
+
+
+Inuktitut (Latin, Region: Kanada) LanguageId värde
+
+### Irish {#Irish}
+```
+public static final MSLanguageId Irish
+```
+
+
+Irländska (Region: Irland) LanguageId värde
+
+### Italian_Italy {#Italian-Italy}
+```
+public static final MSLanguageId Italian_Italy
+```
+
+
+Italienska (Standard, Region: Italien, ITA) LanguageId värde
+
+### Italian_Switzerland {#Italian-Switzerland}
+```
+public static final MSLanguageId Italian_Switzerland
+```
+
+
+Italienska (Schweizisk, Region: Schweiz, ITS) LanguageId värde
+
+### Japanese {#Japanese}
+```
+public static final MSLanguageId Japanese
+```
+
+
+Japanska (Region: Japan) LanguageId värde
+
+### Kannada {#Kannada}
+```
+public static final MSLanguageId Kannada
+```
+
+
+Kannada (Region: Indien) LanguageId värde
+
+### Kazakh {#Kazakh}
+```
+public static final MSLanguageId Kazakh
+```
+
+
+Kazakiska (Region: Kazakstan) LanguageId värde
+
+### Khmer {#Khmer}
+```
+public static final MSLanguageId Khmer
+```
+
+
+Khmer (Region: Kambodja) LanguageId värde
+
+### Kiche {#Kiche}
+```
+public static final MSLanguageId Kiche
+```
+
+
+K\\u2019iche (Region: Guatemala) LanguageId värde
+
+### Kinyarwanda {#Kinyarwanda}
+```
+public static final MSLanguageId Kinyarwanda
+```
+
+
+Kinyarwanda (Region: Rwanda) LanguageId värde
+
+### Kiswahili {#Kiswahili}
+```
+public static final MSLanguageId Kiswahili
+```
+
+
+Kiswahili (Region: Kenya) LanguageId värde
+
+### Konkani {#Konkani}
+```
+public static final MSLanguageId Konkani
+```
+
+
+Konkani (Region: India) LanguageId värde
+
+### Korean {#Korean}
+```
+public static final MSLanguageId Korean
+```
+
+
+Korean (Region: Korea) LanguageId värde
+
+### Kyrgyz {#Kyrgyz}
+```
+public static final MSLanguageId Kyrgyz
+```
+
+
+Kyrgyz (Region: Kyrgyzstan) LanguageId värde
+
+### Lao {#Lao}
+```
+public static final MSLanguageId Lao
+```
+
+
+Lao (Region: Lao P.D.R.) LanguageId-värde
+
+### Latvian {#Latvian}
+```
+public static final MSLanguageId Latvian
+```
+
+
+Latvian (Region: Latvia, LVI) LanguageId värde
+
+### Lithuanian {#Lithuanian}
+```
+public static final MSLanguageId Lithuanian
+```
+
+
+Lithuanian (Region: Lithuania, LTH) LanguageId värde
+
+### Lower_Sorbian {#Lower-Sorbian}
+```
+public static final MSLanguageId Lower_Sorbian
+```
+
+
+Lower Sorbian (Region: Germany) LanguageId värde
+
+### Luxembourgish {#Luxembourgish}
+```
+public static final MSLanguageId Luxembourgish
+```
+
+
+Luxembourgish (Region: Luxembourg) LanguageId värde
+
+### Macedonian {#Macedonian}
+```
+public static final MSLanguageId Macedonian
+```
+
+
+Macedonian (Region: North Macedonia) LanguageId värde
+
+### Malay_Brunei_Darussalam {#Malay-Brunei-Darussalam}
+```
+public static final MSLanguageId Malay_Brunei_Darussalam
+```
+
+
+Malay (Region: Brunei Darussalam) LanguageId värde
+
+### Malay_Malaysia {#Malay-Malaysia}
+```
+public static final MSLanguageId Malay_Malaysia
+```
+
+
+Malay (Region: Malaysia) LanguageId värde
+
+### Malayalam {#Malayalam}
+```
+public static final MSLanguageId Malayalam
+```
+
+
+Malayalam (Region: India) LanguageId värde
+
+### Maltese {#Maltese}
+```
+public static final MSLanguageId Maltese
+```
+
+
+Maltese (Region: Malta) LanguageId värde
+
+### Maori {#Maori}
+```
+public static final MSLanguageId Maori
+```
+
+
+Maori (Region: New Zealand) LanguageId värde
+
+### Mapudungun {#Mapudungun}
+```
+public static final MSLanguageId Mapudungun
+```
+
+
+Mapudungun (Region: Chile) LanguageId värde
+
+### Marathi {#Marathi}
+```
+public static final MSLanguageId Marathi
+```
+
+
+Marathi (Region: India) LanguageId värde
+
+### Mohawk {#Mohawk}
+```
+public static final MSLanguageId Mohawk
+```
+
+
+Mohawk (Region: Mohawk) LanguageId värde
+
+### Mongolian_Cyrillic {#Mongolian-Cyrillic}
+```
+public static final MSLanguageId Mongolian_Cyrillic
+```
+
+
+Mongolian (Cyrillic, Region: Mongolia) LanguageId värde
+
+### Mongolian_Traditional {#Mongolian-Traditional}
+```
+public static final MSLanguageId Mongolian_Traditional
+```
+
+
+Mongolian (Traditional, Region: People\\u2019s Republic of China) LanguageId värde
+
+### Nepali {#Nepali}
+```
+public static final MSLanguageId Nepali
+```
+
+
+Nepali (Region: Nepal) LanguageId värde
+
+### Norwegian_Bokmal {#Norwegian-Bokmal}
+```
+public static final MSLanguageId Norwegian_Bokmal
+```
+
+
+Norwegian (Bokmal, Region: Norway, NOR) LanguageId värde
+
+### Norwegian_Nynorsk {#Norwegian-Nynorsk}
+```
+public static final MSLanguageId Norwegian_Nynorsk
+```
+
+
+Norwegian (Nynorsk, Region: Norway, NON) LanguageId värde
+
+### Occitan {#Occitan}
+```
+public static final MSLanguageId Occitan
+```
+
+
+Occitan (Region: France) LanguageId‑värde
+
+### Odia {#Odia}
+```
+public static final MSLanguageId Odia
+```
+
+
+Odia (tidigare Oriya, Region: India) LanguageId‑värde
+
+### Pashto {#Pashto}
+```
+public static final MSLanguageId Pashto
+```
+
+
+Pashto (Region: Afghanistan) LanguageId‑värde
+
+### Polish {#Polish}
+```
+public static final MSLanguageId Polish
+```
+
+
+Polska (Region: Poland, PLK) LanguageId‑värde
+
+### Portuguese_Brazil {#Portuguese-Brazil}
+```
+public static final MSLanguageId Portuguese_Brazil
+```
+
+
+Portugisiska (brasiliansk, Region: Brazil, PTB) LanguageId‑värde
+
+### Portuguese_Portugal {#Portuguese-Portugal}
+```
+public static final MSLanguageId Portuguese_Portugal
+```
+
+
+Portugisiska (standard, Region: Portugal, PTG) LanguageId‑värde
+
+### Punjabi {#Punjabi}
+```
+public static final MSLanguageId Punjabi
+```
+
+
+Punjabi (Region: India) LanguageId‑värde
+
+### Quechua_Bolivia {#Quechua-Bolivia}
+```
+public static final MSLanguageId Quechua_Bolivia
+```
+
+
+Quechua (Region: Bolivia) LanguageId‑värde
+
+### Quechua_Ecuador {#Quechua-Ecuador}
+```
+public static final MSLanguageId Quechua_Ecuador
+```
+
+
+Quechua (Region: Ecuador) LanguageId‑värde
+
+### Quechua_Peru {#Quechua-Peru}
+```
+public static final MSLanguageId Quechua_Peru
+```
+
+
+Quechua (Region: Peru) LanguageId‑värde
+
+### Romanian {#Romanian}
+```
+public static final MSLanguageId Romanian
+```
+
+
+Rumänska (Region: Romania, ROM) LanguageId‑värde
+
+### Romansh {#Romansh}
+```
+public static final MSLanguageId Romansh
+```
+
+
+Rätoromanska (Region: Switzerland) LanguageId‑värde
+
+### Russian {#Russian}
+```
+public static final MSLanguageId Russian
+```
+
+
+Ryska (Region: Russia, RUS) LanguageId‑värde
+
+### Sami_Inari {#Sami-Inari}
+```
+public static final MSLanguageId Sami_Inari
+```
+
+
+Sami (Inari, Region: Finland) LanguageId‑värde
+
+### Sami_Lule_Norway {#Sami-Lule-Norway}
+```
+public static final MSLanguageId Sami_Lule_Norway
+```
+
+
+Sami (Lule, Region: Norway) LanguageId‑värde
+
+### Sami_Lule_Sweden {#Sami-Lule-Sweden}
+```
+public static final MSLanguageId Sami_Lule_Sweden
+```
+
+
+Sami (Lule, Region: Sweden) LanguageId‑värde
+
+### Sami_Northern_Finland {#Sami-Northern-Finland}
+```
+public static final MSLanguageId Sami_Northern_Finland
+```
+
+
+Sami (nordlig, Region: Finland) LanguageId‑värde
+
+### Sami_Northern_Norway {#Sami-Northern-Norway}
+```
+public static final MSLanguageId Sami_Northern_Norway
+```
+
+
+Sami (nordlig, Region: Norway) LanguageId‑värde
+
+### Sami_Northern_Sweden {#Sami-Northern-Sweden}
+```
+public static final MSLanguageId Sami_Northern_Sweden
+```
+
+
+Sami (nordlig, Region: Sweden) LanguageId‑värde
+
+### Sami_Skolt {#Sami-Skolt}
+```
+public static final MSLanguageId Sami_Skolt
+```
+
+
+Sami (Skolt, Region: Finland) LanguageId‑värde
+
+### Sami_Southern_Norway {#Sami-Southern-Norway}
+```
+public static final MSLanguageId Sami_Southern_Norway
+```
+
+
+Sami (södra, Region: Norway) LanguageId‑värde
+
+### Sami_Southern_Sweden {#Sami-Southern-Sweden}
+```
+public static final MSLanguageId Sami_Southern_Sweden
+```
+
+
+Sami (södra, Region: Sweden) LanguageId‑värde
+
+### Sanskrit {#Sanskrit}
+```
+public static final MSLanguageId Sanskrit
+```
+
+
+Sanskrit (Region: India) LanguageId‑värde
+
+### Serbian_Cyrillic_BIH {#Serbian-Cyrillic-BIH}
+```
+public static final MSLanguageId Serbian_Cyrillic_BIH
+```
+
+
+Serbiska (kyrillisk, Region: Bosnia and Herzegovina) LanguageId‑värde
+
+### Serbian_Cyrillic_Serbia {#Serbian-Cyrillic-Serbia}
+```
+public static final MSLanguageId Serbian_Cyrillic_Serbia
+```
+
+
+Serbiska (kyrillisk, Region: Serbia) LanguageId‑värde
+
+### Serbian_Latin_BIH {#Serbian-Latin-BIH}
+```
+public static final MSLanguageId Serbian_Latin_BIH
+```
+
+
+Serbiska (Latin, Region: Bosnien och Herzegovina) LanguageId värde
+
+### Serbian_Latin_Serbia {#Serbian-Latin-Serbia}
+```
+public static final MSLanguageId Serbian_Latin_Serbia
+```
+
+
+Serbiska (Latin, Region: Serbien) LanguageId värde
+
+### Sesotho_Sa_Leboa {#Sesotho-Sa-Leboa}
+```
+public static final MSLanguageId Sesotho_Sa_Leboa
+```
+
+
+Sesotho sa Leboa (Nordliga Sotho, Region: Sydafrika, SA) LanguageId värde
+
+### Setswana {#Setswana}
+```
+public static final MSLanguageId Setswana
+```
+
+
+Setswana (Region: Sydafrika, SA) LanguageId värde
+
+### Sinhala {#Sinhala}
+```
+public static final MSLanguageId Sinhala
+```
+
+
+Sinhala (Region: Sri Lanka) LanguageId värde
+
+### Slovak {#Slovak}
+```
+public static final MSLanguageId Slovak
+```
+
+
+Slovakiska (Region: Slovakien, SKY) LanguageId värde
+
+### Slovenian {#Slovenian}
+```
+public static final MSLanguageId Slovenian
+```
+
+
+Slovenska (Region: Slovenien, SLV) LanguageId värde
+
+### Spanish_Argentina {#Spanish-Argentina}
+```
+public static final MSLanguageId Spanish_Argentina
+```
+
+
+Spanska (Region: Argentina) LanguageId värde
+
+### Spanish_Bolivia {#Spanish-Bolivia}
+```
+public static final MSLanguageId Spanish_Bolivia
+```
+
+
+Spanska (Region: Bolivia) LanguageId värde
+
+### Spanish_Chile {#Spanish-Chile}
+```
+public static final MSLanguageId Spanish_Chile
+```
+
+
+Spanska (Region: Chile) LanguageId värde
+
+### Spanish_Colombia {#Spanish-Colombia}
+```
+public static final MSLanguageId Spanish_Colombia
+```
+
+
+Spanska (Region: Colombia) LanguageId värde
+
+### Spanish_Costa_Rica {#Spanish-Costa-Rica}
+```
+public static final MSLanguageId Spanish_Costa_Rica
+```
+
+
+Spanska (Region: Costa Rica) LanguageId värde
+
+### Spanish_Dominican_Republic {#Spanish-Dominican-Republic}
+```
+public static final MSLanguageId Spanish_Dominican_Republic
+```
+
+
+Spanska (Region: Dominikanska republiken) LanguageId värde
+
+### Spanish_Ecuador {#Spanish-Ecuador}
+```
+public static final MSLanguageId Spanish_Ecuador
+```
+
+
+Spanska (Region: Ecuador) LanguageId värde
+
+### Spanish_El_Salvador {#Spanish-El-Salvador}
+```
+public static final MSLanguageId Spanish_El_Salvador
+```
+
+
+Spanska (Region: El Salvador) LanguageId värde
+
+### Spanish_Guatemala {#Spanish-Guatemala}
+```
+public static final MSLanguageId Spanish_Guatemala
+```
+
+
+Spanska (Region: Guatemala) LanguageId värde
+
+### Spanish_Honduras {#Spanish-Honduras}
+```
+public static final MSLanguageId Spanish_Honduras
+```
+
+
+Spanska (Region: Honduras) LanguageId värde
+
+### Spanish_Mexico {#Spanish-Mexico}
+```
+public static final MSLanguageId Spanish_Mexico
+```
+
+
+Spanska (Mexikansk, Region: Mexiko, ESM) LanguageId värde
+
+### Spanish_Modern_Sort {#Spanish-Modern-Sort}
+```
+public static final MSLanguageId Spanish_Modern_Sort
+```
+
+
+Spanska (Modern sortering, Region: Spanien, ESN) LanguageId värde
+
+### Spanish_Nicaragua {#Spanish-Nicaragua}
+```
+public static final MSLanguageId Spanish_Nicaragua
+```
+
+
+Spanska (Region: Nicaragua) LanguageId värde
+
+### Spanish_Panama {#Spanish-Panama}
+```
+public static final MSLanguageId Spanish_Panama
+```
+
+
+Spanska (Region: Panama) LanguageId värde
+
+### Spanish_Paraguay {#Spanish-Paraguay}
+```
+public static final MSLanguageId Spanish_Paraguay
+```
+
+
+Spanska (Region: Paraguay) LanguageId värde
+
+### Spanish_Peru {#Spanish-Peru}
+```
+public static final MSLanguageId Spanish_Peru
+```
+
+
+Spanska (Region: Peru) LanguageId värde
+
+### Spanish_Puerto_Rico {#Spanish-Puerto-Rico}
+```
+public static final MSLanguageId Spanish_Puerto_Rico
+```
+
+
+Spanska (Region: Puerto Rico) LanguageId värde
+
+### Spanish_Traditional_Sort {#Spanish-Traditional-Sort}
+```
+public static final MSLanguageId Spanish_Traditional_Sort
+```
+
+
+Spanska (Traditionell sortering, Region: Spanien, ESP) LanguageId värde
+
+### Spanish_United_States {#Spanish-United-States}
+```
+public static final MSLanguageId Spanish_United_States
+```
+
+
+Spanska (Region: USA) LanguageId värde
+
+### Spanish_Uruguay {#Spanish-Uruguay}
+```
+public static final MSLanguageId Spanish_Uruguay
+```
+
+
+Spanska (Region: Uruguay) LanguageId värde
+
+### Spanish_Venezuela {#Spanish-Venezuela}
+```
+public static final MSLanguageId Spanish_Venezuela
+```
+
+
+Spanska (Region: Venezuela) LanguageId värde
+
+### Swedish_Finland {#Swedish-Finland}
+```
+public static final MSLanguageId Swedish_Finland
+```
+
+
+Svenska (Region: Finland) LanguageId värde
+
+### Swedish_Sweden {#Swedish-Sweden}
+```
+public static final MSLanguageId Swedish_Sweden
+```
+
+
+Svenska (Region: Sverige, SVE) LanguageId värde
+
+### Syriac {#Syriac}
+```
+public static final MSLanguageId Syriac
+```
+
+
+Syriska (Region: Syrien) LanguageId värde
+
+### Tajik {#Tajik}
+```
+public static final MSLanguageId Tajik
+```
+
+
+Tadzjikiska (Cyrillisk, Region: Tadzjikistan) LanguageId värde
+
+### Tamazight {#Tamazight}
+```
+public static final MSLanguageId Tamazight
+```
+
+
+Tamazight (Latin, Region: Algeriet) LanguageId värde
+
+### Tamil {#Tamil}
+```
+public static final MSLanguageId Tamil
+```
+
+
+Tamil (Region: Indien) LanguageId värde
+
+### Tatar {#Tatar}
+```
+public static final MSLanguageId Tatar
+```
+
+
+Tatar (Region: Ryssland) LanguageId värde
+
+### Telugu {#Telugu}
+```
+public static final MSLanguageId Telugu
+```
+
+
+Telugu (Region: Indien) LanguageId värde
+
+### Thai {#Thai}
+```
+public static final MSLanguageId Thai
+```
+
+
+Thailändska (Region: Thailand) LanguageId värde
+
+### Tibetan {#Tibetan}
+```
+public static final MSLanguageId Tibetan
+```
+
+
+Tibetanska (Region: PRC) LanguageId värde
+
+### Turkish {#Turkish}
+```
+public static final MSLanguageId Turkish
+```
+
+
+Turkiska (Region: Turkiet, TRK) LanguageId värde
+
+### Turkmen {#Turkmen}
+```
+public static final MSLanguageId Turkmen
+```
+
+
+Turkmeniska (Region: Turkmenistan) LanguageId värde
+
+### Uighur {#Uighur}
+```
+public static final MSLanguageId Uighur
+```
+
+
+Uiguriska (Region: PRC) LanguageId värde
+
+### Ukrainian {#Ukrainian}
+```
+public static final MSLanguageId Ukrainian
+```
+
+
+Ukrainska (Region: Ukraina, UKR) LanguageId värde
+
+### Upper_Sorbian {#Upper-Sorbian}
+```
+public static final MSLanguageId Upper_Sorbian
+```
+
+
+Övre sorbiska (Region: Tyskland) LanguageId värde
+
+### Urdu {#Urdu}
+```
+public static final MSLanguageId Urdu
+```
+
+
+Urdu (Region: Islamiska republiken Pakistan) LanguageId värde
+
+### Uzbek_Cyrillic {#Uzbek-Cyrillic}
+```
+public static final MSLanguageId Uzbek_Cyrillic
+```
+
+
+Uzbekiska (Cyrillisk, Region: Uzbekistan) LanguageId värde
+
+### Uzbek_Latin {#Uzbek-Latin}
+```
+public static final MSLanguageId Uzbek_Latin
+```
+
+
+Uzbekiska (Latin, Region: Uzbekistan) LanguageId värde
+
+### Vietnamese {#Vietnamese}
+```
+public static final MSLanguageId Vietnamese
+```
+
+
+Vietnamesiska (Region: Vietnam) LanguageId värde
+
+### Welsh {#Welsh}
+```
+public static final MSLanguageId Welsh
+```
+
+
+Walesiska (Region: Storbritannien) LanguageId värde
+
+### Wolof {#Wolof}
+```
+public static final MSLanguageId Wolof
+```
+
+
+Wolof (Region: Senegal) LanguageId värde
+
+### Yakut {#Yakut}
+```
+public static final MSLanguageId Yakut
+```
+
+
+Jakutiska (Region: Ryssland) LanguageId värde
+
+### Yi {#Yi}
+```
+public static final MSLanguageId Yi
+```
+
+
+Yi (Region: PRC) LanguageId-värde
+
+### Yoruba {#Yoruba}
+```
+public static final MSLanguageId Yoruba
+```
+
+
+Yoruba (Region: Nigeria) LanguageId-värde
+
+### isiXhosa {#isiXhosa}
+```
+public static final MSLanguageId isiXhosa
+```
+
+
+isiXhosa (Region: Sydafrika, SA) LanguageId-värde
+
+### isiZulu {#isiZulu}
+```
+public static final MSLanguageId isiZulu
+```
+
+
+isiZulu (Region: Sydafrika, SA) LanguageId-värde
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getId() {#getId--}
+```
+public int getId()
+```
+
+
+Hämta heltalsvärdet.
+
+**Returns:**
+int - Heltalsvärdet.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/msplatformspecificid/_index.md
+++ b/swedish/java/com.aspose.font/msplatformspecificid/_index.md
@@ -1,0 +1,331 @@
+---
+title: "MSPlatformSpecificId"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Microsoft-plattformens PlatformSpecificId-enumeration."
+type: docs
+weight: 139
+url: /sv/java/com.aspose.font/msplatformspecificid/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum MSPlatformSpecificId extends Enum<MSPlatformSpecificId>
+```
+
+Representerar Microsoft-plattformens PlatformSpecificId-enumeration.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [Big5](#Big5) | Big5 MS MSPlatformSpecificId. |
+| [Johab](#Johab) | Johab MS MSPlatformSpecificId. |
+| [PRC](#PRC) | PRC MS MSPlatformSpecificId. |
+| [Reserved1](#Reserved1) | Reserved1 MS MSPlatformSpecificId. |
+| [Reserved2](#Reserved2) | Reserved2 MS MSPlatformSpecificId. |
+| [Reserved3](#Reserved3) | Reserved3 MS MSPlatformSpecificId. |
+| [ShiftJIS](#ShiftJIS) | ShiftJIS MS MSPlatformSpecificId. |
+| [Symbol](#Symbol) | Symbol MS MSPlatformSpecificId. |
+| [Unicode_BMP_UCS2](#Unicode-BMP-UCS2) | Unicode BMP (UCS2) MS PlatformSpecificId. |
+| [Unicode_UCS4](#Unicode-UCS4) | Unicode\_UCS4 MS MSPlatformSpecificId. |
+| [Wansung](#Wansung) | Wansung MS MSPlatformSpecificId. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Big5 {#Big5}
+```
+public static final MSPlatformSpecificId Big5
+```
+
+
+Big5 MS MSPlatformSpecificId.
+
+### Johab {#Johab}
+```
+public static final MSPlatformSpecificId Johab
+```
+
+
+Johab MS MSPlatformSpecificId.
+
+### PRC {#PRC}
+```
+public static final MSPlatformSpecificId PRC
+```
+
+
+PRC MS MSPlatformSpecificId.
+
+### Reserved1 {#Reserved1}
+```
+public static final MSPlatformSpecificId Reserved1
+```
+
+
+Reserved1 MS MSPlatformSpecificId.
+
+### Reserved2 {#Reserved2}
+```
+public static final MSPlatformSpecificId Reserved2
+```
+
+
+Reserved2 MS MSPlatformSpecificId.
+
+### Reserved3 {#Reserved3}
+```
+public static final MSPlatformSpecificId Reserved3
+```
+
+
+Reserved3 MS MSPlatformSpecificId.
+
+### ShiftJIS {#ShiftJIS}
+```
+public static final MSPlatformSpecificId ShiftJIS
+```
+
+
+ShiftJIS MS MSPlatformSpecificId.
+
+### Symbol {#Symbol}
+```
+public static final MSPlatformSpecificId Symbol
+```
+
+
+Symbol MS MSPlatformSpecificId.
+
+### Unicode_BMP_UCS2 {#Unicode-BMP-UCS2}
+```
+public static final MSPlatformSpecificId Unicode_BMP_UCS2
+```
+
+
+Unicode BMP (UCS2) MS PlatformSpecificId.
+
+### Unicode_UCS4 {#Unicode-UCS4}
+```
+public static final MSPlatformSpecificId Unicode_UCS4
+```
+
+
+Unicode\_UCS4 MS MSPlatformSpecificId.
+
+### Wansung {#Wansung}
+```
+public static final MSPlatformSpecificId Wansung
+```
+
+
+Wansung MS MSPlatformSpecificId.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static MSPlatformSpecificId valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[MSPlatformSpecificId](../../com.aspose.font/msplatformspecificid)
+### values() {#values--}
+```
+public static MSPlatformSpecificId[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.MSPlatformSpecificId[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/multilanguagestring/_index.md
+++ b/swedish/java/com.aspose.font/multilanguagestring/_index.md
@@ -1,0 +1,296 @@
+---
+title: "MultiLanguageString"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar flerspråkig sträng."
+type: docs
+weight: 66
+url: /sv/java/com.aspose.font/multilanguagestring/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class MultiLanguageString
+```
+
+Representerar flerspråkig sträng.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [MultiLanguageString()](#MultiLanguageString--) | Skapar en tom flerspråkig sträng. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addLanguageString(String str, int languageId)](#addLanguageString-java.lang.String-int-) | Lägger till en sträng för ett specifikt språk. |
+| [containsString(String str)](#containsString-java.lang.String-) | Returnerar true om strängen finns i alla språksträngar. |
+| [equals(Object objToCompare)](#equals-java.lang.Object-) | Returnerar true om objekten anses vara lika. |
+| [getAllLanguageIds()](#getAllLanguageIds--) | Hämtar språkidentifierare för alla strängar eller en tom array om inga strängar finns. |
+| [getAllStrings()](#getAllStrings--) | Returnerar alla strängar för alla språk. |
+| [getClass()](#getClass--) |  |
+| [getEnglishString()](#getEnglishString--) | Returnerar engelsk sträng om den hittas. |
+| [getStringForLanguageId(int languageId)](#getStringForLanguageId-int-) | Returnerar strängen som motsvarar den angivna språkidentifieraren, om den hittas. |
+| [hashCode()](#hashCode--) | GetHashCode-implementation. |
+| [isEmpty()](#isEmpty--) | True, om MultiLanguageString inte har några språksträngar. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(MultiLanguageString obj1, String obj2)](#op-Equality-com.aspose.font.MultiLanguageString-java.lang.String-) | Implementering av likhetsoperator. |
+| [op_Equality(String obj1, MultiLanguageString obj2)](#op-Equality-java.lang.String-com.aspose.font.MultiLanguageString-) | Implementering av likhetsoperator. |
+| [op_Inequality(MultiLanguageString obj1, String obj2)](#op-Inequality-com.aspose.font.MultiLanguageString-java.lang.String-) | Implementering av ojämlikhetsoperator. |
+| [op_Inequality(String obj1, MultiLanguageString obj2)](#op-Inequality-java.lang.String-com.aspose.font.MultiLanguageString-) | Implementering av ojämlikhetsoperator. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MultiLanguageString() {#MultiLanguageString--}
+```
+public MultiLanguageString()
+```
+
+
+Skapar en tom flerspråkig sträng.
+
+### addLanguageString(String str, int languageId) {#addLanguageString-java.lang.String-int-}
+```
+public void addLanguageString(String str, int languageId)
+```
+
+
+Lägger till en sträng för ett specifikt språk.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| str | java.lang.String | Sträng att lägga till |
+| languageId | int | Språkidentifierare |
+
+### containsString(String str) {#containsString-java.lang.String-}
+```
+public boolean containsString(String str)
+```
+
+
+Returnerar true om strängen finns i alla språksträngar.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| str | java.lang.String | Sträng att kontrollera. |
+
+**Returns:**
+boolean - True om strängen finns i alla språksträngar.
+### equals(Object objToCompare) {#equals-java.lang.Object-}
+```
+public boolean equals(Object objToCompare)
+```
+
+
+Returnerar true om objekten anses vara lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| objToCompare | java.lang.Object | objekt att jämföra med |
+
+**Returns:**
+boolean - jämförelsresultat
+### getAllLanguageIds() {#getAllLanguageIds--}
+```
+public int[] getAllLanguageIds()
+```
+
+
+Hämtar språkidentifierare för alla strängar eller en tom array om inga strängar finns.
+
+**Returns:**
+int[] - Array med språkidentifierare eller tom array om inga strängar finns.
+### getAllStrings() {#getAllStrings--}
+```
+public String[] getAllStrings()
+```
+
+
+Returnerar alla strängar för alla språk.
+
+**Returns:**
+java.lang.String[] - Array med alla strängar för alla språk.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEnglishString() {#getEnglishString--}
+```
+public String getEnglishString()
+```
+
+
+Returnerar engelsk sträng om den finns. Annars returneras den första icke-engelska strängen.
+
+**Returns:**
+java.lang.String - Engelsk sträng om den finns, annars den första icke-engelska strängen.
+### getStringForLanguageId(int languageId) {#getStringForLanguageId-int-}
+```
+public String getStringForLanguageId(int languageId)
+```
+
+
+Returnerar sträng relaterad till den angivna språkidentifieraren, om den finns. Tom sträng annars.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| languageId | int | Språkidentifierare. |
+
+**Returns:**
+java.lang.String - Sträng relaterad till den angivna språkidentifieraren, om den finns. Tom sträng annars.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+GetHashCode-implementation.
+
+**Returns:**
+int - hashkod för objektet
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+True, om MultiLanguageString inte har några språksträngar.
+
+**Returns:**
+boolean - Sant, om MultiLanguageString inte har strängar för språk.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(MultiLanguageString obj1, String obj2) {#op-Equality-com.aspose.font.MultiLanguageString-java.lang.String-}
+```
+public static boolean op_Equality(MultiLanguageString obj1, String obj2)
+```
+
+
+Implementering av likhetsoperator.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj1 | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | första objektet att jämföra |
+| obj2 | java.lang.String | andra objektet att jämföra |
+
+**Returns:**
+boolean - jämförelsresultat
+### op_Equality(String obj1, MultiLanguageString obj2) {#op-Equality-java.lang.String-com.aspose.font.MultiLanguageString-}
+```
+public static boolean op_Equality(String obj1, MultiLanguageString obj2)
+```
+
+
+Implementering av likhetsoperator.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj1 | java.lang.String | sträng att jämföra |
+| obj2 | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | flerspråkig sträng att jämföra |
+
+**Returns:**
+boolean - jämförelsresultat
+### op_Inequality(MultiLanguageString obj1, String obj2) {#op-Inequality-com.aspose.font.MultiLanguageString-java.lang.String-}
+```
+public static boolean op_Inequality(MultiLanguageString obj1, String obj2)
+```
+
+
+Implementering av ojämlikhetsoperator.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj1 | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | sträng att jämföra |
+| obj2 | java.lang.String | flerspråkig sträng att jämföra |
+
+**Returns:**
+boolean - jämförelsresultat
+### op_Inequality(String obj1, MultiLanguageString obj2) {#op-Inequality-java.lang.String-com.aspose.font.MultiLanguageString-}
+```
+public static boolean op_Inequality(String obj1, MultiLanguageString obj2)
+```
+
+
+Implementering av ojämlikhetsoperator.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj1 | java.lang.String | sträng att jämföra |
+| obj2 | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | flerspråkig sträng att jämföra |
+
+**Returns:**
+boolean - jämförelsresultat
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/nameid/_index.md
+++ b/swedish/java/com.aspose.font/nameid/_index.md
@@ -1,0 +1,380 @@
+---
+title: "NameId"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar NameId-uppräkning."
+type: docs
+weight: 67
+url: /sv/java/com.aspose.font/nameid/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class NameId
+```
+
+Representerar NameId-uppräkning.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CompatibleFull](#CompatibleFull) | 18 Compatible Full (endast Macintosh); På Macintosh konstrueras menynamnet med hjälp av teckensnittresursen. |
+| [CopyrightNotice](#CopyrightNotice) | 0 Upphovsrättsmeddelande. |
+| [DarkBackground](#DarkBackground) | Detta ID, om det används i CPAL table\\u2019s Palette Labels Array, anger att den motsvarande färgpaletten i CPAL‑tabellen är lämplig att använda med teckensnittet när det visas på en mörk bakgrund såsom svart. |
+| [Description](#Description) | 10 Beskrivning; beskrivning av teckensnittet. |
+| [DesignerName](#DesignerName) | 9 Designer; namn på designern av typsnittet. |
+| [FontFamily](#FontFamily) | 1 Typsnittsfamilj. |
+| [FontSubfamily](#FontSubfamily) | 2 Typsnittssubfamilj. |
+| [FullName](#FullName) | 4 Fullständigt namn på typsnittet. |
+| [LicenseDescription](#LicenseDescription) | 13 Licensbeskrivning; beskrivning av hur typsnittet får användas lagligt, eller olika exempel på scenarier för licensierad användning. |
+| [LicenseInfoUrl](#LicenseInfoUrl) | 14 URL för licensinformation, där ytterligare licensinformation kan hittas. |
+| [LightBackground](#LightBackground) | Detta ID, om det används i CPAL‑tabellens\\u2019s Palette Labels Array, anger att den motsvarande färgpaletten i CPAL‑tabellen är lämplig att använda med typsnittet när det visas på en ljus bakgrund såsom vit |
+| [ManufacturerName](#ManufacturerName) | 8 Tillverkarens namn. |
+| [PostScriptCID](#PostScriptCID) | Dess närvaro i ett typsnitt betyder att nameID 6 innehåller ett PostScript-typsnittsnamn som är avsett att användas med \\u201ccomposefont\\u201d‑anropet för att anropa typsnittet i en PostScript‑tolkare |
+| [PostScriptName](#PostScriptName) | 6 PostScript‑namn på typsnittet. |
+| [PreferredFamily](#PreferredFamily) | 15 Reserverad 16 Föredragen familj (endast Windows); I Windows visas familjenamnet i typsnittsmenyn; subfamiljenamnet presenteras som stilnamnet. |
+| [PreferredSubfamily](#PreferredSubfamily) | 17 Föredragen subfamilj (endast Windows); I Windows visas familjenamnet i typsnittsmenyn; subfamiljenamnet presenteras som stilnamnet. |
+| [SampleText](#SampleText) | 19 Exempeltext. |
+| [TrademarkNotice](#TrademarkNotice) | 7 Varumärkesmeddelande. |
+| [UniqueFontId](#UniqueFontId) | 3 Apple‑spec: Unik subfamiljeidentifiering. 3 MS‑spec: Unik typsnittsidentifierare |
+| [UrlDesigner](#UrlDesigner) | 12 URL till typsnittsdesignern (med protokoll, t.ex. http://, ftp://) |
+| [UrlVendor](#UrlVendor) | 11 URL till typsnittsförsäljaren (med protokoll, t.ex. http://, ftp://). |
+| [VariationsPostScriptNamePrefix](#VariationsPostScriptNamePrefix) | Om den finns i ett variabelt typsnitt kan den användas som familjeprefix i algoritmen för PostScript‑namngenerering för variationstypsnitt. |
+| [Version](#Version) | 5 Version av namntabellen. |
+| [WwsFamilyName](#WwsFamilyName) | Används för att tillhandahålla ett WWS‑konformt familjenamn om posterna för ID‑en 16 och 17 inte följer WWS‑modellen. |
+| [WwsSubfamilyName](#WwsSubfamilyName) | Används tillsammans med ID 21, detta ID tillhandahåller ett WWS‑konformt subfamiljenamn (som bara återspeglar vikt-, bredd- och lutningsattribut) om posterna för ID‑en 16 och 17 inte följer WWS‑modellen. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fromId(int id)](#fromId-int-) | Skapar ett namn‑ID från ett heltalsvärde. |
+| [getClass()](#getClass--) |  |
+| [getId()](#getId--) | Hämta heltalsvärdet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CompatibleFull {#CompatibleFull}
+```
+public static final NameId CompatibleFull
+```
+
+
+18 Kompatibel full (endast Macintosh); På Macintosh konstrueras menynamnet med hjälp av typsnittsresursen. Detta matchar vanligtvis det fullständiga namnet. Om du vill att typsnittets namn ska visas annorlunda än det fullständiga namnet kan du infoga det kompatibla fullständiga namnet i ID 18. Detta namn används inte av själva Mac OS, men kan användas av programutvecklare (t.ex. Adobe).
+
+### CopyrightNotice {#CopyrightNotice}
+```
+public static final NameId CopyrightNotice
+```
+
+
+0 Upphovsrättsmeddelande.
+
+### DarkBackground {#DarkBackground}
+```
+public static final NameId DarkBackground
+```
+
+
+Detta ID, om det används i CPAL table\\u2019s Palette Labels Array, anger att den motsvarande färgpaletten i CPAL‑tabellen är lämplig att använda med teckensnittet när det visas på en mörk bakgrund såsom svart.
+
+### Description {#Description}
+```
+public static final NameId Description
+```
+
+
+10 Beskrivning; beskrivning av typsnittet. Kan innehålla revisionsinformation, användningsrekommendationer, historik, funktioner osv.
+
+### DesignerName {#DesignerName}
+```
+public static final NameId DesignerName
+```
+
+
+9 Designer; namn på designern av typsnittet.
+
+### FontFamily {#FontFamily}
+```
+public static final NameId FontFamily
+```
+
+
+1 Typsnittsfamilj. Denna sträng är typsnittsfamiljens namn som användaren ser på Macintosh‑plattformar.
+
+### FontSubfamily {#FontSubfamily}
+```
+public static final NameId FontSubfamily
+```
+
+
+2 Font Subfamily. Denna sträng är den Font-familj som användaren ser på Macintosh-plattformar.
+
+### FullName {#FullName}
+```
+public static final NameId FullName
+```
+
+
+4 Fullständigt namn på typsnittet.
+
+### LicenseDescription {#LicenseDescription}
+```
+public static final NameId LicenseDescription
+```
+
+
+13 Licensbeskrivning; beskrivning av hur Font får användas lagligt, eller olika exempel på scenarier för licensierad användning. Detta fält bör skrivas på klartext, inte i juridiskt språk.
+
+### LicenseInfoUrl {#LicenseInfoUrl}
+```
+public static final NameId LicenseInfoUrl
+```
+
+
+14 URL för licensinformation, där ytterligare licensinformation kan hittas.
+
+### LightBackground {#LightBackground}
+```
+public static final NameId LightBackground
+```
+
+
+Detta ID, om det används i CPAL‑tabellens\\u2019s Palette Labels Array, anger att den motsvarande färgpaletten i CPAL‑tabellen är lämplig att använda med typsnittet när det visas på en ljus bakgrund såsom vit
+
+### ManufacturerName {#ManufacturerName}
+```
+public static final NameId ManufacturerName
+```
+
+
+8 Tillverkarens namn.
+
+### PostScriptCID {#PostScriptCID}
+```
+public static final NameId PostScriptCID
+```
+
+
+Dess närvaro i ett typsnitt betyder att nameID 6 innehåller ett PostScript-typsnittsnamn som är avsett att användas med \\u201ccomposefont\\u201d‑anropet för att anropa typsnittet i en PostScript‑tolkare
+
+### PostScriptName {#PostScriptName}
+```
+public static final NameId PostScriptName
+```
+
+
+6 PostScript-namn på Fonten. Obs: En Font kan bara ha ett PostScript-namn och det namnet måste vara ASCII.
+
+### PreferredFamily {#PreferredFamily}
+```
+public static final NameId PreferredFamily
+```
+
+
+15 Reserved 16 Preferred Family (endast Windows); I Windows visas familjenamnet i Font-menyn; subfamiljenamnet visas som stilnamn. Av historiska skäl har Font-familjer innehållit högst fyra stilar, men fontdesigners kan gruppera fler än fyra fonter till en enda familj. ID:n för Preferred Family och Preferred Subfamily låter fontdesigners inkludera de föredragna familje-/subfamiljegrupperingarna. Dessa ID:n finns endast om de skiljer sig från ID:n 1 och 2.
+
+### PreferredSubfamily {#PreferredSubfamily}
+```
+public static final NameId PreferredSubfamily
+```
+
+
+17 Preferred Subfamily (endast Windows); I Windows visas familjenamnet i Font-menyn; subfamiljenamnet visas som stilnamn. Av historiska skäl har Font-familjer innehållit högst fyra stilar, men fontdesigners kan gruppera fler än fyra fonter till en enda familj. ID:n för Preferred Family och Preferred Subfamily låter fontdesigners inkludera de föredragna familje-/subfamiljegrupperingarna. Dessa ID:n finns endast om de skiljer sig från ID:n 1 och 2.
+
+### SampleText {#SampleText}
+```
+public static final NameId SampleText
+```
+
+
+19 Exempeltext. Detta kan vara Font-namnet eller någon annan text som designern anser vara den bästa exempeltexten för att visa hur fonten ser ut.
+
+### TrademarkNotice {#TrademarkNotice}
+```
+public static final NameId TrademarkNotice
+```
+
+
+7 Varumärkesmeddelande.
+
+### UniqueFontId {#UniqueFontId}
+```
+public static final NameId UniqueFontId
+```
+
+
+3 Apple‑spec: Unik subfamiljeidentifiering. 3 MS‑spec: Unik typsnittsidentifierare
+
+### UrlDesigner {#UrlDesigner}
+```
+public static final NameId UrlDesigner
+```
+
+
+12 URL till typsnittsdesignern (med protokoll, t.ex. http://, ftp://)
+
+### UrlVendor {#UrlVendor}
+```
+public static final NameId UrlVendor
+```
+
+
+11 URL till Font-leverantören (med protokoll, t.ex. http://, ftp://). Om ett unikt serienummer är inbäddat i URL:en kan det användas för att registrera Fonten.
+
+### VariationsPostScriptNamePrefix {#VariationsPostScriptNamePrefix}
+```
+public static final NameId VariationsPostScriptNamePrefix
+```
+
+
+Om den finns i ett variabelt typsnitt kan den användas som familjeprefix i algoritmen för PostScript‑namngenerering för variationstypsnitt.
+
+### Version {#Version}
+```
+public static final NameId Version
+```
+
+
+5 Version av namntabellen.
+
+### WwsFamilyName {#WwsFamilyName}
+```
+public static final NameId WwsFamilyName
+```
+
+
+Används för att tillhandahålla ett WWS‑konformt familjenamn om posterna för ID‑en 16 och 17 inte följer WWS‑modellen.
+
+### WwsSubfamilyName {#WwsSubfamilyName}
+```
+public static final NameId WwsSubfamilyName
+```
+
+
+Används tillsammans med ID 21, detta ID tillhandahåller ett WWS‑konformt subfamiljenamn (som bara återspeglar vikt-, bredd- och lutningsattribut) om posterna för ID‑en 16 och 17 inte följer WWS‑modellen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fromId(int id) {#fromId-int-}
+```
+public static NameId fromId(int id)
+```
+
+
+Skapar ett namn‑ID från ett heltalsvärde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| id | int | Ett heltalsvärde. |
+
+**Returns:**
+[NameId](../../com.aspose.font/nameid) - The name id.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getId() {#getId--}
+```
+public int getId()
+```
+
+
+Hämta heltalsvärdet.
+
+**Returns:**
+int - Heltalsvärdet.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/nameindexdataprovider/_index.md
+++ b/swedish/java/com.aspose.font/nameindexdataprovider/_index.md
@@ -1,0 +1,250 @@
+---
+title: "NameIndexDataProvider"
+second_title: "Aspose.Font för Java API-referens"
+description: "Tillhandahåller inställningar gemensamma för CFF-typsnitt."
+type: docs
+weight: 68
+url: /sv/java/com.aspose.font/nameindexdataprovider/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.ICffIndexDataProvider](../../com.aspose.font/icffindexdataprovider)
+```
+public abstract class NameIndexDataProvider implements ICffIndexDataProvider
+```
+
+Tillhandahåller inställningar gemensamma för CFF-typsnitt.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [NameIndexDataProvider()](#NameIndexDataProvider--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addName(String name)](#addName-java.lang.String-) | Lägger till ett typsnittsnamn i Name‑INDEX‑strukturen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar typsnittsnamn på angivet index. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet objekt i CFF‑INDEX‑strukturen. |
+| [getName(int index)](#getName-int-) | Hämtar namn på typsnitt på angivet index. |
+| [getRawBytes()](#getRawBytes--) | Hämtar alla byte i CFF INDEX-strukturen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeName(int index)](#removeName-int-) | Tar bort namnet på det angivna indexet. |
+| [set(int index, String name)](#set-int-java.lang.String-) | Anger teckensnittets namn på det angivna indexet. |
+| [setName(String name, int index)](#setName-java.lang.String-int-) | Ställer in teckensnittets namn på det angivna indexet. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NameIndexDataProvider() {#NameIndexDataProvider--}
+```
+public NameIndexDataProvider()
+```
+
+
+### addName(String name) {#addName-java.lang.String-}
+```
+public abstract void addName(String name)
+```
+
+
+Lägger till ett teckensnittsnamn i Name INDEX-strukturen. Använd den här metoden med försiktighet eftersom varje teckensnittsnamn i CFF Name INDEX-strukturen måste ha en motsvarande DICT-struktur i Top DICT-indexet enligt CFF-specifikationen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public abstract String get(int index)
+```
+
+
+Hämtar typsnittsnamn på angivet index.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | Teckensnittindex. |
+
+**Returns:**
+java.lang.String - Teckensnittsnamn.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public abstract int getCount()
+```
+
+
+Hämtar antalet objekt i CFF‑INDEX‑strukturen.
+
+**Returns:**
+int
+### getName(int index) {#getName-int-}
+```
+public abstract String getName(int index)
+```
+
+
+Hämtar namn på typsnitt på angivet index.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | Teckensnittindex. |
+
+**Returns:**
+java.lang.String - Teckensnittsnamnet.
+### getRawBytes() {#getRawBytes--}
+```
+public abstract byte[] getRawBytes()
+```
+
+
+Hämtar alla byte i CFF INDEX-strukturen.
+
+**Returns:**
+byte[] - Byte i CFF INDEX-strukturen
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeName(int index) {#removeName-int-}
+```
+public abstract void removeName(int index)
+```
+
+
+Tar bort namnet på det angivna indexet. Använd den här metoden med försiktighet eftersom varje teckensnittsnamn i CFF Name INDEX-strukturen måste ha en motsvarande DICT-struktur i Top DICT-indexet enligt CFF-specifikationen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | Teckensnittindex. |
+
+### set(int index, String name) {#set-int-java.lang.String-}
+```
+public abstract void set(int index, String name)
+```
+
+
+Anger teckensnittets namn på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | Teckensnittindex. |
+| namn | java.lang.String | Teckensnittsnamn. |
+
+### setName(String name, int index) {#setName-java.lang.String-int-}
+```
+public abstract void setName(String name, int index)
+```
+
+
+Ställer in teckensnittets namn på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String | Teckensnittsnamn. |
+| index | int | Teckensnittindex. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/namerecord/_index.md
+++ b/swedish/java/com.aspose.font/namerecord/_index.md
@@ -1,0 +1,190 @@
+---
+title: "NameRecord"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar NameRecord-strukturen i namntabellen"
+type: docs
+weight: 69
+url: /sv/java/com.aspose.font/namerecord/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class NameRecord
+```
+
+Representerar NameRecord-struktur för 'name'-tabellen
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [NameRecord()](#NameRecord--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getLanguageId()](#getLanguageId--) | Hämtar språkidentifierare. |
+| [getNameId()](#getNameId--) | Hämtar namnidentifierare. |
+| [getPlatformId()](#getPlatformId--) | Hämtar plattformsidentifieringskod. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Hämtar plattformspecifik kodningsidentifierare. |
+| [getString()](#getString--) | Hämtar strängen i stränglagringen som är relaterad till denna namnpost. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NameRecord() {#NameRecord--}
+```
+public NameRecord()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLanguageId() {#getLanguageId--}
+```
+public int getLanguageId()
+```
+
+
+Hämtar språkidentifierare.
+
+**Returns:**
+int - Språkidentifierare.
+### getNameId() {#getNameId--}
+```
+public int getNameId()
+```
+
+
+Hämtar namnidentifierare.
+
+**Returns:**
+int - Namnidentifierare.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Hämtar plattformsidentifieringskod.
+
+**Returns:**
+int - Plattformsidentifieringskod.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Hämtar plattformspecifik kodningsidentifierare.
+
+**Returns:**
+int - Plattformspecifik kodningsidentifierare.
+### getString() {#getString--}
+```
+public String getString()
+```
+
+
+Hämtar strängen i stränglagringen som är relaterad till denna namnpost.
+
+**Returns:**
+java.lang.String - Sträng i stränglagringen relaterad till denna namnpost.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/nametocodemap/_index.md
+++ b/swedish/java/com.aspose.font/nametocodemap/_index.md
@@ -1,0 +1,178 @@
+---
+title: "NameToCodeMap"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar namn-till-kod-karta."
+type: docs
+weight: 70
+url: /sv/java/com.aspose.font/nametocodemap/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class NameToCodeMap
+```
+
+Representerar namn-till-kod-karta.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [containsKey(String name)](#containsKey-java.lang.String-) | Returnerar true om nyckeln redan finns i kartan. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(String name)](#get-java.lang.String-) | Hämtar kod efter namn. |
+| [getClass()](#getClass--) |  |
+| [getKeys()](#getKeys--) | Returnerar samling av strängnamn. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [size()](#size--) | Hämtar antalet namn-kod-par i kartan. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### containsKey(String name) {#containsKey-java.lang.String-}
+```
+public boolean containsKey(String name)
+```
+
+
+Returnerar true om nyckeln redan finns i kartan.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String | Glyfnamn. |
+
+**Returns:**
+boolean - Sant eller falskt.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(String name) {#get-java.lang.String-}
+```
+public int get(String name)
+```
+
+
+Hämtar kod efter namn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String | Glyfnamn. |
+
+**Returns:**
+int - Glyfkod.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getKeys() {#getKeys--}
+```
+public Collection<String> getKeys()
+```
+
+
+Returnerar samling av strängnamn.
+
+**Returns:**
+java.util.Collection<java.lang.String> - Samling av strängnamn.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+Hämtar antalet namn-kod-par i kartan.
+
+**Returns:**
+int - Antal namn‑kod‑par i kartan.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/offsetslist/_index.md
+++ b/swedish/java/com.aspose.font/offsetslist/_index.md
@@ -1,0 +1,151 @@
+---
+title: "TtfLocaTable.OffsetsList"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar lista över glyf-förskjutningar."
+type: docs
+weight: 10
+url: /sv/java/com.aspose.font/ttflocatable.offsetslist/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static class TtfLocaTable.OffsetsList
+```
+
+Representerar lista över glyf-förskjutningar.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar offset efter index. |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [size()](#size--) | Hämtar antalet teckenoffset. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public long get(int index)
+```
+
+
+Hämtar offset efter index.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | Offset-index. |
+
+**Returns:**
+long - Teckenoffset.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+Hämtar antalet teckenoffset.
+
+**Returns:**
+int - Antal teckenoffset.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/parsingstrictness/_index.md
+++ b/swedish/java/com.aspose.font/parsingstrictness/_index.md
@@ -1,0 +1,248 @@
+---
+title: "FontEnvironment.ParsingStrictness"
+second_title: "Aspose.Font för Java API-referens"
+description: 
+type: docs
+weight: 10
+url: /sv/java/com.aspose.font/fontenvironment.parsingstrictness/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum FontEnvironment.ParsingStrictness extends Enum<FontEnvironment.ParsingStrictness>
+```
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [Strict](#Strict) | Anger den strikta typen. |
+| [Tolerant](#Tolerant) | Anger den toleranta typen. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Strict {#Strict}
+```
+public static final FontEnvironment.ParsingStrictness Strict
+```
+
+
+Anger den strikta typen.
+
+### Tolerant {#Tolerant}
+```
+public static final FontEnvironment.ParsingStrictness Tolerant
+```
+
+
+Anger den toleranta typen.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static FontEnvironment.ParsingStrictness valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[ParsingStrictness](../../com.aspose.font/parsingstrictness)
+### values() {#values--}
+```
+public static FontEnvironment.ParsingStrictness[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.FontEnvironment.ParsingStrictness[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/pathsegmentcollection/_index.md
+++ b/swedish/java/com.aspose.font/pathsegmentcollection/_index.md
@@ -1,0 +1,565 @@
+---
+title: "PathSegmentCollection"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar en samling av sökvägssegment."
+type: docs
+weight: 71
+url: /sv/java/com.aspose.font/pathsegmentcollection/
+---
+**Inheritance:**
+java.lang.Object, java.util.AbstractCollection, java.util.AbstractList, java.util.ArrayList
+```
+public class PathSegmentCollection extends ArrayList<IPathSegment>
+```
+
+Representerar en samling av sökvägssegment.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>toArray(T[] arg0)](#-T-toArray-T---) |  |
+| [add(E arg0)](#add-E-) |  |
+| [add(int arg0, E arg1)](#add-int-E-) |  |
+| [addAll(int arg0, Collection<? extends E> arg1)](#addAll-int-java.util.Collection---extends-E--) |  |
+| [addAll(Collection<? extends E> arg0)](#addAll-java.util.Collection---extends-E--) |  |
+| [clear()](#clear--) |  |
+| [clone()](#clone--) |  |
+| [contains(Object arg0)](#contains-java.lang.Object-) |  |
+| [containsAll(Collection<?> arg0)](#containsAll-java.util.Collection----) |  |
+| [ensureCapacity(int arg0)](#ensureCapacity-int-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [forEach(Consumer<? super E> arg0)](#forEach-java.util.function.Consumer---super-E--) |  |
+| [get(int arg0)](#get-int-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object arg0)](#indexOf-java.lang.Object-) |  |
+| [isEmpty()](#isEmpty--) |  |
+| [iterator()](#iterator--) |  |
+| [lastIndexOf(Object arg0)](#lastIndexOf-java.lang.Object-) |  |
+| [listIterator()](#listIterator--) |  |
+| [listIterator(int arg0)](#listIterator-int-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(int arg0)](#remove-int-) |  |
+| [remove(Object arg0)](#remove-java.lang.Object-) |  |
+| [removeAll(Collection<?> arg0)](#removeAll-java.util.Collection----) |  |
+| [removeIf(Predicate<? super E> arg0)](#removeIf-java.util.function.Predicate---super-E--) |  |
+| [replaceAll(UnaryOperator<E> arg0)](#replaceAll-java.util.function.UnaryOperator-E--) |  |
+| [retainAll(Collection<?> arg0)](#retainAll-java.util.Collection----) |  |
+| [set(int arg0, E arg1)](#set-int-E-) |  |
+| [size()](#size--) |  |
+| [sort(Comparator<? super E> arg0)](#sort-java.util.Comparator---super-E--) |  |
+| [spliterator()](#spliterator--) |  |
+| [subList(int arg0, int arg1)](#subList-int-int-) |  |
+| [toArray()](#toArray--) |  |
+| [toString()](#toString--) |  |
+| [trimToSize()](#trimToSize--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>toArray(T[] arg0) {#-T-toArray-T---}
+```
+public T[] <T>toArray(T[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | T[] |  |
+
+**Returns:**
+T[]
+### add(E arg0) {#add-E-}
+```
+public boolean add(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+boolean
+### add(int arg0, E arg1) {#add-int-E-}
+```
+public void add(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+### addAll(int arg0, Collection<? extends E> arg1) {#addAll-int-java.util.Collection---extends-E--}
+```
+public boolean addAll(int arg0, Collection<? extends E> arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### addAll(Collection<? extends E> arg0) {#addAll-java.util.Collection---extends-E--}
+```
+public boolean addAll(Collection<? extends E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.Collection<? extends E> |  |
+
+**Returns:**
+boolean
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### contains(Object arg0) {#contains-java.lang.Object-}
+```
+public boolean contains(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### containsAll(Collection<?> arg0) {#containsAll-java.util.Collection----}
+```
+public boolean containsAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### ensureCapacity(int arg0) {#ensureCapacity-int-}
+```
+public void ensureCapacity(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### forEach(Consumer<? super E> arg0) {#forEach-java.util.function.Consumer---super-E--}
+```
+public void forEach(Consumer<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.function.Consumer<? super E> |  |
+
+### get(int arg0) {#get-int-}
+```
+public E get(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object arg0) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public Iterator<E> iterator()
+```
+
+
+
+
+**Returns:**
+java.util.Iterator<E>
+### lastIndexOf(Object arg0) {#lastIndexOf-java.lang.Object-}
+```
+public int lastIndexOf(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+int
+### listIterator() {#listIterator--}
+```
+public ListIterator<E> listIterator()
+```
+
+
+
+
+**Returns:**
+java.util.ListIterator<E>
+### listIterator(int arg0) {#listIterator-int-}
+```
+public ListIterator<E> listIterator(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+java.util.ListIterator<E>
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(int arg0) {#remove-int-}
+```
+public E remove(int arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+
+**Returns:**
+E
+### remove(Object arg0) {#remove-java.lang.Object-}
+```
+public boolean remove(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### removeAll(Collection<?> arg0) {#removeAll-java.util.Collection----}
+```
+public boolean removeAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### removeIf(Predicate<? super E> arg0) {#removeIf-java.util.function.Predicate---super-E--}
+```
+public boolean removeIf(Predicate<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.function.Predicate<? super E> |  |
+
+**Returns:**
+boolean
+### replaceAll(UnaryOperator<E> arg0) {#replaceAll-java.util.function.UnaryOperator-E--}
+```
+public void replaceAll(UnaryOperator<E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.function.UnaryOperator<E> |  |
+
+### retainAll(Collection<?> arg0) {#retainAll-java.util.Collection----}
+```
+public boolean retainAll(Collection<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.Collection<?> |  |
+
+**Returns:**
+boolean
+### set(int arg0, E arg1) {#set-int-E-}
+```
+public E set(int arg0, E arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | E |  |
+
+**Returns:**
+E
+### size() {#size--}
+```
+public int size()
+```
+
+
+
+
+**Returns:**
+int
+### sort(Comparator<? super E> arg0) {#sort-java.util.Comparator---super-E--}
+```
+public void sort(Comparator<? super E> arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.util.Comparator<? super E> |  |
+
+### spliterator() {#spliterator--}
+```
+public Spliterator<E> spliterator()
+```
+
+
+
+
+**Returns:**
+java.util.Spliterator<E>
+### subList(int arg0, int arg1) {#subList-int-int-}
+```
+public List<E> subList(int arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | int |  |
+| arg1 | int |  |
+
+**Returns:**
+java.util.List<E>
+### toArray() {#toArray--}
+```
+public Object[] toArray()
+```
+
+
+
+
+**Returns:**
+java.lang.Object[]
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### trimToSize() {#trimToSize--}
+```
+public void trimToSize()
+```
+
+
+
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/platformid/_index.md
+++ b/swedish/java/com.aspose.font/platformid/_index.md
@@ -1,0 +1,268 @@
+---
+title: "PlatformId"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar PlatformId-enumeration."
+type: docs
+weight: 141
+url: /sv/java/com.aspose.font/platformid/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum PlatformId extends Enum<PlatformId>
+```
+
+Representerar PlatformId-enumeration.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ISO](#ISO) | Value2 Apple-spec: (reserverad; får inte användas) MS-spec: ISO‑kodning. |
+| [Macintosh](#Macintosh) | Value 1 Macintosh Script Manager‑kod. |
+| [Microsoft](#Microsoft) | Value 3 Microsoft‑kodning. |
+| [Unicode](#Unicode) | Value 0 Unicode |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ISO {#ISO}
+```
+public static final PlatformId ISO
+```
+
+
+Value2 Apple-spec: (reserverad; får inte användas) MS-spec: ISO‑kodning. Observera att plattforms‑ID 2 (ISO) har avskrivits sedan OpenType‑specifikationen v1.3. Den var avsedd att representera ISO/IEC 10646, i motsats till Unicode; båda standarderna har identiska teckenkodstilldelningar.
+
+### Macintosh {#Macintosh}
+```
+public static final PlatformId Macintosh
+```
+
+
+Value 1 Macintosh Script Manager‑kod.
+
+### Microsoft {#Microsoft}
+```
+public static final PlatformId Microsoft
+```
+
+
+Value 3 Microsoft‑kodning.
+
+### Unicode {#Unicode}
+```
+public static final PlatformId Unicode
+```
+
+
+Value 0 Unicode
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static PlatformId valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[PlatformId](../../com.aspose.font/platformid)
+### values() {#values--}
+```
+public static PlatformId[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.PlatformId[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/renderingutils/_index.md
+++ b/swedish/java/com.aspose.font/renderingutils/_index.md
@@ -1,0 +1,202 @@
+---
+title: "RenderingUtils"
+second_title: "Aspose.Font för Java API-referens"
+description: "Tillhandahåller hjälpfunktioner för rendering."
+type: docs
+weight: 72
+url: /sv/java/com.aspose.font/renderingutils/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class RenderingUtils
+```
+
+Tillhandahåller hjälpfunktioner för rendering.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [drawText(Font font, GlyphId[] glyphIds, double fontSize)](#drawText-com.aspose.font.Font-com.aspose.font.GlyphId---double-) | Renderar text i BitMap. |
+| [drawText(Font font, GlyphId[] glyphIds, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)](#drawText-com.aspose.font.Font-com.aspose.font.GlyphId---double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-) | Renderar text i BitMap. |
+| [drawText(Font font, String text, double fontSize)](#drawText-com.aspose.font.Font-java.lang.String-double-) | Renderar text i BitMap. |
+| [drawText(Font font, String text, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)](#drawText-com.aspose.font.Font-java.lang.String-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-) | Renderar text i BitMap. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### drawText(Font font, GlyphId[] glyphIds, double fontSize) {#drawText-com.aspose.font.Font-com.aspose.font.GlyphId---double-}
+```
+public static InputStream drawText(Font font, GlyphId[] glyphIds, double fontSize)
+```
+
+
+Renderar text i BitMap. Returnerar resultatet i PNG-format som en byte‑ström.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.font/font) | Font |
+| glyphIds | [GlyphId\[\]](../../com.aspose.font/glyphid) | Text representerad som en array av glyfid‑identifierare. |
+| fontSize | double | Fontstorlek |
+
+**Returns:**
+java.io.InputStream – bild i PNG-format som en byte‑ström.
+### drawText(Font font, GlyphId[] glyphIds, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth) {#drawText-com.aspose.font.Font-com.aspose.font.GlyphId---double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-}
+```
+public static InputStream drawText(Font font, GlyphId[] glyphIds, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)
+```
+
+
+Renderar text i BitMap. Returnerar resultatet i PNG-format som en byte‑ström.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.font/font) | Font |
+| glyphIds | [GlyphId\[\]](../../com.aspose.font/glyphid) | Text representerad som en array av glyfid‑identifierare. |
+| fontSize | double | Fontstorlek |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Typ av radavstånd. Antal pixlar eller procent av fontens höjd. |
+| lineSpacingValue | int | Värde för radavstånd. |
+| maxWidth | int | Maximal bredd i pixlar för bilden |
+
+**Returns:**
+java.io.InputStream – bild i PNG-format som en byte‑ström.
+### drawText(Font font, String text, double fontSize) {#drawText-com.aspose.font.Font-java.lang.String-double-}
+```
+public static InputStream drawText(Font font, String text, double fontSize)
+```
+
+
+Renderar text i BitMap.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.font/font) | Typsnittet. |
+| text | java.lang.String | Texten. |
+| fontSize | double | Typsnittsstorleken. |
+
+**Returns:**
+java.io.InputStream - PNG‑bilden med texten som en byte‑ström.
+### drawText(Font font, String text, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth) {#drawText-com.aspose.font.Font-java.lang.String-double-com.aspose.font.RenderingUtils.LineSpacingType-int-int-}
+```
+public static InputStream drawText(Font font, String text, double fontSize, RenderingUtils.LineSpacingType lineSpacingType, int lineSpacingValue, int maxWidth)
+```
+
+
+Renderar text i BitMap.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.font/font) | Typsnittet. |
+| text | java.lang.String | Texten. |
+| fontSize | double | Typsnittsstorleken. |
+| lineSpacingType | [LineSpacingType](../../com.aspose.font/linespacingtype) | Typen av radavstånd. Antal pixlar eller procent av typsnittshöjden. |
+| lineSpacingValue | int | Värdet för radavstånd. |
+| maxWidth | int | Den maximala bredden i pixlar för den resulterande bilden. |
+
+**Returns:**
+java.io.InputStream - PNG‑bilden med texten som en byte‑ström.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/segmentpath/_index.md
+++ b/swedish/java/com.aspose.font/segmentpath/_index.md
@@ -1,0 +1,149 @@
+---
+title: "SegmentPath"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar renderingsväg."
+type: docs
+weight: 73
+url: /sv/java/com.aspose.font/segmentpath/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Cloneable
+```
+public class SegmentPath implements Cloneable
+```
+
+Representerar renderingsväg.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clone()](#clone--) | Klonar sökväg. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getSegments()](#getSegments--) | Hämtar sökvägssegmenten. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Klonar sökväg.
+
+**Returns:**
+java.lang.Object – kopia av sökväg.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSegments() {#getSegments--}
+```
+public PathSegmentCollection getSegments()
+```
+
+
+Hämtar sökvägssegmenten.
+
+**Returns:**
+[PathSegmentCollection](../../com.aspose.font/pathsegmentcollection) - Path segments.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/streamsource/_index.md
+++ b/swedish/java/com.aspose.font/streamsource/_index.md
@@ -1,0 +1,195 @@
+---
+title: "StreamSource"
+second_title: "Aspose.Font för Java API-referens"
+description: "Definierar ett sätt att hämta en filström när den behövs."
+type: docs
+weight: 74
+url: /sv/java/com.aspose.font/streamsource/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class StreamSource
+```
+
+Definierar ett sätt att hämta en filström när den behövs.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [StreamSource()](#StreamSource--) | Initierar instans av strömkälla. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Klonar strömkälla-objektet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontStream()](#getFontStream--) | Returnerar teckensnittström. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning i källan. |
+| [hashCode()](#hashCode--) |  |
+| [mustCloseAfterUse()](#mustCloseAfterUse--) | Avärvade klasser kan förhindra att strömmen stängs. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOffset(long value)](#setOffset-long-) | Ställer in förskjutning i källan. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StreamSource() {#StreamSource--}
+```
+public StreamSource()
+```
+
+
+Initierar instans av strömkälla.
+
+### deepClone() {#deepClone--}
+```
+public abstract Object deepClone()
+```
+
+
+Klonar strömkälla-objektet.
+
+**Returns:**
+java.lang.Object - Kopia av strömkälla-objektet.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontStream() {#getFontStream--}
+```
+public abstract InputStream getFontStream()
+```
+
+
+Returnerar teckensnittström.
+
+**Returns:**
+java.io.InputStream - Teckensnittström.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning i källan.
+
+**Returns:**
+long - Förskjutning i källan.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### mustCloseAfterUse() {#mustCloseAfterUse--}
+```
+public boolean mustCloseAfterUse()
+```
+
+
+Avärvade klasser kan förhindra att strömmen stängs. Returnerar true om strömkälla vill att strömmen stängs efter användning. Annars returneras false.
+
+**Returns:**
+boolean - True om strömkälla vill att strömmen stängs efter användning, annars false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOffset(long value) {#setOffset-long-}
+```
+public void setOffset(long value)
+```
+
+
+Ställer in förskjutning i källan.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long | Förskjutning i källan. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/stringindexdataprovider/_index.md
+++ b/swedish/java/com.aspose.font/stringindexdataprovider/_index.md
@@ -1,0 +1,250 @@
+---
+title: "StringIndexDataProvider"
+second_title: "Aspose.Font för Java API-referens"
+description: "Deklarerar funktionalitet för att komma åt CFF String INDEX-struktur."
+type: docs
+weight: 75
+url: /sv/java/com.aspose.font/stringindexdataprovider/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.ICffIndexDataProvider](../../com.aspose.font/icffindexdataprovider)
+```
+public abstract class StringIndexDataProvider implements ICffIndexDataProvider
+```
+
+Deklarerar funktionalitet för att komma åt CFF String INDEX-struktur.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [StringIndexDataProvider()](#StringIndexDataProvider--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addString(String value)](#addString-java.lang.String-) | Lägger till sträng i CFF String INDEX-struktur. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar/sätter sträng på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Antalet objekt i CFF INDEX-strukturen. |
+| [getRawBytes()](#getRawBytes--) | Hämtar alla byte i CFF INDEX-strukturen. |
+| [getString(int index)](#getString-int-) | Hämtar sträng på det angivna indexet från CFF String INDEX-struktur. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeString(int index)](#removeString-int-) | Tar bort sträng från CFF String Index-struktur på det angivna indexet. |
+| [set(int index, String value)](#set-int-java.lang.String-) |  |
+| [setString(String value, int index)](#setString-java.lang.String-int-) | Sätter sträng i CFF String Index-struktur på det angivna indexet. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StringIndexDataProvider() {#StringIndexDataProvider--}
+```
+public StringIndexDataProvider()
+```
+
+
+### addString(String value) {#addString-java.lang.String-}
+```
+public abstract void addString(String value)
+```
+
+
+Lägger till sträng i CFF String INDEX-struktur.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Strängvärde |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public abstract String get(int index)
+```
+
+
+Hämtar/sätter sträng på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | Index för sträng, index betyder ett ordinalt nummer i CFF INDEX-struktur, inte SID |
+
+**Returns:**
+java.lang.String - Sträng
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public abstract int getCount()
+```
+
+
+Antalet objekt i CFF INDEX-strukturen.
+
+**Returns:**
+int
+### getRawBytes() {#getRawBytes--}
+```
+public abstract byte[] getRawBytes()
+```
+
+
+Hämtar alla byte i CFF INDEX-strukturen.
+
+**Returns:**
+byte[] - Byte i CFF INDEX-strukturen
+### getString(int index) {#getString-int-}
+```
+public abstract String getString(int index)
+```
+
+
+Hämtar sträng på det angivna indexet från CFF String INDEX-struktur.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | Index för sträng, index betyder ett ordinalt nummer i CFF INDEX-struktur, inte SID |
+
+**Returns:**
+java.lang.String - Sträng
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeString(int index) {#removeString-int-}
+```
+public abstract void removeString(int index)
+```
+
+
+Tar bort sträng från CFF String Index-struktur på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | Index för sträng, index betyder ett ordinalt nummer i CFF INDEX-struktur, inte SID |
+
+### set(int index, String value) {#set-int-java.lang.String-}
+```
+public abstract void set(int index, String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+| värde | java.lang.String |  |
+
+### setString(String value, int index) {#setString-java.lang.String-int-}
+```
+public abstract void setString(String value, int index)
+```
+
+
+Sätter sträng i CFF String Index-struktur på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Strängvärde |
+| index | int | Index för sträng, index betyder ett ordinalt nummer i CFF INDEX-struktur, inte SID |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/svgconversionexception/_index.md
+++ b/swedish/java/com.aspose.font/svgconversionexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "SvgConversionException"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar fontkonverteringsundantag för SVG-format."
+type: docs
+weight: 76
+url: /sv/java/com.aspose.font/svgconversionexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException, [com.aspose.font.FontException](../../com.aspose.font/fontexception)
+```
+public class SvgConversionException extends FontException
+```
+
+Representerar teckensnittskonverteringsundantag för SVG-format. Undantaget kan kastas vid fel under teckensnittskonverteringsprocessen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [SvgConversionException()](#SvgConversionException--) | Initierar ett nytt SvgConversionException-objekt. |
+| [SvgConversionException(String message)](#SvgConversionException-java.lang.String-) | Initierar ett nytt SvgConversionException-objekt. |
+| [SvgConversionException(String message, RuntimeException innerException)](#SvgConversionException-java.lang.String-java.lang.RuntimeException-) | Initierar ett nytt SvgConversionException-objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SvgConversionException() {#SvgConversionException--}
+```
+public SvgConversionException()
+```
+
+
+Initierar ett nytt SvgConversionException-objekt.
+
+### SvgConversionException(String message) {#SvgConversionException-java.lang.String-}
+```
+public SvgConversionException(String message)
+```
+
+
+Initierar ett nytt SvgConversionException-objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+
+### SvgConversionException(String message, RuntimeException innerException) {#SvgConversionException-java.lang.String-java.lang.RuntimeException-}
+```
+public SvgConversionException(String message, RuntimeException innerException)
+```
+
+
+Initierar ett nytt SvgConversionException-objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+| innerException | java.lang.RuntimeException | Undantaget som är orsaken till det aktuella undantaget. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/topdictdataprovider/_index.md
+++ b/swedish/java/com.aspose.font/topdictdataprovider/_index.md
@@ -1,0 +1,968 @@
+---
+title: "TopDictDataProvider"
+second_title: "Aspose.Font för Java API-referens"
+description: "Deklarerar funktionalitet för att läsa/uppdatera CFF Top DICT-struktur."
+type: docs
+weight: 77
+url: /sv/java/com.aspose.font/topdictdataprovider/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class TopDictDataProvider
+```
+
+Deklarerar funktionalitet för att läsa/uppdatera CFF Top DICT-struktur.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBaseFontName()](#getBaseFontName--) |  |
+| [getCidCount()](#getCidCount--) |  |
+| [getCidFontRevision()](#getCidFontRevision--) |  |
+| [getCidFontType()](#getCidFontType--) |  |
+| [getCidFontVersion()](#getCidFontVersion--) |  |
+| [getClass()](#getClass--) |  |
+| [getCopyright()](#getCopyright--) |  |
+| [getFamilyName()](#getFamilyName--) |  |
+| [getFontBBox()](#getFontBBox--) |  |
+| [getFontMatrix()](#getFontMatrix--) |  |
+| [getFontName()](#getFontName--) |  |
+| [getFullName()](#getFullName--) |  |
+| [getItalicAngle()](#getItalicAngle--) |  |
+| [getNotice()](#getNotice--) |  |
+| [getPaintType()](#getPaintType--) |  |
+| [getPostScript()](#getPostScript--) |  |
+| [getPrivateDictProvider()](#getPrivateDictProvider--) |  |
+| [getRos(int[] registrySid, int[] orderingSid, int[] supplement)](#getRos-int---int---int---) |  |
+| [getRos(String[] registry, String[] ordering, int[] supplement)](#getRos-java.lang.String---java.lang.String---int---) |  |
+| [getStrokeWidth()](#getStrokeWidth--) |  |
+| [getSyntheticBase()](#getSyntheticBase--) |  |
+| [getUidBase()](#getUidBase--) |  |
+| [getUnderlinePosition()](#getUnderlinePosition--) |  |
+| [getUnderlineThickness()](#getUnderlineThickness--) |  |
+| [getUniqueId()](#getUniqueId--) |  |
+| [getVersion()](#getVersion--) |  |
+| [getWeight()](#getWeight--) |  |
+| [getXuid()](#getXuid--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBaseFontName(String value)](#setBaseFontName-java.lang.String-) |  |
+| [setBaseFontNameSid(int sid)](#setBaseFontNameSid-int-) |  |
+| [setCidCount(int value)](#setCidCount-int-) |  |
+| [setCidFontRevision(int value)](#setCidFontRevision-int-) |  |
+| [setCidFontType(int value)](#setCidFontType-int-) |  |
+| [setCidFontVersion(int value)](#setCidFontVersion-int-) |  |
+| [setCopyright(String value)](#setCopyright-java.lang.String-) |  |
+| [setCopyrightSid(int sid)](#setCopyrightSid-int-) |  |
+| [setFamilyName(String value)](#setFamilyName-java.lang.String-) |  |
+| [setFamilyNameSid(int sid)](#setFamilyNameSid-int-) |  |
+| [setFixedPitch(boolean value)](#setFixedPitch-boolean-) |  |
+| [setFontBBox(FontBBox value)](#setFontBBox-com.aspose.font.FontBBox-) |  |
+| [setFontMatrix(TransformationMatrix value)](#setFontMatrix-com.aspose.font.TransformationMatrix-) |  |
+| [setFontName(String value)](#setFontName-java.lang.String-) |  |
+| [setFontNameSid(int sid)](#setFontNameSid-int-) |  |
+| [setFullName(String value)](#setFullName-java.lang.String-) |  |
+| [setFullNameSid(int sid)](#setFullNameSid-int-) |  |
+| [setItalicAngle(int value)](#setItalicAngle-int-) |  |
+| [setNotice(String value)](#setNotice-java.lang.String-) |  |
+| [setNoticeSid(int sid)](#setNoticeSid-int-) |  |
+| [setPaintType(int value)](#setPaintType-int-) |  |
+| [setPostScript(String value)](#setPostScript-java.lang.String-) |  |
+| [setPostScriptSid(int sid)](#setPostScriptSid-int-) |  |
+| [setRos(int registry, int ordering, int supplement)](#setRos-int-int-int-) |  |
+| [setRos(String registry, String ordering, int supplement)](#setRos-java.lang.String-java.lang.String-int-) |  |
+| [setStrokeWidth(int value)](#setStrokeWidth-int-) |  |
+| [setSyntheticBase(int value)](#setSyntheticBase-int-) |  |
+| [setUidBase(int value)](#setUidBase-int-) |  |
+| [setUnderlinePosition(int value)](#setUnderlinePosition-int-) |  |
+| [setUnderlineThickness(int value)](#setUnderlineThickness-int-) |  |
+| [setUniqueId(int value)](#setUniqueId-int-) |  |
+| [setVersion(String value)](#setVersion-java.lang.String-) |  |
+| [setVersionSid(int sid)](#setVersionSid-int-) |  |
+| [setWeight(String value)](#setWeight-java.lang.String-) |  |
+| [setWeightSid(int sid)](#setWeightSid-int-) |  |
+| [setXuid(double[] value)](#setXuid-double---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBaseFontName() {#getBaseFontName--}
+```
+public String getBaseFontName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getCidCount() {#getCidCount--}
+```
+public int getCidCount()
+```
+
+
+
+
+**Returns:**
+int
+### getCidFontRevision() {#getCidFontRevision--}
+```
+public int getCidFontRevision()
+```
+
+
+
+
+**Returns:**
+int
+### getCidFontType() {#getCidFontType--}
+```
+public int getCidFontType()
+```
+
+
+
+
+**Returns:**
+int
+### getCidFontVersion() {#getCidFontVersion--}
+```
+public int getCidFontVersion()
+```
+
+
+
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCopyright() {#getCopyright--}
+```
+public String getCopyright()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getFamilyName() {#getFamilyName--}
+```
+public String getFamilyName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox)
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix)
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getFullName() {#getFullName--}
+```
+public String getFullName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getItalicAngle() {#getItalicAngle--}
+```
+public int getItalicAngle()
+```
+
+
+
+
+**Returns:**
+int
+### getNotice() {#getNotice--}
+```
+public String getNotice()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getPaintType() {#getPaintType--}
+```
+public int getPaintType()
+```
+
+
+
+
+**Returns:**
+int
+### getPostScript() {#getPostScript--}
+```
+public String getPostScript()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getPrivateDictProvider() {#getPrivateDictProvider--}
+```
+public PrivateDictDataProvider getPrivateDictProvider()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.PrivateDictDataProvider
+### getRos(int[] registrySid, int[] orderingSid, int[] supplement) {#getRos-int---int---int---}
+```
+public void getRos(int[] registrySid, int[] orderingSid, int[] supplement)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| registrySid | int[] |  |
+| orderingSid | int[] |  |
+| supplement | int[] |  |
+
+### getRos(String[] registry, String[] ordering, int[] supplement) {#getRos-java.lang.String---java.lang.String---int---}
+```
+public void getRos(String[] registry, String[] ordering, int[] supplement)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| registry | java.lang.String[] |  |
+| ordering | java.lang.String[] |  |
+| supplement | int[] |  |
+
+### getStrokeWidth() {#getStrokeWidth--}
+```
+public int getStrokeWidth()
+```
+
+
+
+
+**Returns:**
+int
+### getSyntheticBase() {#getSyntheticBase--}
+```
+public int getSyntheticBase()
+```
+
+
+
+
+**Returns:**
+int
+### getUidBase() {#getUidBase--}
+```
+public int getUidBase()
+```
+
+
+
+
+**Returns:**
+int
+### getUnderlinePosition() {#getUnderlinePosition--}
+```
+public int getUnderlinePosition()
+```
+
+
+
+
+**Returns:**
+int
+### getUnderlineThickness() {#getUnderlineThickness--}
+```
+public int getUnderlineThickness()
+```
+
+
+
+
+**Returns:**
+int
+### getUniqueId() {#getUniqueId--}
+```
+public int getUniqueId()
+```
+
+
+
+
+**Returns:**
+int
+### getVersion() {#getVersion--}
+```
+public String getVersion()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getWeight() {#getWeight--}
+```
+public String getWeight()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getXuid() {#getXuid--}
+```
+public double[] getXuid()
+```
+
+
+
+
+**Returns:**
+double[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBaseFontName(String value) {#setBaseFontName-java.lang.String-}
+```
+public int setBaseFontName(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+**Returns:**
+int
+### setBaseFontNameSid(int sid) {#setBaseFontNameSid-int-}
+```
+public void setBaseFontNameSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| sid | int |  |
+
+### setCidCount(int value) {#setCidCount-int-}
+```
+public void setCidCount(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setCidFontRevision(int value) {#setCidFontRevision-int-}
+```
+public void setCidFontRevision(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setCidFontType(int value) {#setCidFontType-int-}
+```
+public void setCidFontType(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setCidFontVersion(int value) {#setCidFontVersion-int-}
+```
+public void setCidFontVersion(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setCopyright(String value) {#setCopyright-java.lang.String-}
+```
+public int setCopyright(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+**Returns:**
+int
+### setCopyrightSid(int sid) {#setCopyrightSid-int-}
+```
+public void setCopyrightSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| sid | int |  |
+
+### setFamilyName(String value) {#setFamilyName-java.lang.String-}
+```
+public int setFamilyName(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+**Returns:**
+int
+### setFamilyNameSid(int sid) {#setFamilyNameSid-int-}
+```
+public void setFamilyNameSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| sid | int |  |
+
+### setFixedPitch(boolean value) {#setFixedPitch-boolean-}
+```
+public void setFixedPitch(boolean value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setFontBBox(FontBBox value) {#setFontBBox-com.aspose.font.FontBBox-}
+```
+public void setFontBBox(FontBBox value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [FontBBox](../../com.aspose.font/fontbbox) |  |
+
+### setFontMatrix(TransformationMatrix value) {#setFontMatrix-com.aspose.font.TransformationMatrix-}
+```
+public void setFontMatrix(TransformationMatrix value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [TransformationMatrix](../../com.aspose.font/transformationmatrix) |  |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public int setFontName(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+**Returns:**
+int
+### setFontNameSid(int sid) {#setFontNameSid-int-}
+```
+public void setFontNameSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| sid | int |  |
+
+### setFullName(String value) {#setFullName-java.lang.String-}
+```
+public int setFullName(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+**Returns:**
+int
+### setFullNameSid(int sid) {#setFullNameSid-int-}
+```
+public void setFullNameSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| sid | int |  |
+
+### setItalicAngle(int value) {#setItalicAngle-int-}
+```
+public void setItalicAngle(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setNotice(String value) {#setNotice-java.lang.String-}
+```
+public int setNotice(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+**Returns:**
+int
+### setNoticeSid(int sid) {#setNoticeSid-int-}
+```
+public void setNoticeSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| sid | int |  |
+
+### setPaintType(int value) {#setPaintType-int-}
+```
+public void setPaintType(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPostScript(String value) {#setPostScript-java.lang.String-}
+```
+public int setPostScript(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+**Returns:**
+int
+### setPostScriptSid(int sid) {#setPostScriptSid-int-}
+```
+public void setPostScriptSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| sid | int |  |
+
+### setRos(int registry, int ordering, int supplement) {#setRos-int-int-int-}
+```
+public void setRos(int registry, int ordering, int supplement)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| registry | int |  |
+| ordering | int |  |
+| supplement | int |  |
+
+### setRos(String registry, String ordering, int supplement) {#setRos-java.lang.String-java.lang.String-int-}
+```
+public void setRos(String registry, String ordering, int supplement)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| registry | java.lang.String |  |
+| ordering | java.lang.String |  |
+| supplement | int |  |
+
+### setStrokeWidth(int value) {#setStrokeWidth-int-}
+```
+public void setStrokeWidth(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSyntheticBase(int value) {#setSyntheticBase-int-}
+```
+public void setSyntheticBase(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setUidBase(int value) {#setUidBase-int-}
+```
+public void setUidBase(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setUnderlinePosition(int value) {#setUnderlinePosition-int-}
+```
+public void setUnderlinePosition(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setUnderlineThickness(int value) {#setUnderlineThickness-int-}
+```
+public void setUnderlineThickness(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setUniqueId(int value) {#setUniqueId-int-}
+```
+public void setUniqueId(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setVersion(String value) {#setVersion-java.lang.String-}
+```
+public int setVersion(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+**Returns:**
+int
+### setVersionSid(int sid) {#setVersionSid-int-}
+```
+public void setVersionSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| sid | int |  |
+
+### setWeight(String value) {#setWeight-java.lang.String-}
+```
+public int setWeight(String value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+**Returns:**
+int
+### setWeightSid(int sid) {#setWeightSid-int-}
+```
+public void setWeightSid(int sid)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| sid | int |  |
+
+### setXuid(double[] value) {#setXuid-double---}
+```
+public void setXuid(double[] value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/transformationmatrix/_index.md
+++ b/swedish/java/com.aspose.font/transformationmatrix/_index.md
@@ -1,0 +1,412 @@
+---
+title: "Transformationsmatris"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar 3x3-matris  A   B   0   C   D   0   TX  TY  1 ."
+type: docs
+weight: 78
+url: /sv/java/com.aspose.font/transformationmatrix/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TransformationMatrix
+```
+
+Representerar 3x3-matris | A B 0 | | C D 0 | | TX TY 1 |. Transformerar koordinater på följande sätt: x1 = A\*x + C\*y + TX y1 = B\*x + D\*y + TY.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [TransformationMatrix()](#TransformationMatrix--) | Skapar standard 1 till 1-matris: [ A B C D TX TY ] = [ 1, 0, 0, 1, 0, 0] |
+| [TransformationMatrix(double[] matrixArray)](#TransformationMatrix-double---) | Accepterar en transformationsmatris med följande arrayrepresentation: [ A B C D TX TY ] |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Tillhandahåller åtkomst till underliggande array. |
+| [getA()](#getA--) | Hämtar värdet A i transformationsmatrisen. |
+| [getB()](#getB--) | Hämtar värdet B i transformationsmatrisen. |
+| [getC()](#getC--) | Hämtar värdet C i transformationsmatrisen. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Hämtar värdet D i transformationsmatrisen. |
+| [getTX()](#getTX--) | Hämtar värdet TX i transformationsmatrisen. |
+| [getTY()](#getTY--) | Hämtar värdet TY i transformationsmatrisen. |
+| [hashCode()](#hashCode--) |  |
+| [multiply(TransformationMatrix matrix)](#multiply-com.aspose.font.TransformationMatrix-) | Multiplicerar med en annan transformationsmatris. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [scale(double x, double y, double[] x1, double[] y1)](#scale-double-double-double---double---) | Skalar x och y med transformationsmatrisen: x1 = A\*x + C\*y; y1 = B\*x + D\*y. |
+| [setA(double value)](#setA-double-) | Sätter värdet A i transformationsmatrisen. |
+| [setB(double value)](#setB-double-) | Sätter värdet B i transformationsmatrisen. |
+| [setC(double value)](#setC-double-) | Sätter värdet C i transformationsmatrisen. |
+| [setD(double value)](#setD-double-) | Sätter värdet D i transformationsmatrisen. |
+| [setTX(double value)](#setTX-double-) | Sätter värdet TX i transformationsmatrisen. |
+| [setTY(double value)](#setTY-double-) | Sätter värdet TY i transformationsmatrisen. |
+| [toArray()](#toArray--) | Allokerar ny array, kopierar transformationsmatrisen och returnerar den. |
+| [toString()](#toString--) |  |
+| [transform(double x, double y, double[] x1, double[] y1)](#transform-double-double-double---double---) | Transformerar x och y med transformationsmatrisen: x1 = A\*x + C\*y + TX; y1 = B\*x + D\*y + TY. |
+| [unScale(double x1, double y1, double[] x, double[] y)](#unScale-double-double-double---double---) | Skalar tillbaka x1 och y1 och returnerar x och y före transformationsmatrisen. |
+| [unTransform(double x1, double y1, double[] x, double[] y)](#unTransform-double-double-double---double---) | Transformerar tillbaka x1 och y1 och returnerar x och y före transformationsmatrisen. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TransformationMatrix() {#TransformationMatrix--}
+```
+public TransformationMatrix()
+```
+
+
+Skapar standard 1 till 1-matris: [ A B C D TX TY ] = [ 1, 0, 0, 1, 0, 0]
+
+### TransformationMatrix(double[] matrixArray) {#TransformationMatrix-double---}
+```
+public TransformationMatrix(double[] matrixArray)
+```
+
+
+Accepterar en transformationsmatris med följande arrayrepresentation: [ A B C D TX TY ]
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| matrixArray | double[] | Array med transformationsmatrisvärden, måste ha 6 element. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public double get(int index)
+```
+
+
+Tillhandahåller åtkomst till underliggande array.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | Index i transformationsmatrisarray. |
+
+**Returns:**
+double - Elementet i underliggande array vid index.
+### getA() {#getA--}
+```
+public double getA()
+```
+
+
+Hämtar värdet A i transformationsmatrisen.
+
+**Returns:**
+double - Ett transformationsmatrisvärde.
+### getB() {#getB--}
+```
+public double getB()
+```
+
+
+Hämtar värdet B i transformationsmatrisen.
+
+**Returns:**
+double - B transformationsmatrisvärde.
+### getC() {#getC--}
+```
+public double getC()
+```
+
+
+Hämtar värdet C i transformationsmatrisen.
+
+**Returns:**
+double - C transformationsmatrisvärde.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public double getD()
+```
+
+
+Hämtar värdet D i transformationsmatrisen.
+
+**Returns:**
+double - D transformationsmatrisvärde.
+### getTX() {#getTX--}
+```
+public double getTX()
+```
+
+
+Hämtar värdet TX i transformationsmatrisen.
+
+**Returns:**
+double - TX transformationsmatrisvärde.
+### getTY() {#getTY--}
+```
+public double getTY()
+```
+
+
+Hämtar värdet TY i transformationsmatrisen.
+
+**Returns:**
+double - TY transformationsmatrisvärde.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### multiply(TransformationMatrix matrix) {#multiply-com.aspose.font.TransformationMatrix-}
+```
+public TransformationMatrix multiply(TransformationMatrix matrix)
+```
+
+
+Multiplicerar med en annan transformationsmatris. Ändrar inte den ursprungliga transformationsmatrisen, returnerar ett nytt TransformationMatrix-objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| matrix | [TransformationMatrix](../../com.aspose.font/transformationmatrix) | Transformationsmatris att multiplicera med. |
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - New TransformationMatrix object.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### scale(double x, double y, double[] x1, double[] y1) {#scale-double-double-double---double---}
+```
+public void scale(double x, double y, double[] x1, double[] y1)
+```
+
+
+Skalar x och y med transformationsmatrisen: x1 = A\*x + C\*y; y1 = B\*x + D\*y.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| x | double | Ursprunglig x-koordinat |
+| y | double | Ursprunglig y-koordinat. |
+| x1 | double[] | Koordinat x skalad. |
+| y1 | double[] | Koordinat y skalad. |
+
+### setA(double value) {#setA-double-}
+```
+public void setA(double value)
+```
+
+
+Sätter värdet A i transformationsmatrisen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | A transformationsmatrisvärde. |
+
+### setB(double value) {#setB-double-}
+```
+public void setB(double value)
+```
+
+
+Sätter värdet B i transformationsmatrisen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | B transformationsmatrisvärde. |
+
+### setC(double value) {#setC-double-}
+```
+public void setC(double value)
+```
+
+
+Sätter värdet C i transformationsmatrisen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | C transformationsmatrisvärde. |
+
+### setD(double value) {#setD-double-}
+```
+public void setD(double value)
+```
+
+
+Sätter värdet D i transformationsmatrisen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | D transformationsmatrisvärde. |
+
+### setTX(double value) {#setTX-double-}
+```
+public void setTX(double value)
+```
+
+
+Sätter värdet TX i transformationsmatrisen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | TX transformationsmatrisvärde. |
+
+### setTY(double value) {#setTY-double-}
+```
+public void setTY(double value)
+```
+
+
+Sätter värdet TY i transformationsmatrisen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | TY transformationsmatrisvärde. |
+
+### toArray() {#toArray--}
+```
+public double[] toArray()
+```
+
+
+Allokerar ny array, kopierar transformationsmatrisen och returnerar den.
+
+**Returns:**
+double[] - Transformationsmatris i arrayform.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(double x, double y, double[] x1, double[] y1) {#transform-double-double-double---double---}
+```
+public void transform(double x, double y, double[] x1, double[] y1)
+```
+
+
+Transformerar x och y med transformationsmatrisen: x1 = A\*x + C\*y + TX; y1 = B\*x + D\*y + TY.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| x | double | Ursprunglig x-koordinat. |
+| y | double | Ursprunglig y-koordinat. |
+| x1 | double[] | Transformerad x-koordinat. |
+| y1 | double[] | Transformerad y-koordinat. |
+
+### unScale(double x1, double y1, double[] x, double[] y) {#unScale-double-double-double---double---}
+```
+public void unScale(double x1, double y1, double[] x, double[] y)
+```
+
+
+Skalar tillbaka x1 och y1 och returnerar x och y före transformationsmatrisen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| x1 | double | Koordinat x1 |
+| y1 | double | Koordinat y1 |
+| x | double[] | Koordinat x skalad tillbaka. |
+| y | double[] | Koordinat y skalad tillbaka. |
+
+### unTransform(double x1, double y1, double[] x, double[] y) {#unTransform-double-double-double---double---}
+```
+public void unTransform(double x1, double y1, double[] x, double[] y)
+```
+
+
+Transformerar tillbaka x1 och y1 och returnerar x och y före transformationsmatrisen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| x1 | double | Koordinat x1. |
+| y1 | double | Koordinat y1. |
+| x | double[] | Koordinat x transformerad tillbaka. |
+| y | double[] | Koordinat y transformerad tillbaka. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttcfontfiledefinition/_index.md
+++ b/swedish/java/com.aspose.font/ttcfontfiledefinition/_index.md
@@ -1,0 +1,200 @@
+---
+title: "TtcFontFileDefinition"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar fildefinition för TTC-typsnitt."
+type: docs
+weight: 79
+url: /sv/java/com.aspose.font/ttcfontfiledefinition/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.FontFileDefinition](../../com.aspose.font/fontfiledefinition)
+```
+public class TtcFontFileDefinition extends FontFileDefinition
+```
+
+Representerar fildefinition för TTC-typsnitt.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [TtcFontFileDefinition(int fontIndex, String fileExtension, StreamSource streamSource, long offset)](#TtcFontFileDefinition-int-java.lang.String-com.aspose.font.StreamSource-long-) | Skapar en fildefinition som endast använder filinnehåll. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileExtension()](#getFileExtension--) | Hämtar filändelse. |
+| [getFileName()](#getFileName--) | Hämtar filnamn. |
+| [getFontIndex()](#getFontIndex--) | Hämtar teckensnittets index i TTC-teckensnittet. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning i strömmen. |
+| [getStreamSource()](#getStreamSource--) | Hämtar strömkällan. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TtcFontFileDefinition(int fontIndex, String fileExtension, StreamSource streamSource, long offset) {#TtcFontFileDefinition-int-java.lang.String-com.aspose.font.StreamSource-long-}
+```
+public TtcFontFileDefinition(int fontIndex, String fileExtension, StreamSource streamSource, long offset)
+```
+
+
+Skapar en fildefinition som endast använder filinnehåll.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontIndex | int | Index för teckensnitt i TTC-teckensnittssamling. |
+| fileExtension | java.lang.String | Filändelse för teckensnittssamling. |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) | Källa för teckensnittssamling. |
+| förskjutning | long | Förskjutning till teckensnittsdata i teckensnittssamlingen, se TTC‑huvud, Offset‑tabell i OpenType-teckensnittsfilspecifikationen |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileExtension() {#getFileExtension--}
+```
+public String getFileExtension()
+```
+
+
+Hämtar filändelse.
+
+**Returns:**
+java.lang.String - Filändelse.
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Hämtar filnamn.
+
+**Returns:**
+java.lang.String - Filnamn.
+### getFontIndex() {#getFontIndex--}
+```
+public long getFontIndex()
+```
+
+
+Hämtar teckensnittets index i TTC-teckensnittet.
+
+**Returns:**
+long - Teckensnittindex i TTC‑teckensnitt.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning i strömmen.
+
+**Returns:**
+long - Förskjutning i strömmen.
+### getStreamSource() {#getStreamSource--}
+```
+public StreamSource getStreamSource()
+```
+
+
+Hämtar strömkällan.
+
+**Returns:**
+[StreamSource](../../com.aspose.font/streamsource) - The stream source.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttcfontsource/_index.md
+++ b/swedish/java/com.aspose.font/ttcfontsource/_index.md
@@ -1,0 +1,170 @@
+---
+title: "TtcFontSource"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar TTC-typsnittskälla."
+type: docs
+weight: 80
+url: /sv/java/com.aspose.font/ttcfontsource/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+com.aspose.font.IFontSource
+```
+public class TtcFontSource implements IFontSource
+```
+
+Representerar TTC-typsnittskälla.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [TtcFontSource(StreamSource source)](#TtcFontSource-com.aspose.font.StreamSource-) | Skapar TTC Font-källa baserat på IStreamSource-ström som tillhandahåller objekt. |
+| [TtcFontSource(String filePath)](#TtcFontSource-java.lang.String-) | Skapar TTC Font-källa baserat på sökväg till ttc-typsnittssamlingsfil. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontDefinitions()](#getFontDefinitions--) | Returnerar Font-definitionsarray för TTC Font-källan. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TtcFontSource(StreamSource source) {#TtcFontSource-com.aspose.font.StreamSource-}
+```
+public TtcFontSource(StreamSource source)
+```
+
+
+Skapar TTC Font-källa baserat på IStreamSource-ström som tillhandahåller objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| source | [StreamSource](../../com.aspose.font/streamsource) | Källström för att extrahera TTC Font-samlingsdata från. |
+
+### TtcFontSource(String filePath) {#TtcFontSource-java.lang.String-}
+```
+public TtcFontSource(String filePath)
+```
+
+
+Skapar TTC Font-källa baserat på sökväg till ttc-typsnittssamlingsfil.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| filePath | java.lang.String | Typsnittssamlingsfil. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontDefinitions() {#getFontDefinitions--}
+```
+public FontDefinition[] getFontDefinitions()
+```
+
+
+Returnerar Font-definitionsarray för TTC Font-källan.
+
+**Returns:**
+com.aspose.font.FontDefinition[] - Alla typsnittdefinitioner från TTC-typsnittskälla.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfcfftable/_index.md
+++ b/swedish/java/com.aspose.font/ttfcfftable/_index.md
@@ -1,0 +1,182 @@
+---
+title: "TtfCffTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar cff-tabellen i TTF-fontfilen."
+type: docs
+weight: 90
+url: /sv/java/com.aspose.font/ttfcfftable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfCffTable extends TtfTableBase
+```
+
+Representerar "cff"-tabell i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCffSource()](#getCffSource--) | Råa byte för konturer i Compact Font Format-representation. |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCffSource(StreamSource streamSource)](#setCffSource-com.aspose.font.StreamSource-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCffSource() {#getCffSource--}
+```
+public StreamSource getCffSource()
+```
+
+
+Råa byte för konturer i Compact Font Format-representation.
+
+**Returns:**
+[StreamSource](../../com.aspose.font/streamsource) - Raw bytes for outlines in Compact Font Format representation.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCffSource(StreamSource streamSource) {#setCffSource-com.aspose.font.StreamSource-}
+```
+public void setCffSource(StreamSource streamSource)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| streamSource | [StreamSource](../../com.aspose.font/streamsource) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfcmapformat0table/_index.md
+++ b/swedish/java/com.aspose.font/ttfcmapformat0table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat0Table"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Format0 CMap-undertabell i TTF-typsnittsfilen."
+type: docs
+weight: 81
+url: /sv/java/com.aspose.font/ttfcmapformat0table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat0Table extends TtfCMapFormatBaseTable
+```
+
+Representerar Format0 CMap-undertabell i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Hämtar alla koder från den aktuella CMap:s deltabell. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Hämtar ett glyfindex för en given teckenkod. |
+| [getPlatformId()](#getPlatformId--) | Hämtar PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Hämtar PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Hämtar alla koder från den aktuella CMap:s deltabell.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Alla koder från aktuell CMap:s deltabell.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Hämtar ett glyfindex för en given teckenkod.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| charCode | long | Teckenkod. |
+
+**Returns:**
+long - Glyfindex.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Hämtar PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Hämtar PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfcmapformat10table/_index.md
+++ b/swedish/java/com.aspose.font/ttfcmapformat10table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat10Table"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Format10 CMap-undertabell i TTF-typsnittsfilen."
+type: docs
+weight: 82
+url: /sv/java/com.aspose.font/ttfcmapformat10table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat10Table extends TtfCMapFormatBaseTable
+```
+
+Representerar Format10 CMap-undertabell i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Hämtar alla koder från den aktuella CMap:s deltabell. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Hämtar ett glyfindex för en given teckenkod. |
+| [getPlatformId()](#getPlatformId--) | Hämtar PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Hämtar PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Hämtar alla koder från den aktuella CMap:s deltabell.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Alla koder från aktuell CMap:s deltabell.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Hämtar ett glyfindex för en given teckenkod.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| charCode | long | Teckenkod. |
+
+**Returns:**
+long - Glyfindex.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Hämtar PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Hämtar PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfcmapformat12table/_index.md
+++ b/swedish/java/com.aspose.font/ttfcmapformat12table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat12Table"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Format8 CMap-undertabell i TTF-typsnittsfilen."
+type: docs
+weight: 83
+url: /sv/java/com.aspose.font/ttfcmapformat12table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat12Table extends TtfCMapFormatBaseTable
+```
+
+Representerar Format8 CMap-undertabell i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Hämtar alla koder från den aktuella CMap:s deltabell. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Hämtar ett glyfindex för en given teckenkod. |
+| [getPlatformId()](#getPlatformId--) | Hämtar PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Hämtar PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Hämtar alla koder från den aktuella CMap:s deltabell.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Alla koder från den aktuella CMap:s deltabell.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Hämtar ett glyfindex för en given teckenkod.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| charCode | long | Teckenkod |
+
+**Returns:**
+long - Glyfindex.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Hämtar PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Hämtar PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfcmapformat2table/_index.md
+++ b/swedish/java/com.aspose.font/ttfcmapformat2table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat2Table"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Format2 CMap-undertabell i TTF-typsnittsfilen."
+type: docs
+weight: 84
+url: /sv/java/com.aspose.font/ttfcmapformat2table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat2Table extends TtfCMapFormatBaseTable
+```
+
+Representerar Format2 CMap-undertabell i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Hämtar alla koder från den aktuella CMap:s deltabell. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Hämtar ett glyfindex för en given teckenkod. |
+| [getPlatformId()](#getPlatformId--) | Hämtar PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Hämtar PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Hämtar alla koder från den aktuella CMap:s deltabell.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Alla koder från den aktuella CMap:s deltabell.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Hämtar ett glyfindex för en given teckenkod.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| charCode | long | Teckenkod. |
+
+**Returns:**
+long - Glyfindex.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Hämtar PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Hämtar PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfcmapformat4table/_index.md
+++ b/swedish/java/com.aspose.font/ttfcmapformat4table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat4Table"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Format4 CMap-undertabell i TTF-typsnittsfilen."
+type: docs
+weight: 85
+url: /sv/java/com.aspose.font/ttfcmapformat4table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat4Table extends TtfCMapFormatBaseTable
+```
+
+Representerar Format4 CMap-undertabell i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Hämtar alla koder från den aktuella CMap:s deltabell. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Hämtar ett glyfindex för en given teckenkod. |
+| [getPlatformId()](#getPlatformId--) | Hämtar PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Hämtar PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Hämtar alla koder från den aktuella CMap:s deltabell.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Alla koder från aktuell CMap:s deltabell.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Hämtar ett glyfindex för en given teckenkod.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| charCode | long | Teckenkod. |
+
+**Returns:**
+long - Glyfindex.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Hämtar PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Hämtar PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfcmapformat6table/_index.md
+++ b/swedish/java/com.aspose.font/ttfcmapformat6table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat6Table"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Format6 CMap-undertabell i TTF-typsnittsfilen."
+type: docs
+weight: 86
+url: /sv/java/com.aspose.font/ttfcmapformat6table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat6Table extends TtfCMapFormatBaseTable
+```
+
+Representerar Format6 CMap-undertabell i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Hämtar alla koder från den aktuella CMap:s deltabell. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Hämtar ett glyfindex för en given teckenkod. |
+| [getPlatformId()](#getPlatformId--) | Hämtar PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Hämtar PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Hämtar alla koder från den aktuella CMap:s deltabell.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Alla koder från den aktuella CMap:s deltabell.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Hämtar ett glyfindex för en given teckenkod.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| charCode | long | Teckenkod. |
+
+**Returns:**
+long - Glyfindex.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Hämtar PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Hämtar PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfcmapformat8table/_index.md
+++ b/swedish/java/com.aspose.font/ttfcmapformat8table/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormat8Table"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Format8 CMap-undertabell i TTF-typsnittsfilen."
+type: docs
+weight: 87
+url: /sv/java/com.aspose.font/ttfcmapformat8table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable)
+```
+public class TtfCMapFormat8Table extends TtfCMapFormatBaseTable
+```
+
+Representerar Format8 CMap-undertabell i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Hämtar alla koder från den aktuella CMap:s deltabell. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Hämtar ett glyfindex för en given teckenkod. |
+| [getPlatformId()](#getPlatformId--) | Hämtar PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Hämtar PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Hämtar alla koder från den aktuella CMap:s deltabell.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Alla koder från aktuell CMap:s deltabell.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Hämtar ett glyfindex för en given teckenkod.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| charCode | long | Teckenkod. |
+
+**Returns:**
+long - Glyfindex.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Hämtar PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Hämtar PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfcmapformatbasetable/_index.md
+++ b/swedish/java/com.aspose.font/ttfcmapformatbasetable/_index.md
@@ -1,0 +1,173 @@
+---
+title: "TtfCMapFormatBaseTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar basklass för CMap-undertabell."
+type: docs
+weight: 88
+url: /sv/java/com.aspose.font/ttfcmapformatbasetable/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TtfCMapFormatBaseTable
+```
+
+Representerar basklass för CMap-undertabell.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllCodes()](#getAllCodes--) | Hämtar alla koder från den aktuella CMap:s deltabell. |
+| [getClass()](#getClass--) |  |
+| [getGlyphIndex(long charCode)](#getGlyphIndex-long-) | Hämtar ett glyfindex för en given teckenkod |
+| [getPlatformId()](#getPlatformId--) | Hämtar PlatformId. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Hämtar PlatformSpecificId. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllCodes() {#getAllCodes--}
+```
+public ArrayList<Long> getAllCodes()
+```
+
+
+Hämtar alla koder från den aktuella CMap:s deltabell.
+
+**Returns:**
+java.util.ArrayList<java.lang.Long> - Alla koder från aktuell CMap:s deltabell.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyphIndex(long charCode) {#getGlyphIndex-long-}
+```
+public long getGlyphIndex(long charCode)
+```
+
+
+Hämtar ett glyfindex för en given teckenkod
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| charCode | long | teckenkod |
+
+**Returns:**
+long - Glyfindex.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Hämtar PlatformId.
+
+**Returns:**
+int - PlatformId.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Hämtar PlatformSpecificId.
+
+**Returns:**
+int - PlatformSpecificId.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfcmapsubtabledescription/_index.md
+++ b/swedish/java/com.aspose.font/ttfcmapsubtabledescription/_index.md
@@ -1,0 +1,157 @@
+---
+title: "TtfCMapTable.TtfCMapSubtableDescription"
+second_title: "Aspose.Font för Java API-referens"
+description: "Tillhandahåller kort information om CMap-undertabell."
+type: docs
+weight: 10
+url: /sv/java/com.aspose.font/ttfcmaptable.ttfcmapsubtabledescription/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract static class TtfCMapTable.TtfCMapSubtableDescription
+```
+
+Tillhandahåller kort information om CMap-undertabell.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFormat()](#getFormat--) | Hämtar subtabellformat. |
+| [getPlatformId()](#getPlatformId--) | Hämtar plattforms-ID. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Hämtar plattformspecifik kodnings-ID. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFormat() {#getFormat--}
+```
+public int getFormat()
+```
+
+
+Hämtar subtabellformat.
+
+**Returns:**
+int - subtabellformat.
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Hämtar plattforms-ID.
+
+**Returns:**
+int - plattforms-ID.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Hämtar plattformspecifik kodnings-ID.
+
+**Returns:**
+int - plattformspecifik kodnings-ID.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfcmaptable/_index.md
+++ b/swedish/java/com.aspose.font/ttfcmaptable/_index.md
@@ -1,0 +1,196 @@
+---
+title: "TtfCMapTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar cmap-tabellen i TTF-typsnittsfilen."
+type: docs
+weight: 89
+url: /sv/java/com.aspose.font/ttfcmaptable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfCMapTable extends TtfTableBase
+```
+
+Representerar "cmap"-tabell i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [findUnicodeTable()](#findUnicodeTable--) | Söker och returnerar unicode CMap. |
+| [getAllSubtables()](#getAllSubtables--) | Returnerar alla deltabeller från CMap-tabellen. |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getPlatformTables(int platformId, int platformSpecificId)](#getPlatformTables-int-int-) | Returnerar CMap-deltabeller för planformId och platformSpecificId. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### findUnicodeTable() {#findUnicodeTable--}
+```
+public TtfCMapFormatBaseTable findUnicodeTable()
+```
+
+
+Söker och returnerar unicode CMap. om det finns ucs-4 CMap - returneras den först; annars - returneras någon unicode CMap som kan hittas.
+
+**Returns:**
+[TtfCMapFormatBaseTable](../../com.aspose.font/ttfcmapformatbasetable) - Unicode subtable.
+### getAllSubtables() {#getAllSubtables--}
+```
+public TtfCMapTable.TtfCMapSubtableDescription[] getAllSubtables()
+```
+
+
+Returnerar alla deltabeller från CMap-tabellen.
+
+**Returns:**
+com.aspose.font.TtfCMapTable.TtfCMapSubtableDescription[] - array av TtfCmapSubtableDescription-objekt
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getPlatformTables(int platformId, int platformSpecificId) {#getPlatformTables-int-int-}
+```
+public TtfCMapFormatBaseTable[] getPlatformTables(int platformId, int platformSpecificId)
+```
+
+
+Returnerar CMap-deltabeller för planformId och platformSpecificId.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| platformId | int | Plattforms-ID. |
+| platformSpecificId | int | Plattformspecifik kodnings-ID. |
+
+**Returns:**
+com.aspose.font.TtfCMapFormatBaseTable[] - CMap-deltabeller.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfcvttable/_index.md
+++ b/swedish/java/com.aspose.font/ttfcvttable/_index.md
@@ -1,0 +1,168 @@
+---
+title: "TtfCvtTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Control Value Table CVT för TTF Font-filen."
+type: docs
+weight: 91
+url: /sv/java/com.aspose.font/ttfcvttable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfCvtTable extends TtfTableBase
+```
+
+Representerar Control Value Table (CVT) i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getControlValues()](#getControlValues--) | Hämtar lista över värden som kan refereras av instruktioner. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getControlValues() {#getControlValues--}
+```
+public short[] getControlValues()
+```
+
+
+Hämtar lista över värden som kan refereras av instruktioner.
+
+**Returns:**
+short[] - Lista över värden som kan refereras av instruktioner.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfencoding/_index.md
+++ b/swedish/java/com.aspose.font/ttfencoding/_index.md
@@ -1,0 +1,207 @@
+---
+title: "TtfEncoding"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar TTF-typsnittskodning."
+type: docs
+weight: 92
+url: /sv/java/com.aspose.font/ttfencoding/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFontEncoding](../../com.aspose.font/ifontencoding)
+```
+public class TtfEncoding implements IFontEncoding
+```
+
+Representerar TTF-typsnittskodning.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [decodeToGid(long unicode)](#decodeToGid-long-) | TTF‑fontens DecodeToGlyphId‑implementation hittar unicode‑tabellen och returnerar glyfid för unicode‑tecken. |
+| [decodeToGidParameterized(IEncodingParameters parameters, long charCode)](#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-) | Parametriserad version tillåter att använda en specifik CMap‑tabell (inte unicode). |
+| [encode(long gid, long charCode)](#encode-long-long-) | Kodar tecknet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [gidToUnicode(GlyphId glyphId)](#gidToUnicode-com.aspose.font.GlyphId-) | Avkodar glyfid till unicode. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [unicodeToGid(long unicode)](#unicodeToGid-long-) | Avkodar en unicode och returnerar glyfid. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### decodeToGid(long unicode) {#decodeToGid-long-}
+```
+public GlyphId decodeToGid(long unicode)
+```
+
+
+TTF‑fontens DecodeToGlyphId‑implementation hittar unicode‑tabellen och returnerar glyfid för unicode‑tecken. Glyfid är ett unikt nummer för en glyf, vilket beror på fonttypen. Till exempel: Type1:s id är ett glyfnamn, en instans av klassen ( GlyphStringId ). TTF:s id är ett int‑index, en instans av klassen ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| unicode | long | Teckenkod för att hämta teckenidentifierare för. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to character code passed.
+### decodeToGidParameterized(IEncodingParameters parameters, long charCode) {#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-}
+```
+public GlyphId decodeToGidParameterized(IEncodingParameters parameters, long charCode)
+```
+
+
+Parametriserad version tillåter att använda en specifik CMap‑tabell (inte unicode).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| parameters | [IEncodingParameters](../../com.aspose.font/iencodingparameters) | Implementering av gränssnittet IEncodingParameters. |
+| charCode | long | teckenkod för att hämta glyfid. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to character code passed.
+### encode(long gid, long charCode) {#encode-long-long-}
+```
+public void encode(long gid, long charCode)
+```
+
+
+Kodar glyfen. För TTF‑fonter är teckenkoden unicode.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| gid | long | Glyfidentifierare. |
+| charCode | long | Teckenkod. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### gidToUnicode(GlyphId glyphId) {#gidToUnicode-com.aspose.font.GlyphId-}
+```
+public long gidToUnicode(GlyphId glyphId)
+```
+
+
+Avkodar glyfid till unicode. Glyfid är ett unikt nummer för en glyf, vilket beror på fonttypen. Till exempel: Type1:s id är ett glyfnamn, en instans av klassen ( GlyphStringId ). TTF:s id är ett int‑index, en instans av klassen ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑identifierare för symbol att avkoda. |
+
+**Returns:**
+long – Unicode‑värde relaterat till det angivna glyph‑id.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unicodeToGid(long unicode) {#unicodeToGid-long-}
+```
+public GlyphId unicodeToGid(long unicode)
+```
+
+
+Avkodar en unicode och returnerar glyfid.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| unicode | long | Unicode för att få glyph‑identifierare för. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to unicode passed.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfencodingparameters/_index.md
+++ b/swedish/java/com.aspose.font/ttfencodingparameters/_index.md
@@ -1,0 +1,196 @@
+---
+title: "TtfEncodingParameters"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar TTF-kodningsparametrar."
+type: docs
+weight: 93
+url: /sv/java/com.aspose.font/ttfencodingparameters/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IEncodingParameters](../../com.aspose.font/iencodingparameters)
+```
+public class TtfEncodingParameters implements IEncodingParameters
+```
+
+Representerar TTF-kodningsparametrar. Ska användas för att begära specifik kodning från TTF-typsnitt.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [TtfEncodingParameters(int platformId, int platformSpecificId)](#TtfEncodingParameters-int-int-) | Initierar en ny instans av klassen TtfEncodingParameters. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPlatformId()](#getPlatformId--) | Hämta PlatformId-värdet. |
+| [getPlatformSpecificId()](#getPlatformSpecificId--) | Hämtar PlatformSpecificId-värdet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setPlatformId(int value)](#setPlatformId-int-) | Ställer in PlatformId-värdet. |
+| [setPlatformSpecificId(int value)](#setPlatformSpecificId-int-) | Ställer in PlatformSpecificId-värdet. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TtfEncodingParameters(int platformId, int platformSpecificId) {#TtfEncodingParameters-int-int-}
+```
+public TtfEncodingParameters(int platformId, int platformSpecificId)
+```
+
+
+Initierar en ny instans av klassen TtfEncodingParameters. Tar Platform Id och Platform-specific encoding id som parametrar. Dessa parametrar används för att begära en speciell CMap-undertabell från huvudtypsnittets CMap-tabell, se tabellen 'CMap', 'name' i OpenType Font File-specifikationen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| platformId | int | Platform-id. |
+| platformSpecificId | int | Platform-specifik kodnings-id. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPlatformId() {#getPlatformId--}
+```
+public int getPlatformId()
+```
+
+
+Hämta PlatformId-värdet.
+
+**Returns:**
+int - PlatformId-värdet.
+### getPlatformSpecificId() {#getPlatformSpecificId--}
+```
+public int getPlatformSpecificId()
+```
+
+
+Hämtar PlatformSpecificId-värdet.
+
+**Returns:**
+int - PlatformSpecificId-värdet.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setPlatformId(int value) {#setPlatformId-int-}
+```
+public void setPlatformId(int value)
+```
+
+
+Ställer in PlatformId-värdet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int | PlatformId-värdet. |
+
+### setPlatformSpecificId(int value) {#setPlatformSpecificId-int-}
+```
+public void setPlatformSpecificId(int value)
+```
+
+
+Ställer in PlatformSpecificId-värdet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int | PlatformSpecificId-värdet. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttffont/_index.md
+++ b/swedish/java/com.aspose.font/ttffont/_index.md
@@ -1,0 +1,648 @@
+---
+title: "TtfFont"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar TrueType Font TTF."
+type: docs
+weight: 94
+url: /sv/java/com.aspose.font/ttffont/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Font](../../com.aspose.font/font)
+```
+public class TtfFont extends Font
+```
+
+Representerar TrueType-typsnitt (TTF).
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Konverterar Fonten till ett annat format. |
+| [convert(FontType fontType, Collection<Integer> limitingCharacterSet)](#convert-com.aspose.font.FontType-java.util.Collection-java.lang.Integer--) | Konverterar Fonten till ett annat format med begränsad teckenuppsättning  *Obs: TTF Font-typen stöds nu endast.* |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Returnerar en array med alla glyfid, tillgängliga i Fonten. |
+| [getCffFont()](#getCffFont--) | Hämtar CFF Font om den finns. |
+| [getClass()](#getClass--) |  |
+| [getEncoding()](#getEncoding--) | Hämtar Font‑kodning. |
+| [getFontDefinition()](#getFontDefinition--) | Hämtar Font‑definition. |
+| [getFontFamily()](#getFontFamily--) | Hämtar Font‑familj. |
+| [getFontName()](#getFontName--) | Hämtar Font‑ansiktsnamn. |
+| [getFontNames()](#getFontNames--) | Hämtar Font‑namn. |
+| [getFontSaver()](#getFontSaver--) | Hämtar Font‑sparfunktionalitet. |
+| [getFontStyle()](#getFontStyle--) | Hämtar Font‑stil. |
+| [getFontType()](#getFontType--) | Hämtar Font‑typ. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Font‑glyf‑åtkomst. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Returnerar glyf efter glyfid. |
+| [getGlyphById(String glyphName)](#getGlyphById-java.lang.String-) | Returnerar glyf efter glyfnamn. |
+| [getGlyphById(long id)](#getGlyphById-long-) | Returnerar glyf efter glyfid. |
+| [getGlyphComponentsById(GlyphId id, GlyphIdList componentsToPopulate)](#getGlyphComponentsById-com.aspose.font.GlyphId-com.aspose.font.GlyphIdList-) | Hämtar en glyf med angivet glyfid och fyller den medföljande listan med glyfid med komponenterna i denna glyf. |
+| [getGlyphComponentsById(String glyphName, GlyphIdList componentsToPopulate)](#getGlyphComponentsById-java.lang.String-com.aspose.font.GlyphIdList-) | Hämtar en glyf med angivet glyfnamn och fyller den medföljande listan med glyfid med komponenterna i denna glyf. |
+| [getGlyphComponentsById(long id, GlyphIdList componentsToPopulate)](#getGlyphComponentsById-long-com.aspose.font.GlyphIdList-) | Hämtar en glyf med angivet glyfindex och fyller den medföljande listan med glyfid med komponenterna i denna glyf. |
+| [getGlyphIdType()](#getGlyphIdType--) | Hämtar specifikation för glyfid‑typ. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Hämta glyfrepresentation för text. |
+| [getMetrics()](#getMetrics--) | Hämtar Font‑metrik. |
+| [getNumGlyphs()](#getNumGlyphs--) | Hämtar antalet glyfer i Fonten. |
+| [getPostscriptNames()](#getPostscriptNames--) | Hämtar Postscript-fontnamn. |
+| [getStyle()](#getStyle--) | Hämtar Font‑stil. |
+| [getTtfTables()](#getTtfTables--) | Hämtar TTF-tabeller. |
+| [hashCode()](#hashCode--) |  |
+| [isSymbolic()](#isSymbolic--) | Returnerar true om Font är symbolisk. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Öppnar en font med FontDefinition-objekt. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Öppnar en font med fonttyp och bytearray för fontdata. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Öppnar en font med fonttyp och strömkälla. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Öppnar en font med fonttyp och fontfilnamn. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Sparar Fonten i originalformat. |
+| [save(String fileName)](#save-java.lang.String-) | Sparar Fonten i originalformat. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Sparar Fonten i angivet format. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Ställer in Font-familj. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Ställer in Font face name. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Ställer in Font-stil. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public Font convert(FontType fontType)
+```
+
+
+Konverterar Fonten till ett annat format. Obs: TTF Font-typ stöds nu endast.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Font-formattyp att konvertera till. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### convert(FontType fontType, Collection<Integer> limitingCharacterSet) {#convert-com.aspose.font.FontType-java.util.Collection-java.lang.Integer--}
+```
+public Font convert(FontType fontType, Collection<Integer> limitingCharacterSet)
+```
+
+
+Konverterar Fonten till ett annat format med begränsad teckenuppsättning  *Obs: TTF Font-typen stöds nu endast.*
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Font-formattyp att konvertera till. |
+| limitingCharacterSet | java.util.Collection<java.lang.Integer> | Begränsad teckenuppsättning. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public GlyphId[] getAllGlyphIds()
+```
+
+
+Returnerar en array med alla glyph-id:n som finns i Fonten. Glyph id är ett unikt nummer för en glyph, vilket beror på fonttyp. TTF Font glyph id kan vara en instans av ( GlyphStringId )-klassen eller ( GlyphUInt32Id )-klassen. Namn (string) glyph-adressering stöds för TTF-fonts via Post table-mappning. Om en CFF Font finns inuti används CFF-strukturer för att adressera glyphs efter namn.
+
+**Returns:**
+com.aspose.font.GlyphId[] - Glyph-identifierare.
+### getCffFont() {#getCffFont--}
+```
+public Font getCffFont()
+```
+
+
+Hämtar CFF Font om den finns.
+
+**Returns:**
+[Font](../../com.aspose.font/font) - CFF Font.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncoding() {#getEncoding--}
+```
+public IFontEncoding getEncoding()
+```
+
+
+Hämtar Font‑kodning.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public FontDefinition getFontDefinition()
+```
+
+
+Hämtar Font‑definition.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public String getFontFamily()
+```
+
+
+Hämtar Font‑familj.
+
+**Returns:**
+java.lang.String - Font-familj.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Hämtar Font‑ansiktsnamn.
+
+**Returns:**
+java.lang.String - Font face name.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Hämtar Font‑namn.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Hämtar Font‑sparfunktionalitet.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public int getFontStyle()
+```
+
+
+Hämtar Font-stil. Detta är ett värde som beräknas och representeras i en generaliserad typ.
+
+**Returns:**
+int - Font-stil. Vanligtvis en kombination av konstantflaggvärden i FontStyle-klassen eller 0.
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Hämtar Font-typ. Returnerar värdet FontType.TTF.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Typsnittsglyf‑åtkomst. Hämtar glyfer och glyfidenterifierare.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public Glyph getGlyphById(GlyphId id)
+```
+
+
+Returnerar glyf med glyfid. Glyfid är ett unikt nummer för en glyf, som beror på typsnittstyp. TTF‑typsnittets glyfid kan vara en instans av ( GlyphStringId )-klassen eller ( GlyphUInt32Id )-klassen. Namn (string) glyf‑adressering stöds för TTF‑typsnitt via Post‑tabellmappning. Om ett CFF‑typsnitt finns inuti används CFF‑strukturerna för att adressera glyfer efter namn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) |  |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph)
+### getGlyphById(String glyphName) {#getGlyphById-java.lang.String-}
+```
+public Glyph getGlyphById(String glyphName)
+```
+
+
+Returnerar glyf med glyfnamn. Namn (string) glyf‑adressering stöds för TTF‑typsnitt via Post‑tabellmappning. Om ett CFF‑typsnitt finns inuti används CFF‑strukturerna för att adressera glyfer efter namn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphName | java.lang.String | Glyfsträngsidentifierare. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(long id) {#getGlyphById-long-}
+```
+public Glyph getGlyphById(long id)
+```
+
+
+Returnerar glyf efter glyfid.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| id | long | Glyfindex. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphComponentsById(GlyphId id, GlyphIdList componentsToPopulate) {#getGlyphComponentsById-com.aspose.font.GlyphId-com.aspose.font.GlyphIdList-}
+```
+public void getGlyphComponentsById(GlyphId id, GlyphIdList componentsToPopulate)
+```
+
+
+Hämtar en glyf med den angivna glyfid och fyller den medskickade listan med glyfidenterifierare med komponenterna för denna glyf. Glyfid är ett unikt nummer för en glyf, som beror på typsnittstyp. TTF‑typsnittets glyfid kan vara en instans av ( GlyphStringId )-klassen eller ( GlyphUInt32Id )-klassen. Namn (string) glyf‑adressering stöds för TTF‑typsnitt via Post‑tabellmappning. Om ett CFF‑typsnitt finns inuti används CFF‑strukturerna för att adressera glyfer efter namn.
+
+--------------------
+
+En tom samling componentsToPopulate bör skickas som kommer att innehålla listan med glyfkomponenters id.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | Glyfid. |
+| componentsToPopulate | [GlyphIdList](../../com.aspose.font/glyphidlist) | Lista med glyfidenterifierare att fylla. |
+
+### getGlyphComponentsById(String glyphName, GlyphIdList componentsToPopulate) {#getGlyphComponentsById-java.lang.String-com.aspose.font.GlyphIdList-}
+```
+public void getGlyphComponentsById(String glyphName, GlyphIdList componentsToPopulate)
+```
+
+
+Hämtar en glyf med angivet glyfnamn och fyller den medföljande listan med glyfid med komponenterna i denna glyf.
+
+--------------------
+
+En tom samling componentsToPopulate bör skickas som kommer att innehålla listan med glyfkomponenters id.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphName | java.lang.String | Glyfnamn. |
+| componentsToPopulate | [GlyphIdList](../../com.aspose.font/glyphidlist) | Lista med glyfidenterifierare att fylla. |
+
+### getGlyphComponentsById(long id, GlyphIdList componentsToPopulate) {#getGlyphComponentsById-long-com.aspose.font.GlyphIdList-}
+```
+public void getGlyphComponentsById(long id, GlyphIdList componentsToPopulate)
+```
+
+
+Hämtar en glyf med angivet glyfindex och fyller den medföljande listan med glyfid med komponenterna i denna glyf.
+
+--------------------
+
+En tom samling componentsToPopulate bör skickas som kommer att innehålla listan med glyfkomponenters id.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| id | long | Glyfindex. |
+| componentsToPopulate | [GlyphIdList](../../com.aspose.font/glyphidlist) | Lista med glyfidenterifierare att fylla. |
+
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public GlyphIdType getGlyphIdType()
+```
+
+
+Hämtar specifikation för glyfid‑typ.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype) - Glyph id type specification.
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Hämta glyfrepresentation för text.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| text | java.lang.String | Indatatext. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - GlyphId‑array.
+### getMetrics() {#getMetrics--}
+```
+public IFontMetrics getMetrics()
+```
+
+
+Hämtar Font‑metrik.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Hämtar antalet glyfer i Fonten.
+
+**Returns:**
+int - Antal glyfer i typsnittet.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Hämtar Postscript-fontnamn.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript font names.
+### getStyle() {#getStyle--}
+```
+public String getStyle()
+```
+
+
+Hämtar typsnittsstil. Detta är ett rått strängvärde som tillhandahålls av typsnittsfilen.
+
+**Returns:**
+java.lang.String - Typsnittsstil.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Hämtar TTF-tabeller.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - TTF tables.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isSymbolic() {#isSymbolic--}
+```
+public boolean isSymbolic()
+```
+
+
+Returnerar true om Font är symbolisk.
+
+**Returns:**
+boolean - Sant om typsnittet är symboliskt.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Öppnar en font med FontDefinition-objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Typsnittsdefinitionsobjekt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Öppnar en font med fonttyp och bytearray för fontdata.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fontData | byte[] | Byte‑array för att läsa in typsnitt från. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Öppnar en font med fonttyp och strömkälla.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Strömkälla för typsnitt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Öppnar en font med fonttyp och fontfilnamn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fileName | java.lang.String | Fontfilnamn. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Sparar Fonten i originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.OutputStream | Ström för att spara teckensnitt. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Sparar Fonten i originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | java.lang.String | Fil för att spara teckensnitt. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Sparar Fonten i angivet format.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.OutputStream | ström för att spara teckensnitt |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | önskat format |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public void setFontFamily(String value)
+```
+
+
+Ställer in Font-familj.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Ny fontfamilj. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public void setFontName(String value)
+```
+
+
+Ställer in Font face name.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Nytt teckensnittsansiktsnamn. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public void setStyle(String value)
+```
+
+
+Ställer in fontstil. Detta är ett rått strängvärde som tillhandahålls av fontfilen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Ny fontstil. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttffontmetrics/_index.md
+++ b/swedish/java/com.aspose.font/ttffontmetrics/_index.md
@@ -1,0 +1,484 @@
+---
+title: "TtfFontMetrics"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar TTF-typsnittsmått."
+type: docs
+weight: 95
+url: /sv/java/com.aspose.font/ttffontmetrics/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.FontMetrics](../../com.aspose.font/fontmetrics)
+```
+public class TtfFontMetrics extends FontMetrics
+```
+
+Representerar TTF-typsnittsmått.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAscender()](#getAscender--) | Hämtar ascendervärde. |
+| [getAscender(double fontSize)](#getAscender-double-) | Returnerar ascender för en specifik teckenstorlek. |
+| [getClass()](#getClass--) |  |
+| [getDescender()](#getDescender--) | Hämtar descendervärde. |
+| [getDescender(double fontSize)](#getDescender-double-) | Returnerar descender för en specifik teckenstorlek. |
+| [getFontBBox()](#getFontBBox--) | Hämtar FontBBox‑värdet. |
+| [getFontMatrix()](#getFontMatrix--) | Hämtar FontBBox‑värdet. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Returnerar glyf Bbox. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Returnerar glyfens bredd efter glyfid. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Returnerar kerningvärde för glyfparet. |
+| [getLineGap()](#getLineGap--) | Hämtar LineGap-värde. |
+| [getTypoAscender()](#getTypoAscender--) | Hämtar TypoAscender-värde. |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Returnerar typografisk ascender för specifik Font-storlek. |
+| [getTypoDescender()](#getTypoDescender--) | Hämtar TypoDescender-värde. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Returnerar typografisk descender för specifik fontstorlek. |
+| [getTypoLineGap()](#getTypoLineGap--) | Hämtar TypoLineGap-värde. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Returnerar radgap för specifik Font-storlek. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Hämtar UnitsPerEM-värde. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Hämtar IsFixedPitch-värde. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Mäter sträng och returnerar strängbredd. |
+| [measureString(long[] charCodes, double fontSize)](#measureString-long---double-) | Mäter text representerad som en array av teckenkoder och returnerar strängbredd. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAscender(double value)](#setAscender-double-) | Sätter ascendervärde. |
+| [setDescender(double value)](#setDescender-double-) | Sätter descendervärde. |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) | Ställer in glyfbredd. |
+| [setTypoAscender(double value)](#setTypoAscender-double-) | Ställer in TypoAscender-värde. |
+| [setTypoDescender(double value)](#setTypoDescender-double-) | Ställer in TypoDescender-värde. |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAscender() {#getAscender--}
+```
+public double getAscender()
+```
+
+
+Hämtar ascendervärde.
+
+**Returns:**
+double - Ascender-värde.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public double getAscender(double fontSize)
+```
+
+
+Returnerar ascender för en specifik teckenstorlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Ascender-värde.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescender() {#getDescender--}
+```
+public double getDescender()
+```
+
+
+Hämtar descendervärde.
+
+**Returns:**
+double - Descender-värde.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public double getDescender(double fontSize)
+```
+
+
+Returnerar descender för en specifik teckenstorlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Descender-värde.
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+Hämtar FontBBox‑värdet.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox)
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+Hämtar FontBBox‑värdet.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix)
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Returnerar glyf Bbox. Returnerar FontBBox om BBox inte var definierad för glyfen. Kan åsidosättas av specifika teckenkodningsarvtagare.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyfidentifierare. |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox.
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Returnerar glyfens bredd efter glyfid.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyfidentifierare. |
+
+**Returns:**
+double - Glyph-bredd.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Returnerar kerningvärde för glyfparet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Första glyph i paret. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Fontstorlek. |
+
+**Returns:**
+double - Kerningvärde
+### getLineGap() {#getLineGap--}
+```
+public double getLineGap()
+```
+
+
+Hämtar LineGap-värde.
+
+**Returns:**
+double - LineGap-värde.
+### getTypoAscender() {#getTypoAscender--}
+```
+public double getTypoAscender()
+```
+
+
+Hämtar TypoAscender-värde.
+
+**Returns:**
+double - TypoAscender-värde.
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public double getTypoAscender(double fontSize)
+```
+
+
+Returnerar typografisk ascender för specifik Font-storlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Typographic ascender-värde.
+### getTypoDescender() {#getTypoDescender--}
+```
+public double getTypoDescender()
+```
+
+
+Hämtar TypoDescender-värde.
+
+**Returns:**
+double - TypoDescender-värde.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public double getTypoDescender(double fontSize)
+```
+
+
+Returnerar typografisk descender för specifik fontstorlek.
+
+param fontSize teckenstorlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double |  |
+
+**Returns:**
+double - Typographic descender-värde.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public double getTypoLineGap()
+```
+
+
+Hämtar TypoLineGap-värde.
+
+**Returns:**
+double - TypoLineGap-värde.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public double getTypoLineGap(double fontSize)
+```
+
+
+Returnerar radgap för specifik Font-storlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Line gap-värde.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Hämtar UnitsPerEM-värde.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+Hämtar IsFixedPitch-värde.
+
+**Returns:**
+boolean - IsFixedPitch-värde.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public double measureString(String unicode, double fontSize)
+```
+
+
+Mäter sträng och returnerar strängbredd.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| unicode | java.lang.String | Unicode-sträng. |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Strängbredd.
+### measureString(long[] charCodes, double fontSize) {#measureString-long---double-}
+```
+public double measureString(long[] charCodes, double fontSize)
+```
+
+
+Mäter text representerad som en array av teckenkoder och returnerar strängbredd.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| charCodes | long[] | Textsträng som representeras som en array av teckenkoder. |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Strängbredd.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAscender(double value) {#setAscender-double-}
+```
+public void setAscender(double value)
+```
+
+
+Sätter ascendervärde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | Ascender-värde. |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public void setDescender(double value)
+```
+
+
+Sätter descendervärde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | Descender-värde. |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Ställer in glyfbredd.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyfidentifierare. |
+| värde | double | Ny bredd. |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public void setTypoAscender(double value)
+```
+
+
+Ställer in TypoAscender-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | TypoAscender-värde. |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public void setTypoDescender(double value)
+```
+
+
+Ställer in TypoDescender-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | TypoDescender-värde. |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public void setUnitsPerEM(long value)
+```
+
+
+Ställer in UnitsPerEM-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttffpgmtable/_index.md
+++ b/swedish/java/com.aspose.font/ttffpgmtable/_index.md
@@ -1,0 +1,168 @@
+---
+title: "TtfFpgmTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar fpgm-tabellen i TTF-typsnittsfilen."
+type: docs
+weight: 96
+url: /sv/java/com.aspose.font/ttffpgmtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfFpgmTable extends TtfTableBase
+```
+
+Representerar "fpgm"-tabell i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getProgram()](#getProgram--) | Hämtar fpgm-program. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getProgram() {#getProgram--}
+```
+public byte[] getProgram()
+```
+
+
+Hämtar fpgm-program.
+
+**Returns:**
+byte[] - Fpgm-program.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfgasptable/_index.md
+++ b/swedish/java/com.aspose.font/ttfgasptable/_index.md
@@ -1,0 +1,190 @@
+---
+title: "TtfGaspTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar gasp‑tabellen i TTF‑fontfilen."
+type: docs
+weight: 97
+url: /sv/java/com.aspose.font/ttfgasptable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfGaspTable extends TtfTableBase
+```
+
+Representerar "gasp"-tabell i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGaspRanges()](#getGaspRanges--) | Hämtar listan med GaspRange-poster som ger rekommenderade beteenden för olika ppem-storlekar. |
+| [getNumRanges()](#getNumRanges--) | Hämtar GaspRange-poster. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getTag()](#getTag--) | Hämtar tabelltaggen. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [getVersion()](#getVersion--) | Hämtar tabellversionen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGaspRanges() {#getGaspRanges--}
+```
+public List<GaspRange> getGaspRanges()
+```
+
+
+Hämtar listan med GaspRange-poster som ger rekommenderade beteenden för olika ppem-storlekar.
+
+**Returns:**
+java.util.List<com.aspose.font.GaspRange> - Listan med GaspRange.
+### getNumRanges() {#getNumRanges--}
+```
+public int getNumRanges()
+```
+
+
+Hämtar GaspRange-poster.
+
+**Returns:**
+int - GaspRange-poster.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabelltaggen.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public int getVersion()
+```
+
+
+Hämtar tabellversionen.
+
+**Returns:**
+int - Tabellens version.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfglyftable/_index.md
+++ b/swedish/java/com.aspose.font/ttfglyftable/_index.md
@@ -1,0 +1,189 @@
+---
+title: "TtfGlyfTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar glyf‑tabellen i TTF‑typsnittsfilen."
+type: docs
+weight: 98
+url: /sv/java/com.aspose.font/ttfglyftable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfGlyfTable extends TtfTableBase
+```
+
+Representerar "glyf"-tabell i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [containsGlyph(int glyphIndex)](#containsGlyph-int-) | Returnerar true om tabellen innehåller en glyf med glyphIndex. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGlyph(long glyphIndex)](#getGlyph-long-) | Returnerar en glyf efter glyf‑index. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### containsGlyph(int glyphIndex) {#containsGlyph-int-}
+```
+public boolean containsGlyph(int glyphIndex)
+```
+
+
+Returnerar true om tabellen innehåller en glyf med glyphIndex.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphIndex | int | Glyfindex. |
+
+**Returns:**
+boolean - True om tabellen innehåller en glyf för angivet index, annars false.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGlyph(long glyphIndex) {#getGlyph-long-}
+```
+public Glyph getGlyph(long glyphIndex)
+```
+
+
+Returnerar en glyf efter glyf‑index.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphIndex | long | Glyfindex. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph Glyph related to index specified.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfheadtable/_index.md
+++ b/swedish/java/com.aspose.font/ttfheadtable/_index.md
@@ -1,0 +1,344 @@
+---
+title: "TtfHeadTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar huvudtabell för TTF-teckensnittsfilen."
+type: docs
+weight: 99
+url: /sv/java/com.aspose.font/ttfheadtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfHeadTable extends TtfTableBase
+```
+
+Representerar "head"-tabell i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCheckSumAdjustment()](#getCheckSumAdjustment--) | Hämtar uint32 checkSumAdjustment. |
+| [getClass()](#getClass--) |  |
+| [getCreated()](#getCreated--) | Hämtar longDateTime skapad internationellt datum. |
+| [getFlags()](#getFlags--) | Hämtar uint16 flaggor. |
+| [getFontDirectionHint()](#getFontDirectionHint--) | Hämtar int16 fontDirectionHint. 0 Blandade riktade glyfer; 1 Endast starkt vänster-till-höger glyfer; 2 Som 1 men innehåller också neutrala; -1 Endast starkt höger-till-vänster glyfer; -2 Som -1 men innehåller också neutrala. |
+| [getFontRevision()](#getFontRevision--) | Hämtar fast fontRevision som satts av teckensnittstillverkaren. |
+| [getGlyphDataFormat()](#getGlyphDataFormat--) | Hämtar int16 glyphDataFormat 0 för aktuellt format. |
+| [getIndexToLocFormat()](#getIndexToLocFormat--) | Hämtar int16 indexToLocFormat 0 för korta offset, 1 för långa. |
+| [getLowestRecPPEM()](#getLowestRecPPEM--) | Hämtar uint16 lowestRecPPEM minsta läsbara storlek i pixlar. |
+| [getMacStyle()](#getMacStyle--) | Hämtar uint16 macStyle. |
+| [getMagicNumber()](#getMagicNumber--) | Hämtar uint32 magicNumber satt till 0x5F0F3CF5. |
+| [getModified()](#getModified--) | Hämtar longDateTime modifierat internationellt datum. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Hämtar uint16 unitsPerEM intervall från 64 till 16384. |
+| [getVersion()](#getVersion--) | Fast version 0x00010000 om (version 1.0). |
+| [getXMax()](#getXMax--) | Hämtar FWord xMax för alla glyf-begränsningsrutor. |
+| [getXMin()](#getXMin--) | Hämtar FWord xMin för alla glyf-begränsningsrutor. |
+| [getYMax()](#getYMax--) | Hämtar FWord yMax för alla glyf-begränsningsrutor. |
+| [getYMin()](#getYMin--) | Hämtar FWord yMin för alla glyf-begränsningsrutor. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCheckSumAdjustment() {#getCheckSumAdjustment--}
+```
+public long getCheckSumAdjustment()
+```
+
+
+Hämtar uint32 checkSumAdjustment. För att beräkna: sätt den till 0, beräkna kontrollsumman för 'head'-tabellen och placera den i tabellkatalogen, summera hela teckensnittet som uint32, och lagra sedan B1B0AFBA - summa. Kontrollsumman för 'head'-tabellen kommer inte att vara fel. Det är OK.
+
+**Returns:**
+long - Uint32 checkSumAdjustment.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCreated() {#getCreated--}
+```
+public Date getCreated()
+```
+
+
+Hämtar longDateTime skapad internationellt datum.
+
+**Returns:**
+java.util.Date - LongDateTime skapad internationellt datum.
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Hämtar uint16 flaggor.
+
+**Returns:**
+int - UInt16 flaggor.
+### getFontDirectionHint() {#getFontDirectionHint--}
+```
+public short getFontDirectionHint()
+```
+
+
+Hämtar int16 fontDirectionHint. 0 Blandade riktade glyfer; 1 Endast starkt vänster-till-höger glyfer; 2 Som 1 men innehåller också neutrala; -1 Endast starkt höger-till-vänster glyfer; -2 Som -1 men innehåller också neutrala.
+
+**Returns:**
+short - Int16 fontDirectionHint.
+### getFontRevision() {#getFontRevision--}
+```
+public float getFontRevision()
+```
+
+
+Hämtar fast fontRevision som satts av teckensnittstillverkaren.
+
+**Returns:**
+float - Fast fontRevision satt av teckensnittstillverkaren.
+### getGlyphDataFormat() {#getGlyphDataFormat--}
+```
+public short getGlyphDataFormat()
+```
+
+
+Hämtar int16 glyphDataFormat 0 för aktuellt format.
+
+**Returns:**
+short - Int16 glyphDataFormat 0 för aktuellt format.
+### getIndexToLocFormat() {#getIndexToLocFormat--}
+```
+public short getIndexToLocFormat()
+```
+
+
+Hämtar int16 indexToLocFormat 0 för korta offset, 1 för långa.
+
+**Returns:**
+short - Int16 indexToLocFormat 0 för korta offset, 1 för långa.
+### getLowestRecPPEM() {#getLowestRecPPEM--}
+```
+public int getLowestRecPPEM()
+```
+
+
+Hämtar uint16 lowestRecPPEM minsta läsbara storlek i pixlar.
+
+**Returns:**
+int - UInt16 lowestRecPPEM minsta läsbara storlek i pixlar.
+### getMacStyle() {#getMacStyle--}
+```
+public int getMacStyle()
+```
+
+
+Hämtar uint16 macStyle.
+
+**Returns:**
+int - UInt16 macStyle.
+### getMagicNumber() {#getMagicNumber--}
+```
+public long getMagicNumber()
+```
+
+
+Hämtar uint32 magicNumber satt till 0x5F0F3CF5.
+
+**Returns:**
+long - UInt32 magicNumber satt till 0x5F0F3CF5.
+### getModified() {#getModified--}
+```
+public Date getModified()
+```
+
+
+Hämtar longDateTime modifierat internationellt datum.
+
+**Returns:**
+java.util.Date - LongDateTime modifierat internationellt datum.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Hämtar uint16 unitsPerEM intervall från 64 till 16384.
+
+**Returns:**
+long - UInt16 unitsPerEM intervall från 64 till 16384.
+### getVersion() {#getVersion--}
+```
+public float getVersion()
+```
+
+
+Fast version 0x00010000 om (version 1.0).
+
+**Returns:**
+float - Fast version 0x00010000 om (version 1.0).
+### getXMax() {#getXMax--}
+```
+public short getXMax()
+```
+
+
+Hämtar FWord xMax för alla glyf-begränsningsrutor.
+
+**Returns:**
+short - FWord xMax för alla glyf‑begränsningsrutor.
+### getXMin() {#getXMin--}
+```
+public short getXMin()
+```
+
+
+Hämtar FWord xMin för alla glyf-begränsningsrutor.
+
+**Returns:**
+short - FWord xMin för alla glyf‑begränsningsrutor.
+### getYMax() {#getYMax--}
+```
+public short getYMax()
+```
+
+
+Hämtar FWord yMax för alla glyf-begränsningsrutor.
+
+**Returns:**
+short - FWord yMax för alla glyf‑begränsningsrutor.
+### getYMin() {#getYMin--}
+```
+public short getYMin()
+```
+
+
+Hämtar FWord yMin för alla glyf-begränsningsrutor.
+
+**Returns:**
+short - FWord yMin för alla glyf‑begränsningsrutor.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfhheatable/_index.md
+++ b/swedish/java/com.aspose.font/ttfhheatable/_index.md
@@ -1,0 +1,300 @@
+---
+title: "TtfHheaTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar hhea-tabell i TTF-teckensnittfilen."
+type: docs
+weight: 100
+url: /sv/java/com.aspose.font/ttfhheatable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfHheaTable extends TtfTableBase
+```
+
+Representerar "hhea"-tabellen i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdvanceWidthMax()](#getAdvanceWidthMax--) | Hämtar uFWord advanceWidthMax måste vara konsekvent med horisontella metriker. |
+| [getAscent()](#getAscent--) | Hämtar ascenten. |
+| [getCaretOffset()](#getCaretOffset--) | Hämtar markörens offset. |
+| [getCaretSlopeRise()](#getCaretSlopeRise--) | Hämtar markörens slop rise. |
+| [getCaretSlopeRun()](#getCaretSlopeRun--) | Hämtar markörens slop run. |
+| [getClass()](#getClass--) |  |
+| [getDescent()](#getDescent--) | Hämtar descenten. |
+| [getLineGap()](#getLineGap--) | Hämtar lineGap. |
+| [getMetricDataFormat()](#getMetricDataFormat--) | Hämtar formatet för metrisk data. |
+| [getMinLeftSideBearing()](#getMinLeftSideBearing--) | Hämtar värdet för MinLeftSideBearing. |
+| [getMinRightSideBearing()](#getMinRightSideBearing--) | Hämtar värdet för MinRightSideBearing. |
+| [getNumOfLongHorMetrics()](#getNumOfLongHorMetrics--) | Hämtar uint16 numOfLongHorMetrics antal framstegsbredder i metriktabellen. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [getVersion()](#getVersion--) | Hämtar versionen. |
+| [getXMaxExtent()](#getXMaxExtent--) | Hämtar värdet för XMaxExtent. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdvanceWidthMax() {#getAdvanceWidthMax--}
+```
+public int getAdvanceWidthMax()
+```
+
+
+Hämtar uFWord advanceWidthMax måste vara konsekvent med horisontella metriker.
+
+**Returns:**
+int - uFWord advanceWidthMax måste vara konsekvent med horisontella metriker.
+### getAscent() {#getAscent--}
+```
+public short getAscent()
+```
+
+
+Hämtar ascenten.
+
+**Returns:**
+short - Ascenten.
+### getCaretOffset() {#getCaretOffset--}
+```
+public short getCaretOffset()
+```
+
+
+Hämtar markörens offset.
+
+**Returns:**
+short - Offset för markören.
+### getCaretSlopeRise() {#getCaretSlopeRise--}
+```
+public short getCaretSlopeRise()
+```
+
+
+Hämtar markörens slop rise.
+
+**Returns:**
+short - Markörens slop rise.
+### getCaretSlopeRun() {#getCaretSlopeRun--}
+```
+public short getCaretSlopeRun()
+```
+
+
+Hämtar markörens slop run.
+
+**Returns:**
+short - Markörens slop run.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescent() {#getDescent--}
+```
+public short getDescent()
+```
+
+
+Hämtar descenten.
+
+**Returns:**
+short - Nedstigningen.
+### getLineGap() {#getLineGap--}
+```
+public short getLineGap()
+```
+
+
+Hämtar lineGap.
+
+**Returns:**
+short - Radavståndet.
+### getMetricDataFormat() {#getMetricDataFormat--}
+```
+public short getMetricDataFormat()
+```
+
+
+Hämtar formatet för metrisk data.
+
+**Returns:**
+short - Formatet för metriskdata.
+### getMinLeftSideBearing() {#getMinLeftSideBearing--}
+```
+public short getMinLeftSideBearing()
+```
+
+
+Hämtar värdet för MinLeftSideBearing.
+
+**Returns:**
+short - Värdet för MinLeftSideBearing.
+### getMinRightSideBearing() {#getMinRightSideBearing--}
+```
+public short getMinRightSideBearing()
+```
+
+
+Hämtar värdet för MinRightSideBearing.
+
+**Returns:**
+short - Värdet för MinRightSideBearing.
+### getNumOfLongHorMetrics() {#getNumOfLongHorMetrics--}
+```
+public int getNumOfLongHorMetrics()
+```
+
+
+Hämtar uint16 numOfLongHorMetrics antal framstegsbredder i metriktabellen.
+
+**Returns:**
+int - UInt16 numOfLongHorMetrics antal framstegsbredder i metrisk tabell.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public float getVersion()
+```
+
+
+Hämtar versionen.
+
+**Returns:**
+float - Tabellformatversion.
+### getXMaxExtent() {#getXMaxExtent--}
+```
+public short getXMaxExtent()
+```
+
+
+Hämtar värdet för XMaxExtent.
+
+**Returns:**
+short - Värdet för XMaxExtent.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfhmtxtable/_index.md
+++ b/swedish/java/com.aspose.font/ttfhmtxtable/_index.md
@@ -1,0 +1,190 @@
+---
+title: "TtfHmtxTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar hmtx-tabellen i TTF-typsnittsfilen."
+type: docs
+weight: 101
+url: /sv/java/com.aspose.font/ttfhmtxtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfHmtxTable extends TtfTableBase
+```
+
+Representerar "hmtx"-tabellen i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalAdvanceWidth()](#getAdditionalAdvanceWidth--) | I hmtx-tabellen kan det finnas fall där det totala antalet tecken inte är lika med hhea.numberOfHMetrics. |
+| [getClass()](#getClass--) |  |
+| [getHMetrics()](#getHMetrics--) | Hämtar horisontella mått. |
+| [getLeftSidebearings()](#getLeftSidebearings--) | Hämtar vänstra sidobäringar. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalAdvanceWidth() {#getAdditionalAdvanceWidth--}
+```
+public int getAdditionalAdvanceWidth()
+```
+
+
+I hmtx-tabellen kan det finnas fall där det totala antalet tecken inte är lika med hhea.numberOfHMetrics. För dessa fall innehåller hmtx-tabellen en extra array 'leftSideBearing' som motsvarar egenskapen LeftSidebearings. Men tecken med index från hhea.numOfLongHorMetrics till maxp.numGlyphs har också bredd. Och dessa bredder, i enlighet med specifikationen för hmtx-tabellen, har följande värden: "Här antas advanceWidth vara densamma som advanceWidth för det sista elementet ovan".
+
+**Returns:**
+int – Ytterligare advance width.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHMetrics() {#getHMetrics--}
+```
+public TtfHmtxTable.MetricList getHMetrics()
+```
+
+
+Hämtar horisontella mått.
+
+**Returns:**
+[MetricList](../../com.aspose.font/metriclist) - Horizontal metrics.
+### getLeftSidebearings() {#getLeftSidebearings--}
+```
+public short[] getLeftSidebearings()
+```
+
+
+Hämtar vänstra sidobäringar.
+
+**Returns:**
+short[] – Vänstra sidobäringar.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttflocatable/_index.md
+++ b/swedish/java/com.aspose.font/ttflocatable/_index.md
@@ -1,0 +1,157 @@
+---
+title: "TtfLocaTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar loca-tabellen i TTF-typsnittsfilen."
+type: docs
+weight: 102
+url: /sv/java/com.aspose.font/ttflocatable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfLocaTable extends TtfTableBase
+```
+
+Representerar "loca"-tabellen i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfltshtable/_index.md
+++ b/swedish/java/com.aspose.font/ttfltshtable/_index.md
@@ -1,0 +1,195 @@
+---
+title: "TtfLtshTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Linear Threshold-tabellen i TTF-typsnittsfilen."
+type: docs
+weight: 103
+url: /sv/java/com.aspose.font/ttfltshtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfLtshTable extends TtfTableBase
+```
+
+Representerar Linear Threshold-tabellen i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getNumGlyphs()](#getNumGlyphs--) | Hämtar antalet glyfer (från "numGlyphs" i 'maxp'-tabellen). |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getTag()](#getTag--) | Hämtar tabelltaggen. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [getVersion()](#getVersion--) | Hämtar tabellversionen. |
+| [getYPel(int glyphNum)](#getYPel-int-) | Returnerar den vertikala pelhöjden för glyph/zero om teckennumret är felaktigt. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Hämtar antalet glyfer (från "numGlyphs" i 'maxp'-tabellen).
+
+**Returns:**
+int - Antalet tecken (från "numGlyphs" i 'maxp'-tabellen).
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabelltaggen.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public int getVersion()
+```
+
+
+Hämtar tabellversionen.
+
+**Returns:**
+int - Tabellens version.
+### getYPel(int glyphNum) {#getYPel-int-}
+```
+public byte getYPel(int glyphNum)
+```
+
+
+Returnerar den vertikala pelhöjden för glyph/zero om teckennumret är felaktigt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphNum | int | Ett teckennummer (index). |
+
+**Returns:**
+byte - Den vertikala pelhöjden för glyph/zero om teckennumret är felaktigt.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfmaxptable/_index.md
+++ b/swedish/java/com.aspose.font/ttfmaxptable/_index.md
@@ -1,0 +1,333 @@
+---
+title: "TtfMaxpTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar maxp-tabellen i TTF-fontfilen"
+type: docs
+weight: 104
+url: /sv/java/com.aspose.font/ttfmaxptable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfMaxpTable extends TtfTableBase
+```
+
+Representerar "maxp"-tabellen i TTF-typsnittsfilen
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxComponentContours()](#getMaxComponentContours--) | Hämtar uint16 maxComponentContours konturer i sammansatt glyf. |
+| [getMaxComponentDepth()](#getMaxComponentDepth--) | Hämtar uint16 maxComponentDepth rekursionsnivåer, sätt till 0 om fonten bara har enkla glyfer. |
+| [getMaxComponentElements()](#getMaxComponentElements--) | Hämtar uint16 maxComponentElements antal glyfer som refereras på toppnivå. |
+| [getMaxComponentPoints()](#getMaxComponentPoints--) | Hämtar uint16 maxComponentPoints punkter i sammansatt glyf. |
+| [getMaxContours()](#getMaxContours--) | Hämtar uint16 maxContours konturer i icke-sammansatt glyf. |
+| [getMaxFunctionDefs()](#getMaxFunctionDefs--) | Hämtar uint16 maxFunctionDefs antal FDEF:ar. |
+| [getMaxInstructionDefs()](#getMaxInstructionDefs--) | Hämtar uint16 maxInstructionDefs antal IDEF:ar. |
+| [getMaxPoints()](#getMaxPoints--) | Hämta uint16 maxPoints punkter i icke-sammansatt glyf. |
+| [getMaxSizeOfInstructions()](#getMaxSizeOfInstructions--) | Hämtar uint16 maxSizeOfInstructions byteantal för glyfinstruktioner. |
+| [getMaxStackElements()](#getMaxStackElements--) | Hämtar uint16 maxStackElements maximal stackdjup. |
+| [getMaxStorage()](#getMaxStorage--) | Hämtar uint16 maxStorage antal lagringsområdesplatser. |
+| [getMaxTwilightPoints()](#getMaxTwilightPoints--) | Hämtar uint16 maxTwilightPoints punkter som används i Twilight Zone (Z0). |
+| [getMaxZones()](#getMaxZones--) | Hämtar uint16 maxZones satt till 2. |
+| [getNumGlyphs()](#getNumGlyphs--) | Hämtar uint16 numGlyphs antalet glyfer i Fonten. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getTableVersion()](#getTableVersion--) | Hämtar formatversion. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [getVersion()](#getVersion--) | Hämtar fast version 0x00010000 om (version 1.0). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxComponentContours() {#getMaxComponentContours--}
+```
+public int getMaxComponentContours()
+```
+
+
+Hämtar uint16 maxComponentContours konturer i sammansatt glyf.
+
+**Returns:**
+int - UInt16 maxComponentContours konturer i sammansatt glyf.
+### getMaxComponentDepth() {#getMaxComponentDepth--}
+```
+public int getMaxComponentDepth()
+```
+
+
+Hämtar uint16 maxComponentDepth rekursionsnivåer, sätt till 0 om fonten bara har enkla glyfer.
+
+**Returns:**
+int - Uint16 maxComponentDepth nivåer av rekursion, sätt till 0 om teckensnittet bara har enkla glyfer.
+### getMaxComponentElements() {#getMaxComponentElements--}
+```
+public int getMaxComponentElements()
+```
+
+
+Hämtar uint16 maxComponentElements antal glyfer som refereras på toppnivå.
+
+**Returns:**
+int - UInt16 maxComponentElements antal glyfer som refereras på toppnivå.
+### getMaxComponentPoints() {#getMaxComponentPoints--}
+```
+public int getMaxComponentPoints()
+```
+
+
+Hämtar uint16 maxComponentPoints punkter i sammansatt glyf.
+
+**Returns:**
+int - UInt16 maxComponentPoints punkter i sammansatt glyf.
+### getMaxContours() {#getMaxContours--}
+```
+public int getMaxContours()
+```
+
+
+Hämtar uint16 maxContours konturer i icke-sammansatt glyf.
+
+**Returns:**
+int - UInt16 maxContours konturer i icke-sammansatt glyf.
+### getMaxFunctionDefs() {#getMaxFunctionDefs--}
+```
+public int getMaxFunctionDefs()
+```
+
+
+Hämtar uint16 maxFunctionDefs antal FDEF:ar.
+
+**Returns:**
+int - UInt16 maxFunctionDefs antal FDEF:er.
+### getMaxInstructionDefs() {#getMaxInstructionDefs--}
+```
+public int getMaxInstructionDefs()
+```
+
+
+Hämtar uint16 maxInstructionDefs antal IDEF:ar.
+
+**Returns:**
+int - UInt16 maxInstructionDefs antal IDEF:er.
+### getMaxPoints() {#getMaxPoints--}
+```
+public int getMaxPoints()
+```
+
+
+Hämta uint16 maxPoints punkter i icke-sammansatt glyf.
+
+**Returns:**
+int - UInt16 maxPoints punkter i icke-sammansatt glyf.
+### getMaxSizeOfInstructions() {#getMaxSizeOfInstructions--}
+```
+public int getMaxSizeOfInstructions()
+```
+
+
+Hämtar uint16 maxSizeOfInstructions byteantal för glyfinstruktioner.
+
+**Returns:**
+int - UInt16 maxSizeOfInstructions byteantal för glyfinstruktioner.
+### getMaxStackElements() {#getMaxStackElements--}
+```
+public int getMaxStackElements()
+```
+
+
+Hämtar uint16 maxStackElements maximal stackdjup.
+
+**Returns:**
+int - UInt16 maxStackElements maximal stackdjup.
+### getMaxStorage() {#getMaxStorage--}
+```
+public int getMaxStorage()
+```
+
+
+Hämtar uint16 maxStorage antal lagringsområdesplatser.
+
+**Returns:**
+int - UInt16 maxStorage antal lagringsområdesplatser.
+### getMaxTwilightPoints() {#getMaxTwilightPoints--}
+```
+public int getMaxTwilightPoints()
+```
+
+
+Hämtar uint16 maxTwilightPoints punkter som används i Twilight Zone (Z0).
+
+**Returns:**
+int - UInt16 maxTwilightPoints punkter som används i Twilight Zone (Z0).
+### getMaxZones() {#getMaxZones--}
+```
+public int getMaxZones()
+```
+
+
+Hämtar uint16 maxZones satt till 2.
+
+**Returns:**
+int - Uint16 maxZones satt till 2.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Hämtar uint16 numGlyphs antalet glyfer i Fonten.
+
+**Returns:**
+int - UInt16 numGlyphs antalet glyfer i teckensnittet.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getTableVersion() {#getTableVersion--}
+```
+public Version16Dot16 getTableVersion()
+```
+
+
+Hämtar formatversion. Använd egenskaperna MajorNumber och MinorNUmber i objektet Version16Dot16 i hexadecimal notation för att upptäcka vilken version som används.
+
+**Returns:**
+[Version16Dot16](../../com.aspose.font/version16dot16) - Format version.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public float getVersion()
+```
+
+
+Hämtar fast version 0x00010000 om (version 1.0). Föråldrad, använd egenskapen TableVersion istället.
+
+**Returns:**
+float - Fast version 0x00010000 om (version 1.0).
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfnametable/_index.md
+++ b/swedish/java/com.aspose.font/ttfnametable/_index.md
@@ -1,0 +1,381 @@
+---
+title: "TtfNameTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar namntabellen för TTF-typsnittsfilen."
+type: docs
+weight: 105
+url: /sv/java/com.aspose.font/ttfnametable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfNameTable extends TtfTableBase
+```
+
+Representerar "name"-tabellen i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addMultiLanguageNames(MultiLanguageString mlNames, PlatformId platformId, int platformSpecificId, NameId nameId)](#addMultiLanguageNames-com.aspose.font.MultiLanguageString-com.aspose.font.PlatformId-int-com.aspose.font.NameId-) | Extraherar alla flerspråkiga strängar från det passerade mlNames-objektet och skapar motsvarande NameRecord-struktur för varje extraherad sträng med hjälp av de passerade parametrarna platformId, platformSpecificId och nameId. |
+| [addName(NameId nameId, PlatformId platformId, int platformSpecificId, int languageId, String name)](#addName-com.aspose.font.NameId-com.aspose.font.PlatformId-int-int-java.lang.String-) | Lägger till en post i tabellen. |
+| [deleteRecords(PlatformId platformId, int platformSpecificId)](#deleteRecords-com.aspose.font.PlatformId-int-) | Tar bort alla poster som är relaterade till den angivna plattformen. |
+| [deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId)](#deleteRecords-com.aspose.font.PlatformId-int-com.aspose.font.NameId-) | Tar bort alla poster som är relaterade till de passerade parametrarna. |
+| [deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId)](#deleteRecords-com.aspose.font.PlatformId-int-com.aspose.font.NameId-int-) | Tar bort post(er) som är relaterade till angivna parametrar. |
+| [deleteRecordsByNameId(NameId nameId)](#deleteRecordsByNameId-com.aspose.font.NameId-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllNameRecords()](#getAllNameRecords--) | Returnerar alla NameRecord-strukturer från tabellen. |
+| [getClass()](#getClass--) |  |
+| [getMultiLanguageNameById(NameId nameId)](#getMultiLanguageNameById-com.aspose.font.NameId-) | returnerar ett namn efter nameId |
+| [getMultiLanguageNameById(NameId nameId, PlatformId platformId)](#getMultiLanguageNameById-com.aspose.font.NameId-com.aspose.font.PlatformId-) | Returnerar ett namn efter nameId med den passerade plattformsidentifieraren. |
+| [getMultiLanguageNameById(NameId nameId, PlatformId platformId, int platformSpecificId)](#getMultiLanguageNameById-com.aspose.font.NameId-com.aspose.font.PlatformId-int-) | Returnerar ett namn som objekt av typen MultiLanguageString. |
+| [getNameById(NameId nameId)](#getNameById-com.aspose.font.NameId-) | Returnerar ett namn efter nameId om det hittas, annars null. |
+| [getNameRecordsByNameId(NameId nameId)](#getNameRecordsByNameId-com.aspose.font.NameId-) | Returnerar alla NameRecord-strukturer där NameId-fältet är lika med det passerade nameId-värdet. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [updateName(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId, String newName)](#updateName-com.aspose.font.PlatformId-int-com.aspose.font.NameId-int-java.lang.String-) | Uppdaterar namn i post(er) som är relaterade till angiven plattform (kombination av platformId och platformSpecificId), kategori (nameId) och språk (languageId). |
+| [updateNamesByNameId(NameId nameId, String newName)](#updateNamesByNameId-com.aspose.font.NameId-java.lang.String-) | Väljer alla poster som är relaterade till den logiska strängkategorin, specificerad av parametern nameId, och uppdaterar namnfältet (strängdata) i dessa poster. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### addMultiLanguageNames(MultiLanguageString mlNames, PlatformId platformId, int platformSpecificId, NameId nameId) {#addMultiLanguageNames-com.aspose.font.MultiLanguageString-com.aspose.font.PlatformId-int-com.aspose.font.NameId-}
+```
+public void addMultiLanguageNames(MultiLanguageString mlNames, PlatformId platformId, int platformSpecificId, NameId nameId)
+```
+
+
+Extraherar alla flerspråkiga strängar från det passerade mlNames-objektet och skapar motsvarande NameRecord-struktur för varje extraherad sträng med hjälp av de passerade parametrarna platformId, platformSpecificId och nameId. Värdet för fältet languageID extraheras från mlNames-objektet. Den nyss skapade posten läggs till i tabellen. Om en post som matchar den nyss skapade enligt fälten platformID, platformSpecificID, nameID och languageId hittas, kommer den nyss skapade posten inte att läggas till och endast strängdata kommer att uppdateras för den befintliga posten.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| mlNames | [MultiLanguageString](../../com.aspose.font/multilanguagestring) | Flerspråkig sträng |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Plattformsidentifierare |
+| platformSpecificId | int | Plattformspecifik kodningsidentifierare |
+| nameId | [NameId](../../com.aspose.font/nameid) | Namnsidentifierare, logisk strängkategori, specificerad av NameId‑enumerationen |
+
+### addName(NameId nameId, PlatformId platformId, int platformSpecificId, int languageId, String name) {#addName-com.aspose.font.NameId-com.aspose.font.PlatformId-int-int-java.lang.String-}
+```
+public void addName(NameId nameId, PlatformId platformId, int platformSpecificId, int languageId, String name)
+```
+
+
+Lägger till en post i tabellen. Strängdatakategori som ska läggas till anges av parametern name.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Namnidentifierare, logisk strängkategori, specificerad av [NameId](../../com.aspose.font/nameid)-enumerationen. |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Plattformsidentifierare. |
+| platformSpecificId | int | Plattformspecifik kodningsidentifierare. Använd ett värde från någon av dessa uppräkningar – UnicodePlatformSpecificId, MacPlatformSpecificId, MSPlatformSpecificId. Vilken uppräkning som ska användas definieras av sammanhanget (parametern platformId). |
+| languageId | int | Språkidentifierare. Använd ett värde från uppräkningarna MSLanguageId eller MacLanguageId beroende på sammanhanget, definierat av parametern platformId. |
+| namn | java.lang.String | Faktisk strängdata. |
+
+### deleteRecords(PlatformId platformId, int platformSpecificId) {#deleteRecords-com.aspose.font.PlatformId-int-}
+```
+public void deleteRecords(PlatformId platformId, int platformSpecificId)
+```
+
+
+Tar bort alla poster som är relaterade till den angivna plattformen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Plattformsidentifierare |
+| platformSpecificId | int | Plattformspecifik kodningsidentifierare |
+
+### deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId) {#deleteRecords-com.aspose.font.PlatformId-int-com.aspose.font.NameId-}
+```
+public void deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId)
+```
+
+
+Tar bort alla poster som är relaterade till de passerade parametrarna.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Plattformsidentifierare |
+| platformSpecificId | int | Plattformspecifik kodningsidentifierare |
+| nameId | [NameId](../../com.aspose.font/nameid) | Namnsidentifierare, logisk strängkategori, specificerad av NameId‑enumerationen |
+
+### deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId) {#deleteRecords-com.aspose.font.PlatformId-int-com.aspose.font.NameId-int-}
+```
+public void deleteRecords(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId)
+```
+
+
+Tar bort post(er) som är relaterade till angivna parametrar.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Plattformsidentifierare |
+| platformSpecificId | int | Plattformspecifik kodningsidentifierare |
+| nameId | [NameId](../../com.aspose.font/nameid) | Namnsidentifierare, logisk strängkategori, specificerad av NameId‑enumerationen |
+| languageId | int | Språkidentifierare |
+
+### deleteRecordsByNameId(NameId nameId) {#deleteRecordsByNameId-com.aspose.font.NameId-}
+```
+public void deleteRecordsByNameId(NameId nameId)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllNameRecords() {#getAllNameRecords--}
+```
+public NameRecord[] getAllNameRecords()
+```
+
+
+Returnerar alla NameRecord-strukturer från tabellen.
+
+**Returns:**
+com.aspose.font.NameRecord[] – Alla NameRecord-strukturer från tabellen.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMultiLanguageNameById(NameId nameId) {#getMultiLanguageNameById-com.aspose.font.NameId-}
+```
+public MultiLanguageString getMultiLanguageNameById(NameId nameId)
+```
+
+
+returnerar ett namn efter nameId
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | name Id. |
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - name
+### getMultiLanguageNameById(NameId nameId, PlatformId platformId) {#getMultiLanguageNameById-com.aspose.font.NameId-com.aspose.font.PlatformId-}
+```
+public MultiLanguageString getMultiLanguageNameById(NameId nameId, PlatformId platformId)
+```
+
+
+Returnerar ett namn efter nameId med den passerade plattformsidentifieraren.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Name Id. |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Plattforms-ID. |
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Name.
+### getMultiLanguageNameById(NameId nameId, PlatformId platformId, int platformSpecificId) {#getMultiLanguageNameById-com.aspose.font.NameId-com.aspose.font.PlatformId-int-}
+```
+public MultiLanguageString getMultiLanguageNameById(NameId nameId, PlatformId platformId, int platformSpecificId)
+```
+
+
+Returnerar ett namn som objekt av typen MultiLanguageString. Metoden samlar alla NameRecord-strukturer som överensstämmer med de överförda parametrarna nameId, platformId och platformSpecificId och bygger sedan ett resulterande objekt baserat på denna strukturlista.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Name Id. |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Plattforms-ID. |
+| platformSpecificId | int | Plattformspecifik Id. |
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Name.
+### getNameById(NameId nameId) {#getNameById-com.aspose.font.NameId-}
+```
+public String getNameById(NameId nameId)
+```
+
+
+Returnerar ett namn efter nameId om det hittas, annars null.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | name identifierare |
+
+**Returns:**
+java.lang.String – name
+### getNameRecordsByNameId(NameId nameId) {#getNameRecordsByNameId-com.aspose.font.NameId-}
+```
+public NameRecord[] getNameRecordsByNameId(NameId nameId)
+```
+
+
+Returnerar alla NameRecord-strukturer där NameId-fältet är lika med det överförda nameId‑värdet. Om inga poster hittas returneras en tom array.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | name identifierare |
+
+**Returns:**
+com.aspose.font.NameRecord[] – Array av NameRecord-strukturer
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### updateName(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId, String newName) {#updateName-com.aspose.font.PlatformId-int-com.aspose.font.NameId-int-java.lang.String-}
+```
+public void updateName(PlatformId platformId, int platformSpecificId, NameId nameId, int languageId, String newName)
+```
+
+
+Uppdaterar namn i post(er) som är relaterade till angiven plattform (kombination av platformId och platformSpecificId), kategori (nameId) och språk (languageId).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| platformId | [PlatformId](../../com.aspose.font/platformid) | Plattformsidentifierare |
+| platformSpecificId | int | Plattformspecifik kodningsidentifierare |
+| nameId | [NameId](../../com.aspose.font/nameid) | Namnsidentifierare, logisk strängkategori, specificerad av NameId‑enumerationen |
+| languageId | int | Språkidentifierare |
+| newName | java.lang.String | Nytt namn eller ny strängdata |
+
+### updateNamesByNameId(NameId nameId, String newName) {#updateNamesByNameId-com.aspose.font.NameId-java.lang.String-}
+```
+public void updateNamesByNameId(NameId nameId, String newName)
+```
+
+
+Väljer alla poster som är relaterade till den logiska strängkategorin, specificerad av parametern nameId, och uppdaterar namn‑fältet (strängdata) i dessa poster. Fält som är relaterade till plattform (platformID, Platform-specific encoding ID) och språk (Language ID) påverkas inte av denna metod. Endast namn‑strängdata ersätts med ett nytt namn. Använd metoden med försiktighet, eftersom den kommer att ersätta de ursprungliga namnen för alla plattformar och språk som är kopplade till nameId. Det kan skapa konflikter i fall där de ursprungliga namnen hade olika värden, eftersom ersättningsoperationen ändrar alla dessa värden till ett nytt gemensamt. Och detta nya värde kan ha en logisk inkonsekvens med vissa plattformar och språk. Metoden är användbar i situationer där det ursprungliga namnet har en enda representation för alla plattformar och språk, till exempel när namn‑strängdata är på engelska.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| nameId | [NameId](../../com.aspose.font/nameid) | Namnsidentifierare, logisk strängkategori, specificerad av NameId‑enumerationen |
+| newName | java.lang.String | Nytt namn eller ny strängdata |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfos2table/_index.md
+++ b/swedish/java/com.aspose.font/ttfos2table/_index.md
@@ -1,0 +1,578 @@
+---
+title: "TtfOs2Table"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar OS/2‑tabellen i TTF‑teckensnittsfilen."
+type: docs
+weight: 106
+url: /sv/java/com.aspose.font/ttfos2table/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfOs2Table extends TtfTableBase
+```
+
+Representerar "OS/2"-tabellen i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAchVendId()](#getAchVendId--) | Hämtar AchVendId‑värdet. |
+| [getClass()](#getClass--) |  |
+| [getFSSelection()](#getFSSelection--) | Innehåller information om teckensnittsmönstrens natur. |
+| [getFSType()](#getFSType--) | Hämtar FSType‑värdet. |
+| [getLicenseFlags()](#getLicenseFlags--) | Hämtar en inbäddad flagga (fsType) i objektrepresentation. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getPanose()](#getPanose--) | Denna serie av 10 byte med siffror används för att beskriva de visuella egenskaperna hos ett givet teckensnitt. |
+| [getSCapHeight()](#getSCapHeight--) | Hämtar SCapHeight‑värdet. |
+| [getSFamilyClass()](#getSFamilyClass--) | Denna parameter är en klassificering av teckensnittsfamiljens design. |
+| [getSTypoAscender()](#getSTypoAscender--) | Hämtar STypoAscender‑värdet. |
+| [getSTypoDescender()](#getSTypoDescender--) | Hämtar STypoDescender‑värdet. |
+| [getSTypoLineGap()](#getSTypoLineGap--) | Hämtar STypoLineGap‑värdet. |
+| [getSXHeight()](#getSXHeight--) | Hämtar SXHeight‑värdet. |
+| [getSupportedTableVersions()](#getSupportedTableVersions--) | Hämtar de stödjade versionerna av OS/2‑tabellen. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [getULCodePageRange()](#getULCodePageRange--) | Hämtar ULCodePageRange‑värdet. |
+| [getULUnicodeRange()](#getULUnicodeRange--) | Hämtar ULUnicodeRange‑värdet. |
+| [getUSBreakChar()](#getUSBreakChar--) | Hämtar USBreakChar‑värdet. |
+| [getUSDefaultChar()](#getUSDefaultChar--) | Hämtar USDefaultChar‑värdet. |
+| [getUSFirstCharIndex()](#getUSFirstCharIndex--) | Hämtar USFirstCharIndex‑värdet. |
+| [getUSLastCharIndex()](#getUSLastCharIndex--) | Hämtar USLastCharIndex‑värdet. |
+| [getUSLowerOpticalPointSize()](#getUSLowerOpticalPointSize--) | Hämtar USLowerOpticalPointSize‑värdet. |
+| [getUSMaxContext()](#getUSMaxContext--) | Hämtar USMaxContext‑värdet. |
+| [getUSUpperOpticalPointSize()](#getUSUpperOpticalPointSize--) | Hämtar USUpperOpticalPointSize‑värdet. |
+| [getUSWeightClass()](#getUSWeightClass--) | Anger den visuella vikten (grad av mörkhet eller tjocklek på strecken) för tecknen i teckensnittet. |
+| [getUSWidthClass()](#getUSWidthClass--) | Anger en relativ förändring från det normala bildförhållandet (bredd‑till‑höjd‑förhållande) som specificerats av en teckensnittsdesigner för glyferna i ett teckensnitt. |
+| [getUSWinAscent()](#getUSWinAscent--) | Hämtar USWinAscent‑värdet. |
+| [getUSWinDescent()](#getUSWinDescent--) | Hämtar USWinDescent‑värdet. |
+| [getVersion()](#getVersion--) | Hämtar Version-värde. |
+| [getXAvgCharWidth()](#getXAvgCharWidth--) | Hämtar parametern för genomsnittlig teckenbredd. |
+| [getYStrikeoutPosition()](#getYStrikeoutPosition--) | Hämtar YStrikeoutPosition-värde. |
+| [getYStrikeoutSize()](#getYStrikeoutSize--) | Hämtar YStrikeoutSize-värde. |
+| [getYSubscriptXOffset()](#getYSubscriptXOffset--) | Hämtar YSubscriptXOffset-värde. |
+| [getYSubscriptXSize()](#getYSubscriptXSize--) | Hämtar YSubscriptXSize-värde. |
+| [getYSubscriptYOffset()](#getYSubscriptYOffset--) | Hämtar YSubscriptYOffset-värde. |
+| [getYSubscriptYSize()](#getYSubscriptYSize--) | Hämtar YSubscriptYSize-värde. |
+| [getYSuperscriptXOffset()](#getYSuperscriptXOffset--) | Hämtar YSuperscriptXOffset-värde. |
+| [getYSuperscriptXSize()](#getYSuperscriptXSize--) | Hämtar YSuperscriptXSize-värde. |
+| [getYSuperscriptYOffset()](#getYSuperscriptYOffset--) | Hämtar YSuperscriptYOffset-värde. |
+| [getYSuperscriptYSize()](#getYSuperscriptYSize--) | Hämtar YSuperscriptYSize-värde. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAchVendId() {#getAchVendId--}
+```
+public byte[] getAchVendId()
+```
+
+
+Hämtar AchVendId‑värdet.
+
+**Returns:**
+byte[] - AchVendId-värde.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFSSelection() {#getFSSelection--}
+```
+public int getFSSelection()
+```
+
+
+Innehåller information om teckensnittsmönstrens natur.
+
+> ```
+> 0	bit 1	ITALIC	Font contains Italic characters, otherwise they are upright.
+>  1	 	    UNDERSCORE	Characters are underscored.
+>  2	 	    NEGATIVE	Characters have their foreground and background reversed.
+>  3	 	    OUTLINED	Outline (hollow) characters, otherwise they are solid.
+>  4	 	    STRIKEOUT	Characters are overstruck.
+>  5	bit 0	BOLD	Characters are emboldened.
+>  6	 	    REGULAR	Characters are in the standard weight/style for the font.
+> ```
+
+**Returns:**
+int - Informationen.
+### getFSType() {#getFSType--}
+```
+public int getFSType()
+```
+
+
+Hämtar FSType‑värdet.
+
+--------------------
+
+Anger licensrättigheter för inbäddning av teckensnittet.
+
+**Returns:**
+int - FSType-värde.
+### getLicenseFlags() {#getLicenseFlags--}
+```
+public LicenseFlags getLicenseFlags()
+```
+
+
+Hämtar en inbäddad flagga (fsType) i objektrepresentation.
+
+**Returns:**
+[LicenseFlags](../../com.aspose.font/licenseflags) - Embedded flags.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getPanose() {#getPanose--}
+```
+public byte[] getPanose()
+```
+
+
+Denna serie på 10 byte med siffror används för att beskriva de visuella egenskaperna hos ett givet typsnitt. Dessa egenskaper används sedan för att associera teckensnittet med andra teckensnitt med liknande utseende men olika namn.
+
+**Returns:**
+byte[] - De visuella egenskaperna för ett givet typsnitt.
+### getSCapHeight() {#getSCapHeight--}
+```
+public short getSCapHeight()
+```
+
+
+Hämtar SCapHeight‑värdet.
+
+**Returns:**
+short - SCapHeight-värde.
+### getSFamilyClass() {#getSFamilyClass--}
+```
+public short getSFamilyClass()
+```
+
+
+Denna parameter är en klassificering av teckensnittsfamiljens design. Teckensnittsklassen och teckensnittsubklassen är registrerade värden som tilldelats av IBM till varje teckensnittsfamilj. Denna parameter är avsedd att användas för att välja ett alternativt teckensnitt när det begärda teckensnittet inte är tillgängligt.
+
+**Returns:**
+short - Klassificering av teckensnittsfamiljens design.
+### getSTypoAscender() {#getSTypoAscender--}
+```
+public short getSTypoAscender()
+```
+
+
+Hämtar STypoAscender‑värdet.
+
+**Returns:**
+short - STypoAscender-värde.
+### getSTypoDescender() {#getSTypoDescender--}
+```
+public short getSTypoDescender()
+```
+
+
+Hämtar STypoDescender‑värdet.
+
+**Returns:**
+short - STypoDescender-värde.
+### getSTypoLineGap() {#getSTypoLineGap--}
+```
+public short getSTypoLineGap()
+```
+
+
+Hämtar STypoLineGap‑värdet.
+
+**Returns:**
+short - STypoLineGap-värde.
+### getSXHeight() {#getSXHeight--}
+```
+public short getSXHeight()
+```
+
+
+Hämtar SXHeight‑värdet.
+
+**Returns:**
+short - SXHeight-värde.
+### getSupportedTableVersions() {#getSupportedTableVersions--}
+```
+public int[] getSupportedTableVersions()
+```
+
+
+Hämtar de stödjade versionerna av OS/2‑tabellen.
+
+**Returns:**
+int[] - Stödda versioner av OS/2-tabellen.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getULCodePageRange() {#getULCodePageRange--}
+```
+public long[] getULCodePageRange()
+```
+
+
+Hämtar ULCodePageRange‑värdet.
+
+**Returns:**
+long[] - ULCodePageRange‑värde.
+### getULUnicodeRange() {#getULUnicodeRange--}
+```
+public long[] getULUnicodeRange()
+```
+
+
+Hämtar ULUnicodeRange‑värdet.
+
+**Returns:**
+long[] - ULUnicodeRange‑värde.
+### getUSBreakChar() {#getUSBreakChar--}
+```
+public int getUSBreakChar()
+```
+
+
+Hämtar USBreakChar‑värdet.
+
+**Returns:**
+int - USBreakChar‑värde.
+### getUSDefaultChar() {#getUSDefaultChar--}
+```
+public int getUSDefaultChar()
+```
+
+
+Hämtar USDefaultChar‑värdet.
+
+**Returns:**
+int - USDefaultChar‑värde.
+### getUSFirstCharIndex() {#getUSFirstCharIndex--}
+```
+public int getUSFirstCharIndex()
+```
+
+
+Hämtar USFirstCharIndex‑värdet.
+
+**Returns:**
+int - USFirstCharIndex‑värde.
+### getUSLastCharIndex() {#getUSLastCharIndex--}
+```
+public int getUSLastCharIndex()
+```
+
+
+Hämtar USLastCharIndex‑värdet.
+
+**Returns:**
+int - USLastCharIndex‑värde.
+### getUSLowerOpticalPointSize() {#getUSLowerOpticalPointSize--}
+```
+public int getUSLowerOpticalPointSize()
+```
+
+
+Hämtar USLowerOpticalPointSize‑värdet.
+
+**Returns:**
+int - USLowerOpticalPointSize‑värdet.
+### getUSMaxContext() {#getUSMaxContext--}
+```
+public int getUSMaxContext()
+```
+
+
+Hämtar USMaxContext‑värdet.
+
+**Returns:**
+int - UsMaxContext‑värde.
+### getUSUpperOpticalPointSize() {#getUSUpperOpticalPointSize--}
+```
+public int getUSUpperOpticalPointSize()
+```
+
+
+Hämtar USUpperOpticalPointSize‑värdet.
+
+**Returns:**
+int - USUpperOpticalPointSize‑värdet.
+### getUSWeightClass() {#getUSWeightClass--}
+```
+public int getUSWeightClass()
+```
+
+
+Anger den visuella vikten (grad av mörkhet eller tjocklek på strecken) för tecknen i teckensnittet.
+
+**Returns:**
+int - Den visuella vikten (grad av svarthet eller tjocklek på strecken) för tecknen i teckensnittet.
+### getUSWidthClass() {#getUSWidthClass--}
+```
+public int getUSWidthClass()
+```
+
+
+Anger en relativ förändring från det normala bildförhållandet (bredd‑till‑höjd‑förhållande) som specificerats av en teckensnittsdesigner för glyferna i ett teckensnitt.
+
+**Returns:**
+int - En relativ förändring från det normala bildförhållandet (bredd‑till‑höjd‑förhållande) enligt vad en teckensnittsdesigner specificerat för glyferna i ett teckensnitt.
+### getUSWinAscent() {#getUSWinAscent--}
+```
+public int getUSWinAscent()
+```
+
+
+Hämtar USWinAscent‑värdet.
+
+**Returns:**
+int - USWinAscent‑värde.
+### getUSWinDescent() {#getUSWinDescent--}
+```
+public int getUSWinDescent()
+```
+
+
+Hämtar USWinDescent‑värdet.
+
+**Returns:**
+int - USWinDescent‑värde.
+### getVersion() {#getVersion--}
+```
+public int getVersion()
+```
+
+
+Hämtar Version-värde.
+
+**Returns:**
+int - Version‑värde.
+### getXAvgCharWidth() {#getXAvgCharWidth--}
+```
+public short getXAvgCharWidth()
+```
+
+
+Hämtar parametern för genomsnittlig teckenbredd.
+
+**Returns:**
+short - Genomsnittlig teckenbredd‑parameter.
+### getYStrikeoutPosition() {#getYStrikeoutPosition--}
+```
+public short getYStrikeoutPosition()
+```
+
+
+Hämtar YStrikeoutPosition-värde.
+
+**Returns:**
+short - YStrikeoutPosition‑värde.
+### getYStrikeoutSize() {#getYStrikeoutSize--}
+```
+public short getYStrikeoutSize()
+```
+
+
+Hämtar YStrikeoutSize-värde.
+
+**Returns:**
+short - YStrikeoutSize‑värde.
+### getYSubscriptXOffset() {#getYSubscriptXOffset--}
+```
+public short getYSubscriptXOffset()
+```
+
+
+Hämtar YSubscriptXOffset-värde.
+
+**Returns:**
+short - YSubscriptXOffset‑värde.
+### getYSubscriptXSize() {#getYSubscriptXSize--}
+```
+public short getYSubscriptXSize()
+```
+
+
+Hämtar YSubscriptXSize-värde.
+
+**Returns:**
+short - YSubscriptXSize‑värde.
+### getYSubscriptYOffset() {#getYSubscriptYOffset--}
+```
+public short getYSubscriptYOffset()
+```
+
+
+Hämtar YSubscriptYOffset-värde.
+
+**Returns:**
+short - YSubscriptYOffset‑värde.
+### getYSubscriptYSize() {#getYSubscriptYSize--}
+```
+public short getYSubscriptYSize()
+```
+
+
+Hämtar YSubscriptYSize-värde.
+
+**Returns:**
+short - YSubscriptYSize‑värde.
+### getYSuperscriptXOffset() {#getYSuperscriptXOffset--}
+```
+public short getYSuperscriptXOffset()
+```
+
+
+Hämtar YSuperscriptXOffset-värde.
+
+**Returns:**
+short - YSuperscriptXOffset‑värde.
+### getYSuperscriptXSize() {#getYSuperscriptXSize--}
+```
+public short getYSuperscriptXSize()
+```
+
+
+Hämtar YSuperscriptXSize-värde.
+
+**Returns:**
+short - YSuperscriptXSize‑värde.
+### getYSuperscriptYOffset() {#getYSuperscriptYOffset--}
+```
+public short getYSuperscriptYOffset()
+```
+
+
+Hämtar YSuperscriptYOffset-värde.
+
+**Returns:**
+short - YSuperscriptYOffset‑värde.
+### getYSuperscriptYSize() {#getYSuperscriptYSize--}
+```
+public short getYSuperscriptYSize()
+```
+
+
+Hämtar YSuperscriptYSize-värde.
+
+**Returns:**
+kort - YSuperscriptYSize värde.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfposttable/_index.md
+++ b/swedish/java/com.aspose.font/ttfposttable/_index.md
@@ -1,0 +1,326 @@
+---
+title: "TtfPostTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar post-tabellen i TTF-typsnittsfilen"
+type: docs
+weight: 107
+url: /sv/java/com.aspose.font/ttfposttable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfPostTable extends TtfTableBase
+```
+
+Representerar "post"-tabellen i TTF-typsnittsfilen
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIndexesForGlyphName(String glyphName)](#getAllGlyphIndexesForGlyphName-java.lang.String-) | Hämtar en array av teckenindex efter teckennamn |
+| [getClass()](#getClass--) |  |
+| [getFormat()](#getFormat--) | Hämtar fast format (version) för denna tabell. |
+| [getGlyphIndex(String glyphName)](#getGlyphIndex-java.lang.String-) | Hämtar teckenindex efter teckennamn. |
+| [getGlyphName(long glyphIndex)](#getGlyphName-long-) | Hämtar teckennamn efter teckenindex. |
+| [getItalicAngle()](#getItalicAngle--) | Hämtar fixed italicAngle kursiv vinkel i grader. |
+| [getMaxMemType1()](#getMaxMemType1--) | Hämtar uint32 maxMemType1 Maximalt minnesanvändning när ett TrueType-typsnitt hämtas som ett Type 1-typsnitt. |
+| [getMaxMemType42()](#getMaxMemType42--) | Hämtar uint32 maxMemType42 Maximalt minnesanvändning när ett TrueType-typsnitt hämtas som ett Type 42-typsnitt. |
+| [getMinMemType1()](#getMinMemType1--) | Hämtar uint32 minMemType1 Minimalt minnesanvändning när ett TrueType-typsnitt hämtas som ett Type 1-typsnitt. |
+| [getMinMemType42()](#getMinMemType42--) | Hämtar uint32 minMemType42 Minimalt minnesanvändning när ett TrueType-typsnitt hämtas som ett Type 42-typsnitt. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getTableFormat()](#getTableFormat--) | Hämtar fixed format (version) för denna tabell. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [getUnderlinePosition()](#getUnderlinePosition--) | Hämtar FWord underlinePosition understrykningsposition. |
+| [getUnderlineThickness()](#getUnderlineThickness--) | Hämtar FWord underlineThickness understrykningstjocklek. |
+| [hasNoPostScriptNames()](#hasNoPostScriptNames--) | Indikerar att ingen PostScript-namnsinformation tillhandahålls för glyferna i den här teckensnittsfilen. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Hämtar uint32 isFixedPitch. 0 om teckensnittet har proportionell teckenbredd, icke-noll om teckensnittet inte har proportionell teckenbredd (dvs. monospaced). |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIndexesForGlyphName(String glyphName) {#getAllGlyphIndexesForGlyphName-java.lang.String-}
+```
+public long[] getAllGlyphIndexesForGlyphName(String glyphName)
+```
+
+
+Hämtar en array av teckenindex efter teckennamn
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphName | java.lang.String | Glyfnamn |
+
+**Returns:**
+long[] - array av glyfindex
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFormat() {#getFormat--}
+```
+public float getFormat()
+```
+
+
+Hämtar fast format (version) för denna tabell.
+
+**Returns:**
+float - Fixed format(version) för denna tabell.
+### getGlyphIndex(String glyphName) {#getGlyphIndex-java.lang.String-}
+```
+public long getGlyphIndex(String glyphName)
+```
+
+
+Hämtar teckenindex efter teckennamn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphName | java.lang.String | Glyfnamn. |
+
+**Returns:**
+long - Glyfindex. När ingen PostScript-namnsinformation tillhandahålls för glyferna i den här teckensnittsfilen, returneras index 0, vilket är den odefinierade glyfen eller ".notdef"-glyfen.
+### getGlyphName(long glyphIndex) {#getGlyphName-long-}
+```
+public String getGlyphName(long glyphIndex)
+```
+
+
+Hämtar teckennamn efter teckenindex.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphIndex | long | Glyfindex. |
+
+**Returns:**
+java.lang.String - Glyfnamn. När ingen PostScript-namnsinformation tillhandahålls för glyferna i den här teckensnittsfilen, returneras null.
+### getItalicAngle() {#getItalicAngle--}
+```
+public float getItalicAngle()
+```
+
+
+Hämtar fixed italicAngle kursiv vinkel i grader.
+
+**Returns:**
+float - Fixed italicAngle kursiv vinkel i grader.
+### getMaxMemType1() {#getMaxMemType1--}
+```
+public long getMaxMemType1()
+```
+
+
+Hämtar uint32 maxMemType1 Maximalt minnesanvändning när ett TrueType-typsnitt hämtas som ett Type 1-typsnitt.
+
+**Returns:**
+long - UInt32 maxMemType1 Maximalt minnesanvändning när ett TrueType-typsnitt hämtas som ett Type 1-typsnitt.
+### getMaxMemType42() {#getMaxMemType42--}
+```
+public long getMaxMemType42()
+```
+
+
+Hämtar uint32 maxMemType42 Maximalt minnesanvändning när ett TrueType-typsnitt hämtas som ett Type 42-typsnitt.
+
+**Returns:**
+long - UInt32 maxMemType42 Maximalt minnesanvändning när ett TrueType-typsnitt hämtas som ett Type 42-typsnitt.
+### getMinMemType1() {#getMinMemType1--}
+```
+public long getMinMemType1()
+```
+
+
+Hämtar uint32 minMemType1 Minimalt minnesanvändning när ett TrueType-typsnitt hämtas som ett Type 1-typsnitt.
+
+**Returns:**
+long - UInt32 minMemType1 Minimalt minnesanvändning när ett TrueType-typsnitt hämtas som ett Type 1-typsnitt.
+### getMinMemType42() {#getMinMemType42--}
+```
+public long getMinMemType42()
+```
+
+
+Hämtar uint32 minMemType42 Minimalt minnesanvändning när ett TrueType-typsnitt hämtas som ett Type 42-typsnitt.
+
+**Returns:**
+long - UInt32 minMemType42 Minimalt minnesanvändning när ett TrueType-typsnitt hämtas som ett Type 42-typsnitt.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getTableFormat() {#getTableFormat--}
+```
+public Version16Dot16 getTableFormat()
+```
+
+
+Hämtar fixed format (version) för denna tabell. Använd egenskaperna MajorNumber och MinorNUmber i objektet Version16Dot16 i hexadecimal notation för att upptäcka vilken version som används.
+
+**Returns:**
+[Version16Dot16](../../com.aspose.font/version16dot16) - Fixed format (version) of this table.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getUnderlinePosition() {#getUnderlinePosition--}
+```
+public short getUnderlinePosition()
+```
+
+
+Hämtar FWord underlinePosition understrykningsposition.
+
+**Returns:**
+short - FWord underlinePosition understrykningsposition.
+### getUnderlineThickness() {#getUnderlineThickness--}
+```
+public short getUnderlineThickness()
+```
+
+
+Hämtar FWord underlineThickness understrykningstjocklek.
+
+**Returns:**
+short - FWord underlineThickness understrykningstjocklek.
+### hasNoPostScriptNames() {#hasNoPostScriptNames--}
+```
+public boolean hasNoPostScriptNames()
+```
+
+
+Indikerar att ingen PostScript-namnsinformation tillhandahålls för glyferna i den här teckensnittsfilen.
+
+**Returns:**
+boolean - True, om ingen PostScript-namnsinformation tillhandahålls för glyferna i den här teckensnittsfilen. False, annars.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public long isFixedPitch()
+```
+
+
+Hämtar uint32 isFixedPitch. 0 om teckensnittet har proportionell teckenbredd, icke-noll om teckensnittet inte har proportionell teckenbredd (dvs. monospaced).
+
+**Returns:**
+long - UInt32 isFixedPitch. 0 om teckensnittet har proportionell teckenbredd, icke-noll om teckensnittet inte har proportionell teckenbredd (dvs. monospaced).
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfpreptable/_index.md
+++ b/swedish/java/com.aspose.font/ttfpreptable/_index.md
@@ -1,0 +1,168 @@
+---
+title: "TtfPrepTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar prep‑tabellen i TTF‑typsnittsfilen."
+type: docs
+weight: 108
+url: /sv/java/com.aspose.font/ttfpreptable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfPrepTable extends TtfTableBase
+```
+
+Representerar "prep"-tabellen i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getProgram()](#getProgram--) | Uppsättning av instruktioner. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getProgram() {#getProgram--}
+```
+public byte[] getProgram()
+```
+
+
+Uppsättning av instruktioner.
+
+**Returns:**
+byte[] - Uppsättning av instruktioner.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfstattable/_index.md
+++ b/swedish/java/com.aspose.font/ttfstattable/_index.md
@@ -1,0 +1,267 @@
+---
+title: "TtfStatTable"
+second_title: "Aspose.Font för Java API-referens"
+description: 
+type: docs
+weight: 109
+url: /sv/java/com.aspose.font/ttfstattable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfStatTable extends TtfTableBase
+```
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addAxisRecord(AxisRecord axisRecord)](#addAxisRecord-com.aspose.font.AxisRecord-) | Lägger till en Axis Record‑struktur i tabellen. |
+| [addAxisValueTable(AxisValueTableBase axisValueTable)](#addAxisValueTable-com.aspose.font.AxisValueTableBase-) | Lägger till en Axis Value Table‑struktur i tabellen. |
+| [clearAxisRecords()](#clearAxisRecords--) | Tar bort alla axis‑poster från tabellen. |
+| [clearAxisValueTables()](#clearAxisValueTables--) | Tar bort alla axis‑värdetabeller från tabellen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAxisRecords()](#getAxisRecords--) | Returnerar designaxlar‑arrayen. |
+| [getAxisValueCount()](#getAxisValueCount--) | Returnerar antalet axis‑värdetabeller. |
+| [getAxisValueTables()](#getAxisValueTables--) | Returnerar en array av Axis Value Tables. |
+| [getClass()](#getClass--) |  |
+| [getDesignAxisCount()](#getDesignAxisCount--) | Returnerar antalet axis‑poster. |
+| [getElidedFallbackName()](#getElidedFallbackName--) | Spec: Namn som används som reserv när projektion av namn till en viss teckensnittmodell ger ett underfamiljenamn som endast innehåller utelämningsbara element. |
+| [getElidedFallbackNameId()](#getElidedFallbackNameId--) | Spec: Namn‑ID som används som reserv när projektion av namn till en viss teckensnittmodell ger ett underfamiljenamn som endast innehåller utelämningsbara element. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### addAxisRecord(AxisRecord axisRecord) {#addAxisRecord-com.aspose.font.AxisRecord-}
+```
+public void addAxisRecord(AxisRecord axisRecord)
+```
+
+
+Lägger till en Axis Record‑struktur i tabellen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| axisRecord | [AxisRecord](../../com.aspose.font/axisrecord) | AxisRecord‑struktur |
+
+### addAxisValueTable(AxisValueTableBase axisValueTable) {#addAxisValueTable-com.aspose.font.AxisValueTableBase-}
+```
+public void addAxisValueTable(AxisValueTableBase axisValueTable)
+```
+
+
+Lägger till en Axis Value Table‑struktur i tabellen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| axisValueTable | [AxisValueTableBase](../../com.aspose.font/axisvaluetablebase) | Axis value table‑struktur |
+
+### clearAxisRecords() {#clearAxisRecords--}
+```
+public void clearAxisRecords()
+```
+
+
+Tar bort alla axis‑poster från tabellen.
+
+### clearAxisValueTables() {#clearAxisValueTables--}
+```
+public void clearAxisValueTables()
+```
+
+
+Tar bort alla axis‑värdetabeller från tabellen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAxisRecords() {#getAxisRecords--}
+```
+public AxisRecord[] getAxisRecords()
+```
+
+
+Returnerar designaxlar‑arrayen. Axlar‑arrayen är en array av strukturer av typen Axis Record. Spec: axis‑posten ger information om en enskild designaxel.
+
+**Returns:**
+com.aspose.font.AxisRecord[] - Designaxlar‑arrayen.
+### getAxisValueCount() {#getAxisValueCount--}
+```
+public int getAxisValueCount()
+```
+
+
+Returnerar antalet axis‑värdetabeller.
+
+**Returns:**
+int - Antalet axis‑värdetabeller.
+### getAxisValueTables() {#getAxisValueTables--}
+```
+public AxisValueTableBase[] getAxisValueTables()
+```
+
+
+Returnerar en array av Axis Value Tables. Spec: Axis Value Tables ger detaljer om ett specifikt stilattributvärde på någon specifik axel av designvariation, eller en kombination av designvariationsaxelvärden, samt förhållandet mellan dessa värden och etiketter som används som element i underfamiljenamn.
+
+**Returns:**
+com.aspose.font.AxisValueTableBase[] - Arrayen av Axis Value Tables.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDesignAxisCount() {#getDesignAxisCount--}
+```
+public int getDesignAxisCount()
+```
+
+
+Returnerar antalet axelposter. Spec: i ett teckensnitt med en 'fvar'-tabell måste detta värde vara större än eller lika med axisCount‑värdet i 'fvar'-tabellen. I alla teckensnitt måste det vara större än noll om axisValueCount är större än noll.
+
+**Returns:**
+int - Antalet axelposter.
+### getElidedFallbackName() {#getElidedFallbackName--}
+```
+public String getElidedFallbackName()
+```
+
+
+Spec: Namn som används som reserv när projektion av namn till en viss teckensnittmodell ger ett underfamiljenamn som endast innehåller utelämningsbara element.
+
+**Returns:**
+java.lang.String - Namnet som används som reserv när projektion av namn till en viss teckensnittmodell ger ett underfamiljenamn som endast innehåller eliderbara element.
+### getElidedFallbackNameId() {#getElidedFallbackNameId--}
+```
+public int getElidedFallbackNameId()
+```
+
+
+Spec: Namn‑ID som används som reserv när projektion av namn till en viss teckensnittmodell ger ett underfamiljenamn som endast innehåller utelämningsbara element.
+
+**Returns:**
+int - Namn‑ID.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttftablebase/_index.md
+++ b/swedish/java/com.aspose.font/ttftablebase/_index.md
@@ -1,0 +1,146 @@
+---
+title: "TtfTableBase"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar TTF-tabelldefinition."
+type: docs
+weight: 110
+url: /sv/java/com.aspose.font/ttftablebase/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TtfTableBase
+```
+
+Representerar TTF-tabelldefinition.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttftablerepository/_index.md
+++ b/swedish/java/com.aspose.font/ttftablerepository/_index.md
@@ -1,0 +1,333 @@
+---
+title: "TtfTableRepository"
+second_title: "Aspose.Font för Java API-referens"
+description: "arkiv för TTF-tabeller"
+type: docs
+weight: 111
+url: /sv/java/com.aspose.font/ttftablerepository/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class TtfTableRepository
+```
+
+arkiv för TTF-tabeller
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCMapTable()](#getCMapTable--) | Hämtar cmap-tabellen. |
+| [getCffTable()](#getCffTable--) | Hämtar cff-tabellen. |
+| [getClass()](#getClass--) |  |
+| [getCvtTable()](#getCvtTable--) | Hämtar cvt-tabellen. |
+| [getFpgmTable()](#getFpgmTable--) | Hämtar fpgm-tabellen. |
+| [getGaspTable()](#getGaspTable--) | Hämtar GASP-tabellen. |
+| [getGlyfTable()](#getGlyfTable--) | Hämtar glyf-tabellen. |
+| [getHeadTable()](#getHeadTable--) | Hämtar head-tabellen. |
+| [getHheaTable()](#getHheaTable--) | Hämtar hhea-tabellen. |
+| [getHmtxTable()](#getHmtxTable--) | Hämtar hmtx-tabellen. |
+| [getLocaTable()](#getLocaTable--) | Hämtar loca-tabellen. |
+| [getLtshTable()](#getLtshTable--) | Hämtar LTSH-tabellen. |
+| [getMaxpTable()](#getMaxpTable--) | Hämtar maxp-tabellen. |
+| [getNameTable()](#getNameTable--) | Hämtar name-tabellen. |
+| [getOs2Table()](#getOs2Table--) | Hämtar OS/2-tabellen. |
+| [getPostTable()](#getPostTable--) | Hämtar post-tabellen. |
+| [getPrepTable()](#getPrepTable--) | Hämtar prep-tabellen. |
+| [getStatTable()](#getStatTable--) | Hämtar STAT-tabellen. |
+| [getVheaTable()](#getVheaTable--) | Hämtar vhea-tabellen. |
+| [getVmtxTable()](#getVmtxTable--) | Hämtar vmtx-tabellen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCMapTable() {#getCMapTable--}
+```
+public TtfCMapTable getCMapTable()
+```
+
+
+Hämtar cmap-tabellen.
+
+**Returns:**
+[TtfCMapTable](../../com.aspose.font/ttfcmaptable) - Cmap table.
+### getCffTable() {#getCffTable--}
+```
+public TtfCffTable getCffTable()
+```
+
+
+Hämtar cff-tabellen.
+
+**Returns:**
+[TtfCffTable](../../com.aspose.font/ttfcfftable) - Cff table.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCvtTable() {#getCvtTable--}
+```
+public TtfCvtTable getCvtTable()
+```
+
+
+Hämtar cvt-tabellen.
+
+**Returns:**
+[TtfCvtTable](../../com.aspose.font/ttfcvttable) - Cvt table.
+### getFpgmTable() {#getFpgmTable--}
+```
+public TtfFpgmTable getFpgmTable()
+```
+
+
+Hämtar fpgm-tabellen.
+
+**Returns:**
+[TtfFpgmTable](../../com.aspose.font/ttffpgmtable) - Fpgm table.
+### getGaspTable() {#getGaspTable--}
+```
+public TtfGaspTable getGaspTable()
+```
+
+
+Hämtar GASP-tabellen.
+
+**Returns:**
+[TtfGaspTable](../../com.aspose.font/ttfgasptable) - The GASP table.
+### getGlyfTable() {#getGlyfTable--}
+```
+public TtfGlyfTable getGlyfTable()
+```
+
+
+Hämtar glyf-tabellen.
+
+**Returns:**
+[TtfGlyfTable](../../com.aspose.font/ttfglyftable) - Glyf table.
+### getHeadTable() {#getHeadTable--}
+```
+public TtfHeadTable getHeadTable()
+```
+
+
+Hämtar head-tabellen.
+
+**Returns:**
+[TtfHeadTable](../../com.aspose.font/ttfheadtable) - Head table.
+### getHheaTable() {#getHheaTable--}
+```
+public TtfHheaTable getHheaTable()
+```
+
+
+Hämtar hhea-tabellen.
+
+**Returns:**
+[TtfHheaTable](../../com.aspose.font/ttfhheatable) - Hhea table.
+### getHmtxTable() {#getHmtxTable--}
+```
+public TtfHmtxTable getHmtxTable()
+```
+
+
+Hämtar hmtx-tabellen.
+
+**Returns:**
+[TtfHmtxTable](../../com.aspose.font/ttfhmtxtable) - Hmtx table.
+### getLocaTable() {#getLocaTable--}
+```
+public TtfLocaTable getLocaTable()
+```
+
+
+Hämtar loca-tabellen.
+
+**Returns:**
+[TtfLocaTable](../../com.aspose.font/ttflocatable) - Loca table.
+### getLtshTable() {#getLtshTable--}
+```
+public TtfLtshTable getLtshTable()
+```
+
+
+Hämtar LTSH-tabellen.
+
+**Returns:**
+[TtfLtshTable](../../com.aspose.font/ttfltshtable) - The LTSH table.
+### getMaxpTable() {#getMaxpTable--}
+```
+public TtfMaxpTable getMaxpTable()
+```
+
+
+Hämtar maxp-tabellen.
+
+**Returns:**
+[TtfMaxpTable](../../com.aspose.font/ttfmaxptable) - Maxp table.
+### getNameTable() {#getNameTable--}
+```
+public TtfNameTable getNameTable()
+```
+
+
+Hämtar name-tabellen.
+
+**Returns:**
+[TtfNameTable](../../com.aspose.font/ttfnametable) - Name table.
+### getOs2Table() {#getOs2Table--}
+```
+public TtfOs2Table getOs2Table()
+```
+
+
+Hämtar OS/2-tabellen.
+
+**Returns:**
+[TtfOs2Table](../../com.aspose.font/ttfos2table) - OS/2 table.
+### getPostTable() {#getPostTable--}
+```
+public TtfPostTable getPostTable()
+```
+
+
+Hämtar post-tabellen.
+
+**Returns:**
+[TtfPostTable](../../com.aspose.font/ttfposttable) - Post table.
+### getPrepTable() {#getPrepTable--}
+```
+public TtfPrepTable getPrepTable()
+```
+
+
+Hämtar prep-tabellen.
+
+**Returns:**
+[TtfPrepTable](../../com.aspose.font/ttfpreptable) - Prep table.
+### getStatTable() {#getStatTable--}
+```
+public TtfStatTable getStatTable()
+```
+
+
+Hämtar STAT-tabellen.
+
+**Returns:**
+[TtfStatTable](../../com.aspose.font/ttfstattable) - The STAT table.
+### getVheaTable() {#getVheaTable--}
+```
+public TtfVheaTable getVheaTable()
+```
+
+
+Hämtar vhea-tabellen.
+
+**Returns:**
+[TtfVheaTable](../../com.aspose.font/ttfvheatable) - Vhea table.
+### getVmtxTable() {#getVmtxTable--}
+```
+public TtfVmtxTable getVmtxTable()
+```
+
+
+Hämtar vmtx-tabellen.
+
+**Returns:**
+[TtfVmtxTable](../../com.aspose.font/ttfvmtxtable) - Vmtx table.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfvheatable/_index.md
+++ b/swedish/java/com.aspose.font/ttfvheatable/_index.md
@@ -1,0 +1,300 @@
+---
+title: "TtfVheaTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar hhea-tabell i TTF-teckensnittfilen."
+type: docs
+weight: 112
+url: /sv/java/com.aspose.font/ttfvheatable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfVheaTable extends TtfTableBase
+```
+
+Representerar "hhea"-tabellen i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdvanceHeightMax()](#getAdvanceHeightMax--) | Hämtar AdvanceHeightMax. |
+| [getAscent()](#getAscent--) | Hämtar Ascent. |
+| [getCaretOffset()](#getCaretOffset--) | Hämtar CaretOffset. |
+| [getCaretSlopeRise()](#getCaretSlopeRise--) | Hämtar CaretSlopeRise. |
+| [getCaretSlopeRun()](#getCaretSlopeRun--) | Hämtar CaretSlopeRun. |
+| [getClass()](#getClass--) |  |
+| [getDescent()](#getDescent--) | Hämtar Descent. |
+| [getLineGap()](#getLineGap--) | Hämtar LineGap. |
+| [getMetricDataFormat()](#getMetricDataFormat--) | Hämtar MetricDataFormat. |
+| [getMinBottomSideBearing()](#getMinBottomSideBearing--) | Hämtar MinBottomSideBearing. |
+| [getMinTopSideBearing()](#getMinTopSideBearing--) | Hämtar MinTopSideBearing. |
+| [getNumOfLongVerMetrics()](#getNumOfLongVerMetrics--) | Hämtar MetricDataFormat. |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [getVersion()](#getVersion--) | Hämtar versionsnummer för den vertikala huvudtabellen. |
+| [getYMaxExtent()](#getYMaxExtent--) | Hämtar \_yMaxExtent. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdvanceHeightMax() {#getAdvanceHeightMax--}
+```
+public short getAdvanceHeightMax()
+```
+
+
+Hämtar AdvanceHeightMax. Det maximala avståndet för höjd i FUnits som finns i teckensnittet.
+
+**Returns:**
+short - Det maximala avståndet för AdvanceHeightMax.
+### getAscent() {#getAscent--}
+```
+public short getAscent()
+```
+
+
+Hämtar Ascent. Avstånd i FUnits från mittlinjen till föregående radens \_descent.
+
+**Returns:**
+short - Ascent.
+### getCaretOffset() {#getCaretOffset--}
+```
+public short getCaretOffset()
+```
+
+
+Hämtar CaretOffset.
+
+**Returns:**
+short - CaretOffset.
+### getCaretSlopeRise() {#getCaretSlopeRise--}
+```
+public short getCaretSlopeRise()
+```
+
+
+Hämtar CaretSlopeRise.
+
+**Returns:**
+short - CaretSlopeRise.
+### getCaretSlopeRun() {#getCaretSlopeRun--}
+```
+public short getCaretSlopeRun()
+```
+
+
+Hämtar CaretSlopeRun.
+
+**Returns:**
+short - CaretSlopeRun.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescent() {#getDescent--}
+```
+public short getDescent()
+```
+
+
+Hämtar Descent. Avstånd i FUnits från mittlinjen till nästa radens \_ascent.
+
+**Returns:**
+short - Descent.
+### getLineGap() {#getLineGap--}
+```
+public short getLineGap()
+```
+
+
+Hämtar LineGap. Det vertikala typografiska gapet för detta teckensnitt.
+
+**Returns:**
+short - LineGap.
+### getMetricDataFormat() {#getMetricDataFormat--}
+```
+public short getMetricDataFormat()
+```
+
+
+Hämtar MetricDataFormat.
+
+**Returns:**
+short - MetricDataFormat.
+### getMinBottomSideBearing() {#getMinBottomSideBearing--}
+```
+public short getMinBottomSideBearing()
+```
+
+
+Hämtar MinBottomSideBearing. Den minsta mätningen för botten sidbäring som finns i teckensnittet, i FUnits.
+
+**Returns:**
+short - MinBottomSideBearing.
+### getMinTopSideBearing() {#getMinTopSideBearing--}
+```
+public short getMinTopSideBearing()
+```
+
+
+Hämtar MinTopSideBearing. Den minsta top sidebearing-mätningen som hittas i teckensnittet, i FUnits.
+
+**Returns:**
+short - Den MinTopSideBearing.
+### getNumOfLongVerMetrics() {#getNumOfLongVerMetrics--}
+```
+public int getNumOfLongVerMetrics()
+```
+
+
+Hämtar MetricDataFormat. Antalet framstegshöjder i den vertikala metriktabellen.
+
+**Returns:**
+int - Den MetricDataFormat.
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Taggen.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVersion() {#getVersion--}
+```
+public Version16Dot16 getVersion()
+```
+
+
+Hämtar versionsnummer för den vertikala huvudtabellen.
+
+**Returns:**
+[Version16Dot16](../../com.aspose.font/version16dot16) - The Version number of the vertical header table.
+### getYMaxExtent() {#getYMaxExtent--}
+```
+public short getYMaxExtent()
+```
+
+
+Hämtar \_yMaxExtent.
+
+**Returns:**
+short - Den \_yMaxExtent.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/ttfvmtxtable/_index.md
+++ b/swedish/java/com.aspose.font/ttfvmtxtable/_index.md
@@ -1,0 +1,179 @@
+---
+title: "TtfVmtxTable"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar vmtx-tabellen i TTF-fontfilen."
+type: docs
+weight: 113
+url: /sv/java/com.aspose.font/ttfvmtxtable/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.TtfTableBase](../../com.aspose.font/ttftablebase)
+```
+public class TtfVmtxTable extends TtfTableBase
+```
+
+Representerar "vmtx"-tabellen i TTF-typsnittsfilen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOffset()](#getOffset--) | Hämtar förskjutning från början av sfnt. |
+| [getTag()](#getTag--) | Hämtar tabellens tagg. |
+| [getTopSideBearings()](#getTopSideBearings--) | Hämtar övre sidbärare. |
+| [getTtfTables()](#getTtfTables--) | Referens till TTF-tabellarkivet. |
+| [getVMetrics()](#getVMetrics--) | Hämtar vertikala mått. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOffset() {#getOffset--}
+```
+public long getOffset()
+```
+
+
+Hämtar förskjutning från början av sfnt.
+
+**Returns:**
+long - Förskjutning från början av sfnt.
+### getTag() {#getTag--}
+```
+public static String getTag()
+```
+
+
+Hämtar tabellens tagg.
+
+**Returns:**
+java.lang.String - Tabellens tagg.
+### getTopSideBearings() {#getTopSideBearings--}
+```
+public short[] getTopSideBearings()
+```
+
+
+Hämtar övre sidbärare. Array av övre sidbärare för tecknet.
+
+**Returns:**
+short[] - De övre sidobäringarna.
+### getTtfTables() {#getTtfTables--}
+```
+public TtfTableRepository getTtfTables()
+```
+
+
+Referens till TTF-tabellarkivet.
+
+**Returns:**
+[TtfTableRepository](../../com.aspose.font/ttftablerepository) - Reference to TTF table repository.
+### getVMetrics() {#getVMetrics--}
+```
+public TtfVmtxTable.LongVerMetric[] getVMetrics()
+```
+
+
+Hämtar vertikala mått.
+
+**Returns:**
+com.aspose.font.TtfVmtxTable.LongVerMetric[] - De vertikala måtten.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/type1encoding/_index.md
+++ b/swedish/java/com.aspose.font/type1encoding/_index.md
@@ -1,0 +1,218 @@
+---
+title: "Type1Encoding"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Type1-typsnitts-kodning."
+type: docs
+weight: 114
+url: /sv/java/com.aspose.font/type1encoding/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.font.IFontEncoding](../../com.aspose.font/ifontencoding), [com.aspose.font.ISupportsNameAddressing](../../com.aspose.font/isupportsnameaddressing)
+```
+public class Type1Encoding implements IFontEncoding, ISupportsNameAddressing
+```
+
+Representerar Type1-typsnitts-kodning.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [decodeToGid(long charCode)](#decodeToGid-long-) | Avkodar Gid till unicode. |
+| [decodeToGidParameterized(IEncodingParameters parameters, long charCode)](#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-) | Parametriserad avkodningsmetod. |
+| [encode(long gid, long charCode)](#encode-long-long-) | Kodar tecknet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getNameToCharCodeIndex()](#getNameToCharCodeIndex--) | Returnerar namn‑till‑teckenkod‑kodningskarta. |
+| [gidToUnicode(GlyphId gid)](#gidToUnicode-com.aspose.font.GlyphId-) | Avkodar Gid till Unicode. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [unicodeToGid(long unicode)](#unicodeToGid-long-) | Returnerar GlyphId för unicode. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### decodeToGid(long charCode) {#decodeToGid-long-}
+```
+public GlyphId decodeToGid(long charCode)
+```
+
+
+Avkodar Gid till unicode. Glyph‑id är ett unikt nummer för ett tecken, som beror på font‑typen. Till exempel: Type1:s id är ett teckennamn, en instans av klassen ( GlyphStringId ). TTF:s id är ett heltalsindex, en instans av klassen ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| charCode | long | Teckenkod för att hämta teckenidentifierare för. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to character code passed.
+### decodeToGidParameterized(IEncodingParameters parameters, long charCode) {#decodeToGidParameterized-com.aspose.font.IEncodingParameters-long-}
+```
+public GlyphId decodeToGidParameterized(IEncodingParameters parameters, long charCode)
+```
+
+
+Parametriserad avkodningsmetod. Stöds inte för Type1‑fonttyp.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| parameters | [IEncodingParameters](../../com.aspose.font/iencodingparameters) | Stöds inte för Type1‑fonttyp. |
+| charCode | long | Stöds inte för Type1‑fonttyp. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Not supported for Type1 Font type.
+### encode(long gid, long charCode) {#encode-long-long-}
+```
+public void encode(long gid, long charCode)
+```
+
+
+Kodar tecknet. För TTF‑fonter är teckenkoden unicode. Stöds inte för Type1‑fonttyper.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| gid | long | Glyfid. |
+| charCode | long | Teckenkod associerad med glyph‑id. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getNameToCharCodeIndex() {#getNameToCharCodeIndex--}
+```
+public NameToCodeMap getNameToCharCodeIndex()
+```
+
+
+Returnerar namn‑till‑teckenkod‑kodningskarta. Obs: Teckenkod är inte unicode. Teckenkod är ett teckenindex i Font encoding "table".
+
+**Returns:**
+[NameToCodeMap](../../com.aspose.font/nametocodemap) - Name to character code encoding map.
+### gidToUnicode(GlyphId gid) {#gidToUnicode-com.aspose.font.GlyphId-}
+```
+public long gidToUnicode(GlyphId gid)
+```
+
+
+Avkodar Gid till Unicode. Glyph‑id är ett unikt nummer för ett tecken, som beror på font‑typen. Till exempel: Type1:s id är ett teckennamn, en instans av klassen ( GlyphStringId ). TTF:s id är ett heltalsindex, en instans av klassen ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| gid | [GlyphId](../../com.aspose.font/glyphid) | Glyph‑identifierare för symbol att avkoda. |
+
+**Returns:**
+long – Unicode‑värde relaterat till det angivna glyph‑id.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unicodeToGid(long unicode) {#unicodeToGid-long-}
+```
+public GlyphId unicodeToGid(long unicode)
+```
+
+
+Returnerar GlyphId för unicode. Eller notdef om fonten inte innehåller ett glyph för unicode. Glyph‑id är ett unikt nummer för ett tecken, som beror på font‑typen. Till exempel: Type1:s id är ett teckennamn, en instans av klassen ( GlyphStringId ). TTF:s id är ett heltalsindex, en instans av klassen ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| unicode | long | Unicode för att få glyph‑identifierare för. |
+
+**Returns:**
+[GlyphId](../../com.aspose.font/glyphid) - Glyph identifier related to unicode passed.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/type1font/_index.md
+++ b/swedish/java/com.aspose.font/type1font/_index.md
@@ -1,0 +1,545 @@
+---
+title: "Type1Font"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Type1-typsnitt."
+type: docs
+weight: 115
+url: /sv/java/com.aspose.font/type1font/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Font](../../com.aspose.font/font)
+```
+public class Type1Font extends Font
+```
+
+Representerar Type1-typsnitt.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Konverterar Fonten till ett annat format. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Returnerar en array med alla glyfid, tillgängliga i Fonten. |
+| [getClass()](#getClass--) |  |
+| [getEncoding()](#getEncoding--) | Hämtar Font‑kodning. |
+| [getFontDefinition()](#getFontDefinition--) | Hämtar Font‑definition. |
+| [getFontFamily()](#getFontFamily--) | Hämtar Font‑familj. |
+| [getFontName()](#getFontName--) | Hämtar Font‑ansiktsnamn. |
+| [getFontNames()](#getFontNames--) | Hämtar Font‑namn. |
+| [getFontSaver()](#getFontSaver--) | Hämtar Font‑sparfunktionalitet. |
+| [getFontStyle()](#getFontStyle--) | Hämtar Font‑stil. |
+| [getFontType()](#getFontType--) | Hämtar Font‑typ. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Font‑glyf‑åtkomst. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Returnerar glyf efter glyfid. |
+| [getGlyphById(String id)](#getGlyphById-java.lang.String-) | Returnerar glyf efter glyfid. |
+| [getGlyphById(long id)](#getGlyphById-long-) | Returnerar glyf efter glyfid. |
+| [getGlyphIdType()](#getGlyphIdType--) | Specifikation av glyph-id-typ. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Hämtar glyfrepresentation för text. |
+| [getMetrics()](#getMetrics--) | Hämtar Font‑metrik. |
+| [getNumGlyphs()](#getNumGlyphs--) | Hämtar antalet glyfer i Fonten. |
+| [getPostscriptNames()](#getPostscriptNames--) | Hämtar PostScript Font-namn. |
+| [getStyle()](#getStyle--) | Hämtar Font‑stil. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Öppnar en font med FontDefinition-objekt. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Öppnar en font med fonttyp och bytearray för fontdata. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Öppnar en font med fonttyp och strömkälla. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Öppnar en font med fonttyp och fontfilnamn. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Sparar Fonten i originalformat. |
+| [save(String fileName)](#save-java.lang.String-) | Sparar Fonten i originalformat. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Sparar Fonten i angivet format. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Font-familjens inställare är ännu inte implementerad. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Font-ansiktsnamnets inställare är ännu inte implementerad. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Stil-inställaren är ännu inte implementerad. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public Font convert(FontType fontType)
+```
+
+
+Konverterar Fonten till ett annat format.
+
+> ```
+> Note: TTF Font type is now supported only.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Font-formattyp att konvertera till. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public GlyphId[] getAllGlyphIds()
+```
+
+
+Returnerar en array med alla glyph-id:n, tillgängliga i teckensnittet. Glyph-id är ett unikt nummer för en glyph, som är beroende av teckensnittstypen. Type1-teckensnittets glyph-id kan vara en instans av klassen ( GlyphStringId ) eller klassen ( GlyphUInt32Id ).
+
+**Returns:**
+com.aspose.font.GlyphId[]
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncoding() {#getEncoding--}
+```
+public IFontEncoding getEncoding()
+```
+
+
+Hämtar Font‑kodning.
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding) - Font encoding.
+### getFontDefinition() {#getFontDefinition--}
+```
+public FontDefinition getFontDefinition()
+```
+
+
+Hämtar Font‑definition.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public String getFontFamily()
+```
+
+
+Hämtar Font‑familj.
+
+**Returns:**
+java.lang.String - Font-familj.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Hämtar Font‑ansiktsnamn.
+
+**Returns:**
+java.lang.String - Font face name.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Hämtar Font‑namn.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Hämtar Font‑sparfunktionalitet.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public int getFontStyle()
+```
+
+
+Hämtar Font-stil. Detta är ett värde som beräknas och representeras i en generaliserad typ.
+
+**Returns:**
+int - Font-stil. Vanligtvis en kombination av konstantflaggvärden i FontStyle-klassen eller 0.
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Hämtar teckensnittstyp. Returnerar värdet FontType.Type1.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Typsnittsglyf‑åtkomst. Hämtar glyfer och glyfidenterifierare.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public Glyph getGlyphById(GlyphId id)
+```
+
+
+Returnerar en glyph efter glyph-id. Glyph-id är ett unikt nummer för en glyph, som är beroende av teckensnittstypen. Type1-teckensnittets glyph-id kan vara en instans av klassen ( GlyphStringId ) eller klassen ( GlyphUInt32Id ).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) |  |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph)
+### getGlyphById(String id) {#getGlyphById-java.lang.String-}
+```
+public Glyph getGlyphById(String id)
+```
+
+
+Returnerar glyf efter glyfid.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| id | java.lang.String | Glyfid. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(long id) {#getGlyphById-long-}
+```
+public Glyph getGlyphById(long id)
+```
+
+
+Returnerar glyf efter glyfid.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| id | long | Glyfid. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public GlyphIdType getGlyphIdType()
+```
+
+
+Specifikation av glyph-id-typ.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype)
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Hämtar glyfrepresentation för text.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| text | java.lang.String | Indatatext. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - GlyphId‑array.
+### getMetrics() {#getMetrics--}
+```
+public IFontMetrics getMetrics()
+```
+
+
+Hämtar Font‑metrik.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Hämtar antalet glyfer i Fonten.
+
+**Returns:**
+int - Antal glyfer i typsnittet.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Hämtar PostScript Font-namn.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names
+### getStyle() {#getStyle--}
+```
+public String getStyle()
+```
+
+
+Hämtar typsnittsstil. Detta är ett rått strängvärde som tillhandahålls av typsnittsfilen.
+
+**Returns:**
+java.lang.String - Typsnittsstil.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Öppnar en font med FontDefinition-objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Typsnittsdefinitionsobjekt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Öppnar en font med fonttyp och bytearray för fontdata.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fontData | byte[] | Byte‑array för att läsa in typsnitt från. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Öppnar en font med fonttyp och strömkälla.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Strömkälla för typsnitt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Öppnar en font med fonttyp och fontfilnamn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fileName | java.lang.String | Fontfilnamn. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Sparar Fonten i originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.OutputStream | Ström för att spara teckensnitt. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Sparar Fonten i originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | java.lang.String | Fil för att spara teckensnitt. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Sparar Fonten i angivet format.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.OutputStream | ström för att spara teckensnitt |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | önskat format |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public void setFontFamily(String value)
+```
+
+
+Font-familjens inställare är ännu inte implementerad.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Ny fontfamilj. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public void setFontName(String value)
+```
+
+
+Font-ansiktsnamnets inställare är ännu inte implementerad.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Nytt teckensnittsansiktsnamn. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public void setStyle(String value)
+```
+
+
+Style-settern är ännu inte implementerad. Detta är ett rått strängvärde som tillhandahålls av teckensnittsfilen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Ny fontstil. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/type1fontmetrics/_index.md
+++ b/swedish/java/com.aspose.font/type1fontmetrics/_index.md
@@ -1,0 +1,555 @@
+---
+title: "Type1FontMetrics"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Type1-typsnittsmetrik."
+type: docs
+weight: 116
+url: /sv/java/com.aspose.font/type1fontmetrics/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.FontMetrics](../../com.aspose.font/fontmetrics)
+```
+public class Type1FontMetrics extends FontMetrics
+```
+
+Representerar Type1-typsnittsmetrik.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAscender()](#getAscender--) | Hämtar ascendervärde. |
+| [getAscender(double fontSize)](#getAscender-double-) | Returnerar ascender för en specifik teckenstorlek. |
+| [getCapHeight()](#getCapHeight--) | Hämtar värdet för cap-höjd. |
+| [getClass()](#getClass--) |  |
+| [getDescender()](#getDescender--) | Hämtar descendervärde. |
+| [getDescender(double fontSize)](#getDescender-double-) | Returnerar descender för en specifik teckenstorlek. |
+| [getFontBBox()](#getFontBBox--) | Hämtar FontBBox‑värdet. |
+| [getFontMatrix()](#getFontMatrix--) | Hämtar fontens transformationsmatris. |
+| [getGlyphBBox(GlyphId glyphId)](#getGlyphBBox-com.aspose.font.GlyphId-) | Returnerar glyf Bbox. |
+| [getGlyphWidth(GlyphId glyphId)](#getGlyphWidth-com.aspose.font.GlyphId-) | Returnerar glyfbredd. |
+| [getItalicAngle()](#getItalicAngle--) | Hämtar värdet för kursiv vinkel. |
+| [getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)](#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-) | Returnerar kerningvärde för glyfparet. |
+| [getLineGap()](#getLineGap--) | Hämtar LineGap-värde. |
+| [getStdHW()](#getStdHW--) | Hämtar StdHW-värdet. |
+| [getStdVW()](#getStdVW--) | Hämtar StdVW-värdet. |
+| [getTypoAscender()](#getTypoAscender--) | Hämtar TypoAscender-värde. |
+| [getTypoAscender(double fontSize)](#getTypoAscender-double-) | Returnerar typografisk ascender för specifik Font-storlek. |
+| [getTypoDescender()](#getTypoDescender--) | Hämtar TypoDescender-värde. |
+| [getTypoDescender(double fontSize)](#getTypoDescender-double-) | Returnerar typografisk descender för specifik fontstorlek. |
+| [getTypoLineGap()](#getTypoLineGap--) | Hämtar TypoLineGap-värde. |
+| [getTypoLineGap(double fontSize)](#getTypoLineGap-double-) | Returnerar radgap för specifik Font-storlek. |
+| [getUnderlinePosition()](#getUnderlinePosition--) | Hämtar värdet för understrykningens position. |
+| [getUnderlineThickness()](#getUnderlineThickness--) | Hämtar värdet för understrykningens tjocklek. |
+| [getUnitsPerEM()](#getUnitsPerEM--) | Hämtar värdet för understrykningens UnitsPerEM. |
+| [getWeight()](#getWeight--) | Hämtar vikt. |
+| [getXHeight()](#getXHeight--) | Hämtar XHeight-värdet. |
+| [hashCode()](#hashCode--) |  |
+| [isFixedPitch()](#isFixedPitch--) | Hämtar IsFixedPitch-värde. |
+| [measureString(String unicode, double fontSize)](#measureString-java.lang.String-double-) | Mäter sträng och returnerar strängbredd. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAscender(double value)](#setAscender-double-) | Ställer in Ascender-värde. |
+| [setDescender(double value)](#setDescender-double-) | Ställer in Descender-värde. |
+| [setGlyphWidth(GlyphId glyphId, double value)](#setGlyphWidth-com.aspose.font.GlyphId-double-) | Ställer in glyfbredd. |
+| [setTypoAscender(double value)](#setTypoAscender-double-) | Ställer in TypoAscender-värde. |
+| [setTypoDescender(double value)](#setTypoDescender-double-) | Ställer in TypoDescender-värde. |
+| [setUnitsPerEM(long value)](#setUnitsPerEM-long-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAscender() {#getAscender--}
+```
+public double getAscender()
+```
+
+
+Hämtar ascendervärde.
+
+**Returns:**
+double - Ascender-värde.
+### getAscender(double fontSize) {#getAscender-double-}
+```
+public double getAscender(double fontSize)
+```
+
+
+Returnerar ascender för en specifik teckenstorlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Ascender-värde.
+### getCapHeight() {#getCapHeight--}
+```
+public double getCapHeight()
+```
+
+
+Hämtar värdet för cap-höjd.
+
+**Returns:**
+double - värde för versalhöjd.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescender() {#getDescender--}
+```
+public double getDescender()
+```
+
+
+Hämtar descendervärde.
+
+**Returns:**
+double - Descender-värde.
+### getDescender(double fontSize) {#getDescender-double-}
+```
+public double getDescender(double fontSize)
+```
+
+
+Returnerar descender för en specifik teckenstorlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Descender-värde.
+### getFontBBox() {#getFontBBox--}
+```
+public FontBBox getFontBBox()
+```
+
+
+Hämtar FontBBox‑värdet.
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - FontBBox value.
+### getFontMatrix() {#getFontMatrix--}
+```
+public TransformationMatrix getFontMatrix()
+```
+
+
+Hämtar fontens transformationsmatris.
+
+**Returns:**
+[TransformationMatrix](../../com.aspose.font/transformationmatrix) - Font transformation matrix.
+### getGlyphBBox(GlyphId glyphId) {#getGlyphBBox-com.aspose.font.GlyphId-}
+```
+public FontBBox getGlyphBBox(GlyphId glyphId)
+```
+
+
+Returnerar glyf Bbox. Returnerar FontBBox om BBox inte var definierad för glyfen. Kan åsidosättas av specifika teckenkodningsarvtagare.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyfidentifierare. |
+
+**Returns:**
+[FontBBox](../../com.aspose.font/fontbbox) - Glyph BBox.
+### getGlyphWidth(GlyphId glyphId) {#getGlyphWidth-com.aspose.font.GlyphId-}
+```
+public double getGlyphWidth(GlyphId glyphId)
+```
+
+
+Returnerar glyfbredd. Kan åsidosättas av specifika teckenkodningsärvda klasser.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyfidentifierare. |
+
+**Returns:**
+double - Glyph-bredd.
+### getItalicAngle() {#getItalicAngle--}
+```
+public double getItalicAngle()
+```
+
+
+Hämtar värdet för kursiv vinkel.
+
+**Returns:**
+double - värde för kursiv vinkel.
+### getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId) {#getKerningValue-com.aspose.font.GlyphId-com.aspose.font.GlyphId-}
+```
+public double getKerningValue(GlyphId prevGlyphId, GlyphId nextGlyphId)
+```
+
+
+Returnerar kerningvärde för glyfparet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| prevGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Första glyph i paret. |
+| nextGlyphId | [GlyphId](../../com.aspose.font/glyphid) | Fontstorlek. |
+
+**Returns:**
+double - Kerningvärde.
+### getLineGap() {#getLineGap--}
+```
+public double getLineGap()
+```
+
+
+Hämtar LineGap-värde.
+
+**Returns:**
+double - LineGap-värde.
+### getStdHW() {#getStdHW--}
+```
+public double getStdHW()
+```
+
+
+Hämtar StdHW-värdet.
+
+**Returns:**
+double - StdHW-värde.
+### getStdVW() {#getStdVW--}
+```
+public double getStdVW()
+```
+
+
+Hämtar StdVW-värdet.
+
+**Returns:**
+double - StdVW-värde.
+### getTypoAscender() {#getTypoAscender--}
+```
+public double getTypoAscender()
+```
+
+
+Hämtar TypoAscender-värde.
+
+**Returns:**
+double - TypoAscender-värde.
+### getTypoAscender(double fontSize) {#getTypoAscender-double-}
+```
+public double getTypoAscender(double fontSize)
+```
+
+
+Returnerar typografisk ascender för specifik Font-storlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Typographic ascender-värde.
+### getTypoDescender() {#getTypoDescender--}
+```
+public double getTypoDescender()
+```
+
+
+Hämtar TypoDescender-värde.
+
+**Returns:**
+double - TypoDescender-värde.
+### getTypoDescender(double fontSize) {#getTypoDescender-double-}
+```
+public double getTypoDescender(double fontSize)
+```
+
+
+Returnerar typografisk descender för specifik fontstorlek.
+
+param fontSize teckenstorlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double |  |
+
+**Returns:**
+double - Typographic descender-värde.
+### getTypoLineGap() {#getTypoLineGap--}
+```
+public double getTypoLineGap()
+```
+
+
+Hämtar TypoLineGap-värde.
+
+**Returns:**
+double - TypoLineGap-värde.
+### getTypoLineGap(double fontSize) {#getTypoLineGap-double-}
+```
+public double getTypoLineGap(double fontSize)
+```
+
+
+Returnerar radgap för specifik Font-storlek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Line gap-värde.
+### getUnderlinePosition() {#getUnderlinePosition--}
+```
+public double getUnderlinePosition()
+```
+
+
+Hämtar värdet för understrykningens position.
+
+**Returns:**
+double - värde för understrykningens position.
+### getUnderlineThickness() {#getUnderlineThickness--}
+```
+public double getUnderlineThickness()
+```
+
+
+Hämtar värdet för understrykningens tjocklek.
+
+**Returns:**
+double - värde för understrykningens tjocklek.
+### getUnitsPerEM() {#getUnitsPerEM--}
+```
+public long getUnitsPerEM()
+```
+
+
+Hämtar värdet för understrykningens UnitsPerEM.
+
+**Returns:**
+long - värde för understrykningens UnitsPerEM.
+### getWeight() {#getWeight--}
+```
+public String getWeight()
+```
+
+
+Hämtar vikt.
+
+**Returns:**
+java.lang.String - Vikt.
+### getXHeight() {#getXHeight--}
+```
+public double getXHeight()
+```
+
+
+Hämtar XHeight-värdet.
+
+**Returns:**
+double - XHeight-värde.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isFixedPitch() {#isFixedPitch--}
+```
+public boolean isFixedPitch()
+```
+
+
+Hämtar IsFixedPitch-värde.
+
+**Returns:**
+boolean - IsFixedPitch-värde.
+### measureString(String unicode, double fontSize) {#measureString-java.lang.String-double-}
+```
+public double measureString(String unicode, double fontSize)
+```
+
+
+Mäter sträng och returnerar strängbredd.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| unicode | java.lang.String | Unicode-sträng. |
+| fontSize | double | Fontstorlek. |
+
+**Returns:**
+double - Strängbredd.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAscender(double value) {#setAscender-double-}
+```
+public void setAscender(double value)
+```
+
+
+Ställer in Ascender-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | Ascender-värde. |
+
+### setDescender(double value) {#setDescender-double-}
+```
+public void setDescender(double value)
+```
+
+
+Ställer in Descender-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | Descender-värde. |
+
+### setGlyphWidth(GlyphId glyphId, double value) {#setGlyphWidth-com.aspose.font.GlyphId-double-}
+```
+public void setGlyphWidth(GlyphId glyphId, double value)
+```
+
+
+Ställer in glyfbredd.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| glyphId | [GlyphId](../../com.aspose.font/glyphid) | Glyfidentifierare. |
+| värde | double | Ny bredd. |
+
+### setTypoAscender(double value) {#setTypoAscender-double-}
+```
+public void setTypoAscender(double value)
+```
+
+
+Ställer in TypoAscender-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | TypoAscender-värde. |
+
+### setTypoDescender(double value) {#setTypoDescender-double-}
+```
+public void setTypoDescender(double value)
+```
+
+
+Ställer in TypoDescender-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | TypoDescender-värde. |
+
+### setUnitsPerEM(long value) {#setUnitsPerEM-long-}
+```
+public void setUnitsPerEM(long value)
+```
+
+
+Ställer in UnitsPerEM-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/type1metricfont/_index.md
+++ b/swedish/java/com.aspose.font/type1metricfont/_index.md
@@ -1,0 +1,574 @@
+---
+title: "Type1MetricFont"
+second_title: "Aspose.Font för Java API-referens"
+description: "Type1-metrisk typsnittsimplementation."
+type: docs
+weight: 117
+url: /sv/java/com.aspose.font/type1metricfont/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.font.Font](../../com.aspose.font/font), [com.aspose.font.Type1Font](../../com.aspose.font/type1font)
+```
+public class Type1MetricFont extends Type1Font
+```
+
+Type1‑metrisk typsnittimplementation. Detta type1‑typsnitt skapas endast med metriska data. Funktioner för hämtning av glyfer och vissa andra som kräver ett riktigt typsnitt är inte tillåtna; otillåtna funktioner kastar undantaget Type1NotSupportedException. Andra egenskaper (FontName, Weight, Metrics och Encoding) hämtas från metrikfilen.
+
+--------------------
+
+> ```
+> Note: If metrics file defines Encoding as "FontSpecific", user should provide the specific encoding with following way:
+>      string[] zapfDingbatsEncoding = new string[256] {null, null, ... , "space", "a1", ...};
+>      FontEnvironment.Current.FontSpecificEncodings.RegisterEncoding("ZapfDingbats", zapfDingbatsEncoding);
+>  ```
+> 
+>      System::ArrayPtr<System::String> zapfDingbatsEncoding = System::MakeArray<System::String>({nullptr, nullptr, ..., u"space", u"a1", ...});
+>      FontEnvironment::get_Current()->get_FontSpecificEncodings()->RegisterEncoding(u"ZapfDingbats", zapfDingbatsEncoding);
+>  
+> ```
+> ```
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [convert(FontType fontType)](#convert-com.aspose.font.FontType-) | Konverterar Fonten till ett annat format. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAllGlyphIds()](#getAllGlyphIds--) | Returnerar alla glyfid, tillgängliga i typsnittet. |
+| [getClass()](#getClass--) |  |
+| [getEncoding()](#getEncoding--) | Kodning definieras i metrikfilen. |
+| [getFontDefinition()](#getFontDefinition--) | Hämtar Font‑definition. |
+| [getFontFamily()](#getFontFamily--) | Hämtar Font‑familj. |
+| [getFontName()](#getFontName--) | Hämtar typsnittets namn. |
+| [getFontNames()](#getFontNames--) | Hämtar Font‑namn. |
+| [getFontSaver()](#getFontSaver--) | Hämtar Font‑sparfunktionalitet. |
+| [getFontStyle()](#getFontStyle--) | Hämtar Font‑stil. |
+| [getFontType()](#getFontType--) | Hämtar Font‑typ. |
+| [getGlyphAccessor()](#getGlyphAccessor--) | Font‑glyf‑åtkomst. |
+| [getGlyphById(GlyphId id)](#getGlyphById-com.aspose.font.GlyphId-) | Returnerar glyf efter glyfid. |
+| [getGlyphById(String id)](#getGlyphById-java.lang.String-) | Returnerar glyf efter glyfid. |
+| [getGlyphById(long id)](#getGlyphById-long-) | Returnerar glyf efter glyfid. |
+| [getGlyphIdType()](#getGlyphIdType--) | Specifikation av glyph-id-typ. |
+| [getGlyphsForText(String text)](#getGlyphsForText-java.lang.String-) | Hämtar glyfrepresentation för text. |
+| [getMetrics()](#getMetrics--) | Hämtar Font‑metrik. |
+| [getNumGlyphs()](#getNumGlyphs--) | Hämtar antalet glyfer i Fonten. |
+| [getPostscriptNames()](#getPostscriptNames--) | Hämtar PostScript Font-namn. |
+| [getStyle()](#getStyle--) | Hämtar Font‑stil. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [open(FontDefinition fontDefinition)](#open-com.aspose.font.FontDefinition-) | Öppnar en font med FontDefinition-objekt. |
+| [open(FontType fontType, byte[] fontData)](#open-com.aspose.font.FontType-byte---) | Öppnar en font med fonttyp och bytearray för fontdata. |
+| [open(FontType fontType, StreamSource fontStreamSource)](#open-com.aspose.font.FontType-com.aspose.font.StreamSource-) | Öppnar en font med fonttyp och strömkälla. |
+| [open(FontType fontType, String fileName)](#open-com.aspose.font.FontType-java.lang.String-) | Öppnar en font med fonttyp och fontfilnamn. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Sparar Fonten i originalformat. |
+| [save(String fileName)](#save-java.lang.String-) | Sparar Fonten i originalformat. |
+| [saveToFormat(OutputStream stream, FontSavingFormats outFormat)](#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-) | Sparar Fonten i angivet format. |
+| [setFontFamily(String value)](#setFontFamily-java.lang.String-) | Font-familjens inställare är ännu inte implementerad. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Font-ansiktsnamnets inställare är ännu inte implementerad. |
+| [setStyle(String value)](#setStyle-java.lang.String-) | Stil-inställaren är ännu inte implementerad. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### convert(FontType fontType) {#convert-com.aspose.font.FontType-}
+```
+public Font convert(FontType fontType)
+```
+
+
+Konverterar Fonten till ett annat format.
+
+> ```
+> Note: TTF Font type is now supported only.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Font-formattyp att konvertera till. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font converted into new format.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAllGlyphIds() {#getAllGlyphIds--}
+```
+public GlyphId[] getAllGlyphIds()
+```
+
+
+Returnerar alla glyfid, tillgängliga i typsnittet. Stöds inte för Type1MetricFont‑typen.
+
+**Returns:**
+com.aspose.font.GlyphId[] - Alla glyfid‑identifierare, tillgängliga i typsnittet.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncoding() {#getEncoding--}
+```
+public IFontEncoding getEncoding()
+```
+
+
+Kodning definieras i metrikfilen. StandardAdobeEncoding: kodningen fylls i automatiskt
+
+--------------------
+
+> ```
+> FontSpecific:
+>         user should provide the specific encoding with following way:
+>      string[] zapfDingbatsEncoding = new string[256] {null, null, ... , "space", "a1", ...};
+>      FontEnvironment.Current.FontSpecificEncodings.RegisterEncoding("ZapfDingbats", zapfDingbatsEncoding);
+>  ```
+> 
+>      System::ArrayPtr<System::String> zapfDingbatsEncoding = System::MakeArray<System::String>({nullptr, nullptr, ..., u"space", u"a1", ...});
+>      FontEnvironment::get_Current()->get_FontSpecificEncodings()->RegisterEncoding(u"ZapfDingbats", zapfDingbatsEncoding);
+>  
+> ```
+> ```
+
+**Returns:**
+[IFontEncoding](../../com.aspose.font/ifontencoding)
+### getFontDefinition() {#getFontDefinition--}
+```
+public FontDefinition getFontDefinition()
+```
+
+
+Hämtar Font‑definition.
+
+**Returns:**
+[FontDefinition](../../com.aspose.font/fontdefinition) - Font definition.
+### getFontFamily() {#getFontFamily--}
+```
+public String getFontFamily()
+```
+
+
+Hämtar Font‑familj.
+
+**Returns:**
+java.lang.String - Font-familj.
+### getFontName() {#getFontName--}
+```
+public String getFontName()
+```
+
+
+Hämtar typsnittets namn.
+
+**Returns:**
+java.lang.String - Teckensnittsnamn.
+### getFontNames() {#getFontNames--}
+```
+public MultiLanguageString getFontNames()
+```
+
+
+Hämtar Font‑namn.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Font names.
+### getFontSaver() {#getFontSaver--}
+```
+public IFontSaver getFontSaver()
+```
+
+
+Hämtar Font‑sparfunktionalitet.
+
+**Returns:**
+[IFontSaver](../../com.aspose.font/ifontsaver) - Font save functionality.
+### getFontStyle() {#getFontStyle--}
+```
+public int getFontStyle()
+```
+
+
+Hämtar Font-stil. Detta är ett värde som beräknas och representeras i en generaliserad typ.
+
+**Returns:**
+int - Hämtar typsnittsstil. Vanligtvis en kombination av konstantflaggvärden från FontStyle‑klassen eller 0.
+### getFontType() {#getFontType--}
+```
+public FontType getFontType()
+```
+
+
+Hämtar teckensnittstyp. Returnerar värdet FontType.Type1.
+
+**Returns:**
+[FontType](../../com.aspose.font/fonttype) - Font type.
+### getGlyphAccessor() {#getGlyphAccessor--}
+```
+public IGlyphAccessor getGlyphAccessor()
+```
+
+
+Typsnittsglyf‑åtkomst. Hämtar glyfer och glyfidenterifierare.
+
+**Returns:**
+[IGlyphAccessor](../../com.aspose.font/iglyphaccessor) - Font glyph accessor.
+### getGlyphById(GlyphId id) {#getGlyphById-com.aspose.font.GlyphId-}
+```
+public Glyph getGlyphById(GlyphId id)
+```
+
+
+Returnerar glyf efter glyfid. Stöds inte för typen (@code Type1MetricFont\}.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| id | [GlyphId](../../com.aspose.font/glyphid) | Glyfidentifierare. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(String id) {#getGlyphById-java.lang.String-}
+```
+public Glyph getGlyphById(String id)
+```
+
+
+Returnerar glyf efter glyfid. Stöds inte för typen (@code Type1MetricFont\}.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| id | java.lang.String | Glyfidentifierare. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphById(long id) {#getGlyphById-long-}
+```
+public Glyph getGlyphById(long id)
+```
+
+
+Returnerar glyf efter glyfid.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| id | long | Glyfid. |
+
+**Returns:**
+[Glyph](../../com.aspose.font/glyph) - Glyph.
+### getGlyphIdType() {#getGlyphIdType--}
+```
+public GlyphIdType getGlyphIdType()
+```
+
+
+Specifikation av glyph-id-typ.
+
+**Returns:**
+[GlyphIdType](../../com.aspose.font/glyphidtype)
+### getGlyphsForText(String text) {#getGlyphsForText-java.lang.String-}
+```
+public GlyphId[] getGlyphsForText(String text)
+```
+
+
+Hämtar glyfrepresentation för text.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| text | java.lang.String | Indatatext. |
+
+**Returns:**
+com.aspose.font.GlyphId[] - GlyphId‑array.
+### getMetrics() {#getMetrics--}
+```
+public IFontMetrics getMetrics()
+```
+
+
+Hämtar Font‑metrik.
+
+**Returns:**
+[IFontMetrics](../../com.aspose.font/ifontmetrics) - Font metrics.
+### getNumGlyphs() {#getNumGlyphs--}
+```
+public int getNumGlyphs()
+```
+
+
+Hämtar antalet glyfer i Fonten.
+
+**Returns:**
+int - Antal glyfer i typsnittet.
+### getPostscriptNames() {#getPostscriptNames--}
+```
+public MultiLanguageString getPostscriptNames()
+```
+
+
+Hämtar PostScript Font-namn.
+
+**Returns:**
+[MultiLanguageString](../../com.aspose.font/multilanguagestring) - Postscript Font names
+### getStyle() {#getStyle--}
+```
+public String getStyle()
+```
+
+
+Hämtar Font‑stil.
+
+**Returns:**
+java.lang.String - Typsnittsstil.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### open(FontDefinition fontDefinition) {#open-com.aspose.font.FontDefinition-}
+```
+public static Font open(FontDefinition fontDefinition)
+```
+
+
+Öppnar en font med FontDefinition-objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontDefinition | [FontDefinition](../../com.aspose.font/fontdefinition) | Typsnittsdefinitionsobjekt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, byte[] fontData) {#open-com.aspose.font.FontType-byte---}
+```
+public static Font open(FontType fontType, byte[] fontData)
+```
+
+
+Öppnar en font med fonttyp och bytearray för fontdata.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fontData | byte[] | Byte‑array för att läsa in typsnitt från. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, StreamSource fontStreamSource) {#open-com.aspose.font.FontType-com.aspose.font.StreamSource-}
+```
+public static Font open(FontType fontType, StreamSource fontStreamSource)
+```
+
+
+Öppnar en font med fonttyp och strömkälla.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fontStreamSource | [StreamSource](../../com.aspose.font/streamsource) | Strömkälla för typsnitt. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### open(FontType fontType, String fileName) {#open-com.aspose.font.FontType-java.lang.String-}
+```
+public static Font open(FontType fontType, String fileName)
+```
+
+
+Öppnar en font med fonttyp och fontfilnamn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontType | [FontType](../../com.aspose.font/fonttype) | Typsnittstyp. |
+| fileName | java.lang.String | Fontfilnamn. |
+
+**Returns:**
+[Font](../../com.aspose.font/font) - Font loaded.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Sparar Fonten i originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.OutputStream | Ström för att spara teckensnitt. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Sparar Fonten i originalformat.
+
+--------------------
+
+> ```
+> Note: following Font types are supported for saving:
+>  New TTF fonts;
+>  TTF Font subsets;
+>  CFF Font subsets;
+>  Type1 Font subsets.
+> ```
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | java.lang.String | Fil för att spara teckensnitt. |
+
+### saveToFormat(OutputStream stream, FontSavingFormats outFormat) {#saveToFormat-java.io.OutputStream-com.aspose.font.FontSavingFormats-}
+```
+public void saveToFormat(OutputStream stream, FontSavingFormats outFormat)
+```
+
+
+Sparar Fonten i angivet format.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.OutputStream | ström för att spara teckensnitt |
+| outFormat | [FontSavingFormats](../../com.aspose.font/fontsavingformats) | önskat format |
+
+### setFontFamily(String value) {#setFontFamily-java.lang.String-}
+```
+public void setFontFamily(String value)
+```
+
+
+Font-familjens inställare är ännu inte implementerad.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Ny fontfamilj. |
+
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public void setFontName(String value)
+```
+
+
+Font-ansiktsnamnets inställare är ännu inte implementerad.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Nytt teckensnittsansiktsnamn. |
+
+### setStyle(String value) {#setStyle-java.lang.String-}
+```
+public void setStyle(String value)
+```
+
+
+Style-settern är ännu inte implementerad. Detta är ett rått strängvärde som tillhandahålls av teckensnittsfilen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Ny fontstil. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/unicodeplatformspecificid/_index.md
+++ b/swedish/java/com.aspose.font/unicodeplatformspecificid/_index.md
@@ -1,0 +1,277 @@
+---
+title: "UnicodePlatformSpecificId"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar unicode-plattformspecifik enumeration."
+type: docs
+weight: 143
+url: /sv/java/com.aspose.font/unicodeplatformspecificid/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum UnicodePlatformSpecificId extends Enum<UnicodePlatformSpecificId>
+```
+
+Representerar unicode-plattformspecifik enumeration.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [Default](#Default) | Värde 0 Standardsemantik (Unicode 1.0). |
+| [ISO10646_1993](#ISO10646-1993) | Värde 2 ISO 10646 1993 semantik (föråldrad). |
+| [Unicode1_1](#Unicode1-1) | Värde 1 Unicode 1.1 semantik. |
+| [Unicode2_0](#Unicode2-0) | Värde 3 Unicode 2.0 eller senare semantik. |
+| [Unicode2_0_Full](#Unicode2-0-Full) | Värde 4 Unicode 2.0 och framåt semantik (icke-BMP-tecken tillåtna), Unicode full repertoar. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Default {#Default}
+```
+public static final UnicodePlatformSpecificId Default
+```
+
+
+Värde 0 Standardsemantik (Unicode 1.0).
+
+### ISO10646_1993 {#ISO10646-1993}
+```
+public static final UnicodePlatformSpecificId ISO10646_1993
+```
+
+
+Värde 2 ISO 10646 1993 semantik (föråldrad).
+
+### Unicode1_1 {#Unicode1-1}
+```
+public static final UnicodePlatformSpecificId Unicode1_1
+```
+
+
+Värde 1 Unicode 1.1 semantik.
+
+### Unicode2_0 {#Unicode2-0}
+```
+public static final UnicodePlatformSpecificId Unicode2_0
+```
+
+
+Värde 3 Unicode 2.0 eller senare semantik. Endast Unicode BMP.
+
+### Unicode2_0_Full {#Unicode2-0-Full}
+```
+public static final UnicodePlatformSpecificId Unicode2_0_Full
+```
+
+
+Värde 4 Unicode 2.0 och framåt semantik (icke-BMP-tecken tillåtna), Unicode full repertoar.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static UnicodePlatformSpecificId valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[UnicodePlatformSpecificId](../../com.aspose.font/unicodeplatformspecificid)
+### values() {#values--}
+```
+public static UnicodePlatformSpecificId[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.font.UnicodePlatformSpecificId[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/version16dot16/_index.md
+++ b/swedish/java/com.aspose.font/version16dot16/_index.md
@@ -1,0 +1,227 @@
+---
+title: "Version16Dot16"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar Version16Dot16-datatypen"
+type: docs
+weight: 118
+url: /sv/java/com.aspose.font/version16dot16/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Cloneable
+```
+public class Version16Dot16 implements Cloneable
+```
+
+Representerar Version16Dot16-datatypen
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Version16Dot16()](#Version16Dot16--) | Konstruktor |
+| [Version16Dot16(int majorNumber, int minorNumber)](#Version16Dot16-int-int-) | Konstruktor |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clone()](#clone--) | Skapa en kopia av  Version16Dot16  objektet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMajorNumber()](#getMajorNumber--) | Hämtar huvudversionsnummer. |
+| [getMinorNumber()](#getMinorNumber--) | Hämtar mindre versionsnummer. |
+| [getRawBytes()](#getRawBytes--) | Hämtar alla råa bitar för Version16Dot16 versionsnummer som byte-array med storlek 4 byte. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setMajorNumber(int value)](#setMajorNumber-int-) | Ställer in huvudversionsnummer. |
+| [setMinorNumber(int value)](#setMinorNumber-int-) | Ställer in mindre versionsnummer. |
+| [toString()](#toString--) | Returnerar versionsvärdet som en formaterad sträng. Till exempel "0.5", "1.1", "3.0" osv. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Version16Dot16() {#Version16Dot16--}
+```
+public Version16Dot16()
+```
+
+
+Konstruktor
+
+### Version16Dot16(int majorNumber, int minorNumber) {#Version16Dot16-int-int-}
+```
+public Version16Dot16(int majorNumber, int minorNumber)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| majorNumber | int | Huvudversionsnummer |
+| minorNumber | int | Mindre versionsnummer |
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+Skapa en kopia av  Version16Dot16  objektet.
+
+**Returns:**
+java.lang.Object - Objekt av typen  Version16Dot16
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMajorNumber() {#getMajorNumber--}
+```
+public int getMajorNumber()
+```
+
+
+Hämtar huvudversionsnummer. Värdet har bara mening i hexadecimal notation, till exempel version 0.5 för 'maxp' i faktiska teckensnittsfiler är 4 byte: \{0, 0, 80, 0\}, vilket har hexadecimal representation 0x00005000. Efter att ha läst denna version från teckensnittsfilen kommer huvud- och sekundära nummer för objektet  Version16Dot16  att vara 0 respektive 20480. Och dessa värden i hexadecimal form är 0x0000 och 0x5000.
+
+**Returns:**
+int - Huvudversionsnummer.
+### getMinorNumber() {#getMinorNumber--}
+```
+public int getMinorNumber()
+```
+
+
+Hämtar mindre versionsnummer. Värdet har bara mening i hexadecimal notation, till exempel version 0.5 för 'maxp' i faktiska teckensnittsfiler är 4 byte: \{0, 0, 80, 0\}, vilket har hexadecimal representation 0x00005000. Efter att ha läst denna version från teckensnittsfilen kommer huvud- och sekundära nummer för objektet  Version16Dot16  att vara 0 respektive 20480. Och dessa värden i hexadecimal form är 0x0000 och 0x5000.
+
+**Returns:**
+int - Mindre versionsnummer.
+### getRawBytes() {#getRawBytes--}
+```
+public byte[] getRawBytes()
+```
+
+
+Hämtar alla råa bitar för Version16Dot16 versionsnummer som byte-array med storlek 4 byte.
+
+**Returns:**
+byte[] - Alla råa bitar för Version16Dot16 versionsnummer som byte-array med storlek 4 byte.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setMajorNumber(int value) {#setMajorNumber-int-}
+```
+public void setMajorNumber(int value)
+```
+
+
+Ställer in huvudversionsnummer. Värdet har bara mening i hexadecimal notation, till exempel version 0.5 för 'maxp' i faktiska teckensnittsfiler är 4 byte: \{0, 0, 80, 0\}, vilket har hexadecimal representation 0x00005000. Efter att ha läst denna version från teckensnittsfilen kommer huvud- och sekundära nummer för objektet  Version16Dot16  att vara 0 respektive 20480. Och dessa värden i hexadecimal form är 0x0000 och 0x5000.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int | Huvudversionsnummer. |
+
+### setMinorNumber(int value) {#setMinorNumber-int-}
+```
+public void setMinorNumber(int value)
+```
+
+
+Ställer in mindre versionsnummer. Värdet har bara mening i hexadecimal notation, till exempel version 0.5 för 'maxp' i faktiska teckensnittsfiler är 4 byte: \{0, 0, 80, 0\}, vilket har hexadecimal representation 0x00005000. Efter att ha läst denna version från teckensnittsfilen kommer huvud- och sekundära nummer för objektet  Version16Dot16  att vara 0 respektive 20480. Och dessa värden i hexadecimal form är 0x0000 och 0x5000.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int | Mindre versionsnummer. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+Returnerar versionsvärdet som en formaterad sträng. Till exempel "0.5", "1.1", "3.0" osv.
+
+**Returns:**
+java.lang.String - Objekt av  String  typ
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.font/woffformatexception/_index.md
+++ b/swedish/java/com.aspose.font/woffformatexception/_index.md
@@ -1,0 +1,313 @@
+---
+title: "WoffFormatException"
+second_title: "Aspose.Font för Java API-referens"
+description: "Representerar undantag relaterat till WOFF-typsnittshantering."
+type: docs
+weight: 119
+url: /sv/java/com.aspose.font/woffformatexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException, java.lang.IllegalStateException
+```
+public class WoffFormatException extends IllegalStateException
+```
+
+Representerar undantag relaterat till WOFF-typsnittshantering.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [WoffFormatException()](#WoffFormatException--) | Initierar ett nytt  WoffFormatException  objekt. |
+| [WoffFormatException(String message)](#WoffFormatException-java.lang.String-) | Initierar ett nytt  WoffFormatException  objekt. |
+| [WoffFormatException(String message, RuntimeException innerException)](#WoffFormatException-java.lang.String-java.lang.RuntimeException-) | Initierar ett nytt  WoffFormatException  objekt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### WoffFormatException() {#WoffFormatException--}
+```
+public WoffFormatException()
+```
+
+
+Initierar ett nytt  WoffFormatException  objekt.
+
+### WoffFormatException(String message) {#WoffFormatException-java.lang.String-}
+```
+public WoffFormatException(String message)
+```
+
+
+Initierar ett nytt  WoffFormatException  objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+
+### WoffFormatException(String message, RuntimeException innerException) {#WoffFormatException-java.lang.String-java.lang.RuntimeException-}
+```
+public WoffFormatException(String message, RuntimeException innerException)
+```
+
+
+Initierar ett nytt  WoffFormatException  objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| meddelande | java.lang.String | Ett meddelande som beskriver felet. |
+| innerException | java.lang.RuntimeException | Undantaget som är orsaken till det aktuella undantaget. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **Swedish** (`sv`) generated by RDA.

- Pages translated: 151/151
- Errors: 0
- Source: `english/java`
- Output: `swedish/java`

🤖 Generated by RDA