### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Chinese

### DIFF
--- a/chinese/javascript-cpp/_index.md
+++ b/chinese/javascript-cpp/_index.md
@@ -1,0 +1,73 @@
+---
+title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "Aspose.Font 用于 JavaScript，通过 C++"
+keywords:  "JavaScript via C++, JavaScript Font toolkit"
+tags: ['font-to-ttf', 'font-to-woff',  'font-to-woff2', 'font-to-svg', 'font-convert', 'font-tools']
+weight: 40
+url: /zh/javascript-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.Font for JavaScript via C++ allows developers manipulate them Font files directly in the Web.
+>
+> Such operations are very time consuming, so we recommend using Web Worker. 
+
+
+## Convert functions
+
+| 函数 | 描述 |
+| -------- | ----------- |
+| [AsposeFontConvert](./convert/) | 将字体转换为 TrueType 字体。 |
+| [AsposeFontConvertToTTF](./convert/asposefontconverttottf/) | 将字体转换为 TTF 格式。 |
+| [AsposeFontConvertToWOFF](./convert/asposefontconverttowoff/) | 将字体转换为 WOFF 格式。 |
+| [AsposeFontConvertToWOFF2](./convert/asposefontconverttowoff2/) | 将字体转换为 WOFF2 格式。 |
+| [AsposeFontConvertToSVG](./convert/asposefontconverttosvg/) | 将字体转换为 SVG 格式。 |
+
+
+## Metadata Font functions
+
+| 函数 | 描述 |
+| -------- | ----------- |
+| [AsposeFontGetInfo](./metadata/asposefontgetinfo/) | 从字体文件获取信息（元数据）。 |
+| [AsposeFontSetInfo](./metadata/asposefontsetinfo/) | 在字体文件中设置信息（元数据）。 |
+
+
+## Glyph Font functions
+
+| 函数 | 描述 |
+| -------- | ----------- |
+| [AsposeFontGetGlyphCount](./glyph/asposefontgetglyphcount/) | 获取字体的字形计数。 |
+| [AsposeFontGetMetrics](./glyph/asposefontgetmetrics/) | 获取字体的度量信息。 |
+
+
+## Core Functions
+
+| 函数 | 描述 |
+| -------- | ----------- |
+| [AsposeFontPrepare](./core/asposefontprepare/) | 将 BLOB 保存到内存文件系统以进行处理。 |
+| [AsposeFontPrepareBase64](./core/asposefontpreparebase64/) | 将字符串表示的 BLOB 保存到内存文件系统以进行处理。 |
+
+
+## Miscellaneous
+
+| 名称 | 描述 |
+| -------------- | -------------- |
+| [AsposeFontAbout](./misc/asposefontabout/) | 获取关于产品的信息。 |
+| [DownloadFile](./misc/downloadfile/) | 在 HTML 中创建链接以下载文件。 |
+| [DownloadFileAuto](./misc/downloadfileauto) | 在 HTML 中创建链接以下载文件，并在 2 秒后开始下载。 |
+
+
+## 枚举
+
+| 枚举类型 | 描述 |
+| ----------- | ----------- |
+| [FontSavingFormats](./enumerations/fontsavingformats/) | 指定字体类型。 |
+| [FontStyle](./enumerations/fontstyle/) | 指定字体样式。 |
+| [TtfNameTableNameId](./enumerations/ttfnametablenameid/) | 指定 NameId。 |
+| [TtfNameTablePlatformId](./enumerations/ttfnametableplatformid/) | 表示 PlatformId 枚举。 |
+| [TtfNameTableMacPlatformSpecificId](./enumerations/ttfnametablemacplatformspecificid/) | 表示 Macintosh 平台特定 ID 枚举。 |
+| [TtfNameTableMSPlatformSpecificId](./enumerations/ttfnametablemsplatformspecificid/) | 表示 Microsoft 平台特定 ID 枚举。 |
+| [TtfNameTableUnicodePlatformSpecificId](./enumerations/ttfnametableunicodeplatformspecificid/) | 表示 Unicode 平台特定 ID 枚举。 |
+| [TtfNameTableMacLanguageId](./enumerations/ttfnametablemaclanguageid/) | MacLanguageId 枚举。 |
+| [TtfNameTableMSLanguageId](./enumerations/ttfnametablemslanguageid/) | MSLanguageId 枚举。 |

