### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to German

### DIFF
--- a/german/javascript-cpp/_index.md
+++ b/german/javascript-cpp/_index.md
@@ -1,0 +1,73 @@
+---
+title: "Aspose.Font für JavaScript über C++"
+description: "Aspose.Font für JavaScript über C++"
+keywords:  "JavaScript via C++, JavaScript Font toolkit"
+tags: ['font-to-ttf', 'font-to-woff',  'font-to-woff2', 'font-to-svg', 'font-convert', 'font-tools']
+weight: 40
+url: /de/javascript-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.Font for JavaScript via C++ allows developers manipulate them Font files directly in the Web.
+>
+> Such operations are very time consuming, so we recommend using Web Worker. 
+
+
+## Convert functions
+
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [AsposeFontConvert](./convert/) | Konvertiere eine Schriftart in TrueType-Schriften. |
+| [AsposeFontConvertToTTF](./convert/asposefontconverttottf/) | Konvertiere eine Schriftart in das TTF-Format. |
+| [AsposeFontConvertToWOFF](./convert/asposefontconverttowoff/) | Konvertiere eine Schriftart in das WOFF-Format. |
+| [AsposeFontConvertToWOFF2](./convert/asposefontconverttowoff2/) | Konvertiere eine Schriftart in das WOFF2-Format. |
+| [AsposeFontConvertToSVG](./convert/asposefontconverttosvg/) | Konvertiere eine Schriftart in das SVG-Format. |
+
+
+## Metadata Font functions
+
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [AsposeFontGetInfo](./metadata/asposefontgetinfo/) | Lese Informationen (Metadaten) aus einer Schriftdatei. |
+| [AsposeFontSetInfo](./metadata/asposefontsetinfo/) | Setze Informationen (Metadaten) in einer Schriftdatei. |
+
+
+## Glyph Font functions
+
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [AsposeFontGetGlyphCount](./glyph/asposefontgetglyphcount/) | Lese die Glyphenanzahl der Schriftart. |
+| [AsposeFontGetMetrics](./glyph/asposefontgetmetrics/) | Lese die Metriken der Schriftart. |
+
+
+## Core Functions
+
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [AsposeFontPrepare](./core/asposefontprepare/) | Speichere das BLOB im Memory-FS zur Verarbeitung. |
+| [AsposeFontPrepareBase64](./core/asposefontpreparebase64/) | Speichere das BLOB der String-Darstellung im Memory-FS zur Verarbeitung. |
+
+
+## Miscellaneous
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposeFontAbout](./misc/asposefontabout/) | Lese Informationen über das Produkt. |
+| [DownloadFile](./misc/downloadfile/) | Erstelle einen Link in HTML, um die Datei herunterzuladen. |
+| [DownloadFileAuto](./misc/downloadfileauto) | Erstelle einen Link in HTML, um die Datei herunterzuladen und starte den Download nach 2 Sekunden. |
+
+
+## Aufzählungen
+
+| Aufzählung | Beschreibung |
+| ----------- | ----------- |
+| [FontSavingFormats](./enumerations/fontsavingformats/) | Gibt den Schrifttyp an. |
+| [FontStyle](./enumerations/fontstyle/) | Gibt den Schriftstil an. |
+| [TtfNameTableNameId](./enumerations/ttfnametablenameid/) | Gibt die NameId an. |
+| [TtfNameTablePlatformId](./enumerations/ttfnametableplatformid/) | Stellt die PlatformId-Aufzählung dar. |
+| [TtfNameTableMacPlatformSpecificId](./enumerations/ttfnametablemacplatformspecificid/) | Stellt die plattformspezifische ID-Aufzählung für Macintosh dar. |
+| [TtfNameTableMSPlatformSpecificId](./enumerations/ttfnametablemsplatformspecificid/) | Stellt die Microsoft-Plattform-spezifische ID-Aufzählung dar. |
+| [TtfNameTableUnicodePlatformSpecificId](./enumerations/ttfnametableunicodeplatformspecificid/) | Stellt die Unicode-Plattform-spezifische ID-Aufzählung dar. |
+| [TtfNameTableMacLanguageId](./enumerations/ttfnametablemaclanguageid/) | MacLanguageId-Aufzählung. |
+| [TtfNameTableMSLanguageId](./enumerations/ttfnametablemslanguageid/) | MSLanguageId-Aufzählung. |

--- a/german/javascript-cpp/convert/_index.md
+++ b/german/javascript-cpp/convert/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Funktionen zum Konvertieren von Schriftarten"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Funktionen zum Konvertieren von Schriftarten in True-Type-Formate."
+type: docs
+url: /de/javascript-cpp/convert/
+---
+
+## Convert functions
+
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [AsposeFontConvert](./asposefontconvert) | Konvertiere eine Schriftart in unterstützte Formate. |
+| [AsposeFontConvertToTTF](./asposefontconverttottf/) | Konvertiere eine Schriftart in das TTF-Format. |
+| [AsposeFontConvertToWOFF](./asposefontconverttowoff/) | Konvertiere eine Schriftart in das WOFF-Format. |
+| [AsposeFontConvertToWOFF2](./asposefontconverttowoff2/) | Konvertiere eine Schriftart in das WOFF2-Format. |
+| [AsposeFontConvertToSVG](./asposefontconverttosvg/) | Konvertiere eine Schriftart in das SVG-Format. |
+
+## Detailed Description
+
+Funktionen zum Konvertieren von Schriftarten in True-Type-Formate.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```
+

--- a/german/javascript-cpp/convert/asposefontconvert/_index.md
+++ b/german/javascript-cpp/convert/asposefontconvert/_index.md
@@ -1,0 +1,94 @@
+---
+title: "AsposeFontConvert"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Konvertiert die Schriftart in ein anderes Format"
+type: docs
+weight: 10
+url: /de/javascript-cpp/convert/asposefontconvert/
+---
+## AsposeFontConvert function
+
+Konvertiert die Schriftart in ein anderes Format.
+
+```js
+function AsposeFontConvert(
+    fileBlob,
+    fileName,
+    fontType,
+    fontSavingFormat
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschrift für die Konvertierung. |
+| fileName | string | Dateiname. |
+| fontType | FontType | Schriftarttyp zum Konvertieren. |
+| fontSavingFormat | FontSavingFormats | Schriftartformat, in das konvertiert werden soll. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Hinweise
+
+Hinweis: TTF-Schriftarttyp wird jetzt nur noch unterstützt.
+
+### Beispiele
+
+```js
+  var fTTF2WOFF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvert(event.target.result, e.target.files[0].name, Module.FontType.TTF, Module.FontSavingFormats.WOFF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "woff");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoTTF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to TTF and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvert', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF', 'Module.FontSavingFormats.TTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* enum [FontType](../../enumerations/fonttype/)
+* enum [FontSavingFormats](../../enumerations/fontsavingformats/)

--- a/german/javascript-cpp/convert/asposefontconverttottf/_index.md
+++ b/german/javascript-cpp/convert/asposefontconverttottf/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToTTF"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Konvertiert die Schriftart in das ttf-Format"
+type: docs
+weight: 10
+url: /de/javascript-cpp/convert/asposefontconverttottf/
+---
+## AsposeFontConvertToTTF function
+
+Konvertiert die Schriftart in das TTF-Format.
+
+```js
+function AsposeFontConvertToTTF(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschrift für die Konvertierung. |
+| fileName | string | Dateiname. |
+| fontType | FontType | Schriftarttyp zum Konvertieren. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fEOT2TTF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToTTF(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoTTF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to TTF and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToTTF', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/german/javascript-cpp/convert/asposefontconverttowoff/_index.md
+++ b/german/javascript-cpp/convert/asposefontconverttowoff/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToWOFF"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Konvertiert die Schriftart in das woff-Format"
+type: docs
+weight: 10
+url: /de/javascript-cpp/convert/asposefontconverttowoff/
+---
+## AsposeFontConvertToWOFF function
+
+Konvertiert die Schriftart in das WOFF-Format.
+
+```js
+function AsposeFontConvertToWOFF(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschrift für die Konvertierung. |
+| fileName | string | Dateiname. |
+| fontType | FontType | Schriftarttyp zum Konvertieren. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fEOT2WOFF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToWOFF(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoWOFF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to WOFF and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToWOFF', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/german/javascript-cpp/convert/asposefontconverttowoff2/_index.md
+++ b/german/javascript-cpp/convert/asposefontconverttowoff2/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToWOFF2"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Konvertiert die Schriftart in das woff2-Format"
+type: docs
+weight: 10
+url: /de/javascript-cpp/convert/asposefontconverttowoff2/
+---
+## AsposeFontConvertToWOFF2 function
+
+Konvertiert die Schriftart in das WOFF2-Format.
+
+```js
+function AsposeFontConvertToWOFF2(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschrift für die Konvertierung. |
+| fileName | string | Dateiname. |
+| fontType | FontType | Schriftarttyp zum Konvertieren. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fEOT2WOFF2 = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToWOFF2(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoWOFF2 = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to WOFF2 and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToWOFF2', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/german/javascript-cpp/convert/asposefontconverttowsvg/_index.md
+++ b/german/javascript-cpp/convert/asposefontconverttowsvg/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToSVG"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Konvertiert die Schriftart in das svg-Format"
+type: docs
+weight: 10
+url: /de/javascript-cpp/convert/asposefontconverttosvg/
+---
+## AsposeFontConvertToSVG function
+
+Konvertiert die Schriftart in das SVG-Format.
+
+```js
+function AsposeFontConvertToSVG(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschrift für die Konvertierung. |
+| fileName | string | Dateiname. |
+| fontType | FontType | Schriftarttyp zum Konvertieren. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fEOT2SVG = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToSVG(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoSVG = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to SVG and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToSVG', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/german/javascript-cpp/core/_index.md
+++ b/german/javascript-cpp/core/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Kernfunktionen"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Kernfunktionen zum Arbeiten mit Font-Dateien."
+type: docs
+url: /de/javascript-cpp/core/
+---
+
+## Core Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposeFontPrepare](./asposefontprepare/) | Speichere das BLOB im Memory-FS zur Verarbeitung. |
+| [AsposeFontPrepareBase64](./asposefontpreparebase64/) | Speichere das BLOB der String-Darstellung im Memory-FS zur Verarbeitung. |
+
+## Detailed Description
+
+Kernfunktionen zum Arbeiten mit Font-Dateien.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/german/javascript-cpp/core/asposefontprepare/_index.md
+++ b/german/javascript-cpp/core/asposefontprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposeFontPrepare"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Speichere das BLOB im Memory-FS zur Verarbeitung."
+type: docs
+url: /de/javascript-cpp/core/asposefontprepare/
+---
+
+_Speichert das BLOB im Memory FS zur Verarbeitung._
+
+```js
+function AsposeFontPrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+JSON-Objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposeFontPrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposeFontAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposeFontWebWorker.postMessage(
+        { "operation": 'AsposeFontPrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposeFontPrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/german/javascript-cpp/core/asposefontpreparebase64/_index.md
+++ b/german/javascript-cpp/core/asposefontpreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposeFontPrepareBase64"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Speichere das BLOB der String-Darstellung im Memory-FS zur Verarbeitung."
+type: docs
+url: /de/javascript-cpp/core/asposefontpreparebase64/
+---
+## AsposeFontPrepareBase64 function
+_Speichert die String-Darstellung des BLOB im Memory FS zur Verarbeitung._
+
+```js
+function AsposeFontPrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### Hinweise
+**AsposeFontPrepareBase64** doesn't work in Web Worker mode, use AsposeFontPrepare
+
+### Beispiele
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposeFontPrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposeFontPrepareBase64 for Web Worker*/
+  const AsposeFontPrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposeFontWebWorker.postMessage(
+                 { "operation": 'AsposeFontPrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposeFontPrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/Font");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/german/javascript-cpp/enumerations/_index.md
+++ b/german/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Aufzählungen"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Funktionen zum Konvertieren von Schriftarten in True-Type-Formate."
+type: docs
+url: /de/javascript-cpp/enumerations/
+---
+
+## Aufzählungen
+
+| Aufzählung | Beschreibung |
+| ----------- | ----------- |
+| [FontSavingFormats](./fontsavingformats/) | Gibt den Schrifttyp an. |
+| [FontType](./fonttype/) | Gibt den Schrifttyp an. |
+| [TtfNameTableNameId](./ttfnametablenameid/) | Gibt die NameId an. |
+| [TtfNameTablePlatformId](./ttfnametableplatformid/) | Stellt die PlatformId-Aufzählung dar. |
+| [TtfNameTableMSPlatformSpecificId](./ttfnametableMSPlatformSpecificId/) | Stellt die MSPlatformSpecificId-Aufzählung dar. |
+| [TtfNameTableMacPlatformSpecificId](./ttfnametableMacPlatformSpecificId/) | Stellt die MacPlatformSpecificId-Aufzählung dar. |
+| [TtfNameTableUnicodePlatformSpecificId](./ttfnametableUnicodePlatformSpecificId/) | Stellt die UnicodePlatformSpecificId-Aufzählung dar. |
+| [TtfNameTableMacLanguageId](./ttfnametablemaclanguageid/) | Macintosh-Plattform-Sprach-ID-Aufzählung. |
+| [TtfNameTableMSLanguageId](./ttfnametablemslanguageid/) | Microsoft-Plattform-Sprach-ID-Aufzählung. |
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```
+

--- a/german/javascript-cpp/enumerations/fontsavingformats/_index.md
+++ b/german/javascript-cpp/enumerations/fontsavingformats/_index.md
@@ -1,0 +1,26 @@
+---
+title: "Enum FontSavingFormats"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Aspose.Font.FontSavingFormats enum. Gibt den Font-Typ an"
+type: docs
+weight: 110
+url: /de/javascript-cpp/enumerations/fontsavingformats/
+---
+## FontSavingFormats enumeration
+
+Gibt den Schrifttyp an.
+
+```csharp
+public enum FontSavingFormats
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+| TTF | `0` | TTF (TrueType) Font-Format. |
+| WOFF | `1` | WOFF (Web Open Font Format). |
+| WOFF2 | `2` | WOFF-Dateiformat 2.0 |
+| SVG | `3` | SVG (Scalable Vector Graphics) Font-Format |
+| OTF | `4` | OTF (OpenType) Font-Format |
+

--- a/german/javascript-cpp/enumerations/fonttype/_index.md
+++ b/german/javascript-cpp/enumerations/fonttype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum FontType"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Aspose.Font.FontType enum. Gibt den Font-Typ an"
+type: docs
+weight: 100
+url: /de/javascript-cpp/enumerations/fonttype/
+---
+## FontType enumeration
+
+Gibt den Schrifttyp an.
+
+```csharp
+public enum FontType
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+| TTF | `0` | TTF (TrueType) Font-Typ und zugehörige |
+| Type1 | `1` | Type1 Font-Typ. |
+| CFF | `2` | CFF (Compact font format) Font-Typ. |
+| OTF | `3` | OpenType Font. Das OpenType Font-Format ist eine Erweiterung des TrueType Font-Formats und fügt Unterstützung für PostScript Font-Daten hinzu. |
+

--- a/german/javascript-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
+++ b/german/javascript-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
@@ -1,0 +1,53 @@
+---
+title: "Aufzählung TtfNameTableMacPlatformSpecificId"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Aspose.Font.TtfNameTableMacPlatformSpecificId Aufzählung. Gibt an MacPlatformSpecificId"
+type: docs
+weight: 131
+url: /de/javascript-cpp/enumerations/ttfnametablemacplatformspecificid/
+---
+## TtfNameTableMacPlatformSpecificId enumeration
+
+Gibt an MacPlatformSpecificId.
+
+```csharp
+ enum TtfNameTableMacPlatformSpecificId
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+|  | Roman | `0` | Roman plattformspezifischer Wert. |
+|  | Japanese | `1` | Japanischer plattformspezifischer Wert. |
+|  | Traditional_Chinese | `2` | Traditioneller chinesischer plattformspezifischer Wert. |
+|  | Korean | `3` | Koreanischer plattformspezifischer Wert. |
+|  | Arabic | `4` | Arabischer plattformspezifischer Wert. |
+|  | Hebrew | `5` | Hebräisch plattformspezifischer Wert. |
+|  | Greek | `6` | Griechisch plattformspezifischer Wert. |
+|  | Russian | `7` | Russisch plattformspezifischer Wert. |
+|  | RSymbol | `8` | RSymbol plattformspezifischer Wert. |
+|  | Devanagari | `9` | Devanagari plattformspezifischer Wert. |
+|  | Gurmukhi | `10` | Gurmukhi plattformspezifischer Wert. |
+|  | Gujarati | `11` | Gujarati plattformspezifischer Wert. |
+|  | Oriya | `12` | Oriya plattformspezifischer Wert. |
+|  | Bengali | `13` | Bengalisch plattformspezifischer Wert. |
+|  | Tamil | `14` | Tamilisch plattformspezifischer Wert. |
+|  | Telugu | `15` | Telugu plattformspezifischer Wert. |
+|  | Kannada | `16` | Kannada plattformspezifischer Wert. |
+|  | Malayalam | `17` | Malayalam plattformspezifischer Wert. |
+|  | Sinhalese | `18` | Singhalesisch plattformspezifischer Wert. |
+|  | Burmese | `19` | Birmanisch plattformspezifischer Wert. |
+|  | Khmer | `20` | Khmer plattformspezifischer Wert. |
+|  | Thai | `21` | Thailändisch plattformspezifischer Wert. |
+|  | Laotian | `22` | Laotisch plattformspezifischer Wert. |
+|  | Georgian | `23` | Georgisch plattformspezifischer Wert. |
+|  | Armenian | `24` | Armenisch plattformspezifischer Wert. |
+|  | Simplified_Chinese | `25` | Vereinfachtes Chinesisch plattformspezifischer Wert. |
+|  | Tibetan | `26` | Tibetisch plattformspezifischer Wert. |
+|  | Mongolian | `27` | Mongolisch plattformspezifischer Wert. |
+|  | Geez | `28` | Geez plattformspezifischer Wert. |
+|  | Slavic | `29` | Slawisch plattformspezifischer Wert. |
+|  | Vietnamese | `30` | Plattformspezifischer Wert für Vietnamesisch. |
+|  | Sindhi | `31` | Plattformspezifischer Wert für Sindhi. |
+|  | Uninterpreted | `32` | Nicht interpretierter plattformspezifischer Wert. |

--- a/german/javascript-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
+++ b/german/javascript-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Enum TtfNameTableMSPlatformSpecificId"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Aspose.Font.TtfNameTableMSPlatformSpecificId enum. Gibt MSPlatformSpecificId an."
+type: docs
+weight: 132
+url: /de/javascript-cpp/enumerations/ttfnametablemsplatformspecificid/
+---
+## TtfNameTableMSPlatformSpecificId enumeration
+
+Gibt MSPlatformSpecificId an.
+
+```csharp
+ enum TtfNameTableMSPlatformSpecificId
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+|  | Symbol | `0` | Symbol MS PlatformSpecificId. |
+|  | Unicode_BMP_UCS2 | `1` | Unicode BMP (UCS2) MS PlatformSpecificId. |
+|  | ShiftJIS | `2` | ShiftJIS MS PlatformSpecificId. |
+|  | PRC | `3` | PRC MS PlatformSpecificId. |
+|  | Big5 | `4` | Big5 MS PlatformSpecificId. |
+|  | Wansung | `5` | Wansung MS PlatformSpecificId. |
+|  | Johab | `6` | Johab MS PlatformSpecificId. |
+|  | Reserved1 | `7` | Reserved1 MS PlatformSpecificId. |
+|  | Reserved2 | `8` | Reserved2 MS PlatformSpecificId. |
+|  | Reserved3 | `9` | Reserved3 MS PlatformSpecificId. |
+|  | Unicode_UCS4 | `10` | Unicode UCS4 MS PlatformSpecificId. |
+

--- a/german/javascript-cpp/enumerations/ttfnametablenameid/_index.md
+++ b/german/javascript-cpp/enumerations/ttfnametablenameid/_index.md
@@ -1,0 +1,46 @@
+---
+title: "Enum TtfNameTableNameId"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Aspose.Font.TtfNameTableNameId-Enum. Gibt NameId an."
+type: docs
+weight: 120
+url: /de/javascript-cpp/enumerations/ttfnametablenameid/
+---
+## TtfNameTableNameId enumeration
+
+Gibt die NameId an.
+
+```csharp
+ enum TtfNameTableNameId
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+|  | CopyrightNotice | `0` | Urheberrechtshinweis. |
+|  | FontFamily | `1` | Schriftfamilie. Diese Zeichenkette ist der Schriftfamilienname, den der Benutzer auf Macintosh-Plattformen sieht. |
+|  | FontSubfamily | `2` | Schriftunterfamilie. Diese Zeichenkette ist die Schriftfamilie, die der Benutzer auf Macintosh-Plattformen sieht. |
+|  | UniqueFontId | `3` | Eindeutige Unterfamilienidentifikation (Apple-Spezifikation). 3 Eindeutiger Schrift-Identifikator (MS-Spezifikation). |
+|  | FullName | `4` | Vollständiger Name der Schrift. |
+|  | Version | `5` | Version der Namens-Tabelle. |
+|  | PostScriptName | `6` | PostScript-Name der Schrift. Hinweis: Eine Schrift darf nur einen PostScript-Namen haben und dieser Name muss ASCII sein. |
+|  | TrademarkNotice | `7` | Markenhinweis. |
+|  | ManufacturerName | `8` | Herstellername. |
+|  | DesignerName | `9` | Designer; Name des Designers der Schriftart. |
+|  | Description | `10` | Beschreibung; Beschreibung der Schriftart. Kann Versionsinformationen, Nutzungsempfehlungen, Geschichte, Merkmale usw. enthalten. |
+|  | UrlVendor | `11` | URL des Schriftanbieters (mit Protokoll, z. B. http://, ftp://). Wenn eine eindeutige Seriennummer in der URL eingebettet ist, kann sie zur Registrierung der Schrift verwendet werden. |
+|  | UrlDesigner | `12` | URL des Schrift-Designers (mit Protokoll, z. B. http://, ftp://) |
+|  | LicenseDescription | `13` | Lizenzbeschreibung; Beschreibung, wie die Schrift rechtlich verwendet werden darf, oder verschiedene Beispielszenarien für lizenzierte Nutzung. Dieses Feld sollte in einfacher Sprache verfasst sein, nicht in Rechtssprache. |
+|  | LicenseInfoUrl | `14` | URL für Lizenzinformationen, wo zusätzliche Lizenzinformationen gefunden werden können. |
+|  | PreferredFamily | `16` | `15` Reserviert `16` Bevorzugte Familie (nur Windows); In Windows wird der Familienname im Schriftmenü angezeigt; der Unterfamilienname wird als Stilname dargestellt. Aus historischen Gründen enthalten Schriftfamilien maximal vier Stile, aber Schriftgestalter können mehr als vier Schriften zu einer einzigen Familie gruppieren. Die IDs für bevorzugte Familie und bevorzugte Unterfamilie ermöglichen es Schriftgestaltern, die bevorzugten Familien-/Unterfamilien‑Gruppierungen einzubeziehen. Diese IDs sind nur vorhanden, wenn sie sich von den IDs 1 und 2 unterscheiden. |
+|  | PreferredSubfamily | `17` | Bevorzugte Unterfamilie (nur Windows); In Windows wird der Familienname im Schriftmenü angezeigt; der Unterfamilienname wird als Stilname dargestellt. Aus historischen Gründen enthalten Schriftfamilien maximal vier Stile, aber Schriftgestalter können mehr als vier Schriften zu einer einzigen Familie gruppieren. Die IDs für bevorzugte Familie und bevorzugte Unterfamilie ermöglichen es Schriftgestaltern, die bevorzugten Familien-/Unterfamilien‑Gruppierungen einzubeziehen. Diese IDs sind nur vorhanden, wenn sie sich von den IDs 1 und 2 unterscheiden. |
+|  | CompatibleFull | `18` | Kompatibler Vollname (nur Macintosh); Auf dem Macintosh wird der Menüname mithilfe der Schriftressource erstellt. Dieser stimmt in der Regel mit dem Vollnamen überein. Wenn Sie möchten, dass der Schriftname anders als der Vollname angezeigt wird, können Sie den kompatiblen Vollnamen in ID 18 einfügen. Dieser Name wird vom Mac‑OS selbst nicht verwendet, kann aber von Anwendungsentwicklern genutzt werden (z. B. Adobe). |
+|  | SampleText | `19` | Beispieltext. Dies kann der Schriftname sein oder jeder andere Text, den der Designer für den besten Beispieltext hält, um zu zeigen, wie die Schrift aussieht. |
+|  | PostScriptCID | `20` | Seine Anwesenheit in einer Schrift bedeutet, dass nameID 6 einen PostScript-Schriftnamen enthält, der mit dem Aufruf "composefont" verwendet werden soll, um die Schrift in einem PostScript‑Interpreter zu aktivieren. |
+|  | WwsFamilyName | `21` | Wird verwendet, um einen WWS-konformen Familiennamen bereitzustellen, falls die Einträge für IDs 16 und 17 nicht dem WWS-Modell entsprechen. |
+|  | WwsSubfamilyName | `22` | In Verbindung mit ID 21 wird diese ID verwendet, um einen WWS-konformen Subfamiliennamen (der nur Gewicht-, Breiten- und Neigungsattribute widerspiegelt) bereitzustellen, falls die Einträge für IDs 16 und 17 nicht dem WWS-Modell entsprechen. |
+|  | LightBackground | `23` | Diese ID gibt, wenn sie im Palette Labels Array der CPAL-Tabelle verwendet wird, an, dass die entsprechende Farbpalette in der CPAL-Tabelle für die Verwendung mit der Schrift geeignet ist, wenn sie auf einem hellen Hintergrund wie Weiß angezeigt wird. |
+|  | DarkBackground | `24` | Diese ID gibt, wenn sie im Palette Labels Array der CPAL-Tabelle verwendet wird, an, dass die entsprechende Farbpalette in der CPAL-Tabelle für die Verwendung mit der Schrift geeignet ist, wenn sie auf einem dunklen Hintergrund wie Schwarz angezeigt wird. |
+|  | VariationsPostScriptNamePrefix | `25` | Falls sie in einer variablen Schrift vorhanden ist, kann sie als Familienpräfix im Algorithmus zur PostScript-Namensgenerierung für Variationsschriften verwendet werden. |
+

--- a/german/javascript-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
+++ b/german/javascript-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
@@ -1,0 +1,138 @@
+---
+title: "Enum TtfNameTableMacLanguageId"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Aspose.Font.TtfNameTableMacLanguageId enum. Gibt MacLanguageId an"
+type: docs
+weight: 140
+url: /de/javascript-cpp/enumerations/ttfnametablemaclanguageid/
+---
+## TtfNameTableMacLanguageId enumeration
+
+Stellt die MacLanguageId-Enumeration dar.
+
+```csharp
+ enum TtfNameTableMacLanguageId
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+|  | English | `0` | Englischer LanguageId-Wert |
+|  | French | `1` | Französischer LanguageId-Wert |
+|  | German | `2` | Deutscher LanguageId-Wert |
+|  | Italian | `3` | Italienischer LanguageId-Wert |
+|  | Dutch | `4` | Niederländischer LanguageId-Wert |
+|  | Swedish | `5` | Schwedischer LanguageId-Wert |
+|  | Spanish | `6` | Spanischer LanguageId-Wert |
+|  | Danish | `7` | Dänischer LanguageId-Wert |
+|  | Portuguese | `8` | Portugiesischer LanguageId-Wert |
+|  | Norwegian | `9` | Norwegischer LanguageId-Wert |
+|  | Hebrew | `10` | Hebräischer LanguageId-Wert |
+|  | Japanese | `11` | Japanischer LanguageId-Wert |
+|  | Arabic | `12` | Arabischer LanguageId-Wert |
+|  | Finnish | `13` | Finnischer LanguageId-Wert |
+|  | Greek | `14` | Griechischer LanguageId-Wert |
+|  | Icelandic | `15` | Isländischer LanguageId-Wert |
+|  | Maltese | `16` | Maltesischer LanguageId-Wert |
+|  | Turkish | `17` | Türkischer LanguageId-Wert |
+|  | Croatian | `18` | Kroatischer LanguageId-Wert |
+|  | Chinese_Traditional | `19` | Chinesischer (Traditionell) LanguageId-Wert |
+|  | Urdu | `20` | Urdu LanguageId-Wert |
+|  | Hindi | `21` | Hindi LanguageId-Wert |
+|  | Thai | `22` | Thailändischer LanguageId-Wert |
+|  | Korean | `23` | Koreanischer LanguageId-Wert |
+|  | Lithuanian | `24` | Litauischer LanguageId-Wert |
+|  | Polish | `25` | Polnisch LanguageId Wert |
+|  | Hungarian | `26` | Ungarisch LanguageId Wert |
+|  | Estonian | `27` | Estnisch LanguageId Wert |
+|  | Latvian | `28` | Lettisch LanguageId Wert |
+|  | Sami | `29` | Samisch LanguageId Wert |
+|  | Faroese | `30` | Färöisch LanguageId Wert |
+|  | Farsi_Persian | `31` | Farsi/Persisch LanguageId Wert |
+|  | Russian | `32` | Russisch LanguageId Wert |
+|  | Chinese_Simplified | `33` | Chinesisch (Vereinfacht) LanguageId Wert |
+|  | Flemish | `34` | Flämisch LanguageId Wert |
+|  | Irish_Gaelic | `35` | Irisch Gälisch LanguageId Wert |
+|  | Albanian | `36` | Albanisch LanguageId Wert |
+|  | Romanian | `37` | Rumänisch LanguageId Wert |
+|  | Czech | `38` | Tschechisch LanguageId Wert |
+|  | Slovak | `39` | Slowakisch LanguageId Wert |
+|  | Slovenian | `40` | Slowenisch LanguageId Wert |
+|  | Yiddish | `41` | Jiddisch LanguageId Wert |
+|  | Serbian | `42` | Serbisch LanguageId Wert |
+|  | Macedonian | `43` | Mazedonisch LanguageId Wert |
+|  | Bulgarian | `44` | Bulgarisch LanguageId Wert |
+|  | Ukrainian | `45` | Ukrainisch LanguageId Wert |
+|  | Byelorussian | `46` | Belarussisch LanguageId Wert |
+|  | Uzbek | `47` | Usbekisch LanguageId Wert |
+|  | Kazakh | `48` | Kasachisch LanguageId Wert |
+|  | Azerbaijani_Cyrillic | `49` | Aserbaidschanisch (Kyrillisches Skript) LanguageId Wert |
+|  | Azerbaijani_Arabic | `50` | Aserbaidschanisch (Arabische Schrift) LanguageId Wert |
+|  | Armenian | `51` | Armenisch LanguageId Wert |
+|  | Georgian | `52` | Georgisch LanguageId Wert |
+|  | Moldavian | `53` | Moldauisch LanguageId Wert |
+|  | Kirghiz | `54` | Kirgisisch LanguageId Wert |
+|  | Tajiki | `55` | Tadschikisch LanguageId Wert |
+|  | Turkmen | `56` | Turkmenisch LanguageId Wert |
+|  | Mongolian | `57` | Mongolisch (Mongolische Schrift) LanguageId Wert |
+|  | Mongolian_Cyrillic | `58` | Mongolisch (Kyrillische Schrift) LanguageId Wert |
+|  | Pashto | `59` | Paschtunisch LanguageId Wert |
+|  | Kurdish | `60` | Paschtunisch LanguageId Wert |
+|  | Kashmiri | `61` | Kaschmirisch LanguageId Wert |
+|  | Sindhi | `62` | Sindhi LanguageId Wert |
+|  | Tibetan | `63` | Tibetisch LanguageId Wert |
+|  | Nepali | `64` | Nepalesisch LanguageId Wert |
+|  | Sanskrit | `65` | Sanskrit LanguageId Wert |
+|  | Marathi | `66` | Marathi LanguageId Wert |
+|  | Bengali | `67` | Bengalisch LanguageId Wert |
+|  | Assamese | `68` | Assamesisch LanguageId Wert |
+|  | Gujarati | `69` | Gujarati LanguageId Wert |
+|  | Punjabi | `70` | Punjabi LanguageId Wert |
+|  | Oriya | `71` | Oriya LanguageId Wert |
+|  | Malayalam | `72` | Malayalam LanguageId Wert |
+|  | Kannada | `73` | Kannada LanguageId Wert |
+|  | Tamil | `74` | Tamil LanguageId Wert |
+|  | Telugu | `75` | Telugu LanguageId Wert |
+|  | Sinhalese | `76` | Singhalesisch LanguageId-Wert |
+|  | Burmese | `77` | Burmesisch LanguageId-Wert |
+|  | Khmer | `78` | Khmer LanguageId-Wert |
+|  | Lao | `79` | Laotisch LanguageId-Wert |
+|  | Vietnamese | `80` | Vietnamesisch LanguageId-Wert |
+|  | Indonesian | `81` | Indonesisch LanguageId-Wert |
+|  | Tagalog | `82` | Tagalog LanguageId-Wert |
+|  | Malay_Roman | `83` | Malaiisch (römische Schrift) LanguageId-Wert |
+|  | Malay_Arabic | `84` | Malaiisch (arabische Schrift) LanguageId-Wert |
+|  | Amharic | `85` | Amharisch LanguageId-Wert |
+|  | Tigrinya | `86` | Tigrinya LanguageId-Wert |
+|  | Galla | `87` | Galla LanguageId-Wert |
+|  | Somali | `88` | Somali LanguageId-Wert |
+|  | Swahili | `89` | Swahili LanguageId-Wert |
+|  | Kinyarwanda_Ruanda | `90` | Kinyarwanda/Ruanda LanguageId-Wert |
+|  | Rundi | `91` | Rundi LanguageId-Wert |
+|  | Nyanja_Chewa | `92` | Nyanja/Chewa LanguageId-Wert |
+|  | Malagasy | `93` | Madagassisch LanguageId-Wert |
+|  | Esperanto | `94` | Esperanto LanguageId-Wert |
+|  | Welsh | `128` | Walisisch LanguageId-Wert |
+|  | Basque | `129` | Baskisch LanguageId-Wert |
+|  | Catalan | `130` | Katalanisch LanguageId-Wert |
+|  | Latin | `131` | Lateinisch LanguageId-Wert |
+|  | Quechua | `132` | Quechua LanguageId-Wert |
+|  | Guarani | `133` | Guaraní LanguageId-Wert |
+|  | Aymara | `134` | Aymara LanguageId Wert |
+|  | Tatar | `135` | Tatar LanguageId Wert |
+|  | Uighur | `136` | Uighur LanguageId Wert |
+|  | Dzongkha | `137` | Dzongkha LanguageId Wert |
+|  | Javanese | `138` | Javanisch (Roman script) LanguageId Wert |
+|  | Sundanese | `139` | Sundanesisch (Roman script) LanguageId Wert |
+|  | Galician | `140` | Galicisch LanguageId Wert |
+|  | Afrikaans | `141` | Afrikaans LanguageId Wert |
+|  | Breton | `142` | Bretonisch LanguageId Wert |
+|  | Inuktitut | `143` | Inuktitut LanguageId Wert |
+|  | Scottish_Gaelic | `144` | Schottisch-gälisch LanguageId Wert |
+|  | Manx_Gaelic | `145` | Manx-Gälisch LanguageId Wert |
+|  | Irish_Gaelic_WDA | `146` | Irisch-gälisch (mit Punkt darüber) LanguageId Wert |
+|  | Tongan | `147` | Tongaisch LanguageId Wert |
+|  | Greek_Polytonic | `148` | Griechisch (polytonisch) LanguageId Wert |
+|  | Greenlandic | `149` | Grönländisch LanguageId Wert |
+|  | Azerbaijani_Roman | `150` | Aserbaidschanisch (Roman script) LanguageId Wert |

--- a/german/javascript-cpp/enumerations/ttfnametablenmslanguageid/_index.md
+++ b/german/javascript-cpp/enumerations/ttfnametablenmslanguageid/_index.md
@@ -1,0 +1,225 @@
+---
+title: "Aufzählung TtfNameTableMSLanguageId"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Aspose.Font.TtfNameTableMSLanguageId enum. Gibt MSLanguageId an."
+type: docs
+weight: 150
+url: /de/javascript-cpp/enumerations/ttfnametablemslanguageid/
+---
+## TtfNameTableMSLanguageId enumeration
+
+Stellt die MSLanguageId‑Aufzählung dar.
+
+```csharp
+ enum TtfNameTableMSLanguageId
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+|  | Afrikaans | `0x0436` | Afrikaans (Region: Südafrika, SA) LanguageId‑Wert |
+|  | Albanian | `0x041c` | Albanisch (Region: Albanien, SQI) LanguageId‑Wert |
+|  | Alsatian | `0x0484` | Elsässisch (Region: Frankreich) LanguageId‑Wert |
+|  | Amharic | `0x045E` | Amharisch (Region: Äthiopien) LanguageId‑Wert |
+|  | Arabic_Algeria | `0x1401` | Arabisch (Region: Algerien) LanguageId‑Wert |
+|  | Arabic_Bahrain | `0x3C01` | Arabisch (Region: Bahrain) LanguageId‑Wert |
+|  | Arabic_Egypt | `0x0C01` | Arabisch (Region: Ägypten) LanguageId‑Wert |
+|  | Arabic_Iraq | `0x0801` | Arabisch (Region: Irak) LanguageId‑Wert |
+|  | Arabic_Jordan | `0x2C01` | Arabisch (Region: Jordanien) LanguageId‑Wert |
+|  | Arabic_Kuwait | `0x3401` | Arabisch (Region: Kuwait) LanguageId‑Wert |
+|  | Arabic_Lebanon | `0x3001` | Arabisch (Region: Libanon) LanguageId‑Wert |
+|  | Arabic_Libya | `0x1001` | Arabisch (Region: Libyen) LanguageId‑Wert |
+|  | Arabic_Morocco | `0x1801` | Arabisch (Region: Marokko) LanguageId‑Wert |
+|  | Arabic_Oman | `0x2001` | Arabisch (Region: Oman) LanguageId‑Wert |
+|  | Arabic_Qatar | `0x4001` | Arabisch (Region: Katar) LanguageId‑Wert |
+|  | Arabic_Saudi_Arabia | `0x0401` | Arabisch (Region: Saudi-Arabien) LanguageId‑Wert |
+|  | Arabic_Syria | `0x2801` | Arabisch (Region: Syrien) LanguageId‑Wert |
+|  | Arabic_Tunisia | `0x1C01` | Arabisch (Region: Tunesien) LanguageId-Wert |
+|  | Arabic_U_A_E | `0x3801` | Arabisch (Region: VAE) LanguageId-Wert |
+|  | Arabic_Yemen | `0x2401` | Arabisch (Region: Jemen) LanguageId-Wert |
+|  | Armenian | `0x042B` | Armenisch (Region: Armenien) LanguageId-Wert |
+|  | Assamese | `0x044D` | Assamesisch (Region: Indien) LanguageId-Wert |
+|  | Azeri_Cyrillic | `0x082C` | Aserbaidschanisch (Kyrillisch, Region: Aserbaidschan) LanguageId-Wert |
+|  | Azeri_Latin | `0x042C` | Aserbaidschanisch (Lateinisch, Region: Aserbaidschan) LanguageId-Wert |
+|  | Bashkir | `0x046D` | Baschkirisch (Region: Russland) LanguageId-Wert |
+|  | Basque | `0x042D` | Baskisch (Region: Baskenland, EUQ) LanguageId-Wert |
+|  | Belarusian | `0x0423` | Weißrussisch (Region: Belarus, BEL) LanguageId-Wert |
+|  | Bengali_Bangladesh | `0x0845` | Bengalisch (Region: Bangladesch) LanguageId-Wert |
+|  | Bengali_India | `0x0445` | Bengalisch (Region: Indien) LanguageId-Wert |
+|  | Bosnian_Cyrillic | `0x201A` | Bosnisch (Kyrillisch, Region: Bosnien und Herzegowina) LanguageId-Wert |
+|  | Bosnian_Latin | `0x141A` | Bosnisch (Lateinisch, Region: Bosnien und Herzegowina) LanguageId-Wert |
+|  | Breton | `0x047E` | Bretonisch (Region: Frankreich) LanguageId-Wert |
+|  | Bulgarian | `0x0402` | Bulgarisch (Region: Bulgarien, BGR) LanguageId-Wert |
+|  | Catalan | `0x0403` | Katalanisch (Region: Katalonien, CAT) LanguageId-Wert |
+|  | Chinese_Hong_Kong | `0x0C04` | Chinesisch (Region: Hongkong SAR) LanguageId-Wert |
+|  | Chinese_Macao | `0x1404` | Chinesisch (Region: Macau SAR) LanguageId-Wert |
+|  | Chinese_PRC | `0x0804` | Chinesisch (Region: Volksrepublik China) LanguageId-Wert |
+|  | Chinese_Singapore | `0x1004` | Chinesisch (Region: Singapur) LanguageId-Wert |
+|  | Chinese_Taiwan | `0x0404` | Chinesisch (Region: Taiwan) LanguageId-Wert |
+|  | Corsican | `0x0483` | Korsisch (Region: Frankreich) LanguageId-Wert |
+|  | Croatian | `0x041A` | Kroatisch (Region: Kroatien, SHL) LanguageId-Wert |
+|  | Croatian_Latin | `0x101A` | Kroatisch (Lateinisch, Region: Bosnien und Herzegowina) LanguageId-Wert |
+|  | Czech | `0x0405` | Tschechisch (Region: Tschechien, CSY) LanguageId Wert |
+|  | Danish | `0x0406` | Dänisch (Region: Dänemark, DAN) LanguageId Wert |
+|  | Dari | `0x048C` | Dari (Region: Afghanistan) LanguageId Wert |
+|  | Divehi | `0x0465` | Divehi (Region: Malediven) LanguageId Wert |
+|  | Dutch_Belgium | `0x0813` | Niederländisch (Flämisch, Region: Belgien, NLB) LanguageId Wert |
+|  | Dutch_Netherlands | `0x0413` | Niederländisch (Standard, Region: Niederlande, NLD) LanguageId Wert |
+|  | English_Australia | `0x0C09` | Englisch (Australisch, Region: Australien, ENA) LanguageId Wert |
+|  | English_Belize | `0x2809` | Englisch (Region: Belize) LanguageId Wert |
+|  | English_Canada | `0x1009` | Englisch (Kanadisch, Region: Kanada, ENC) LanguageId Wert |
+|  | English_Caribbean | `0x2409` | Englisch (Region: Karibik) LanguageId Wert |
+|  | English_India | `0x4009` | Englisch (Region: Indien) LanguageId Wert |
+|  | English_Ireland | `0x1809` | Englisch (Region: Irland, ENI) LanguageId Wert |
+|  | English_Jamaica | `0x2009` | Englisch (Region: Jamaika) LanguageId Wert |
+|  | English_Malaysia | `0x4409` | Englisch (Region: Malaysia) LanguageId Wert |
+|  | English_New_Zealand | `0x1409` | Englisch (Region: Neuseeland, ENZ) LanguageId Wert |
+|  | English_ROP | `0x3409` | Englisch (Region: Republik der Philippinen, ROP) LanguageId Wert |
+|  | English_Singapore | `0x4809` | Englisch (Region: Singapur) LanguageId Wert |
+|  | English_South_Africa | `0x1C09` | Englisch (Region: Südafrika, SA) LanguageId Wert |
+|  | English_TT | `0x2C09` | Englisch (Region: Trinidad und Tobago, TT) LanguageId Wert |
+|  | English_United_Kingdom | `0x0809` | Englisch (Britisch, Region: Vereinigtes Königreich, ENG) LanguageId Wert |
+|  | English_United_States | `0x0409` | Englisch (Amerikanisch, Region: Vereinigte Staaten, ENU) LanguageId Wert |
+|  | English_Zimbabwe | `0x3009` | Englisch (Region: Simbabwe) LanguageId Wert |
+|  | Estonian | `0x0425` | Estnisch (Region: Estland, ETI) LanguageId Wert |
+|  | Faroese | `0x0438` | Färöisch (Region: Färöer) LanguageId Wert |
+|  | Filipino | `0x0464` | Filipino (Region: Philippinen) LanguageId Wert |
+|  | Finnish | `0x040B` | Finnisch (Region: Finland, FIN) LanguageId-Wert |
+|  | French_Belgium | `0x080C` | Französisch (Belgisch, Region: Belgium, FRB) LanguageId-Wert |
+|  | French_Canada | `0x0C0C` | Französisch (Kanadisch, Region: Canada, FRC) LanguageId-Wert |
+|  | French_France | `0x040C` | Französisch (Standard, Region: France, FRA) LanguageId-Wert |
+|  | French_Luxembourg | `0x140c` | Französisch (Region: Luxembourg, FRL) LanguageId-Wert |
+|  | French_MC | `0x180C` | Französisch (Region: Fürstentum Monaco, MC) LanguageId-Wert |
+|  | French_Switzerland | `0x100C` | Französisch (Schweizerisch, Region: Switzerland, FRS) LanguageId-Wert |
+|  | Frisian | `0x0462` | Friesisch (Region: Netherlands, NLD) LanguageId-Wert |
+|  | Galician | `0x0456` | Galicisch (Region: Galician) LanguageId-Wert |
+|  | Georgian | `0x0437` | Georgisch (Region: Georgia) LanguageId-Wert |
+|  | German_Austria | `0x0C07` | Deutsch (Österreichisch, Region: Austria, DEA) LanguageId-Wert |
+|  | German_Germany | `0x0407` | Deutsch (Standard, Region: Germany, DEU) LanguageId-Wert |
+|  | German_Liechtenstein | `0x1407` | Deutsch (Region: Liechtenstein, DEC) LanguageId-Wert |
+|  | German_Luxembourg | `0x1007` | Deutsch (Region: Luxembourg, DEL) LanguageId-Wert |
+|  | German_Switzerland | `0x0807` | Deutsch (Schweizerisch, Region: Switzerland, DES) LanguageId-Wert |
+|  | Greek | `0x0408` | Griechisch (Region: Greece, ELL) LanguageId-Wert |
+|  | Greenlandic | `0x046F` | Grönländisch (Region: Greenland) LanguageId-Wert |
+|  | Gujarati | `0x0447` | Gujarati (Region: India) LanguageId-Wert |
+|  | Hausa | `0x0468` | Hausa (Lateinisch, Region: Nigeria) LanguageId-Wert |
+|  | Hebrew | `0x040D` | Hebräisch (Region: Israel) LanguageId-Wert |
+|  | Hindi | `0x0439` | Hindi (Region: India) LanguageId-Wert |
+|  | Hungarian | `0x040E` | Ungarisch (Region: Hungary, HUN) LanguageId-Wert |
+|  | Icelandic | `0x040F` | Isländisch (Region: Iceland, ISL) LanguageId-Wert |
+|  | Igbo | `0x0470` | Igbo (Region: Nigeria) LanguageId-Wert |
+|  | Indonesian | `0x0421` | Indonesisch (Region: Indonesia) LanguageId-Wert |
+|  | Inuktitut | `0x045D` | Inuktitut (Region: Kanada) LanguageId Wert |
+|  | Inuktitut_Latin | `0x085D` | Inuktitut (Latein, Region: Kanada) LanguageId Wert |
+|  | Irish | `0x083C` | Irisch (Region: Irland) LanguageId Wert |
+|  | isiXhosa | `0x0434` | isiXhosa (Region: Südafrika, SA) LanguageId Wert |
+|  | isiZulu | `0x0435` | isiZulu (Region: Südafrika, SA) LanguageId Wert |
+|  | Italian_Italy | `0x0410` | Italienisch (Standard, Region: Italien, ITA) LanguageId Wert |
+|  | Italian_Switzerland | `0x0810` | Italienisch (Schweiz, Region: Schweiz, ITS) LanguageId Wert |
+|  | Japanese | `0x0411` | Japanisch (Region: Japan) LanguageId Wert |
+|  | Kannada | `0x044B` | Kannada (Region: Indien) LanguageId Wert |
+|  | Kazakh | `0x043F` | Kasachisch (Region: Kasachstan) LanguageId Wert |
+|  | Khmer | `0x0453` | Khmer (Region: Kambodscha) LanguageId Wert |
+|  | Kiche | `0x0486` | K�iche (Region: Guatemala) LanguageId Wert |
+|  | Kinyarwanda | `0x0487` | Kinyarwanda (Region: Ruanda) LanguageId Wert |
+|  | Kiswahili | `0x0441` | Kiswahili (Region: Kenia) LanguageId Wert |
+|  | Konkani | `0x0457` | Konkani (Region: Indien) LanguageId Wert |
+|  | Korean | `0x0412` | Koreanisch (Region: Korea) LanguageId Wert |
+|  | Kyrgyz | `0x0440` | Kirgisisch (Region: Kirgisistan) LanguageId Wert |
+|  | Lao | `0x0454` | Laotisch (Region: Laos) LanguageId Wert |
+|  | Latvian | `0x0426` | Lettisch (Region: Lettland, LVI) LanguageId Wert |
+|  | Lithuanian | `0x0427` | Litauisch (Region: Litauen, LTH) LanguageId Wert |
+|  | Lower_Sorbian | `0x082E` | Niedersorbisch (Region: Deutschland) LanguageId Wert |
+|  | Luxembourgish | `0x046E` | Luxemburgisch (Region: Luxemburg) LanguageId Wert |
+|  | Macedonian | `0x042F` | Mazedonisch (Region: Nordmazedonien) LanguageId Wert |
+|  | Malay_Brunei_Darussalam | `0x083E` | Malaiisch (Region: Brunei Darussalam) LanguageId Wert |
+|  | Malay_Malaysia | `0x043E` | Malaiisch (Region: Malaysia) LanguageId Wert |
+|  | Malayalam | `0x044C` | Malayalam (Region: Indien) LanguageId Wert |
+|  | Maltese | `0x043A` | Maltesisch (Region: Malta) LanguageId Wert |
+|  | Maori | `0x0481` | Maori (Region: Neuseeland) LanguageId Wert |
+|  | Mapudungun | `0x047A` | Mapudungun (Region: Chile) LanguageId Wert |
+|  | Marathi | `0x044E` | Marathi (Region: Indien) LanguageId Wert |
+|  | Mohawk | `0x047C` | Mohawk (Region: Mohawk) LanguageId Wert |
+|  | Mongolian_Cyrillic | `0x0450` | Mongolisch (Kyrillisch, Region: Mongolei) LanguageId Wert |
+|  | Mongolian_Traditional | `0x0850` | Mongolisch (Traditionell, Region: Volksrepublik China) LanguageId Wert |
+|  | Nepali | `0x0461` | Nepali (Region: Nepal) LanguageId Wert |
+|  | Norwegian_Bokmal | `0x0414` | Norwegisch (Bokmål, Region: Norwegen, NOR) LanguageId Wert |
+|  | Norwegian_Nynorsk | `0x0814` | Norwegisch (Nynorsk, Region: Norwegen, NON) LanguageId Wert |
+|  | Occitan | `0x0482` | Okzitanisch (Region: Frankreich) LanguageId Wert |
+|  | Odia | `0x0448` | Odia (früher Oriya, Region: Indien) LanguageId Wert |
+|  | Pashto | `0x0463` | Paschtunisch (Region: Afghanistan) LanguageId Wert |
+|  | Polish | `0x0415` | Polnisch (Region: Polen, PLK) LanguageId Wert |
+|  | Portuguese_Brazil | `0x0416` | Portugiesisch (Brasilianisch, Region: Brasilien, PTB) LanguageId Wert |
+|  | Portuguese_Portugal | `0x0816` | Portugiesisch (Standard, Region: Portugal, PTG) LanguageId Wert |
+|  | Punjabi | `0x0446` | Punjabi (Region: Indien) LanguageId Wert |
+|  | Quechua_Bolivia | `0x046B` | Quechua (Region: Bolivien) LanguageId Wert |
+|  | Quechua_Ecuador | `0x086B` | Quechua (Region: Ecuador) LanguageId Wert |
+|  | Quechua_Peru | `0x0C6B` | Quechua (Region: Peru) LanguageId Wert |
+|  | Romanian | `0x0418` | Rumänisch (Region: Rumänien, ROM) LanguageId Wert |
+|  | Romansh | `0x0417` | Rätoromanisch (Region: Schweiz) LanguageId Wert |
+|  | Russian | `0x0419` | Russisch (Region: Russland, RUS) LanguageId Wert |
+|  | Sami_Inari | `0x243B` | Samisch (Inari, Region: Finnland) LanguageId Wert |
+|  | Sami_Lule_Norway | `0x103B` | Sami (Lule, Region: Norwegen) LanguageId-Wert |
+|  | Sami_Lule_Sweden | `0x143B` | Sami (Lule, Region: Schweden) LanguageId-Wert |
+|  | Sami_Northern_Finland | `0x0C3B` | Sami (Northern, Region: Finnland) LanguageId-Wert |
+|  | Sami_Northern_Norway | `0x043B` | Sami (Northern, Region: Norwegen) LanguageId-Wert |
+|  | Sami_Northern_Sweden | `0x083B` | Sami (Northern, Region: Norwegen) LanguageId-Wert |
+|  | Sami_Skolt | `0x203B` | Sami (Skolt, Region: Finnland) LanguageId-Wert |
+|  | Sami_Southern_Norway | `0x183B` | Sami (Southern, Region: Norwegen) LanguageId-Wert |
+|  | Sami_Southern_Sweden | `0x1C3B` | Sami (Southern, Region: Schweden) LanguageId-Wert |
+|  | Sanskrit | `0x044F` | Sanskrit (Region: Indien) LanguageId-Wert |
+|  | Serbian_Cyrillic_BIH | `0x1C1A` | Serbisch (Kyrillisch, Region: Bosnien und Herzegowina) LanguageId-Wert |
+|  | Serbian_Cyrillic_Serbia | `0x0C1A` | Serbisch (Kyrillisch, Region: Serbien) LanguageId-Wert |
+|  | Serbian_Latin_BIH | `0x181A` | Serbisch (Lateinisch, Region: Bosnien und Herzegowina) LanguageId-Wert |
+|  | Serbian_Latin_Serbia | `0x081A` | Serbisch (Lateinisch, Region: Serbien) LanguageId-Wert |
+|  | Sesotho_Sa_Leboa | `0x046C` | Sesotho sa Leboa (Northern Sotho, Region: Südafrika, SA) LanguageId-Wert |
+|  | Setswana | `0x0432` | Setswana (Region: Südafrika, SA) LanguageId-Wert |
+|  | Sinhala | `0x045B` | Sinhala (Region: Sri Lanka) LanguageId-Wert |
+|  | Slovak | `0x041B` | Slowakisch (Region: Slowakei, SKY) LanguageId-Wert |
+|  | Slovenian | `0x0424` | Slowenisch (Region: Slowenien, SLV) LanguageId-Wert |
+|  | Spanish_Argentina | `0x2C0A` | Spanisch (Region: Argentinien) LanguageId-Wert |
+|  | Spanish_Bolivia | `0x400A` | Spanisch (Region: Bolivien) LanguageId-Wert |
+|  | Spanish_Chile | `0x340A` | Spanisch (Region: Chile) LanguageId-Wert |
+|  | Spanish_Colombia | `0x240A` | Spanisch (Region: Kolumbien) LanguageId-Wert |
+|  | Spanish_Costa_Rica | `0x140A` | Spanisch (Region: Costa Rica) LanguageId-Wert |
+|  | Spanish_Dominican_Republic | `0x1C0A` | Spanisch (Region: Dominikanische Republik) LanguageId-Wert |
+|  | Spanish_Ecuador | `0x300A` | Spanisch (Region: Dominikanische Republik) LanguageId-Wert |
+|  | Spanish_El_Salvador | `0x440A` | Spanisch (Region: Dominikanische Republik) LanguageId-Wert |
+|  | Spanish_Guatemala | `0x100A` | Spanisch (Region: Guatemala) LanguageId-Wert |
+|  | Spanish_Honduras | `0x480A` | Spanisch (Region: Honduras) LanguageId-Wert |
+|  | Spanish_Mexico | `0x080A` | Spanisch (Mexikanisch, Region: Mexiko, ESM) LanguageId Wert |
+|  | Spanish_Nicaragua | `0x4C0A` | Spanisch (Region: Nicaragua) LanguageId Wert |
+|  | Spanish_Panama | `0x180A` | Spanisch (Region: Panama) LanguageId Wert |
+|  | Spanish_Paraguay | `0x3C0A` | Spanisch (Region: Paraguay) LanguageId Wert |
+|  | Spanish_Peru | `0x280A` | Spanisch (Region: Peru) LanguageId Wert |
+|  | Spanish_Puerto_Rico | `0x500A` | Spanisch (Region: Puerto Rico) LanguageId Wert |
+|  | Spanish_Modern_Sort | `0x0C0A` | Spanisch (Moderne Sortierung, Region: Spanien, ESN) LanguageId Wert |
+|  | Spanish_Traditional_Sort | `0x040A` | Spanisch (Traditionelle Sortierung, Region: Spanien, ESP) LanguageId Wert |
+|  | Spanish_United_States | `0x540A` | Spanisch (Region: Vereinigte Staaten) LanguageId Wert |
+|  | Spanish_Uruguay | `0x380A` | Spanisch (Region: Uruguay) LanguageId Wert |
+|  | Spanish_Venezuela | `0x200A` | Spanisch (Region: Venezuela) LanguageId Wert |
+|  | Swedish_Finland | `0x081D` | Schwedisch (Region: Finnland) LanguageId Wert |
+|  | Swedish_Sweden | `0x041D` | Schwedisch (Region: Schweden, SVE) LanguageId Wert |
+|  | Syriac | `0x045A` | Syrisch (Region: Syrien) LanguageId Wert |
+|  | Tajik | `0x0428` | Tadschikisch (Kyrillisch, Region: Tadschikistan) LanguageId Wert |
+|  | Tamazight | `0x085F` | Tamazight (Lateinisch, Region: Algerien) LanguageId Wert |
+|  | Tamil | `0x0449` | Tamil (Region: Indien) LanguageId Wert |
+|  | Tatar | `0x0444` | Tatarisch (Region: Russland) LanguageId Wert |
+|  | Telugu | `0x044A` | Telugu (Region: Indien) LanguageId Wert |
+|  | Thai | `0x041E` | Thailändisch (Region: Thailand) LanguageId Wert |
+|  | Tibetan | `0x0451` | Tibetisch (Region: PRC) LanguageId Wert |
+|  | Turkish | `0x041F` | Türkisch (Region: Türkei, TRK) LanguageId Wert |
+|  | Turkmen | `0x0442` | Turkmenisch (Region: Turkmenistan) LanguageId Wert |
+|  | Uighur | `0x0480` | Uigurisch (Region: PRC) LanguageId Wert |
+|  | Ukrainian | `0x0422` | Ukrainisch (Region: Ukraine, UKR) LanguageId Wert |
+|  | Upper_Sorbian | `0x042E` | Obersorbisch (Region: Deutschland) LanguageId-Wert |
+|  | Urdu | `0x0420` | Urdu (Region: Islamische Republik Pakistan) LanguageId-Wert |
+|  | Uzbek_Cyrillic | `0x0843` | Usbekisch (Kyrillisch, Region: Usbekistan) LanguageId-Wert |
+|  | Uzbek_Latin | `0x0443` | Usbekisch (Lateinisch, Region: Usbekistan) LanguageId-Wert |
+|  | Vietnamese | `0x042A` | Vietnamesisch (Region: Vietnam) LanguageId-Wert |
+|  | Welsh | `0x0452` | Walisisch (Region: Vereinigtes Königreich) LanguageId-Wert |
+|  | Wolof | `0x0488` | Wolof (Region: Senegal) LanguageId-Wert |
+|  | Yakut | `0x0485` | Jakutisch (Region: Russland) LanguageId-Wert |
+|  | Yi | `0x0478` | Yi (Region: VR China) LanguageId-Wert |
+| Yoruba | `0x046A` | Yoruba (Region: Nigeria) LanguageId-Wert |

--- a/german/javascript-cpp/enumerations/ttfnametableplatformid/_index.md
+++ b/german/javascript-cpp/enumerations/ttfnametableplatformid/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Enum TtfNameTablePlatformId"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Aspose.Font.TtfNameTablePlatformId enum. Gibt PlatformId an."
+type: docs
+weight: 130
+url: /de/javascript-cpp/enumerations/ttfnametableplatformid/
+---
+## TtfNameTablePlatformId enumeration
+
+Gibt PlatformId an.
+
+```cssharp
+ enum TtfNameTablePlatformId
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+|  | Unicode | `0` | Unicode |
+|  | Macintosh | `1` | Macintosh Script Manager-Code. |
+|  | ISO | `2` | Apple-Spezifikation: (reserviert; nicht verwenden) MS-Spezifikation: ISO-Codierung. Hinweis: Die Plattform-ID 2 (ISO) ist seit der OpenType-Spezifikation v1.3 veraltet. Sie sollte ISO/IEC 10646 darstellen, im Gegensatz zu Unicode; beide Standards haben identische Zeichenkodierungszuweisungen. |
+|  | Microsoft | `3` | Microsoft-Codierung. |

--- a/german/javascript-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
+++ b/german/javascript-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum TtfNameTableUnicodePlatformSpecificId"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Aspose.Font.TtfNameTableUnicodePlatformSpecificId enum. Gibt UnicodePlatformSpecificId an"
+type: docs
+weight: 133
+url: /de/javascript-cpp/enumerations/ttfnametableunicodeplatformspecificid/
+---
+## TtfNameTableUnicodePlatformSpecificId enumeration
+
+Gibt UnicodePlatformSpecificId an.
+
+```csharp
+ enum TtfNameTableUnicodePlatformSpecificId
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+|  | Default | `0` | Standardsemantik (Unicode 1.0). |
+|  | Unicode1_1 | `1` | Unicode 1.1 Semantik. |
+|  | ISO10646_1993 | `2` | ISO 10646 1993 Semantik (veraltet). |
+|  | Unicode2_0 | `3` | Unicode 2.0 oder spätere Semantik. Nur Unicode BMP. |
+|  | Unicode2_0_Full | `4Unicode 2.0 and onwards semantics (non-BMP characters allowed)` | Vollständiges Unicode-Repertoire. |

--- a/german/javascript-cpp/glyph/_index.md
+++ b/german/javascript-cpp/glyph/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Glyph Font-Funktionen"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Funktionen zum Arbeiten mit Glyphen von Font-Dateien"
+type: docs
+url: /de/javascript-cpp/glyph/
+---
+
+## Glyph Font functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposeFontGetGlyphCount](./asposefontgetglyphcount/) | Lese die Glyphenanzahl der Schriftart. |
+| [AsposeFontGetMetrics](./asposefontgetmetrics/) | Lese die Metriken der Schriftart. |
+
+
+## Detailed Description
+
+Funktionen zum Arbeiten mit Font-Glyphen.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/german/javascript-cpp/glyph/asposefontgetglyphcount/_index.md
+++ b/german/javascript-cpp/glyph/asposefontgetglyphcount/_index.md
@@ -1,0 +1,72 @@
+---
+title: "AsposeFontGetGlyphCount"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Lese Informationen (Metadaten) aus einer Schriftdatei."
+type: docs
+url: /de/javascript-cpp/glyph/asposefontgetglyphcount/
+---
+## AsposeFontGetGlyphCount function
+
+_Anzahl der Glyphen der Schrift abrufen._
+
+```js
+function AsposeFontGetGlyphCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschrift für die Konvertierung. |
+| fileName | string | Dateiname. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | glyphCount | Anzahl der Glyphen |
+
+### Beispiele
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    evt.data == "ready"
+      ? "loaded!"
+      : evt.data.json.errorCode == 0
+      ? "Glyph count: " + evt.data.json.glyphCount
+      : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFontGetGlyphCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get glyph count of font - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontGetGlyphCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+
+**Simple example**:
+```js
+  var ffileFontGetGlyphCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontGetGlyphCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Glyph count: " + json.glyphCount;
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/german/javascript-cpp/glyph/asposefontgetmetrics/_index.md
+++ b/german/javascript-cpp/glyph/asposefontgetmetrics/_index.md
@@ -1,0 +1,79 @@
+---
+title: "FontGetFontMetrics"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Lese Informationen (Metadaten) aus einer Schriftdatei."
+type: docs
+url: /de/javascript-cpp/glyph/asposefontgetmetrics/
+---
+## FontGetFontMetrics function
+
+_Anzahl der Glyphen der Schrift abrufen._
+
+```js
+function FontGetFontMetrics(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschrift für die Konvertierung. |
+| fileName | string | Dateiname. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | Metriken | JSON-Objekt |
+| * ascent |
+| * descent |
+| * lineGap |
+| * advanceWidthMax |
+| * minLeftSideBearing |
+| * minRightSideBearing |
+| * xMaxExtent |
+
+### Beispiele
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    evt.data == "ready"
+      ? "loaded!"
+      : evt.data.json.errorCode == 0
+      ? JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')
+      : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFontGetMetrics = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get metrics of font - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontGetMetrics', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+
+**Simple example**:
+```js
+  var ffileFontGetGlyphCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = FontGetFontMetrics(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Glyph count: " + json.glyphCount;
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/german/javascript-cpp/metadata/_index.md
+++ b/german/javascript-cpp/metadata/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Metadata Font-Funktionen"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Funktionen zum Arbeiten mit Metadata Font-Dateien"
+type: docs
+url: /de/javascript-cpp/metadata/
+---
+
+## Metadata Font functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposeFontGetInfo](./asposefontgetinfo/) | Lese Informationen (Metadaten) aus einer Schriftdatei. |
+| [AsposeFontSetInfo](./asposefontsetinfo/) | Informationen (Metadaten) in eine Font-Datei setzen. |
+
+## Detailed Description
+
+Funktionen zum Arbeiten mit Metadata Font-Dateien.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/german/javascript-cpp/metadata/asposefontgetinfo/_index.md
+++ b/german/javascript-cpp/metadata/asposefontgetinfo/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeFontGetInfo"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Lese Informationen (Metadaten) aus einer Schriftdatei."
+type: docs
+url: /de/javascript-cpp/metadata/asposefontgetinfo/
+---
+## AsposeFontGetInfo function
+
+_Informationen (Metadaten) aus einer Schriftdatei abrufen._
+
+```js
+function AsposeFontGetInfo(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschrift für die Konvertierung. |
+| fileName | string | Dateiname. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | Datensätze | Array von JSON-Objekten : |
+|  | * NameId | Namensbezeichner |
+|  | * PlatformId | Plattformbezeichner |
+|  | * PlatformSpecificId | plattform-spezifischer Bezeichner |
+|  | * LanguageId | Sprachbezeichner |
+|  | * Info | Inhalt des Namensdatensatzes |
+
+### Beispiele
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    evt.data == "ready"
+      ? "loaded!"
+      : evt.data.json.errorCode == 0
+      ? "Name records count: " + evt.data.json.records.length + 
+                                            evt.data.json.records.reduce((ret, a) => ret +
+                                            "\nNameId : " + a.NameId
+                                          + "; PlatformId : " + a.PlatformId
+                                          + "; PlatformSpecificId : " + a.PlatformSpecificId
+                                          + "; LanguageId : " + a.LanguageId
+                                          + "; Info : " + a.Info,"")
+      : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFontGetInfo = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get info (metadata) from a Font-file - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontGetInfo', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileFontGetInfo = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontGetInfo(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Name records count: " + json.records.length;
+        for (let recordIndex = 0; recordIndex < json.records.length; recordIndex++) 
+			document.getElementById('output').textContent += " " + "\n"
+                                                         + "NameId : " + json.records[recordIndex].NameId
+                                                         + ";  PlatformId : " + json.records[recordIndex].PlatformId
+                                                         + ";  PlatformSpecificId : " + json.records[recordIndex].PlatformSpecificId
+                                                         + ";  LanguageId : " + json.records[recordIndex].LanguageId
+                                                         + ";  Info : " + json.records[recordIndex].Info;
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/german/javascript-cpp/metadata/asposefontsetinfo/_index.md
+++ b/german/javascript-cpp/metadata/asposefontsetinfo/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeFontSetInfo"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Informationen (Metadaten) in eine Font-Datei setzen."
+type: docs
+url: /de/javascript-cpp/metadata/asposefontsetinfo/
+---
+## AsposeFontSetInfo function
+
+_Setze Informationen (Metadaten) in eine Font-Datei._
+
+```js
+function AsposeFontSetInfo(
+    fileBlob,
+    fileName,
+    nameId, 
+    platformId, 
+    platformSpecificId, 
+    languageId, 
+    text
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschrift für die Konvertierung. |
+| fileName | string | Dateiname. |
+| nameId | TtfNameTableNameId | Namensbezeichner, logische Zeichenkettenkategorie, angegeben durch die [`NameId`](../../enumerations/ttfnametablenameid/) Aufzählung |
+|  | platformId | TtfNameTablePlatformId | Plattformbezeichner |
+| platformSpecificId | int | Plattform-spezifischer Codierungsbezeichner. Bitte verwenden Sie einen Wert aus einer der folgenden Aufzählungen – [`UnicodePlatformSpecificId`](../../enumerations/ttfnametableunicodeplatformspecificid/), [`MacPlatformSpecificId`](../../ttfnametable.macplatformspecificid/), [`MSPlatformSpecificId`](../../enumerations/ttfnametablemsplatformspecificid/). Welche Aufzählung zu verwenden ist, wird durch den Kontext (*platformId* Parameter) definiert. |
+| languageId | int | Sprachbezeichner. Bitte verwenden Sie einen Wert aus der [`MSLanguageId`](../../enumerations/ttfnametablemslanguageid/) oder [`MacLanguageId`](../../enumerations/ttfnametablemaclanguageid/) Aufzählung, abhängig vom Kontext, definiert durch den *platformId* Parameter. |
+|  | text | string | Tatsächliche Zeichenkettendaten |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    (evt.data == 'ready') ? 'library loaded!' :
+    (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+ 
+ /*Event handler*/
+  const ffileFontSetInfo = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+          const nameId = 'Module.TtfNameTableNameId.' + document.getElementById("NameId").value;
+          //Value will be changed for PlatformId = PlatformId.Microsoft, PlatformSpecificId = MSPlatformSpecificId.Unicode_BMP_UCS2 (1) and languageID = 1033 (English_United_States = 0x0409)
+          const platformId = 'Module.TtfNameTablePlatformId.Microsoft';
+          const platformSpecificId = 'Module.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2';
+          const langID = 'Module.TtfNameTableMSLanguageId.English_United_States';
+          const text = document.getElementById("textValue").value;
+          transfer = [event.target.result];
+          params = [event.target.result, e.target.files[0].name, nameId, platformId, platformSpecificId, langID, text];
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontSetInfo', "params": params }, transfer);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var fFontSetInfo = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+
+      const nameId = new Function("return Module.TtfNameTableNameId." + document.getElementById("NameId").value)();
+      const platformId = Module.TtfNameTablePlatformId.Microsoft;
+      const platformSpecificId = Module.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+      const text = document.getElementById("textValue").value;
+      const langID = 1033;
+
+      const json = AsposeFontSetInfo(blob, file.name, nameId, platformId, platformSpecificId, langID, text);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult);
+        //DownloadFile(file.name);
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(file);
+  }
+```
+
+### Siehe auch
+
+* enum [TtfNameTableNameId](../../enumerations/ttfnametablenameid/)
+* enum [TtfNameTablePlatformId](../../enumerations/ttfnametableplatformid/)
+* enum [TtfNameTableMacPlatformSpecificId](../../enumerations/ttfnametablemacplatformspecificid/)
+* enum [TtfNameTableMSPlatformSpecificId](../../enumerations/ttfnametablemsplatformspecificid/)
+* enum [TtfNameTableUnicodePlatformSpecificId](../../enumerations/ttfnametableunicodeplatformspecificid/)
+* enum [TtfNameTableMacLanguageId](../../enumerations/ttfnametablemaclanguageid/)
+* enum [TtfNameTableMSLanguageId](../../enumerations/ttfnametablemslanguageid/)

--- a/german/javascript-cpp/misc/_index.md
+++ b/german/javascript-cpp/misc/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Verschiedene Funktionen"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Sekundäre Funktionen zum Arbeiten mit Font-Dateien."
+type: docs
+url: /de/javascript-cpp/misc/
+---
+## Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposeFontAbout](./asposeFontabout/) | Lese Informationen über das Produkt. |
+| [DownloadFile](./downloadfile/) | Erstelle einen Link in HTML, um die Datei herunterzuladen. |
+| [DownloadFileAuto](./downloadfileauto/) | Erstelle einen Link in HTML, um die Datei herunterzuladen und starte den Download nach 2 Sekunden. |
+
+## Detailed Description
+
+Sekundäre Funktionen zum Arbeiten mit Font-Dateien.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/german/javascript-cpp/misc/asposefontabout/_index.md
+++ b/german/javascript-cpp/misc/asposefontabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeFontAbout"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Lese Informationen über das Produkt."
+type: docs
+url: /de/javascript-cpp/misc/asposefontabout/
+---
+
+## AsposeFontAbout function
+
+Lese Informationen über das Produkt.
+
+```js
+function AsposeFontAbout()
+```
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+| errorCode | Fehlercode (0 kein Fehler) |
+| errorText | Fehlertext ("" kein Fehler) |
+| Produkt | Produktname |
+| Version | Produktversion |
+| islicensed | Produkt ist lizenziert |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposeFontAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposeFontAbout = function () {
+    /*Get info about Product*/
+    const json = AsposeFontAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/german/javascript-cpp/misc/downloadfile/_index.md
+++ b/german/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Erstelle einen Link in HTML, um die Datei herunterzuladen."
+type: docs
+url: /de/javascript-cpp/misc/downloadfile/
+---
+
+_Erstellt einen Link in HTML, um die Datei herunterzuladen._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/german/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/german/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Font für JavaScript über C++"
+description: "Erstelle einen Link in HTML, um die Datei herunterzuladen und starte den Download nach 2 Sekunden."
+type: docs
+url: /de/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+Erstelle einen Link in HTML, um die Datei herunterzuladen und starte den Download nach 2 Sekunden.
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### Parameter
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### Hinweise
+
+Funktioniert nicht im Web Worker.


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **German** (`de`) generated by RDA.

- Pages translated: 30/30
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `german/javascript-cpp`

🤖 Generated by RDA