--- a/chinese/javascript-cpp/convert/_index.md
+++ b/chinese/javascript-cpp/convert/_index.md
@@ -1,0 +1,32 @@
+---
+title: "字体转换功能"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "用于将字体转换为 TrueType 格式的功能。"
+type: docs
+url: /zh/javascript-cpp/convert/
+---
+
+## Convert functions
+
+| 函数 | 描述 |
+| -------- | ----------- |
+| [AsposeFontConvert](./asposefontconvert) | 将字体转换为受支持的格式。 |
+| [AsposeFontConvertToTTF](./asposefontconverttottf/) | 将字体转换为 TTF 格式。 |
+| [AsposeFontConvertToWOFF](./asposefontconverttowoff/) | 将字体转换为 WOFF 格式。 |
+| [AsposeFontConvertToWOFF2](./asposefontconverttowoff2/) | 将字体转换为 WOFF2 格式。 |
+| [AsposeFontConvertToSVG](./asposefontconverttosvg/) | 将字体转换为 SVG 格式。 |
+
+## Detailed Description
+
+用于将字体转换为 TrueType 格式的功能。
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+或
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```
+

--- a/chinese/javascript-cpp/convert/asposefontconvert/_index.md
+++ b/chinese/javascript-cpp/convert/asposefontconvert/_index.md
@@ -1,0 +1,94 @@
+---
+title: "AsposeFontConvert"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "将字体转换为其他格式"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/convert/asposefontconvert/
+---
+## AsposeFontConvert function
+
+将字体转换为其他格式。
+
+```js
+function AsposeFontConvert(
+    fileBlob,
+    fileName,
+    fontType,
+    fontSavingFormat
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 用于转换的源字体内容。 |
+| fileName | 字符串 | 文件名。 |
+| fontType | FontType | 要转换的字体类型。 |
+| fontSavingFormat | FontSavingFormats | 要转换成的字体格式。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | fileNameResult | 结果文件名 |
+
+### 备注
+
+注意：目前仅支持 TTF 字体类型。
+
+### 示例
+
+```js
+  var fTTF2WOFF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvert(event.target.result, e.target.files[0].name, Module.FontType.TTF, Module.FontSavingFormats.WOFF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "woff");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoTTF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to TTF and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvert', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF', 'Module.FontSavingFormats.TTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另请参阅
+
+* enum [FontType](../../enumerations/fonttype/)
+* enum [FontSavingFormats](../../enumerations/fontsavingformats/)

--- a/chinese/javascript-cpp/convert/asposefontconverttottf/_index.md
+++ b/chinese/javascript-cpp/convert/asposefontconverttottf/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToTTF"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "将字体转换为 ttf 格式"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/convert/asposefontconverttottf/
+---
+## AsposeFontConvertToTTF function
+
+将字体转换为 TTF 格式。
+
+```js
+function AsposeFontConvertToTTF(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 用于转换的源字体内容。 |
+| fileName | 字符串 | 文件名。 |
+| fontType | FontType | 要转换的字体类型。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fEOT2TTF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToTTF(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoTTF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to TTF and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToTTF', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另请参阅
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/chinese/javascript-cpp/convert/asposefontconverttowoff/_index.md
+++ b/chinese/javascript-cpp/convert/asposefontconverttowoff/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToWOFF"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "将字体转换为 woff 格式"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/convert/asposefontconverttowoff/
+---
+## AsposeFontConvertToWOFF function
+
+将字体转换为 WOFF 格式。
+
+```js
+function AsposeFontConvertToWOFF(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 用于转换的源字体内容。 |
+| fileName | 字符串 | 文件名。 |
+| fontType | FontType | 要转换的字体类型。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fEOT2WOFF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToWOFF(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoWOFF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to WOFF and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToWOFF', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另请参阅
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/chinese/javascript-cpp/convert/asposefontconverttowoff2/_index.md
+++ b/chinese/javascript-cpp/convert/asposefontconverttowoff2/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToWOFF2"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "将字体转换为 woff2 格式"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/convert/asposefontconverttowoff2/
+---
+## AsposeFontConvertToWOFF2 function
+
+将字体转换为 WOFF2 格式。
+
+```js
+function AsposeFontConvertToWOFF2(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 用于转换的源字体内容。 |
+| fileName | 字符串 | 文件名。 |
+| fontType | FontType | 要转换的字体类型。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fEOT2WOFF2 = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToWOFF2(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoWOFF2 = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to WOFF2 and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToWOFF2', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另请参阅
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/chinese/javascript-cpp/convert/asposefontconverttowsvg/_index.md
+++ b/chinese/javascript-cpp/convert/asposefontconverttowsvg/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToSVG"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "将字体转换为 svg 格式"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/convert/asposefontconverttosvg/
+---
+## AsposeFontConvertToSVG function
+
+将字体转换为 SVG 格式。
+
+```js
+function AsposeFontConvertToSVG(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 用于转换的源字体内容。 |
+| fileName | 字符串 | 文件名。 |
+| fontType | FontType | 要转换的字体类型。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fEOT2SVG = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToSVG(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoSVG = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to SVG and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToSVG', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另请参阅
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/chinese/javascript-cpp/core/_index.md
+++ b/chinese/javascript-cpp/core/_index.md
@@ -1,0 +1,28 @@
+---
+title: "核心功能"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "用于处理字体文件的核心功能。"
+type: docs
+url: /zh/javascript-cpp/core/
+---
+
+## Core Functions
+
+| 名称 | 描述 |
+| -------------- | -------------- |
+| [AsposeFontPrepare](./asposefontprepare/) | 将 BLOB 保存到内存文件系统以进行处理。 |
+| [AsposeFontPrepareBase64](./asposefontpreparebase64/) | 将字符串表示的 BLOB 保存到内存文件系统以进行处理。 |
+
+## Detailed Description
+
+用于处理字体文件的核心功能。
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+或
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/chinese/javascript-cpp/core/asposefontprepare/_index.md
+++ b/chinese/javascript-cpp/core/asposefontprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposeFontPrepare"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "将 BLOB 保存到内存文件系统以进行处理。"
+type: docs
+url: /zh/javascript-cpp/core/asposefontprepare/
+---
+
+_保存 BLOB 到内存文件系统以供处理._
+
+```js
+function AsposeFontPrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+JSON 对象
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposeFontPrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposeFontAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposeFontWebWorker.postMessage(
+        { "operation": 'AsposeFontPrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposeFontPrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/chinese/javascript-cpp/core/asposefontpreparebase64/_index.md
+++ b/chinese/javascript-cpp/core/asposefontpreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposeFontPrepareBase64"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "将字符串表示的 BLOB 保存到内存文件系统以进行处理。"
+type: docs
+url: /zh/javascript-cpp/core/asposefontpreparebase64/
+---
+## AsposeFontPrepareBase64 function
+_保存字符串表示的 BLOB 到内存文件系统以供处理._
+
+```js
+function AsposeFontPrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### 备注
+**AsposeFontPrepareBase64** doesn't work in Web Worker mode, use AsposeFontPrepare
+
+### 示例
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposeFontPrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposeFontPrepareBase64 for Web Worker*/
+  const AsposeFontPrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposeFontWebWorker.postMessage(
+                 { "operation": 'AsposeFontPrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposeFontPrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/Font");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/chinese/javascript-cpp/enumerations/_index.md
+++ b/chinese/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,32 @@
+---
+title: "枚举"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "用于将字体转换为 TrueType 格式的功能。"
+type: docs
+url: /zh/javascript-cpp/enumerations/
+---
+
+## 枚举
+
+| 枚举类型 | 描述 |
+| ----------- | ----------- |
+| [FontSavingFormats](./fontsavingformats/) | 指定字体类型。 |
+| [FontType](./fonttype/) | 指定字体类型。 |
+| [TtfNameTableNameId](./ttfnametablenameid/) | 指定 NameId。 |
+| [TtfNameTablePlatformId](./ttfnametableplatformid/) | 表示 PlatformId 枚举。 |
+| [TtfNameTableMSPlatformSpecificId](./ttfnametableMSPlatformSpecificId/) | 表示 MSPlatformSpecificId 枚举。 |
+| [TtfNameTableMacPlatformSpecificId](./ttfnametableMacPlatformSpecificId/) | 表示 MacPlatformSpecificId 枚举。 |
+| [TtfNameTableUnicodePlatformSpecificId](./ttfnametableUnicodePlatformSpecificId/) | 表示 UnicodePlatformSpecificId 枚举。 |
+| [TtfNameTableMacLanguageId](./ttfnametablemaclanguageid/) | Macintosh 平台语言 ID 枚举。 |
+| [TtfNameTableMSLanguageId](./ttfnametablemslanguageid/) | Microsoft 平台语言 ID 枚举。 |
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+或
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```
+

--- a/chinese/javascript-cpp/enumerations/fontsavingformats/_index.md
+++ b/chinese/javascript-cpp/enumerations/fontsavingformats/_index.md
@@ -1,0 +1,26 @@
+---
+title: "枚举 FontSavingFormats"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "Aspose.Font.FontSavingFormats 枚举。指定字体类型"
+type: docs
+weight: 110
+url: /zh/javascript-cpp/enumerations/fontsavingformats/
+---
+## FontSavingFormats enumeration
+
+指定字体类型。
+
+```csharp
+public enum FontSavingFormats
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+| TTF | `0` | TTF（TrueType）字体格式。 |
+| WOFF | `1` | WOFF（Web Open Font Format）。 |
+| WOFF2 | `2` | WOFF 文件格式 2.0 |
+| SVG | `3` | SVG（可缩放矢量图形）字体格式 |
+| OTF | `4` | OTF（OpenType）字体格式 |
+

--- a/chinese/javascript-cpp/enumerations/fonttype/_index.md
+++ b/chinese/javascript-cpp/enumerations/fonttype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "枚举 FontType"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "Aspose.Font.FontType 枚举。指定字体类型"
+type: docs
+weight: 100
+url: /zh/javascript-cpp/enumerations/fonttype/
+---
+## FontType enumeration
+
+指定字体类型。
+
+```csharp
+public enum FontType
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+| TTF | `0` | TTF（TrueType）字体类型及相关内容。 |
+| Type1 | `1` | Type1 字体类型。 |
+| CFF | `2` | CFF（紧凑字体格式）字体类型。 |
+| OTF | `3` | OpenType 字体。OpenType 字体格式是 TrueType 字体格式的扩展，增加了对 PostScript 字体数据的支持。 |
+

--- a/chinese/javascript-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
+++ b/chinese/javascript-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
@@ -1,0 +1,53 @@
+---
+title: "枚举 TtfNameTableMacPlatformSpecificId"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "Aspose.Font.TtfNameTableMacPlatformSpecificId 枚举。指定 MacPlatformSpecificId"
+type: docs
+weight: 131
+url: /zh/javascript-cpp/enumerations/ttfnametablemacplatformspecificid/
+---
+## TtfNameTableMacPlatformSpecificId enumeration
+
+指定 MacPlatformSpecificId。
+
+```csharp
+ enum TtfNameTableMacPlatformSpecificId
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+|  | Roman | `0` | Roman 平台特定值。 |
+|  | Japanese | `1` | Japanese 平台特定值。 |
+|  | Traditional_Chinese | `2` | Traditional Chinese 平台特定值。 |
+|  | Korean | `3` | Korean 平台特定值。 |
+|  | Arabic | `4` | Arabic 平台特定值。 |
+|  | Hebrew | `5` | 希伯来平台特定值。 |
+|  | Greek | `6` | 希腊平台特定值。 |
+|  | Russian | `7` | 俄语平台特定值。 |
+|  | RSymbol | `8` | RSymbol平台特定值。 |
+|  | Devanagari | `9` | 天城文平台特定值。 |
+|  | Gurmukhi | `10` | 古木基平台特定值。 |
+|  | Gujarati | `11` | 古吉拉特文平台特定值。 |
+|  | Oriya | `12` | 奥里亚文平台特定值。 |
+|  | Bengali | `13` | 孟加拉文平台特定值。 |
+|  | Tamil | `14` | 泰米尔文平台特定值。 |
+|  | Telugu | `15` | 泰卢固文平台特定值。 |
+|  | Kannada | `16` | 卡纳达文平台特定值。 |
+|  | Malayalam | `17` | 马拉雅拉姆文平台特定值。 |
+|  | Sinhalese | `18` | 僧伽罗文平台特定值。 |
+|  | Burmese | `19` | 缅甸文平台特定值。 |
+|  | Khmer | `20` | 高棉文平台特定值。 |
+|  | Thai | `21` | 泰文平台特定值。 |
+|  | Laotian | `22` | 老挝文平台特定值。 |
+|  | Georgian | `23` | 格鲁吉亚文平台特定值。 |
+|  | Armenian | `24` | 亚美尼亚文平台特定值。 |
+|  | Simplified_Chinese | `25` | 简体中文平台特定值。 |
+|  | Tibetan | `26` | 藏文平台特定值。 |
+|  | Mongolian | `27` | 蒙古文平台特定值。 |
+|  | Geez | `28` | 吉兹文平台特定值。 |
+|  | Slavic | `29` | 斯拉夫文平台特定值。 |
+|  | Vietnamese | `30` | 越南平台特定值。 |
+|  | Sindhi | `31` | 信德语平台特定值。 |
+|  | Uninterpreted | `32` | 未解释的平台特定值。 |

--- a/chinese/javascript-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
+++ b/chinese/javascript-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
@@ -1,0 +1,32 @@
+---
+title: "枚举 TtfNameTableMSPlatformSpecificId"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "Aspose.Font.TtfNameTableMSPlatformSpecificId 枚举。指定 MSPlatformSpecificId"
+type: docs
+weight: 132
+url: /zh/javascript-cpp/enumerations/ttfnametablemsplatformspecificid/
+---
+## TtfNameTableMSPlatformSpecificId enumeration
+
+指定 MSPlatformSpecificId.
+
+```csharp
+ enum TtfNameTableMSPlatformSpecificId
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+|  | Symbol | `0` | 符号 MS PlatformSpecificId. |
+|  | Unicode_BMP_UCS2 | `1` | Unicode BMP (UCS2) MS PlatformSpecificId. |
+|  | ShiftJIS | `2` | ShiftJIS MS PlatformSpecificId. |
+|  | PRC | `3` | PRC MS PlatformSpecificId. |
+|  | Big5 | `4` | Big5 MS PlatformSpecificId. |
+|  | Wansung | `5` | Wansung MS PlatformSpecificId. |
+|  | Johab | `6` | Johab MS PlatformSpecificId. |
+|  | Reserved1 | `7` | Reserved1 MS PlatformSpecificId. |
+|  | Reserved2 | `8` | Reserved2 MS PlatformSpecificId. |
+|  | Reserved3 | `9` | Reserved3 MS PlatformSpecificId. |
+|  | Unicode_UCS4 | `10` | Unicode UCS4 MS PlatformSpecificId. |
+

--- a/chinese/javascript-cpp/enumerations/ttfnametablenameid/_index.md
+++ b/chinese/javascript-cpp/enumerations/ttfnametablenameid/_index.md
@@ -1,0 +1,46 @@
+---
+title: "枚举 TtfNameTableNameId"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "Aspose.Font.TtfNameTableNameId 枚举。指定 NameId"
+type: docs
+weight: 120
+url: /zh/javascript-cpp/enumerations/ttfnametablenameid/
+---
+## TtfNameTableNameId enumeration
+
+指定 NameId。
+
+```csharp
+ enum TtfNameTableNameId
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+|  | CopyrightNotice | `0` | 版权声明。 |
+|  | FontFamily | `1` | 字体族。此字符串是用户在 Macintosh 平台上看到的字体族名称。 |
+|  | FontSubfamily | `2` | 字体子族。此字符串是用户在 Macintosh 平台上看到的字体族。 |
+|  | UniqueFontId | `3` | 唯一子族标识（Apple 规范）。3 唯一字体标识符（MS 规范）。 |
+|  | FullName | `4` | 字体的完整名称。 |
+|  | Version | `5` | 名称表的版本。 |
+|  | PostScriptName | `6` | 字体的 PostScript 名称。注意：一个字体只能有一个 PostScript 名称，且该名称必须是 ASCII。 |
+|  | TrademarkNotice | `7` | 商标声明。 |
+|  | ManufacturerName | `8` | 制造商名称。 |
+|  | DesignerName | `9` | 设计师；字体设计者的姓名。 |
+|  | Description | `10` | 描述；字体的描述。可以包含修订信息、使用建议、历史、特性等。 |
+|  | UrlVendor | `11` | 字体供应商的 URL（带协议，例如 http://、ftp://）。如果在 URL 中嵌入唯一序列号，可用于注册该字体。 |
+|  | UrlDesigner | `12` | 字体设计者的 URL（带协议，例如 http://、ftp://） |
+|  | LicenseDescription | `13` | 许可证描述；说明字体的合法使用方式或不同的授权使用示例场景。此字段应使用通俗语言撰写，而非法律术语。 |
+|  | LicenseInfoUrl | `14` | 许可证信息 URL，可在此获取更多许可证信息。 |
+|  | PreferredFamily | `16` | `15` 保留 `16` 首选族（仅限 Windows）；在 Windows 中，族名称显示在字体菜单中；子族名称显示为样式名称。出于历史原因，字体族最多包含四种样式，但字体设计师可以将超过四个字体分组到同一族。首选族和首选子族 ID 允许字体设计师包含首选的族/子族分组。仅当这些 ID 与 ID 1 和 2 不同时时才会出现这些 ID。 |
+|  | PreferredSubfamily | `17` | 首选子族（仅限 Windows）；在 Windows 中，族名称显示在字体菜单中；子族名称显示为样式名称。出于历史原因，字体族最多包含四种样式，但字体设计师可以将超过四个字体分组到同一族。首选族和首选子族 ID 允许字体设计师包含首选的族/子族分组。仅当这些 ID 与 ID 1 和 2 不同时时才会出现这些 ID。 |
+|  | CompatibleFull | `18` | 兼容完整名称（仅限 Macintosh）；在 Macintosh 上，菜单名称使用字体资源构建。通常与完整名称匹配。如果希望字体名称与完整名称不同，可以在 ID 18 中插入兼容完整名称。此名称并未被 Mac OS 本身使用，但可能被应用程序开发者使用（例如 Adobe）。 |
+|  | SampleText | `19` | 示例文本。可以是字体名称，也可以是设计师认为最能展示字体外观的任何其他文本。 |
+|  | PostScriptCID | `20` | 它在字体中的存在意味着 nameID 6 包含一个 PostScript 字体名称，该名称旨在与 "composefont" 调用一起使用，以在 PostScript 解释器中调用该字体。 |
+|  | WwsFamilyName | `21` | 用于在 ID 16 和 17 的条目不符合 WWS 模型时提供符合 WWS 标准的族名。 |
+|  | WwsSubfamilyName | `22` | 与 ID 21 结合使用时，此 ID 在 ID 16 和 17 的条目不符合 WWS 模型时提供符合 WWS 标准的子族名（仅反映粗细、宽度和倾斜属性）。 |
+|  | LightBackground | `23` | 如果此 ID 用于 CPAL 表的 Palette Labels Array，则指定 CPAL 表中相应的颜色调色板在将字体显示在如白色的浅色背景上时适合使用。 |
+|  | DarkBackground | `24` | 如果此 ID 用于 CPAL 表的 Palette Labels Array，则指定 CPAL 表中相应的颜色调色板在将字体显示在如黑色的深色背景上时适合使用。 |
+|  | VariationsPostScriptNamePrefix | `25` | 如果在可变字体中出现，它可以用作变体字体的 PostScript 名称生成算法中的族前缀。 |
+

--- a/chinese/javascript-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
+++ b/chinese/javascript-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
@@ -1,0 +1,138 @@
+---
+title: "枚举 TtfNameTableMacLanguageId"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "Aspose.Font.TtfNameTableMacLanguageId 枚举。指定 MacLanguageId。"
+type: docs
+weight: 140
+url: /zh/javascript-cpp/enumerations/ttfnametablemaclanguageid/
+---
+## TtfNameTableMacLanguageId enumeration
+
+表示 MacLanguageId 枚举。
+
+```csharp
+ enum TtfNameTableMacLanguageId
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+|  | English | `0` | 英语 LanguageId value |
+|  | French | `1` | 法语 LanguageId value |
+|  | German | `2` | 德语 LanguageId value |
+|  | Italian | `3` | 意大利语 LanguageId value |
+|  | Dutch | `4` | 荷兰语 LanguageId value |
+|  | Swedish | `5` | 瑞典语 LanguageId value |
+|  | Spanish | `6` | 西班牙语 LanguageId value |
+|  | Danish | `7` | 丹麦语 LanguageId value |
+|  | Portuguese | `8` | 葡萄牙语 LanguageId value |
+|  | Norwegian | `9` | 挪威语 LanguageId value |
+|  | Hebrew | `10` | 希伯来语 LanguageId value |
+|  | Japanese | `11` | 日语 LanguageId value |
+|  | Arabic | `12` | 阿拉伯语 LanguageId value |
+|  | Finnish | `13` | 芬兰语 LanguageId value |
+|  | Greek | `14` | 希腊语 LanguageId value |
+|  | Icelandic | `15` | 冰岛语 LanguageId value |
+|  | Maltese | `16` | 马耳他语 LanguageId value |
+|  | Turkish | `17` | 土耳其语 LanguageId value |
+|  | Croatian | `18` | 克罗地亚语 LanguageId value |
+|  | Chinese_Traditional | `19` | 中文（繁体） LanguageId value |
+|  | Urdu | `20` | 乌尔都语 LanguageId value |
+|  | Hindi | `21` | 印地语 LanguageId value |
+|  | Thai | `22` | 泰语 LanguageId value |
+|  | Korean | `23` | 韩语 LanguageId value |
+|  | Lithuanian | `24` | 立陶宛语 LanguageId value |
+|  | Polish | `25` | 波兰语 LanguageId 值 |
+|  | Hungarian | `26` | 匈牙利语 LanguageId 值 |
+|  | Estonian | `27` | 爱沙尼亚语 LanguageId 值 |
+|  | Latvian | `28` | 拉脱维亚语 LanguageId 值 |
+|  | Sami | `29` | 萨米语 LanguageId 值 |
+|  | Faroese | `30` | 法罗语 LanguageId 值 |
+|  | Farsi_Persian | `31` | 波斯语 LanguageId 值 |
+|  | Russian | `32` | 俄语 LanguageId 值 |
+|  | Chinese_Simplified | `33` | 中文（简体） LanguageId 值 |
+|  | Flemish | `34` | 荷兰语（比利时） LanguageId 值 |
+|  | Irish_Gaelic | `35` | 爱尔兰语 LanguageId 值 |
+|  | Albanian | `36` | 阿尔巴尼亚语 LanguageId 值 |
+|  | Romanian | `37` | 罗马尼亚语 LanguageId 值 |
+|  | Czech | `38` | 捷克语 LanguageId 值 |
+|  | Slovak | `39` | 斯洛伐克语 LanguageId 值 |
+|  | Slovenian | `40` | 斯洛文尼亚语 LanguageId 值 |
+|  | Yiddish | `41` | 意第绪语 LanguageId 值 |
+|  | Serbian | `42` | 塞尔维亚语 LanguageId 值 |
+|  | Macedonian | `43` | 马其顿语 LanguageId 值 |
+|  | Bulgarian | `44` | 保加利亚语 LanguageId 值 |
+|  | Ukrainian | `45` | 乌克兰语 LanguageId 值 |
+|  | Byelorussian | `46` | 白俄罗斯语 LanguageId 值 |
+|  | Uzbek | `47` | 乌兹别克语 LanguageId 值 |
+|  | Kazakh | `48` | 哈萨克语 LanguageId 值 |
+|  | Azerbaijani_Cyrillic | `49` | 阿塞拜疆语（西里尔文） LanguageId 值 |
+|  | Azerbaijani_Arabic | `50` | 阿塞拜疆语（阿拉伯文字）LanguageId 值 |
+|  | Armenian | `51` | 亚美尼亚语LanguageId 值 |
+|  | Georgian | `52` | 格鲁吉亚语LanguageId 值 |
+|  | Moldavian | `53` | 摩尔多瓦语LanguageId 值 |
+|  | Kirghiz | `54` | 吉尔吉斯语LanguageId 值 |
+|  | Tajiki | `55` | 塔吉克语LanguageId 值 |
+|  | Turkmen | `56` | 土库曼语LanguageId 值 |
+|  | Mongolian | `57` | 蒙古语（蒙古文字）LanguageId 值 |
+|  | Mongolian_Cyrillic | `58` | 蒙古语（西里尔文字）LanguageId 值 |
+|  | Pashto | `59` | 普什图语LanguageId 值 |
+|  | Kurdish | `60` | 普什图语LanguageId 值 |
+|  | Kashmiri | `61` | 克什米尔语LanguageId 值 |
+|  | Sindhi | `62` | 信德语LanguageId 值 |
+|  | Tibetan | `63` | 藏语LanguageId 值 |
+|  | Nepali | `64` | 尼泊尔语LanguageId 值 |
+|  | Sanskrit | `65` | 梵语LanguageId 值 |
+|  | Marathi | `66` | 马拉地语LanguageId 值 |
+|  | Bengali | `67` | 孟加拉语LanguageId 值 |
+|  | Assamese | `68` | 阿萨姆语LanguageId 值 |
+|  | Gujarati | `69` | 古吉拉特语LanguageId 值 |
+|  | Punjabi | `70` | 旁遮普语LanguageId 值 |
+|  | Oriya | `71` | 奥里亚语LanguageId 值 |
+|  | Malayalam | `72` | 马拉雅拉姆语LanguageId 值 |
+|  | Kannada | `73` | 坎纳达语LanguageId 值 |
+|  | Tamil | `74` | 泰米尔语LanguageId 值 |
+|  | Telugu | `75` | 泰卢固语LanguageId 值 |
+|  | Sinhalese | `76` | 僧伽罗语 LanguageId value |
+|  | Burmese | `77` | 缅甸语 LanguageId value |
+|  | Khmer | `78` | 高棉语 LanguageId value |
+|  | Lao | `79` | 老挝语 LanguageId value |
+|  | Vietnamese | `80` | 越南语 LanguageId value |
+|  | Indonesian | `81` | 印度尼西亚语 LanguageId value |
+|  | Tagalog | `82` | 他加禄语 LanguageId value |
+|  | Malay_Roman | `83` | 马来语（拉丁字母） LanguageId value |
+|  | Malay_Arabic | `84` | 马来语（阿拉伯字母） LanguageId value |
+|  | Amharic | `85` | 阿姆哈拉语 LanguageId value |
+|  | Tigrinya | `86` | 提格里尼亚语 LanguageId value |
+|  | Galla | `87` | 加拉语 LanguageId value |
+|  | Somali | `88` | 索马里语 LanguageId value |
+|  | Swahili | `89` | 斯瓦希里语 LanguageId value |
+|  | Kinyarwanda_Ruanda | `90` | 基尼亚卢旺达语/卢旺达语 LanguageId value |
+|  | Rundi | `91` | 隆迪语 LanguageId value |
+|  | Nyanja_Chewa | `92` | 尼扬贾语/切瓦语 LanguageId value |
+|  | Malagasy | `93` | 马达加斯加语 LanguageId value |
+|  | Esperanto | `94` | 世界语 LanguageId value |
+|  | Welsh | `128` | 威尔士语 LanguageId value |
+|  | Basque | `129` | 巴斯克语 LanguageId value |
+|  | Catalan | `130` | 加泰罗尼亚语 LanguageId value |
+|  | Latin | `131` | 拉丁语 LanguageId value |
+|  | Quechua | `132` | 克丘亚语 LanguageId value |
+|  | Guarani | `133` | 瓜拉尼语 LanguageId value |
+|  | Aymara | `134` | Aymara LanguageId 值 |
+|  | Tatar | `135` | Tatar LanguageId 值 |
+|  | Uighur | `136` | Uighur LanguageId 值 |
+|  | Dzongkha | `137` | Dzongkha LanguageId 值 |
+|  | Javanese | `138` | Javanese (Roman script) LanguageId 值 |
+|  | Sundanese | `139` | Sundanese (Roman script) LanguageId 值 |
+|  | Galician | `140` | Galician LanguageId 值 |
+|  | Afrikaans | `141` | Afrikaans LanguageId 值 |
+|  | Breton | `142` | Breton LanguageId 值 |
+|  | Inuktitut | `143` | Inuktitut LanguageId 值 |
+|  | Scottish_Gaelic | `144` | Scottish Gaelic LanguageId 值 |
+|  | Manx_Gaelic | `145` | Manx Gaelic LanguageId 值 |
+|  | Irish_Gaelic_WDA | `146` | Irish Gaelic (with dot above) LanguageId 值 |
+|  | Tongan | `147` | Tongan LanguageId 值 |
+|  | Greek_Polytonic | `148` | Greek (polytonic) LanguageId 值 |
+|  | Greenlandic | `149` | Greenlandic LanguageId 值 |
+|  | Azerbaijani_Roman | `150` | Azerbaijani (Roman script) LanguageId 值 |

--- a/chinese/javascript-cpp/enumerations/ttfnametablenmslanguageid/_index.md
+++ b/chinese/javascript-cpp/enumerations/ttfnametablenmslanguageid/_index.md
@@ -1,0 +1,225 @@
+---
+title: "枚举 TtfNameTableMSLanguageId"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "Aspose.Font.TtfNameTableMSLanguageId 枚举。指定 MSLanguageId"
+type: docs
+weight: 150
+url: /zh/javascript-cpp/enumerations/ttfnametablemslanguageid/
+---
+## TtfNameTableMSLanguageId enumeration
+
+表示 MSLanguageId 枚举。
+
+```csharp
+ enum TtfNameTableMSLanguageId
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+|  | Afrikaans | `0x0436` | Afrikaans（地区：南非，SA）LanguageId 值 |
+|  | Albanian | `0x041c` | Albanian（地区：阿尔巴尼亚，SQI）LanguageId 值 |
+|  | Alsatian | `0x0484` | Alsatian（地区：法国）LanguageId 值 |
+|  | Amharic | `0x045E` | Amharic（地区：埃塞俄比亚）LanguageId 值 |
+|  | Arabic_Algeria | `0x1401` | Arabic（地区：阿尔及利亚）LanguageId 值 |
+|  | Arabic_Bahrain | `0x3C01` | Arabic（地区：巴林）LanguageId 值 |
+|  | Arabic_Egypt | `0x0C01` | Arabic（地区：埃及）LanguageId 值 |
+|  | Arabic_Iraq | `0x0801` | Arabic（地区：伊拉克）LanguageId 值 |
+|  | Arabic_Jordan | `0x2C01` | Arabic（地区：约旦）LanguageId 值 |
+|  | Arabic_Kuwait | `0x3401` | Arabic（地区：科威特）LanguageId 值 |
+|  | Arabic_Lebanon | `0x3001` | Arabic（地区：黎巴嫩）LanguageId 值 |
+|  | Arabic_Libya | `0x1001` | Arabic（地区：利比亚）LanguageId 值 |
+|  | Arabic_Morocco | `0x1801` | Arabic（地区：摩洛哥）LanguageId 值 |
+|  | Arabic_Oman | `0x2001` | Arabic（地区：阿曼）LanguageId 值 |
+|  | Arabic_Qatar | `0x4001` | Arabic（地区：卡塔尔）LanguageId 值 |
+|  | Arabic_Saudi_Arabia | `0x0401` | Arabic（地区：沙特阿拉伯）LanguageId 值 |
+|  | Arabic_Syria | `0x2801` | Arabic（地区：叙利亚）LanguageId 值 |
+|  | Arabic_Tunisia | `0x1C01` | 阿拉伯语 (地区：突尼斯) LanguageId 值 |
+|  | Arabic_U_A_E | `0x3801` | 阿拉伯语 (地区：阿联酋) LanguageId 值 |
+|  | Arabic_Yemen | `0x2401` | 阿拉伯语 (地区：也门) LanguageId 值 |
+|  | Armenian | `0x042B` | 亚美尼亚语 (地区：亚美尼亚) LanguageId 值 |
+|  | Assamese | `0x044D` | 阿萨姆语 (地区：印度) LanguageId 值 |
+|  | Azeri_Cyrillic | `0x082C` | 阿塞拜疆语 (西里尔文，地区：阿塞拜疆) LanguageId 值 |
+|  | Azeri_Latin | `0x042C` | 阿塞拜疆语 (拉丁文，地区：阿塞拜疆) LanguageId 值 |
+|  | Bashkir | `0x046D` | 巴什基尔语 (地区：俄罗斯) LanguageId 值 |
+|  | Basque | `0x042D` | 巴斯克语 (地区：巴斯克，EUQ) LanguageId 值 |
+|  | Belarusian | `0x0423` | 白俄罗斯语 (地区：白俄罗斯，BEL) LanguageId 值 |
+|  | Bengali_Bangladesh | `0x0845` | 孟加拉语 (地区：孟加拉国) LanguageId 值 |
+|  | Bengali_India | `0x0445` | 孟加拉语 (地区：印度) LanguageId 值 |
+|  | Bosnian_Cyrillic | `0x201A` | 波斯尼亚语 (西里尔文，地区：波斯尼亚和黑塞哥维那) LanguageId 值 |
+|  | Bosnian_Latin | `0x141A` | 波斯尼亚语 (拉丁文，地区：波斯尼亚和黑塞哥维那) LanguageId 值 |
+|  | Breton | `0x047E` | 布列塔尼语 (地区：法国) LanguageId 值 |
+|  | Bulgarian | `0x0402` | 保加利亚语 (地区：保加利亚，BGR) LanguageId 值 |
+|  | Catalan | `0x0403` | 加泰罗尼亚语 (地区：加泰罗尼亚，CAT) LanguageId 值 |
+|  | Chinese_Hong_Kong | `0x0C04` | 中文 (地区：香港特别行政区) LanguageId 值 |
+|  | Chinese_Macao | `0x1404` | 中文 (地区：澳门特别行政区) LanguageId 值 |
+|  | Chinese_PRC | `0x0804` | 中文 (地区：中华人民共和国) LanguageId 值 |
+|  | Chinese_Singapore | `0x1004` | 中文 (地区：新加坡) LanguageId 值 |
+|  | Chinese_Taiwan | `0x0404` | 中文 (地区：台湾) LanguageId 值 |
+|  | Corsican | `0x0483` | 科西嘉语 (地区：法国) LanguageId 值 |
+|  | Croatian | `0x041A` | 克罗地亚语 (地区：克罗地亚，SHL) LanguageId 值 |
+|  | Croatian_Latin | `0x101A` | 克罗地亚语 (拉丁文，地区：波斯尼亚和黑塞哥维那) LanguageId 值 |
+|  | Czech | `0x0405` | 捷克语（地区：捷克共和国，CSY）LanguageId 值 |
+|  | Danish | `0x0406` | 丹麦语（地区：丹麦，DAN）LanguageId 值 |
+|  | Dari | `0x048C` | 达里语（地区：阿富汗）LanguageId 值 |
+|  | Divehi | `0x0465` | 迪维希语（地区：马尔代夫）LanguageId 值 |
+|  | Dutch_Belgium | `0x0813` | 荷兰语（弗拉芒语，地区：比利时，NLB）LanguageId 值 |
+|  | Dutch_Netherlands | `0x0413` | 荷兰语（标准，地区：荷兰，NLD）LanguageId 值 |
+|  | English_Australia | `0x0C09` | 英语（澳大利亚，地区：澳大利亚，ENA）LanguageId 值 |
+|  | English_Belize | `0x2809` | 英语（地区：伯利兹）LanguageId 值 |
+|  | English_Canada | `0x1009` | 英语（加拿大，地区：加拿大，ENC）LanguageId 值 |
+|  | English_Caribbean | `0x2409` | 英语（地区：加勒比海）LanguageId 值 |
+|  | English_India | `0x4009` | 英语（地区：印度）LanguageId 值 |
+|  | English_Ireland | `0x1809` | 英语（地区：爱尔兰，ENI）LanguageId 值 |
+|  | English_Jamaica | `0x2009` | 英语（地区：牙买加）LanguageId 值 |
+|  | English_Malaysia | `0x4409` | 英语（地区：马来西亚）LanguageId 值 |
+|  | English_New_Zealand | `0x1409` | 英语（地区：新西兰，ENZ）LanguageId 值 |
+|  | English_ROP | `0x3409` | 英语（地区：菲律宾共和国，ROP）LanguageId 值 |
+|  | English_Singapore | `0x4809` | 英语（地区：新加坡）LanguageId 值 |
+|  | English_South_Africa | `0x1C09` | 英语（地区：南非，SA）LanguageId 值 |
+|  | English_TT | `0x2C09` | 英语（地区：特立尼达和多巴哥，TT）LanguageId 值 |
+|  | English_United_Kingdom | `0x0809` | 英语（英国，地区：联合王国，ENG）LanguageId 值 |
+|  | English_United_States | `0x0409` | 英语（美国，地区：美国，ENU）LanguageId 值 |
+|  | English_Zimbabwe | `0x3009` | 英语（地区：津巴布韦）LanguageId 值 |
+|  | Estonian | `0x0425` | 爱沙尼亚语（地区：爱沙尼亚，ETI）LanguageId 值 |
+|  | Faroese | `0x0438` | 法罗语（地区：法罗群岛）LanguageId 值 |
+|  | Filipino | `0x0464` | 菲律宾语（地区：菲律宾）LanguageId 值 |
+|  | Finnish | `0x040B` | 芬兰语（地区：芬兰，FIN）LanguageId 值 |
+|  | French_Belgium | `0x080C` | 法语（比利时，地区：比利时，FRB）LanguageId 值 |
+|  | French_Canada | `0x0C0C` | 法语（加拿大，地区：加拿大，FRC）LanguageId 值 |
+|  | French_France | `0x040C` | 法语（标准，地区：法国，FRA）LanguageId 值 |
+|  | French_Luxembourg | `0x140c` | 法语（地区：卢森堡，FRL）LanguageId 值 |
+|  | French_MC | `0x180C` | 法语（地区：摩纳哥公国，MC）LanguageId 值 |
+|  | French_Switzerland | `0x100C` | 法语（瑞士，地区：瑞士，FRS）LanguageId 值 |
+|  | Frisian | `0x0462` | 弗里斯兰语（地区：荷兰，NLD）LanguageId 值 |
+|  | Galician | `0x0456` | 加利西亚语（地区：加利西亚）LanguageId 值 |
+|  | Georgian | `0x0437` | 格鲁吉亚语（地区：格鲁吉亚）LanguageId 值 |
+|  | German_Austria | `0x0C07` | 德语（奥地利，地区：奥地利，DEA）LanguageId 值 |
+|  | German_Germany | `0x0407` | 德语（标准，地区：德国，DEU）LanguageId 值 |
+|  | German_Liechtenstein | `0x1407` | 德语（地区：列支敦士登，DEC）LanguageId 值 |
+|  | German_Luxembourg | `0x1007` | 德语（地区：卢森堡，DEL）LanguageId 值 |
+|  | German_Switzerland | `0x0807` | 德语（瑞士，地区：瑞士，DES）LanguageId 值 |
+|  | Greek | `0x0408` | 希腊语（地区：希腊，ELL）LanguageId 值 |
+|  | Greenlandic | `0x046F` | 格陵兰语（地区：格陵兰）LanguageId 值 |
+|  | Gujarati | `0x0447` | 古吉拉特语（地区：印度）LanguageId 值 |
+|  | Hausa | `0x0468` | 豪萨语（拉丁文，地区：尼日利亚）LanguageId 值 |
+|  | Hebrew | `0x040D` | 希伯来语（地区：以色列）LanguageId 值 |
+|  | Hindi | `0x0439` | 印地语（地区：印度）LanguageId 值 |
+|  | Hungarian | `0x040E` | 匈牙利语（地区：匈牙利，HUN）LanguageId 值 |
+|  | Icelandic | `0x040F` | 冰岛语（地区：冰岛，ISL）LanguageId 值 |
+|  | Igbo | `0x0470` | 伊博语（地区：尼日利亚）LanguageId 值 |
+|  | Indonesian | `0x0421` | 印尼语（地区：印度尼西亚）LanguageId 值 |
+|  | Inuktitut | `0x045D` | Inuktitut (地区: Canada) LanguageId 值 |
+|  | Inuktitut_Latin | `0x085D` | Inuktitut (Latin, 地区: Canada) LanguageId 值 |
+|  | Irish | `0x083C` | Irish (地区: Ireland) LanguageId 值 |
+|  | isiXhosa | `0x0434` | isiXhosa (地区: South Africa, SA) LanguageId 值 |
+|  | isiZulu | `0x0435` | isiZulu (地区: South Africa, SA) LanguageId 值 |
+|  | Italian_Italy | `0x0410` | Italian (Standard, 地区: Italy, ITA) LanguageId 值 |
+|  | Italian_Switzerland | `0x0810` | Italian (Swiss, 地区: Switzerland, ITS) LanguageId 值 |
+|  | Japanese | `0x0411` | Japanese (地区: Japan) LanguageId 值 |
+|  | Kannada | `0x044B` | Kannada (地区: India) LanguageId 值 |
+|  | Kazakh | `0x043F` | Kazakh (地区: Kazakhstan) LanguageId 值 |
+|  | Khmer | `0x0453` | Khmer (地区: Cambodia) LanguageId 值 |
+|  | Kiche | `0x0486` | K�iche (地区: Guatemala) LanguageId 值 |
+|  | Kinyarwanda | `0x0487` | Kinyarwanda (地区: Rwanda) LanguageId 值 |
+|  | Kiswahili | `0x0441` | Kiswahili (地区: Kenya) LanguageId 值 |
+|  | Konkani | `0x0457` | Konkani (地区: India) LanguageId 值 |
+|  | Korean | `0x0412` | Korean (地区: Korea) LanguageId 值 |
+|  | Kyrgyz | `0x0440` | Kyrgyz (地区: Kyrgyzstan) LanguageId 值 |
+|  | Lao | `0x0454` | Lao (地区: Lao P.D.R.) LanguageId 值 |
+|  | Latvian | `0x0426` | Latvian (地区: Latvia, LVI) LanguageId 值 |
+|  | Lithuanian | `0x0427` | Lithuanian (地区: Lithuania, LTH) LanguageId 值 |
+|  | Lower_Sorbian | `0x082E` | Lower Sorbian (地区: Germany) LanguageId 值 |
+|  | Luxembourgish | `0x046E` | Luxembourgish (地区: Luxembourg) LanguageId 值 |
+|  | Macedonian | `0x042F` | Macedonian (地区: North Macedonia) LanguageId 值 |
+|  | Malay_Brunei_Darussalam | `0x083E` | Malay (地区: Brunei Darussalam) LanguageId 值 |
+|  | Malay_Malaysia | `0x043E` | Malay (地区: Malaysia) LanguageId 值 |
+|  | Malayalam | `0x044C` | Malayalam (地区：印度) LanguageId 值 |
+|  | Maltese | `0x043A` | Maltese (地区：马耳他) LanguageId 值 |
+|  | Maori | `0x0481` | Maori (地区：新西兰) LanguageId 值 |
+|  | Mapudungun | `0x047A` | Mapudungun (地区：智利) LanguageId 值 |
+|  | Marathi | `0x044E` | Marathi (地区：印度) LanguageId 值 |
+|  | Mohawk | `0x047C` | Mohawk (地区：莫霍克) LanguageId 值 |
+|  | Mongolian_Cyrillic | `0x0450` | Mongolian (西里尔文, 地区：蒙古) LanguageId 值 |
+|  | Mongolian_Traditional | `0x0850` | Mongolian (传统, 地区：中华人民共和国) LanguageId 值 |
+|  | Nepali | `0x0461` | Nepali (地区：尼泊尔) LanguageId 值 |
+|  | Norwegian_Bokmal | `0x0414` | Norwegian (Bokmal, 地区：挪威, NOR) LanguageId 值 |
+|  | Norwegian_Nynorsk | `0x0814` | Norwegian (Nynorsk, 地区：挪威, NON) LanguageId 值 |
+|  | Occitan | `0x0482` | Occitan (地区：法国) LanguageId 值 |
+|  | Odia | `0x0448` | Odia (原名 Oriya, 地区：印度) LanguageId 值 |
+|  | Pashto | `0x0463` | Pashto (地区：阿富汗) LanguageId 值 |
+|  | Polish | `0x0415` | Polish (地区：波兰, PLK) LanguageId 值 |
+|  | Portuguese_Brazil | `0x0416` | Portuguese (巴西, 地区：巴西, PTB) LanguageId 值 |
+|  | Portuguese_Portugal | `0x0816` | Portuguese (标准, 地区：葡萄牙, PTG) LanguageId 值 |
+|  | Punjabi | `0x0446` | Punjabi (地区：印度) LanguageId 值 |
+|  | Quechua_Bolivia | `0x046B` | Quechua (地区：玻利维亚) LanguageId 值 |
+|  | Quechua_Ecuador | `0x086B` | Quechua (地区：厄瓜多尔) LanguageId 值 |
+|  | Quechua_Peru | `0x0C6B` | Quechua (地区：秘鲁) LanguageId 值 |
+|  | Romanian | `0x0418` | Romanian (地区：罗马尼亚, ROM) LanguageId 值 |
+|  | Romansh | `0x0417` | Romansh (地区：瑞士) LanguageId 值 |
+|  | Russian | `0x0419` | Russian (地区：俄罗斯, RUS) LanguageId 值 |
+|  | Sami_Inari | `0x243B` | Sami (Inari, 地区：芬兰) LanguageId 值 |
+|  | Sami_Lule_Norway | `0x103B` | 萨米语（Lule，地区：挪威）LanguageId 值 |
+|  | Sami_Lule_Sweden | `0x143B` | 萨米语（Lule，地区：瑞典）LanguageId 值 |
+|  | Sami_Northern_Finland | `0x0C3B` | 萨米语（Northern，地区：芬兰）LanguageId 值 |
+|  | Sami_Northern_Norway | `0x043B` | 萨米语（Northern，地区：挪威）LanguageId 值 |
+|  | Sami_Northern_Sweden | `0x083B` | 萨米语（Northern，地区：挪威）LanguageId 值 |
+|  | Sami_Skolt | `0x203B` | 萨米语（Skolt，地区：芬兰）LanguageId 值 |
+|  | Sami_Southern_Norway | `0x183B` | 萨米语（Southern，地区：挪威）LanguageId 值 |
+|  | Sami_Southern_Sweden | `0x1C3B` | 萨米语（Southern，地区：瑞典）LanguageId 值 |
+|  | Sanskrit | `0x044F` | 梵语（地区：印度）LanguageId 值 |
+|  | Serbian_Cyrillic_BIH | `0x1C1A` | 塞尔维亚语（西里尔文，地区：波斯尼亚和黑塞哥维那）LanguageId 值 |
+|  | Serbian_Cyrillic_Serbia | `0x0C1A` | 塞尔维亚语（西里尔文，地区：塞尔维亚）LanguageId 值 |
+|  | Serbian_Latin_BIH | `0x181A` | 塞尔维亚语（拉丁文，地区：波斯尼亚和黑塞哥维那）LanguageId 值 |
+|  | Serbian_Latin_Serbia | `0x081A` | 塞尔维亚语（拉丁文，地区：塞尔维亚）LanguageId 值 |
+|  | Sesotho_Sa_Leboa | `0x046C` | 塞索托语（北索托语，地区：南非，SA）LanguageId 值 |
+|  | Setswana | `0x0432` | 茨瓦纳语（地区：南非，SA）LanguageId 值 |
+|  | Sinhala | `0x045B` | 僧伽罗语（地区：斯里兰卡）LanguageId 值 |
+|  | Slovak | `0x041B` | 斯洛伐克语（地区：斯洛伐克，SKY）LanguageId 值 |
+|  | Slovenian | `0x0424` | 斯洛文尼亚语（地区：斯洛文尼亚，SLV）LanguageId 值 |
+|  | Spanish_Argentina | `0x2C0A` | 西班牙语（地区：阿根廷）LanguageId 值 |
+|  | Spanish_Bolivia | `0x400A` | 西班牙语（地区：玻利维亚）LanguageId 值 |
+|  | Spanish_Chile | `0x340A` | 西班牙语（地区：智利）LanguageId 值 |
+|  | Spanish_Colombia | `0x240A` | 西班牙语（地区：哥伦比亚）LanguageId 值 |
+|  | Spanish_Costa_Rica | `0x140A` | 西班牙语（地区：哥斯达黎加）LanguageId 值 |
+|  | Spanish_Dominican_Republic | `0x1C0A` | 西班牙语（地区：多米尼加共和国）LanguageId 值 |
+|  | Spanish_Ecuador | `0x300A` | 西班牙语（地区：多米尼加共和国）LanguageId 值 |
+|  | Spanish_El_Salvador | `0x440A` | 西班牙语（地区：多米尼加共和国）LanguageId 值 |
+|  | Spanish_Guatemala | `0x100A` | 西班牙语（地区：危地马拉）LanguageId 值 |
+|  | Spanish_Honduras | `0x480A` | 西班牙语（地区：洪都拉斯）LanguageId 值 |
+|  | Spanish_Mexico | `0x080A` | 西班牙语（墨西哥，地区：墨西哥，ESM）LanguageId 值 |
+|  | Spanish_Nicaragua | `0x4C0A` | 西班牙语（地区：尼加拉瓜）LanguageId 值 |
+|  | Spanish_Panama | `0x180A` | 西班牙语（地区：巴拿马）LanguageId 值 |
+|  | Spanish_Paraguay | `0x3C0A` | 西班牙语（地区：巴拉圭）LanguageId 值 |
+|  | Spanish_Peru | `0x280A` | 西班牙语（地区：秘鲁）LanguageId 值 |
+|  | Spanish_Puerto_Rico | `0x500A` | 西班牙语（地区：波多黎各）LanguageId 值 |
+|  | Spanish_Modern_Sort | `0x0C0A` | 西班牙语（现代排序，地区：西班牙，ESN）LanguageId 值 |
+|  | Spanish_Traditional_Sort | `0x040A` | 西班牙语（传统排序，地区：西班牙，ESP）LanguageId 值 |
+|  | Spanish_United_States | `0x540A` | 西班牙语（地区：美国）LanguageId 值 |
+|  | Spanish_Uruguay | `0x380A` | 西班牙语（地区：乌拉圭）LanguageId 值 |
+|  | Spanish_Venezuela | `0x200A` | 西班牙语（地区：委内瑞拉）LanguageId 值 |
+|  | Swedish_Finland | `0x081D` | 瑞典语（地区：芬兰）LanguageId 值 |
+|  | Swedish_Sweden | `0x041D` | 瑞典语（地区：瑞典，SVE）LanguageId 值 |
+|  | Syriac | `0x045A` | 叙利亚语（地区：叙利亚）LanguageId 值 |
+|  | Tajik | `0x0428` | 塔吉克语（西里尔文，地区：塔吉克斯坦）LanguageId 值 |
+|  | Tamazight | `0x085F` | 塔马齐格特语（拉丁文，地区：阿尔及利亚）LanguageId 值 |
+|  | Tamil | `0x0449` | 泰米尔语（地区：印度）LanguageId 值 |
+|  | Tatar | `0x0444` | 鞑靼语（地区：俄罗斯）LanguageId 值 |
+|  | Telugu | `0x044A` | 泰卢固语（地区：印度）LanguageId 值 |
+|  | Thai | `0x041E` | 泰语（地区：泰国）LanguageId 值 |
+|  | Tibetan | `0x0451` | 藏语（地区：中国）LanguageId 值 |
+|  | Turkish | `0x041F` | 土耳其语（地区：土耳其，TRK）LanguageId 值 |
+|  | Turkmen | `0x0442` | 土库曼语（地区：土库曼斯坦）LanguageId 值 |
+|  | Uighur | `0x0480` | 维吾尔语（地区：中国）LanguageId 值 |
+|  | Ukrainian | `0x0422` | 乌克兰语（地区：乌克兰，UKR）LanguageId 值 |
+|  | Upper_Sorbian | `0x042E` | 上索布语（地区：德国）LanguageId 值 |
+|  | Urdu | `0x0420` | 乌尔都语（地区：巴基斯坦伊斯兰共和国）LanguageId 值 |
+|  | Uzbek_Cyrillic | `0x0843` | 乌兹别克语（西里尔文，地区：乌兹别克斯坦）LanguageId 值 |
+|  | Uzbek_Latin | `0x0443` | 乌兹别克语（拉丁文，地区：乌兹别克斯坦）LanguageId 值 |
+|  | Vietnamese | `0x042A` | 越南语（地区：越南）LanguageId 值 |
+|  | Welsh | `0x0452` | 威尔士语（地区：英国）LanguageId 值 |
+|  | Wolof | `0x0488` | 沃洛夫语（地区：塞内加尔）LanguageId 值 |
+|  | Yakut | `0x0485` | 雅库特语（地区：俄罗斯）LanguageId 值 |
+|  | Yi | `0x0478` | 彝语（地区：中国）LanguageId 值 |
+| Yoruba | `0x046A` | 约鲁巴语（地区：尼日利亚）LanguageId 值 |

--- a/chinese/javascript-cpp/enumerations/ttfnametableplatformid/_index.md
+++ b/chinese/javascript-cpp/enumerations/ttfnametableplatformid/_index.md
@@ -1,0 +1,24 @@
+---
+title: "枚举 TtfNameTablePlatformId"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "Aspose.Font.TtfNameTablePlatformId 枚举。指定 PlatformId"
+type: docs
+weight: 130
+url: /zh/javascript-cpp/enumerations/ttfnametableplatformid/
+---
+## TtfNameTablePlatformId enumeration
+
+指定 PlatformId.
+
+```cssharp
+ enum TtfNameTablePlatformId
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+|  | Unicode | `0` | Unicode |
+|  | Macintosh | `1` | Macintosh 脚本管理器代码. |
+|  | ISO | `2` | Apple 规范:（保留；请勿使用）MS 规范: ISO 编码。注意，自 OpenType 规范 v1.3 起，平台 ID 2（ISO）已被弃用。它本意是表示 ISO/IEC 10646，而非 Unicode；两者的字符代码分配完全相同。 |
+|  | Microsoft | `3` | Microsoft 编码. |

--- a/chinese/javascript-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
+++ b/chinese/javascript-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
@@ -1,0 +1,25 @@
+---
+title: "枚举 TtfNameTableUnicodePlatformSpecificId"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "Aspose.Font.TtfNameTableUnicodePlatformSpecificId 枚举。指定 UnicodePlatformSpecificId"
+type: docs
+weight: 133
+url: /zh/javascript-cpp/enumerations/ttfnametableunicodeplatformspecificid/
+---
+## TtfNameTableUnicodePlatformSpecificId enumeration
+
+指定 UnicodePlatformSpecificId.
+
+```csharp
+ enum TtfNameTableUnicodePlatformSpecificId
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+|  | Default | `0` | 默认语义 (Unicode 1.0). |
+|  | Unicode1_1 | `1` | Unicode 1.1 语义. |
+|  | ISO10646_1993 | `2` | ISO 10646 1993 语义（已弃用）. |
+|  | Unicode2_0 | `3` | Unicode 2.0 或更高版本的语义。仅 Unicode BMP。 |
+|  | Unicode2_0_Full | `4Unicode 2.0 and onwards semantics (non-BMP characters allowed)` | Unicode 完整字符集. |

--- a/chinese/javascript-cpp/glyph/_index.md
+++ b/chinese/javascript-cpp/glyph/_index.md
@@ -1,0 +1,29 @@
+---
+title: "字形字体功能"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "用于处理字体文件字形的功能"
+type: docs
+url: /zh/javascript-cpp/glyph/
+---
+
+## Glyph Font functions
+
+| 名称 | 描述 |
+| -------------- | -------------- |
+| [AsposeFontGetGlyphCount](./asposefontgetglyphcount/) | 获取字体的字形计数。 |
+| [AsposeFontGetMetrics](./asposefontgetmetrics/) | 获取字体的度量信息。 |
+
+
+## Detailed Description
+
+用于处理字体字形的功能。
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+或
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/chinese/javascript-cpp/glyph/asposefontgetglyphcount/_index.md
+++ b/chinese/javascript-cpp/glyph/asposefontgetglyphcount/_index.md
@@ -1,0 +1,72 @@
+---
+title: "AsposeFontGetGlyphCount"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "从字体文件获取信息（元数据）。"
+type: docs
+url: /zh/javascript-cpp/glyph/asposefontgetglyphcount/
+---
+## AsposeFontGetGlyphCount function
+
+_获取字体的字形计数._
+
+```js
+function AsposeFontGetGlyphCount(
+    fileBlob,
+    fileName
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 用于转换的源字体内容。 |
+| fileName | 字符串 | 文件名。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | glyphCount | 字形计数 |
+
+### 示例
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    evt.data == "ready"
+      ? "loaded!"
+      : evt.data.json.errorCode == 0
+      ? "Glyph count: " + evt.data.json.glyphCount
+      : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFontGetGlyphCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get glyph count of font - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontGetGlyphCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+
+**Simple example**:
+```js
+  var ffileFontGetGlyphCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontGetGlyphCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Glyph count: " + json.glyphCount;
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/chinese/javascript-cpp/glyph/asposefontgetmetrics/_index.md
+++ b/chinese/javascript-cpp/glyph/asposefontgetmetrics/_index.md
@@ -1,0 +1,79 @@
+---
+title: "FontGetFontMetrics"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "从字体文件获取信息（元数据）。"
+type: docs
+url: /zh/javascript-cpp/glyph/asposefontgetmetrics/
+---
+## FontGetFontMetrics function
+
+_获取字体的字形计数._
+
+```js
+function FontGetFontMetrics(
+    fileBlob,
+    fileName
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 用于转换的源字体内容。 |
+| fileName | 字符串 | 文件名。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | 度量 | JSON 对象 |
+| * 上升 |
+| * 下降 |
+| * 行间距 |
+| * 最大前进宽度 |
+| * 最小左侧间距 |
+| * 最小右侧间距 |
+| * x最大范围 |
+
+### 示例
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    evt.data == "ready"
+      ? "loaded!"
+      : evt.data.json.errorCode == 0
+      ? JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')
+      : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFontGetMetrics = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get metrics of font - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontGetMetrics', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+
+**Simple example**:
+```js
+  var ffileFontGetGlyphCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = FontGetFontMetrics(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Glyph count: " + json.glyphCount;
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/chinese/javascript-cpp/metadata/_index.md
+++ b/chinese/javascript-cpp/metadata/_index.md
@@ -1,0 +1,28 @@
+---
+title: "元数据字体功能"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "用于处理元数据字体文件的功能"
+type: docs
+url: /zh/javascript-cpp/metadata/
+---
+
+## Metadata Font functions
+
+| 名称 | 描述 |
+| -------------- | -------------- |
+| [AsposeFontGetInfo](./asposefontgetinfo/) | 从字体文件获取信息（元数据）。 |
+| [AsposeFontSetInfo](./asposefontsetinfo/) | 将信息（元数据）设置到 Font-file 中。 |
+
+## Detailed Description
+
+用于处理元数据字体文件的功能。
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+或
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/chinese/javascript-cpp/metadata/asposefontgetinfo/_index.md
+++ b/chinese/javascript-cpp/metadata/asposefontgetinfo/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeFontGetInfo"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "从字体文件获取信息（元数据）。"
+type: docs
+url: /zh/javascript-cpp/metadata/asposefontgetinfo/
+---
+## AsposeFontGetInfo function
+
+_获取来自字体文件的元数据信息._
+
+```js
+function AsposeFontGetInfo(
+    fileBlob,
+    fileName
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 用于转换的源字体内容。 |
+| fileName | 字符串 | 文件名。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | 记录 | JSON 对象数组： |
+|  | * NameId | 名称标识符 |
+|  | * PlatformId | 平台标识符 |
+|  | * PlatformSpecificId | 平台特定标识符 |
+|  | * LanguageId | 语言标识符 |
+|  | * Info | 名称记录的内容 |
+
+### 示例
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    evt.data == "ready"
+      ? "loaded!"
+      : evt.data.json.errorCode == 0
+      ? "Name records count: " + evt.data.json.records.length + 
+                                            evt.data.json.records.reduce((ret, a) => ret +
+                                            "\nNameId : " + a.NameId
+                                          + "; PlatformId : " + a.PlatformId
+                                          + "; PlatformSpecificId : " + a.PlatformSpecificId
+                                          + "; LanguageId : " + a.LanguageId
+                                          + "; Info : " + a.Info,"")
+      : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFontGetInfo = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get info (metadata) from a Font-file - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontGetInfo', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileFontGetInfo = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontGetInfo(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Name records count: " + json.records.length;
+        for (let recordIndex = 0; recordIndex < json.records.length; recordIndex++) 
+			document.getElementById('output').textContent += " " + "\n"
+                                                         + "NameId : " + json.records[recordIndex].NameId
+                                                         + ";  PlatformId : " + json.records[recordIndex].PlatformId
+                                                         + ";  PlatformSpecificId : " + json.records[recordIndex].PlatformSpecificId
+                                                         + ";  LanguageId : " + json.records[recordIndex].LanguageId
+                                                         + ";  Info : " + json.records[recordIndex].Info;
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/chinese/javascript-cpp/metadata/asposefontsetinfo/_index.md
+++ b/chinese/javascript-cpp/metadata/asposefontsetinfo/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeFontSetInfo"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "将信息（元数据）设置到 Font-file 中。"
+type: docs
+url: /zh/javascript-cpp/metadata/asposefontsetinfo/
+---
+## AsposeFontSetInfo function
+
+_将信息（元数据）写入字体文件。_
+
+```js
+function AsposeFontSetInfo(
+    fileBlob,
+    fileName,
+    nameId, 
+    platformId, 
+    platformSpecificId, 
+    languageId, 
+    text
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 用于转换的源字体内容。 |
+| fileName | 字符串 | 文件名。 |
+| nameId | TtfNameTableNameId | 名称标识符，逻辑字符串类别，由[`NameId`](../../enumerations/ttfnametablenameid/)枚举指定 |
+|  | platformId | TtfNameTablePlatformId | 平台标识符 |
+| platformSpecificId | int | 平台特定编码标识符。请使用以下枚举之一的值 - [`UnicodePlatformSpecificId`](../../enumerations/ttfnametableunicodeplatformspecificid/)、[`MacPlatformSpecificId`](../../ttfnametable.macplatformspecificid/)、[`MSPlatformSpecificId`](../../enumerations/ttfnametablemsplatformspecificid/)。使用哪个枚举由上下文（*platformId* 参数）决定 |
+| languageId | int | 语言标识符。请根据上下文使用[`MSLanguageId`](../../enumerations/ttfnametablemslanguageid/)或[`MacLanguageId`](../../enumerations/ttfnametablemaclanguageid/)枚举的值，上下文由 *platformId* 参数定义。 |
+|  | 文本 | 字符串 | 实际字符串数据 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    (evt.data == 'ready') ? 'library loaded!' :
+    (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+ 
+ /*Event handler*/
+  const ffileFontSetInfo = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+          const nameId = 'Module.TtfNameTableNameId.' + document.getElementById("NameId").value;
+          //Value will be changed for PlatformId = PlatformId.Microsoft, PlatformSpecificId = MSPlatformSpecificId.Unicode_BMP_UCS2 (1) and languageID = 1033 (English_United_States = 0x0409)
+          const platformId = 'Module.TtfNameTablePlatformId.Microsoft';
+          const platformSpecificId = 'Module.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2';
+          const langID = 'Module.TtfNameTableMSLanguageId.English_United_States';
+          const text = document.getElementById("textValue").value;
+          transfer = [event.target.result];
+          params = [event.target.result, e.target.files[0].name, nameId, platformId, platformSpecificId, langID, text];
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontSetInfo', "params": params }, transfer);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var fFontSetInfo = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+
+      const nameId = new Function("return Module.TtfNameTableNameId." + document.getElementById("NameId").value)();
+      const platformId = Module.TtfNameTablePlatformId.Microsoft;
+      const platformSpecificId = Module.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+      const text = document.getElementById("textValue").value;
+      const langID = 1033;
+
+      const json = AsposeFontSetInfo(blob, file.name, nameId, platformId, platformSpecificId, langID, text);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult);
+        //DownloadFile(file.name);
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(file);
+  }
+```
+
+### 另请参阅
+
+* enum [TtfNameTableNameId](../../enumerations/ttfnametablenameid/)
+* enum [TtfNameTablePlatformId](../../enumerations/ttfnametableplatformid/)
+* enum [TtfNameTableMacPlatformSpecificId](../../enumerations/ttfnametablemacplatformspecificid/)
+* enum [TtfNameTableMSPlatformSpecificId](../../enumerations/ttfnametablemsplatformspecificid/)
+* enum [TtfNameTableUnicodePlatformSpecificId](../../enumerations/ttfnametableunicodeplatformspecificid/)
+* enum [TtfNameTableMacLanguageId](../../enumerations/ttfnametablemaclanguageid/)
+* enum [TtfNameTableMSLanguageId](../../enumerations/ttfnametablemslanguageid/)

--- a/chinese/javascript-cpp/misc/_index.md
+++ b/chinese/javascript-cpp/misc/_index.md
@@ -1,0 +1,28 @@
+---
+title: "杂项功能"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "用于处理字体文件的次要功能。"
+type: docs
+url: /zh/javascript-cpp/misc/
+---
+## Functions
+
+| 名称 | 描述 |
+| -------------- | -------------- |
+| [AsposeFontAbout](./asposeFontabout/) | 获取关于产品的信息。 |
+| [DownloadFile](./downloadfile/) | 在 HTML 中创建链接以下载文件。 |
+| [DownloadFileAuto](./downloadfileauto/) | 在 HTML 中创建链接以下载文件，并在 2 秒后开始下载。 |
+
+## Detailed Description
+
+用于处理字体文件的次要功能。
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+或
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/chinese/javascript-cpp/misc/asposefontabout/_index.md
+++ b/chinese/javascript-cpp/misc/asposefontabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeFontAbout"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "获取关于产品的信息。"
+type: docs
+url: /zh/javascript-cpp/misc/asposefontabout/
+---
+
+## AsposeFontAbout function
+
+获取关于产品的信息。
+
+```js
+function AsposeFontAbout()
+```
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+| errorCode | 错误代码（0 表示无错误） |
+| errorText | 错误文本（"" 表示无错误） |
+| 产品 | 产品名称 |
+| 版本 | 产品版本 |
+| 已授权 | 产品已授权 |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposeFontAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposeFontAbout = function () {
+    /*Get info about Product*/
+    const json = AsposeFontAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/chinese/javascript-cpp/misc/downloadfile/_index.md
+++ b/chinese/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "在 HTML 中创建链接以下载文件。"
+type: docs
+url: /zh/javascript-cpp/misc/downloadfile/
+---
+
+_在 HTML 中创建一个链接以下载文件._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/chinese/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/chinese/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Font 用于 JavaScript，通过 C++"
+description: "在 HTML 中创建链接以下载文件，并在 2 秒后开始下载。"
+type: docs
+url: /zh/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+在 HTML 中创建链接以下载文件，并在 2 秒后开始下载。
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### 参数
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### 备注
+
+在 Web Worker 中无法工作。


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Chinese** (`zh`) generated by RDA.

- Pages translated: 30/30
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `chinese/javascript-cpp`

🤖 Generated by RDA