### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Italian

### DIFF
--- a/italian/javascript-cpp/_index.md
+++ b/italian/javascript-cpp/_index.md
@@ -1,0 +1,73 @@
+---
+title: "Aspose.Font per JavaScript via C++"
+description: "Aspose.Font per JavaScript via C++"
+keywords:  "JavaScript via C++, JavaScript Font toolkit"
+tags: ['font-to-ttf', 'font-to-woff',  'font-to-woff2', 'font-to-svg', 'font-convert', 'font-tools']
+weight: 40
+url: /it/javascript-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.Font for JavaScript via C++ allows developers manipulate them Font files directly in the Web.
+>
+> Such operations are very time consuming, so we recommend using Web Worker. 
+
+
+## Convert functions
+
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [AsposeFontConvert](./convert/) | Converti un font in font TrueType. |
+| [AsposeFontConvertToTTF](./convert/asposefontconverttottf/) | Converti un font in formato TTF. |
+| [AsposeFontConvertToWOFF](./convert/asposefontconverttowoff/) | Converti un font in formato WOFF. |
+| [AsposeFontConvertToWOFF2](./convert/asposefontconverttowoff2/) | Converti un font in formato WOFF2. |
+| [AsposeFontConvertToSVG](./convert/asposefontconverttosvg/) | Converti un font in formato SVG. |
+
+
+## Metadata Font functions
+
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [AsposeFontGetInfo](./metadata/asposefontgetinfo/) | Ottieni informazioni (metadati) da un file Font. |
+| [AsposeFontSetInfo](./metadata/asposefontsetinfo/) | Imposta informazioni (metadati) in un file Font. |
+
+
+## Glyph Font functions
+
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [AsposeFontGetGlyphCount](./glyph/asposefontgetglyphcount/) | Ottieni il conteggio dei glifi del font. |
+| [AsposeFontGetMetrics](./glyph/asposefontgetmetrics/) | Ottieni le metriche del font. |
+
+
+## Core Functions
+
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [AsposeFontPrepare](./core/asposefontprepare/) | Salva il BLOB nel Memory FS per l'elaborazione. |
+| [AsposeFontPrepareBase64](./core/asposefontpreparebase64/) | Salva il BLOB di rappresentazione stringa nel Memory FS per l'elaborazione. |
+
+
+## Miscellaneous
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposeFontAbout](./misc/asposefontabout/) | Ottieni informazioni sul Prodotto. |
+| [DownloadFile](./misc/downloadfile/) | Crea un collegamento in HTML per scaricare il file. |
+| [DownloadFileAuto](./misc/downloadfileauto) | Crea un collegamento in HTML per scaricare il file e avvia il download dopo 2 secondi. |
+
+
+## Enumerazioni
+
+| Enumerazione | Descrizione |
+| ----------- | ----------- |
+| [FontSavingFormats](./enumerations/fontsavingformats/) | Specifica il tipo di Font. |
+| [FontStyle](./enumerations/fontstyle/) | Specifica lo stile del Font. |
+| [TtfNameTableNameId](./enumerations/ttfnametablenameid/) | Specifica NameId. |
+| [TtfNameTablePlatformId](./enumerations/ttfnametableplatformid/) | Rappresenta l'enumerazione PlatformId. |
+| [TtfNameTableMacPlatformSpecificId](./enumerations/ttfnametablemacplatformspecificid/) | Rappresenta l'enumerazione dell'ID specifico della piattaforma Macintosh. |
+| [TtfNameTableMSPlatformSpecificId](./enumerations/ttfnametablemsplatformspecificid/) | Rappresenta l'enumerazione dell'ID specifico della piattaforma Microsoft. |
+| [TtfNameTableUnicodePlatformSpecificId](./enumerations/ttfnametableunicodeplatformspecificid/) | Rappresenta l'enumerazione dell'ID specifico della piattaforma Unicode. |
+| [TtfNameTableMacLanguageId](./enumerations/ttfnametablemaclanguageid/) | Enumerazione MacLanguageId. |
+| [TtfNameTableMSLanguageId](./enumerations/ttfnametablemslanguageid/) | Enumerazione MSLanguageId. |

--- a/italian/javascript-cpp/convert/_index.md
+++ b/italian/javascript-cpp/convert/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Funzioni di conversione dei font"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Funzioni per la conversione dei font in formati TrueType."
+type: docs
+url: /it/javascript-cpp/convert/
+---
+
+## Convert functions
+
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [AsposeFontConvert](./asposefontconvert) | Converti un font nei formati supportati. |
+| [AsposeFontConvertToTTF](./asposefontconverttottf/) | Converti un font in formato TTF. |
+| [AsposeFontConvertToWOFF](./asposefontconverttowoff/) | Converti un font in formato WOFF. |
+| [AsposeFontConvertToWOFF2](./asposefontconverttowoff2/) | Converti un font in formato WOFF2. |
+| [AsposeFontConvertToSVG](./asposefontconverttosvg/) | Converti un font in formato SVG. |
+
+## Detailed Description
+
+Funzioni per la conversione dei font in formati TrueType.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```
+

--- a/italian/javascript-cpp/convert/asposefontconvert/_index.md
+++ b/italian/javascript-cpp/convert/asposefontconvert/_index.md
@@ -1,0 +1,94 @@
+---
+title: "AsposeFontConvert"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Converte il Font in un altro formato"
+type: docs
+weight: 10
+url: /it/javascript-cpp/convert/asposefontconvert/
+---
+## AsposeFontConvert function
+
+Converte il Font in un altro formato.
+
+```js
+function AsposeFontConvert(
+    fileBlob,
+    fileName,
+    fontType,
+    fontSavingFormat
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font sorgente per la conversione. |
+| fileName | stringa | Nome file. |
+| fontType | FontType | Tipo di Font da convertire. |
+| fontSavingFormat | FontSavingFormats | Formato di Font in cui convertire. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | codice errore (0 nessun errore) |
+|  | errorText | testo errore (\"\" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Osservazioni
+
+Nota: il tipo di Font TTF è ora supportato solo.
+
+### Esempi
+
+```js
+  var fTTF2WOFF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvert(event.target.result, e.target.files[0].name, Module.FontType.TTF, Module.FontSavingFormats.WOFF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "woff");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoTTF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to TTF and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvert', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF', 'Module.FontSavingFormats.TTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* enum [FontType](../../enumerations/fonttype/)
+* enum [FontSavingFormats](../../enumerations/fontsavingformats/)

--- a/italian/javascript-cpp/convert/asposefontconverttottf/_index.md
+++ b/italian/javascript-cpp/convert/asposefontconverttottf/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToTTF"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Converte il Font in formato ttf"
+type: docs
+weight: 10
+url: /it/javascript-cpp/convert/asposefontconverttottf/
+---
+## AsposeFontConvertToTTF function
+
+Converte il Font in formato TTF.
+
+```js
+function AsposeFontConvertToTTF(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font sorgente per la conversione. |
+| fileName | stringa | Nome file. |
+| fontType | FontType | Tipo di Font da convertire. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | codice errore (0 nessun errore) |
+|  | errorText | testo errore (\"\" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fEOT2TTF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToTTF(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoTTF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to TTF and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToTTF', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/italian/javascript-cpp/convert/asposefontconverttowoff/_index.md
+++ b/italian/javascript-cpp/convert/asposefontconverttowoff/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToWOFF"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Converte il Font nel formato woff"
+type: docs
+weight: 10
+url: /it/javascript-cpp/convert/asposefontconverttowoff/
+---
+## AsposeFontConvertToWOFF function
+
+Converte il Font nel formato WOFF.
+
+```js
+function AsposeFontConvertToWOFF(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font sorgente per la conversione. |
+| fileName | stringa | Nome file. |
+| fontType | FontType | Tipo di Font da convertire. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | codice errore (0 nessun errore) |
+|  | errorText | testo errore (\"\" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fEOT2WOFF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToWOFF(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoWOFF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to WOFF and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToWOFF', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/italian/javascript-cpp/convert/asposefontconverttowoff2/_index.md
+++ b/italian/javascript-cpp/convert/asposefontconverttowoff2/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToWOFF2"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Converte il Font nel formato woff2"
+type: docs
+weight: 10
+url: /it/javascript-cpp/convert/asposefontconverttowoff2/
+---
+## AsposeFontConvertToWOFF2 function
+
+Converte il Font nel formato WOFF2.
+
+```js
+function AsposeFontConvertToWOFF2(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font sorgente per la conversione. |
+| fileName | stringa | Nome file. |
+| fontType | FontType | Tipo di Font da convertire. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | codice errore (0 nessun errore) |
+|  | errorText | testo errore (\"\" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fEOT2WOFF2 = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToWOFF2(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoWOFF2 = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to WOFF2 and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToWOFF2', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/italian/javascript-cpp/convert/asposefontconverttowsvg/_index.md
+++ b/italian/javascript-cpp/convert/asposefontconverttowsvg/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToSVG"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Converte il Font nel formato svg"
+type: docs
+weight: 10
+url: /it/javascript-cpp/convert/asposefontconverttosvg/
+---
+## AsposeFontConvertToSVG function
+
+Converte il Font nel formato SVG.
+
+```js
+function AsposeFontConvertToSVG(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font sorgente per la conversione. |
+| fileName | stringa | Nome file. |
+| fontType | FontType | Tipo di Font da convertire. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | codice errore (0 nessun errore) |
+|  | errorText | testo errore (\"\" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fEOT2SVG = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToSVG(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoSVG = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to SVG and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToSVG', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/italian/javascript-cpp/core/_index.md
+++ b/italian/javascript-cpp/core/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Funzioni di base"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Funzioni di base per lavorare con i file Font."
+type: docs
+url: /it/javascript-cpp/core/
+---
+
+## Core Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposeFontPrepare](./asposefontprepare/) | Salva il BLOB nel Memory FS per l'elaborazione. |
+| [AsposeFontPrepareBase64](./asposefontpreparebase64/) | Salva il BLOB di rappresentazione stringa nel Memory FS per l'elaborazione. |
+
+## Detailed Description
+
+Funzioni di base per lavorare con i file Font.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/italian/javascript-cpp/core/asposefontprepare/_index.md
+++ b/italian/javascript-cpp/core/asposefontprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposeFontPrepare"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Salva il BLOB nel Memory FS per l'elaborazione."
+type: docs
+url: /it/javascript-cpp/core/asposefontprepare/
+---
+
+_Salva il BLOB nel Memory FS per l'elaborazione._
+
+```js
+function AsposeFontPrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+oggetto JSON
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposeFontPrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposeFontAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposeFontWebWorker.postMessage(
+        { "operation": 'AsposeFontPrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposeFontPrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/italian/javascript-cpp/core/asposefontpreparebase64/_index.md
+++ b/italian/javascript-cpp/core/asposefontpreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposeFontPrepareBase64"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Salva il BLOB di rappresentazione stringa nel Memory FS per l'elaborazione."
+type: docs
+url: /it/javascript-cpp/core/asposefontpreparebase64/
+---
+## AsposeFontPrepareBase64 function
+_Salva la rappresentazione stringa BLOB nel Memory FS per l'elaborazione._
+
+```js
+function AsposeFontPrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### Osservazioni
+**AsposeFontPrepareBase64** doesn't work in Web Worker mode, use AsposeFontPrepare
+
+### Esempi
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposeFontPrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposeFontPrepareBase64 for Web Worker*/
+  const AsposeFontPrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposeFontWebWorker.postMessage(
+                 { "operation": 'AsposeFontPrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposeFontPrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/Font");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/italian/javascript-cpp/enumerations/_index.md
+++ b/italian/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Enumerazioni"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Funzioni per la conversione dei font in formati TrueType."
+type: docs
+url: /it/javascript-cpp/enumerations/
+---
+
+## Enumerazioni
+
+| Enumerazione | Descrizione |
+| ----------- | ----------- |
+| [FontSavingFormats](./fontsavingformats/) | Specifica il tipo di Font. |
+| [FontType](./fonttype/) | Specifica il tipo di Font. |
+| [TtfNameTableNameId](./ttfnametablenameid/) | Specifica NameId. |
+| [TtfNameTablePlatformId](./ttfnametableplatformid/) | Rappresenta l'enumerazione PlatformId. |
+| [TtfNameTableMSPlatformSpecificId](./ttfnametableMSPlatformSpecificId/) | Rappresenta l'enumerazione MSPlatformSpecificId. |
+| [TtfNameTableMacPlatformSpecificId](./ttfnametableMacPlatformSpecificId/) | Rappresenta l'enumerazione MacPlatformSpecificId. |
+| [TtfNameTableUnicodePlatformSpecificId](./ttfnametableUnicodePlatformSpecificId/) | Rappresenta l'enumerazione UnicodePlatformSpecificId. |
+| [TtfNameTableMacLanguageId](./ttfnametablemaclanguageid/) | Enumerazione dell'ID lingua della piattaforma Macintosh. |
+| [TtfNameTableMSLanguageId](./ttfnametablemslanguageid/) | Enumerazione dell'ID lingua della piattaforma Microsoft. |
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```
+

--- a/italian/javascript-cpp/enumerations/fontsavingformats/_index.md
+++ b/italian/javascript-cpp/enumerations/fontsavingformats/_index.md
@@ -1,0 +1,26 @@
+---
+title: "Enum FontSavingFormats"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Aspose.Font.FontSavingFormats enum. Specifica il tipo di Font"
+type: docs
+weight: 110
+url: /it/javascript-cpp/enumerations/fontsavingformats/
+---
+## FontSavingFormats enumeration
+
+Specifica il tipo di Font.
+
+```csharp
+public enum FontSavingFormats
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+| TTF | `0` | TTF (TrueType) formato Font. |
+| WOFF | `1` | WOFF(Web Open Font Format). |
+| WOFF2 | `2` | WOFF File Format 2.0 |
+| SVG | `3` | SVG (Scalable Vector Graphics) formato Font |
+| OTF | `4` | OTF (OpenType) formato Font |
+

--- a/italian/javascript-cpp/enumerations/fonttype/_index.md
+++ b/italian/javascript-cpp/enumerations/fonttype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum FontType"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Aspose.Font.FontType enum. Specifica il tipo di Font"
+type: docs
+weight: 100
+url: /it/javascript-cpp/enumerations/fonttype/
+---
+## FontType enumeration
+
+Specifica il tipo di Font.
+
+```csharp
+public enum FontType
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+| TTF | `0` | TTF (TrueType) tipo di Font e correlati. |
+| Type1 | `1` | Tipo di Font Type1. |
+| CFF | `2` | CFF (Compact font format) tipo di Font. |
+| OTF | `3` | OpenType Font. Il formato OpenType Font è un'estensione del formato TrueType Font, aggiungendo il supporto per i dati PostScript Font. |
+

--- a/italian/javascript-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
+++ b/italian/javascript-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
@@ -1,0 +1,53 @@
+---
+title: "Enum TtfNameTableMacPlatformSpecificId"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Aspose.Font.TtfNameTableMacPlatformSpecificId enum. Specifica MacPlatformSpecificId"
+type: docs
+weight: 131
+url: /it/javascript-cpp/enumerations/ttfnametablemacplatformspecificid/
+---
+## TtfNameTableMacPlatformSpecificId enumeration
+
+Specifica MacPlatformSpecificId.
+
+```csharp
+ enum TtfNameTableMacPlatformSpecificId
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+|  | Roman | `0` | Valore specifico della piattaforma Roman. |
+|  | Japanese | `1` | Valore specifico della piattaforma Japanese. |
+|  | Traditional_Chinese | `2` | Valore specifico della piattaforma Cinese tradizionale. |
+|  | Korean | `3` | Valore specifico della piattaforma Coreano. |
+|  | Arabic | `4` | Valore specifico della piattaforma Arabo. |
+|  | Hebrew | `5` | Valore specifico della piattaforma ebraica. |
+|  | Greek | `6` | Valore specifico della piattaforma greca. |
+|  | Russian | `7` | Valore specifico della piattaforma russa. |
+|  | RSymbol | `8` | Valore specifico della piattaforma RSymbol. |
+|  | Devanagari | `9` | Valore specifico della piattaforma Devanagari. |
+|  | Gurmukhi | `10` | Valore specifico della piattaforma Gurmukhi. |
+|  | Gujarati | `11` | Valore specifico della piattaforma Gujarati. |
+|  | Oriya | `12` | Valore specifico della piattaforma Oriya. |
+|  | Bengali | `13` | Valore specifico della piattaforma bengalese. |
+|  | Tamil | `14` | Valore specifico della piattaforma tamil. |
+|  | Telugu | `15` | Valore specifico della piattaforma telugu. |
+|  | Kannada | `16` | Valore specifico della piattaforma kannada. |
+|  | Malayalam | `17` | Valore specifico della piattaforma malayalam. |
+|  | Sinhalese | `18` | Valore specifico della piattaforma singalese. |
+|  | Burmese | `19` | Valore specifico della piattaforma birmana. |
+|  | Khmer | `20` | Valore specifico della piattaforma khmer. |
+|  | Thai | `21` | Valore specifico della piattaforma tailandese. |
+|  | Laotian | `22` | Valore specifico della piattaforma laotiana. |
+|  | Georgian | `23` | Valore specifico della piattaforma georgiana. |
+|  | Armenian | `24` | Valore specifico della piattaforma armena. |
+|  | Simplified_Chinese | `25` | Valore specifico della piattaforma cinese semplificata. |
+|  | Tibetan | `26` | Valore specifico della piattaforma tibetana. |
+|  | Mongolian | `27` | Valore specifico della piattaforma mongola. |
+|  | Geez | `28` | Valore specifico della piattaforma Geez. |
+|  | Slavic | `29` | Valore specifico della piattaforma slava. |
+|  | Vietnamese | `30` | Valore specifico della piattaforma vietnamita. |
+|  | Sindhi | `31` | Valore specifico della piattaforma sindhi. |
+|  | Uninterpreted | `32` | Valore specifico della piattaforma non interpretato. |

--- a/italian/javascript-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
+++ b/italian/javascript-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Enum TtfNameTableMSPlatformSpecificId"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Aspose.Font.TtfNameTableMSPlatformSpecificId enum. Specifica MSPlatformSpecificId"
+type: docs
+weight: 132
+url: /it/javascript-cpp/enumerations/ttfnametablemsplatformspecificid/
+---
+## TtfNameTableMSPlatformSpecificId enumeration
+
+Specifica MSPlatformSpecificId.
+
+```csharp
+ enum TtfNameTableMSPlatformSpecificId
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+|  | Symbol | `0` | Simbolo MS PlatformSpecificId. |
+|  | Unicode_BMP_UCS2 | `1` | Unicode BMP (UCS2) MS PlatformSpecificId. |
+|  | ShiftJIS | `2` | ShiftJIS MS PlatformSpecificId. |
+|  | PRC | `3` | PRC MS PlatformSpecificId. |
+|  | Big5 | `4` | Big5 MS PlatformSpecificId. |
+|  | Wansung | `5` | Wansung MS PlatformSpecificId. |
+|  | Johab | `6` | Johab MS PlatformSpecificId. |
+|  | Reserved1 | `7` | Reserved1 MS PlatformSpecificId. |
+|  | Reserved2 | `8` | Reserved2 MS PlatformSpecificId. |
+|  | Reserved3 | `9` | Reserved3 MS PlatformSpecificId. |
+|  | Unicode_UCS4 | `10` | Unicode UCS4 MS PlatformSpecificId. |
+

--- a/italian/javascript-cpp/enumerations/ttfnametablenameid/_index.md
+++ b/italian/javascript-cpp/enumerations/ttfnametablenameid/_index.md
@@ -1,0 +1,46 @@
+---
+title: "Enum TtfNameTableNameId"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Aspose.Font.TtfNameTableNameId enum. Specifica NameId"
+type: docs
+weight: 120
+url: /it/javascript-cpp/enumerations/ttfnametablenameid/
+---
+## TtfNameTableNameId enumeration
+
+Specifica NameId.
+
+```csharp
+ enum TtfNameTableNameId
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+|  | CopyrightNotice | `0` | Avviso di copyright. |
+|  | FontFamily | `1` | Famiglia Font. Questa stringa è il nome della famiglia del Font che l'utente vede sulle piattaforme Macintosh. |
+|  | FontSubfamily | `2` | Sottofamiglia Font. Questa stringa è la famiglia del Font che l'utente vede sulle piattaforme Macintosh. |
+|  | UniqueFontId | `3` | Identificazione unica della sottofamiglia (specifica Apple). 3 Identificatore unico del Font (specifica MS). |
+|  | FullName | `4` | Nome completo del Font. |
+|  | Version | `5` | Versione della tabella dei nomi. |
+|  | PostScriptName | `6` | Nome PostScript del Font. Nota: un Font può avere un solo nome PostScript e quel nome deve essere ASCII. |
+|  | TrademarkNotice | `7` | Avviso di marchio registrato. |
+|  | ManufacturerName | `8` | Nome del produttore. |
+|  | DesignerName | `9` | Designer; nome del designer del carattere tipografico. |
+|  | Description | `10` | Descrizione; descrizione del carattere tipografico. Può contenere informazioni di revisione, raccomandazioni d'uso, storia, funzionalità, ecc. |
+|  | UrlVendor | `11` | URL del fornitore del Font (con protocollo, ad es., http://, ftp://). Se un numero di serie unico è incorporato nell'URL, può essere usato per registrare il Font. |
+|  | UrlDesigner | `12` | URL del designer del Font (con protocollo, ad es., http://, ftp://) |
+|  | LicenseDescription | `13` | Descrizione della licenza; descrizione di come il Font può essere usato legalmente, o diversi scenari di esempio per l'uso con licenza. Questo campo dovrebbe essere scritto in linguaggio semplice, non in gergo legale. |
+|  | LicenseInfoUrl | `14` | URL delle informazioni sulla licenza, dove è possibile trovare ulteriori informazioni sulla licenza. |
+|  | PreferredFamily | `16` | `15` Riservato `16` Famiglia Preferita (solo Windows); In Windows, il nome della Famiglia è visualizzato nel menu Font; il nome della Sottofamiglia è presentato come nome Stile. Per ragioni storiche, le famiglie di Font hanno contenuto un massimo di quattro stili, ma i designer di Font possono raggruppare più di quattro font in una singola famiglia. Gli ID Famiglia Preferita e Sottofamiglia Preferita consentono ai designer di Font di includere i raggruppamenti di famiglia/sottofamiglia preferiti. Questi ID sono presenti solo se sono diversi dagli ID 1 e 2. |
+|  | PreferredSubfamily | `17` | Sottofamiglia Preferita (solo Windows); In Windows, il nome della Famiglia è visualizzato nel menu Font; il nome della Sottofamiglia è presentato come nome Stile. Per ragioni storiche, le famiglie di Font hanno contenuto un massimo di quattro stili, ma i designer di Font possono raggruppare più di quattro font in una singola famiglia. Gli ID Famiglia Preferita e Sottofamiglia Preferita consentono ai designer di Font di includere i raggruppamenti di famiglia/sottofamiglia preferiti. Questi ID sono presenti solo se sono diversi dagli ID 1 e 2. |
+|  | CompatibleFull | `18` | Compatibile Completo (solo Macintosh); Su Macintosh, il nome del menu è costruito usando la risorsa Font. Questo di solito corrisponde al Nome Completo. Se vuoi che il nome del Font appaia diversamente dal Nome Completo, puoi inserire il Nome Compatibile Completo nell'ID 18. Questo nome non è usato dal Mac OS stesso, ma può essere usato dagli sviluppatori di applicazioni (ad es., Adobe). |
+|  | SampleText | `19` | Testo di esempio. Questo può essere il nome del Font, o qualsiasi altro testo che il designer ritiene il miglior esempio per mostrare l'aspetto del Font. |
+|  | PostScriptCID | `20` | La sua presenza in un font indica che il nameID 6 contiene un nome PostScript del font destinato ad essere usato con l\"composefont\" invocazione per richiamare il font in un interprete PostScript. |
+|  | WwsFamilyName | `21` | Utilizzato per fornire un nome di famiglia WWS-conformant nel caso in cui le voci per gli ID 16 e 17 non siano conformi al modello WWS. |
+|  | WwsSubfamilyName | `22` | Utilizzato in combinazione con l'ID 21, questo ID fornisce un nome di sottofamiglia WWS-conformant (che riflette solo gli attributi di peso, larghezza e inclinazione) nel caso in cui le voci per gli ID 16 e 17 non siano conformi al modello WWS. |
+|  | LightBackground | `23` | Questo ID, se utilizzato nell'Array di Etichette della Palette della tabella CPAL, specifica che la palette di colori corrispondente nella tabella CPAL è appropriata per l'uso con il carattere quando viene visualizzato su uno sfondo chiaro, come il bianco. |
+|  | DarkBackground | `24` | Questo ID, se utilizzato nell'Array di Etichette della Palette della tabella CPAL, specifica che la palette di colori corrispondente nella tabella CPAL è appropriata per l'uso con il carattere quando viene visualizzato su uno sfondo scuro, come il nero. |
+|  | VariationsPostScriptNamePrefix | `25` | Se presente in un font variabile, può essere utilizzato come prefisso di famiglia nell'algoritmo PostScript Name Generation for Variation Fonts. |
+

--- a/italian/javascript-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
+++ b/italian/javascript-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
@@ -1,0 +1,138 @@
+---
+title: "Enum TtfNameTableMacLanguageId"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Enum Aspose.Font.TtfNameTableMacLanguageId. Specifica MacLanguageId"
+type: docs
+weight: 140
+url: /it/javascript-cpp/enumerations/ttfnametablemaclanguageid/
+---
+## TtfNameTableMacLanguageId enumeration
+
+Rappresenta l'enumerazione MacLanguageId.
+
+```csharp
+ enum TtfNameTableMacLanguageId
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+|  | English | `0` | Valore LanguageId inglese |
+|  | French | `1` | Valore LanguageId francese |
+|  | German | `2` | Valore LanguageId tedesco |
+|  | Italian | `3` | Valore LanguageId italiano |
+|  | Dutch | `4` | Valore LanguageId olandese |
+|  | Swedish | `5` | Valore LanguageId svedese |
+|  | Spanish | `6` | Valore LanguageId spagnolo |
+|  | Danish | `7` | Valore LanguageId danese |
+|  | Portuguese | `8` | Valore LanguageId portoghese |
+|  | Norwegian | `9` | Valore LanguageId norvegese |
+|  | Hebrew | `10` | Valore LanguageId ebraico |
+|  | Japanese | `11` | Valore LanguageId giapponese |
+|  | Arabic | `12` | Valore LanguageId arabo |
+|  | Finnish | `13` | Valore LanguageId finlandese |
+|  | Greek | `14` | Valore LanguageId greco |
+|  | Icelandic | `15` | Valore LanguageId islandese |
+|  | Maltese | `16` | Valore LanguageId maltese |
+|  | Turkish | `17` | Valore LanguageId turco |
+|  | Croatian | `18` | Valore LanguageId croato |
+|  | Chinese_Traditional | `19` | Valore LanguageId cinese (tradizionale) |
+|  | Urdu | `20` | Valore LanguageId urdu |
+|  | Hindi | `21` | Valore LanguageId hindi |
+|  | Thai | `22` | Valore LanguageId tailandese |
+|  | Korean | `23` | Valore LanguageId coreano |
+|  | Lithuanian | `24` | Valore LanguageId lituano |
+|  | Polish | `25` | Valore LanguageId polacco |
+|  | Hungarian | `26` | Valore LanguageId ungherese |
+|  | Estonian | `27` | Valore LanguageId estone |
+|  | Latvian | `28` | Valore LanguageId lettone |
+|  | Sami | `29` | Valore LanguageId sami |
+|  | Faroese | `30` | Valore LanguageId faroe |
+|  | Farsi_Persian | `31` | Valore LanguageId Farsi/persiano |
+|  | Russian | `32` | Valore LanguageId russo |
+|  | Chinese_Simplified | `33` | Valore LanguageId cinese (semplificato) |
+|  | Flemish | `34` | Valore LanguageId fiammingo |
+|  | Irish_Gaelic | `35` | Valore LanguageId gaelico irlandese |
+|  | Albanian | `36` | Valore LanguageId albanese |
+|  | Romanian | `37` | Valore LanguageId rumeno |
+|  | Czech | `38` | Valore LanguageId ceco |
+|  | Slovak | `39` | Valore LanguageId slovacco |
+|  | Slovenian | `40` | Valore LanguageId sloveno |
+|  | Yiddish | `41` | Valore LanguageId yiddish |
+|  | Serbian | `42` | Valore LanguageId serbo |
+|  | Macedonian | `43` | Valore LanguageId macedone |
+|  | Bulgarian | `44` | Valore LanguageId bulgaro |
+|  | Ukrainian | `45` | Valore LanguageId ucraino |
+|  | Byelorussian | `46` | Valore LanguageId bielorusso |
+|  | Uzbek | `47` | Valore LanguageId uzbeco |
+|  | Kazakh | `48` | Valore LanguageId kazako |
+|  | Azerbaijani_Cyrillic | `49` | Valore LanguageId azero (scrittura cirillica) |
+|  | Azerbaijani_Arabic | `50` | Valore LanguageId azero (scrittura araba) |
+|  | Armenian | `51` | Valore LanguageId armeno |
+|  | Georgian | `52` | Valore LanguageId georgiano |
+|  | Moldavian | `53` | Valore LanguageId moldavo |
+|  | Kirghiz | `54` | Valore LanguageId kirghiso |
+|  | Tajiki | `55` | Valore LanguageId tagico |
+|  | Turkmen | `56` | Valore LanguageId turkmeno |
+|  | Mongolian | `57` | Valore LanguageId mongolo (scrittura mongola) |
+|  | Mongolian_Cyrillic | `58` | Valore LanguageId mongolo (scrittura cirillica) |
+|  | Pashto | `59` | Valore LanguageId pashto |
+|  | Kurdish | `60` | Valore LanguageId pashto |
+|  | Kashmiri | `61` | Valore LanguageId kashmiri |
+|  | Sindhi | `62` | Valore LanguageId sindhi |
+|  | Tibetan | `63` | Valore LanguageId tibetano |
+|  | Nepali | `64` | Valore LanguageId nepalese |
+|  | Sanskrit | `65` | Valore LanguageId sanscrito |
+|  | Marathi | `66` | Valore LanguageId marathi |
+|  | Bengali | `67` | Valore LanguageId bengalese |
+|  | Assamese | `68` | Valore LanguageId assamese |
+|  | Gujarati | `69` | Valore LanguageId gujarati |
+|  | Punjabi | `70` | Valore LanguageId punjabi |
+|  | Oriya | `71` | Valore LanguageId oriya |
+|  | Malayalam | `72` | Valore LanguageId malayalam |
+|  | Kannada | `73` | Valore LanguageId kannada |
+|  | Tamil | `74` | Valore LanguageId tamil |
+|  | Telugu | `75` | Valore LanguageId telugu |
+|  | Sinhalese | `76` | Singalese LanguageId valore |
+|  | Burmese | `77` | Birmano LanguageId valore |
+|  | Khmer | `78` | Khmer LanguageId valore |
+|  | Lao | `79` | Lao LanguageId valore |
+|  | Vietnamese | `80` | Vietnamita LanguageId valore |
+|  | Indonesian | `81` | Indonesiano LanguageId valore |
+|  | Tagalog | `82` | Tagalog LanguageId valore |
+|  | Malay_Roman | `83` | Malese (scrittura romana) LanguageId valore |
+|  | Malay_Arabic | `84` | Malese (scrittura araba) LanguageId valore |
+|  | Amharic | `85` | Amarico LanguageId valore |
+|  | Tigrinya | `86` | Tigrino LanguageId valore |
+|  | Galla | `87` | Galla LanguageId valore |
+|  | Somali | `88` | Somalo LanguageId valore |
+|  | Swahili | `89` | Swahili LanguageId valore |
+|  | Kinyarwanda_Ruanda | `90` | Kinyarwanda/Ruanda LanguageId valore |
+|  | Rundi | `91` | Rundi LanguageId valore |
+|  | Nyanja_Chewa | `92` | Nyanja/Chewa LanguageId valore |
+|  | Malagasy | `93` | Malgascio LanguageId valore |
+|  | Esperanto | `94` | Esperanto LanguageId valore |
+|  | Welsh | `128` | Gallese LanguageId valore |
+|  | Basque | `129` | Basco LanguageId valore |
+|  | Catalan | `130` | Catalano LanguageId valore |
+|  | Latin | `131` | Latino LanguageId valore |
+|  | Quechua | `132` | Quechua LanguageId valore |
+|  | Guarani | `133` | Guarani LanguageId valore |
+|  | Aymara | `134` | Valore LanguageId Aymara |
+|  | Tatar | `135` | Valore LanguageId Tatar |
+|  | Uighur | `136` | Valore LanguageId Uighur |
+|  | Dzongkha | `137` | Valore LanguageId Dzongkha |
+|  | Javanese | `138` | Valore LanguageId Javanese (scrittura romana) |
+|  | Sundanese | `139` | Valore LanguageId Sundanese (scrittura romana) |
+|  | Galician | `140` | Valore LanguageId Galician |
+|  | Afrikaans | `141` | Valore LanguageId Afrikaans |
+|  | Breton | `142` | Valore LanguageId Breton |
+|  | Inuktitut | `143` | Valore LanguageId Inuktitut |
+|  | Scottish_Gaelic | `144` | Valore LanguageId Gaelico scozzese |
+|  | Manx_Gaelic | `145` | Valore LanguageId Gaelico di Man |
+|  | Irish_Gaelic_WDA | `146` | Valore LanguageId Gaelico irlandese (con punto sopra) |
+|  | Tongan | `147` | Valore LanguageId Tongan |
+|  | Greek_Polytonic | `148` | Valore LanguageId Greco (politonico) |
+|  | Greenlandic | `149` | Valore LanguageId Groenlandese |
+|  | Azerbaijani_Roman | `150` | Valore LanguageId Azerbaijani (scrittura romana) |

--- a/italian/javascript-cpp/enumerations/ttfnametablenmslanguageid/_index.md
+++ b/italian/javascript-cpp/enumerations/ttfnametablenmslanguageid/_index.md
@@ -1,0 +1,225 @@
+---
+title: "Enum TtfNameTableMSLanguageId"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Aspose.Font.TtfNameTableMSLanguageId enum. Specifica MSLanguageId"
+type: docs
+weight: 150
+url: /it/javascript-cpp/enumerations/ttfnametablemslanguageid/
+---
+## TtfNameTableMSLanguageId enumeration
+
+Rappresenta l'enumerazione MSLanguageId.
+
+```csharp
+ enum TtfNameTableMSLanguageId
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+|  | Afrikaans | `0x0436` | Afrikaans (Regione: South Africa, SA) valore LanguageId |
+|  | Albanian | `0x041c` | Albanian (Regione: Albania,  SQI) valore LanguageId |
+|  | Alsatian | `0x0484` | Alsatian (Regione: France) valore LanguageId |
+|  | Amharic | `0x045E` | Amharic (Regione: Ethiopia) valore LanguageId |
+|  | Arabic_Algeria | `0x1401` | Arabic (Regione: Algeria) valore LanguageId |
+|  | Arabic_Bahrain | `0x3C01` | Arabic (Regione: Bahrain) valore LanguageId |
+|  | Arabic_Egypt | `0x0C01` | Arabic (Regione: Egypt) valore LanguageId |
+|  | Arabic_Iraq | `0x0801` | Arabic (Regione: Iraq) valore LanguageId |
+|  | Arabic_Jordan | `0x2C01` | Arabic (Regione: Jordan) valore LanguageId |
+|  | Arabic_Kuwait | `0x3401` | Arabic (Regione: Kuwait) valore LanguageId |
+|  | Arabic_Lebanon | `0x3001` | Arabic (Regione: Lebanon) valore LanguageId |
+|  | Arabic_Libya | `0x1001` | Arabic (Regione: Libya) valore LanguageId |
+|  | Arabic_Morocco | `0x1801` | Arabic (Regione: Morocco) valore LanguageId |
+|  | Arabic_Oman | `0x2001` | Arabic (Regione: Oman) valore LanguageId |
+|  | Arabic_Qatar | `0x4001` | Arabic (Regione: Qatar) valore LanguageId |
+|  | Arabic_Saudi_Arabia | `0x0401` | Arabic (Regione: Saudi Arabia) valore LanguageId |
+|  | Arabic_Syria | `0x2801` | Arabic (Regione: Syria) valore LanguageId |
+|  | Arabic_Tunisia | `0x1C01` | Arabo (Regione: Tunisia) valore LanguageId |
+|  | Arabic_U_A_E | `0x3801` | Arabo (Regione: U.A.E.) valore LanguageId |
+|  | Arabic_Yemen | `0x2401` | Arabo (Regione: Yemen) valore LanguageId |
+|  | Armenian | `0x042B` | Armeno (Regione: Armenia) valore LanguageId |
+|  | Assamese | `0x044D` | Assamese (Regione: India) valore LanguageId |
+|  | Azeri_Cyrillic | `0x082C` | Azero (Cirillico, Regione: Azerbaijan) valore LanguageId |
+|  | Azeri_Latin | `0x042C` | Azero (Latino, Regione: Azerbaijan) valore LanguageId |
+|  | Bashkir | `0x046D` | Bashkir (Regione: Russia) valore LanguageId |
+|  | Basque | `0x042D` | Basco (Regione: Basque, EUQ) valore LanguageId |
+|  | Belarusian | `0x0423` | Bielorusso (Regione: Belarus,  BEL) valore LanguageId |
+|  | Bengali_Bangladesh | `0x0845` | Bengalese (Regione: Bangladesh) valore LanguageId |
+|  | Bengali_India | `0x0445` | Bengalese (Regione: India) valore LanguageId |
+|  | Bosnian_Cyrillic | `0x201A` | Bosniaco (Cirillico, Regione: Bosnia and Herzegovina) valore LanguageId |
+|  | Bosnian_Latin | `0x141A` | Bosniaco (Latino, Regione: Bosnia and Herzegovina) valore LanguageId |
+|  | Breton | `0x047E` | Bretone (Regione: France) valore LanguageId |
+|  | Bulgarian | `0x0402` | Bulgaro (Regione: Bulgaria, BGR) valore LanguageId |
+|  | Catalan | `0x0403` | Catalano (Regione: Catalan, CAT) valore LanguageId |
+|  | Chinese_Hong_Kong | `0x0C04` | Cinese (Regione: Hong Kong S.A.R.) valore LanguageId |
+|  | Chinese_Macao | `0x1404` | Cinese (Regione: Macao S.A.R.) valore LanguageId |
+|  | Chinese_PRC | `0x0804` | Cinese (Regione: Repubblica Popolare Cinese) valore LanguageId |
+|  | Chinese_Singapore | `0x1004` | Cinese (Regione: Singapore) valore LanguageId |
+|  | Chinese_Taiwan | `0x0404` | Cinese (Regione: Taiwan) valore LanguageId |
+|  | Corsican | `0x0483` | Corso (Regione: France) valore LanguageId |
+|  | Croatian | `0x041A` | Croato (Regione: Croatia, SHL) valore LanguageId |
+|  | Croatian_Latin | `0x101A` | Croato (Latino, Regione: Bosnia and Herzegovina) valore LanguageId |
+|  | Czech | `0x0405` | Ceco (Regione: Repubblica Ceca, CSY) LanguageId valore |
+|  | Danish | `0x0406` | Danese (Regione: Danimarca, DAN) LanguageId valore |
+|  | Dari | `0x048C` | Dari (Regione: Afghanistan) LanguageId valore |
+|  | Divehi | `0x0465` | Divehi (Regione: Maldive) LanguageId valore |
+|  | Dutch_Belgium | `0x0813` | Olandese (Fiammingo, Regione: Belgio, NLB) LanguageId valore |
+|  | Dutch_Netherlands | `0x0413` | Olandese (Standard, Regione: Paesi Bassi, NLD) LanguageId valore |
+|  | English_Australia | `0x0C09` | Inglese (Australiano, Regione: Australia, ENA) LanguageId valore |
+|  | English_Belize | `0x2809` | Inglese (Regione: Belize) LanguageId valore |
+|  | English_Canada | `0x1009` | Inglese (Canadese, Regione: Canada, ENC) LanguageId valore |
+|  | English_Caribbean | `0x2409` | Inglese (Regione: Caraibi) LanguageId valore |
+|  | English_India | `0x4009` | Inglese (Regione: India) LanguageId valore |
+|  | English_Ireland | `0x1809` | Inglese (Regione: Irlanda, ENI) LanguageId valore |
+|  | English_Jamaica | `0x2009` | Inglese (Regione: Giamaica) LanguageId valore |
+|  | English_Malaysia | `0x4409` | Inglese (Regione: Malesia) LanguageId valore |
+|  | English_New_Zealand | `0x1409` | Inglese (Regione: Nuova Zelanda, ENZ) LanguageId valore |
+|  | English_ROP | `0x3409` | Inglese (Regione: Repubblica delle Filippine, ROP) LanguageId valore |
+|  | English_Singapore | `0x4809` | Inglese (Regione: Singapore) LanguageId valore |
+|  | English_South_Africa | `0x1C09` | Inglese (Regione: Sudafrica, SA) LanguageId valore |
+|  | English_TT | `0x2C09` | Inglese (Regione: Trinidad e Tobago, TT) LanguageId valore |
+|  | English_United_Kingdom | `0x0809` | Inglese (Britannico, Regione: Regno Unito, ENG) LanguageId valore |
+|  | English_United_States | `0x0409` | Inglese (Americano, Regione: Stati Uniti, ENU) LanguageId valore |
+|  | English_Zimbabwe | `0x3009` | Inglese (Regione: Zimbabwe) LanguageId valore |
+|  | Estonian | `0x0425` | Estone (Regione: Estonia, ETI) LanguageId valore |
+|  | Faroese | `0x0438` | Faroese (Regione: Isole Faroe) LanguageId valore |
+|  | Filipino | `0x0464` | Filippino (Regione: Filippine) LanguageId valore |
+|  | Finnish | `0x040B` | Finlandese (Regione: Finlandia, FIN) valore LanguageId |
+|  | French_Belgium | `0x080C` | Francese (Belga, Regione: Belgio, FRB) valore LanguageId |
+|  | French_Canada | `0x0C0C` | Francese (Canadese, Regione: Canada, FRC) valore LanguageId |
+|  | French_France | `0x040C` | Francese (Standard, Regione: Francia, FRA) valore LanguageId |
+|  | French_Luxembourg | `0x140c` | Francese (Regione: Lussemburgo, FRL) valore LanguageId |
+|  | French_MC | `0x180C` | Francese (Regione: Principato di Monaco, MC) valore LanguageId |
+|  | French_Switzerland | `0x100C` | Francese (Svizzero, Regione: Svizzera, FRS) valore LanguageId |
+|  | Frisian | `0x0462` | Frisone (Regione: Paesi Bassi, NLD) valore LanguageId |
+|  | Galician | `0x0456` | Galiziano (Regione: Galizia) valore LanguageId |
+|  | Georgian | `0x0437` | Georgiano (Regione: Georgia) valore LanguageId |
+|  | German_Austria | `0x0C07` | Tedesco (Austriaco, Regione: Austria, DEA) valore LanguageId |
+|  | German_Germany | `0x0407` | Tedesco (Standard, Regione: Germania, DEU) valore LanguageId |
+|  | German_Liechtenstein | `0x1407` | Tedesco (Regione: Liechtenstein, DEC) valore LanguageId |
+|  | German_Luxembourg | `0x1007` | Tedesco (Regione: Lussemburgo, DEL) valore LanguageId |
+|  | German_Switzerland | `0x0807` | Tedesco (Svizzero, Regione: Svizzera, DES) valore LanguageId |
+|  | Greek | `0x0408` | Greco (Regione: Grecia, ELL) valore LanguageId |
+|  | Greenlandic | `0x046F` | Groenlandese (Regione: Groenlandia) valore LanguageId |
+|  | Gujarati | `0x0447` | Gujarati (Regione: India) valore LanguageId |
+|  | Hausa | `0x0468` | Hausa (Latino, Regione: Nigeria) valore LanguageId |
+|  | Hebrew | `0x040D` | Ebraico (Regione: Israele) valore LanguageId |
+|  | Hindi | `0x0439` | Hindi (Regione: India) valore LanguageId |
+|  | Hungarian | `0x040E` | Ungherese (Regione: Ungheria, HUN) valore LanguageId |
+|  | Icelandic | `0x040F` | Islandese (Regione: Islanda, ISL) valore LanguageId |
+|  | Igbo | `0x0470` | Igbo (Regione: Nigeria) valore LanguageId |
+|  | Indonesian | `0x0421` | Indonesiano (Regione: Indonesia) valore LanguageId |
+|  | Inuktitut | `0x045D` | Inuktitut (Regione: Canada) valore LanguageId |
+|  | Inuktitut_Latin | `0x085D` | Inuktitut (Latino, Regione: Canada) valore LanguageId |
+|  | Irish | `0x083C` | Irlandese (Regione: Irlanda) valore LanguageId |
+|  | isiXhosa | `0x0434` | isiXhosa (Regione: Sudafrica, SA) valore LanguageId |
+|  | isiZulu | `0x0435` | isiZulu (Regione: Sudafrica, SA) valore LanguageId |
+|  | Italian_Italy | `0x0410` | Italian (Standard, Regione: Italia, ITA) valore LanguageId |
+|  | Italian_Switzerland | `0x0810` | Italian (Svizzero, Regione: Svizzera, ITS) valore LanguageId |
+|  | Japanese | `0x0411` | Giapponese (Regione: Giappone) valore LanguageId |
+|  | Kannada | `0x044B` | Kannada (Regione: India) valore LanguageId |
+|  | Kazakh | `0x043F` | Kazako (Regione: Kazakistan) valore LanguageId |
+|  | Khmer | `0x0453` | Khmer (Regione: Cambogia) valore LanguageId |
+|  | Kiche | `0x0486` | K�iche (Regione: Guatemala) valore LanguageId |
+|  | Kinyarwanda | `0x0487` | Kinyarwanda (Regione: Ruanda) valore LanguageId |
+|  | Kiswahili | `0x0441` | Kiswahili (Regione: Kenya) valore LanguageId |
+|  | Konkani | `0x0457` | Konkani (Regione: India) valore LanguageId |
+|  | Korean | `0x0412` | Coreano (Regione: Corea) valore LanguageId |
+|  | Kyrgyz | `0x0440` | Kirghiso (Regione: Kirghizistan) valore LanguageId |
+|  | Lao | `0x0454` | Lao (Regione: Lao P.D.R.) valore LanguageId |
+|  | Latvian | `0x0426` | Lettone (Regione: Lettonia, LVI) valore LanguageId |
+|  | Lithuanian | `0x0427` | Lituano (Regione: Lituania, LTH) valore LanguageId |
+|  | Lower_Sorbian | `0x082E` | Basso Sorabo (Regione: Germania) valore LanguageId |
+|  | Luxembourgish | `0x046E` | Lussemburghese (Regione: Lussemburgo) valore LanguageId |
+|  | Macedonian | `0x042F` | Macedone (Regione: Macedonia del Nord) valore LanguageId |
+|  | Malay_Brunei_Darussalam | `0x083E` | Malese (Regione: Brunei Darussalam) valore LanguageId |
+|  | Malay_Malaysia | `0x043E` | Malese (Regione: Malaysia) valore LanguageId |
+|  | Malayalam | `0x044C` | Malayalam (Regione: India) valore LanguageId |
+|  | Maltese | `0x043A` | Maltese (Regione: Malta) valore LanguageId |
+|  | Maori | `0x0481` | Maori (Regione: Nuova Zelanda) valore LanguageId |
+|  | Mapudungun | `0x047A` | Mapudungun (Regione: Cile) valore LanguageId |
+|  | Marathi | `0x044E` | Marathi (Regione: India) valore LanguageId |
+|  | Mohawk | `0x047C` | Mohawk (Regione: Mohawk) valore LanguageId |
+|  | Mongolian_Cyrillic | `0x0450` | Mongolo (Cirillico, Regione: Mongolia) valore LanguageId |
+|  | Mongolian_Traditional | `0x0850` | Mongolo (Tradizionale, Regione: Repubblica Popolare Cinese) valore LanguageId |
+|  | Nepali | `0x0461` | Nepali (Regione: Nepal) valore LanguageId |
+|  | Norwegian_Bokmal | `0x0414` | Norvegese (Bokmål, Regione: Norvegia, NOR) valore LanguageId |
+|  | Norwegian_Nynorsk | `0x0814` | Norvegese (Nynorsk, Regione: Norvegia, NON) valore LanguageId |
+|  | Occitan | `0x0482` | Occitano (Regione: Francia) valore LanguageId |
+|  | Odia | `0x0448` | Odia (precedentemente Oriya, Regione: India) valore LanguageId |
+|  | Pashto | `0x0463` | Pashto (Regione: Afghanistan) valore LanguageId |
+|  | Polish | `0x0415` | Polacco (Regione: Polonia, PLK) valore LanguageId |
+|  | Portuguese_Brazil | `0x0416` | Portoghese (Brasiliano, Regione: Brasile, PTB) valore LanguageId |
+|  | Portuguese_Portugal | `0x0816` | Portoghese (Standard, Regione: Portogallo, PTG) valore LanguageId |
+|  | Punjabi | `0x0446` | Punjabi (Regione: India) valore LanguageId |
+|  | Quechua_Bolivia | `0x046B` | Quechua (Regione: Bolivia) valore LanguageId |
+|  | Quechua_Ecuador | `0x086B` | Quechua (Regione: Ecuador) valore LanguageId |
+|  | Quechua_Peru | `0x0C6B` | Quechua (Regione: Perù) valore LanguageId |
+|  | Romanian | `0x0418` | Rumeno (Regione: Romania, ROM) valore LanguageId |
+|  | Romansh | `0x0417` | Romancio (Regione: Svizzera) valore LanguageId |
+|  | Russian | `0x0419` | Russo (Regione: Russia, RUS) valore LanguageId |
+|  | Sami_Inari | `0x243B` | Sami (Inari, Regione: Finlandia) valore LanguageId |
+|  | Sami_Lule_Norway | `0x103B` | Sami (Lule, Regione: Norvegia) valore LanguageId |
+|  | Sami_Lule_Sweden | `0x143B` | Sami (Lule, Regione: Svezia) valore LanguageId |
+|  | Sami_Northern_Finland | `0x0C3B` | Sami (Nord, Regione: Finlandia) valore LanguageId |
+|  | Sami_Northern_Norway | `0x043B` | Sami (Nord, Regione: Norvegia) valore LanguageId |
+|  | Sami_Northern_Sweden | `0x083B` | Sami (Nord, Regione: Norvegia) valore LanguageId |
+|  | Sami_Skolt | `0x203B` | Sami (Skolt, Regione: Finlandia) valore LanguageId |
+|  | Sami_Southern_Norway | `0x183B` | Sami (Sud, Regione: Norvegia) valore LanguageId |
+|  | Sami_Southern_Sweden | `0x1C3B` | Sami (Sud, Regione: Svezia) valore LanguageId |
+|  | Sanskrit | `0x044F` | Sanscrito (Regione: India) valore LanguageId |
+|  | Serbian_Cyrillic_BIH | `0x1C1A` | Serbo (Cirillico, Regione: Bosnia ed Erzegovina) valore LanguageId |
+|  | Serbian_Cyrillic_Serbia | `0x0C1A` | Serbo (Cirillico, Regione: Serbia) valore LanguageId |
+|  | Serbian_Latin_BIH | `0x181A` | Serbo (Latino, Regione: Bosnia ed Erzegovina) valore LanguageId |
+|  | Serbian_Latin_Serbia | `0x081A` | Serbo (Latino, Regione: Serbia) valore LanguageId |
+|  | Sesotho_Sa_Leboa | `0x046C` | Sesotho sa Leboa (Sotho del Nord, Regione: Sudafrica, SA) valore LanguageId |
+|  | Setswana | `0x0432` | Setswana (Regione: Sudafrica, SA) valore LanguageId |
+|  | Sinhala | `0x045B` | Sinhala (Regione: Sri Lanka) valore LanguageId |
+|  | Slovak | `0x041B` | Slovacco (Regione: Slovacchia, SKY) valore LanguageId |
+|  | Slovenian | `0x0424` | Sloveno (Regione: Slovenia, SLV) valore LanguageId |
+|  | Spanish_Argentina | `0x2C0A` | Spagnolo (Regione: Argentina) valore LanguageId |
+|  | Spanish_Bolivia | `0x400A` | Spagnolo (Regione: Bolivia) valore LanguageId |
+|  | Spanish_Chile | `0x340A` | Spagnolo (Regione: Cile) valore LanguageId |
+|  | Spanish_Colombia | `0x240A` | Spagnolo (Regione: Colombia) valore LanguageId |
+|  | Spanish_Costa_Rica | `0x140A` | Spagnolo (Regione: Costa Rica) valore LanguageId |
+|  | Spanish_Dominican_Republic | `0x1C0A` | Spagnolo (Regione: Repubblica Dominicana) valore LanguageId |
+|  | Spanish_Ecuador | `0x300A` | Spagnolo (Regione: Repubblica Dominicana) valore LanguageId |
+|  | Spanish_El_Salvador | `0x440A` | Spagnolo (Regione: Repubblica Dominicana) valore LanguageId |
+|  | Spanish_Guatemala | `0x100A` | Spagnolo (Regione: Guatemala) valore LanguageId |
+|  | Spanish_Honduras | `0x480A` | Spagnolo (Regione: Honduras) valore LanguageId |
+|  | Spanish_Mexico | `0x080A` | Spagnolo (Messicano, Regione: Messico, ESM) valore LanguageId |
+|  | Spanish_Nicaragua | `0x4C0A` | Spagnolo (Regione: Nicaragua) valore LanguageId |
+|  | Spanish_Panama | `0x180A` | Spagnolo (Regione: Panama) valore LanguageId |
+|  | Spanish_Paraguay | `0x3C0A` | Spagnolo (Regione: Paraguay) valore LanguageId |
+|  | Spanish_Peru | `0x280A` | Spagnolo (Regione: Perù) valore LanguageId |
+|  | Spanish_Puerto_Rico | `0x500A` | Spagnolo (Regione: Porto Rico) valore LanguageId |
+|  | Spanish_Modern_Sort | `0x0C0A` | Spagnolo (Ordinamento Moderno, Regione: Spagna, ESN) valore LanguageId |
+|  | Spanish_Traditional_Sort | `0x040A` | Spagnolo (Ordinamento Tradizionale, Regione: Spagna, ESP) valore LanguageId |
+|  | Spanish_United_States | `0x540A` | Spagnolo (Regione: Stati Uniti) valore LanguageId |
+|  | Spanish_Uruguay | `0x380A` | Spagnolo (Regione: Uruguay) valore LanguageId |
+|  | Spanish_Venezuela | `0x200A` | Spagnolo (Regione: Venezuela) valore LanguageId |
+|  | Swedish_Finland | `0x081D` | Svedese (Regione: Finlandia) valore LanguageId |
+|  | Swedish_Sweden | `0x041D` | Svedese (Regione: Svezia, SVE) valore LanguageId |
+|  | Syriac | `0x045A` | Siriano (Regione: Siria) valore LanguageId |
+|  | Tajik | `0x0428` | Tagico (Cirillico, Regione: Tagikistan) valore LanguageId |
+|  | Tamazight | `0x085F` | Tamazight (Latino, Regione: Algeria) valore LanguageId |
+|  | Tamil | `0x0449` | Tamil (Regione: India) valore LanguageId |
+|  | Tatar | `0x0444` | Tatar (Regione: Russia) valore LanguageId |
+|  | Telugu | `0x044A` | Telugu (Regione: India) valore LanguageId |
+|  | Thai | `0x041E` | Thai (Regione: Thailandia) valore LanguageId |
+|  | Tibetan | `0x0451` | Tibetano (Regione: PRC) valore LanguageId |
+|  | Turkish | `0x041F` | Turco (Regione: Turchia, TRK) valore LanguageId |
+|  | Turkmen | `0x0442` | Turkmeno (Regione: Turkmenistan) valore LanguageId |
+|  | Uighur | `0x0480` | Uiguro (Regione: PRC) valore LanguageId |
+|  | Ukrainian | `0x0422` | Ucraino (Regione: Ucraina, UKR) valore LanguageId |
+|  | Upper_Sorbian | `0x042E` | Upper Sorbian (Regione: Germania) valore LanguageId |
+|  | Urdu | `0x0420` | Urdu (Regione: Repubblica Islamica del Pakistan) valore LanguageId |
+|  | Uzbek_Cyrillic | `0x0843` | Uzbek (Cirillico, Regione: Uzbekistan) valore LanguageId |
+|  | Uzbek_Latin | `0x0443` | Uzbek (Latino, Regione: Uzbekistan) valore LanguageId |
+|  | Vietnamese | `0x042A` | Vietnamita (Regione: Vietnam) valore LanguageId |
+|  | Welsh | `0x0452` | Gallese (Regione: Regno Unito) valore LanguageId |
+|  | Wolof | `0x0488` | Wolof (Regione: Senegal) valore LanguageId |
+|  | Yakut | `0x0485` | Yakut (Regione: Russia) valore LanguageId |
+|  | Yi | `0x0478` | Yi (Regione: RPC) valore LanguageId |
+| Yoruba | `0x046A` | Yoruba (Regione: Nigeria) valore LanguageId |

--- a/italian/javascript-cpp/enumerations/ttfnametableplatformid/_index.md
+++ b/italian/javascript-cpp/enumerations/ttfnametableplatformid/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Enum TtfNameTablePlatformId"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Aspose.Font.TtfNameTablePlatformId enum. Specifica PlatformId"
+type: docs
+weight: 130
+url: /it/javascript-cpp/enumerations/ttfnametableplatformid/
+---
+## TtfNameTablePlatformId enumeration
+
+Specifica PlatformId.
+
+```cssharp
+ enum TtfNameTablePlatformId
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+|  | Unicode | `0` | Unicode |
+|  | Macintosh | `1` | Codice Macintosh Script Manager. |
+|  | ISO | `2` | Specifica Apple: (riservata; non utilizzare) Specifica MS: codifica ISO. Nota che l'ID piattaforma 2 (ISO) è stato deprecato a partire dalla Specifica OpenType v1.3. Era destinata a rappresentare ISO/IEC 10646, in contrapposizione a Unicode; entrambi gli standard hanno assegnazioni di codici carattere identiche |
+|  | Microsoft | `3` | Codifica Microsoft. |

--- a/italian/javascript-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
+++ b/italian/javascript-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum TtfNameTableUnicodePlatformSpecificId"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Aspose.Font.TtfNameTableUnicodePlatformSpecificId enum. Specifica UnicodePlatformSpecificId"
+type: docs
+weight: 133
+url: /it/javascript-cpp/enumerations/ttfnametableunicodeplatformspecificid/
+---
+## TtfNameTableUnicodePlatformSpecificId enumeration
+
+Specifica UnicodePlatformSpecificId.
+
+```csharp
+ enum TtfNameTableUnicodePlatformSpecificId
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+|  | Default | `0` | Semantica predefinita (Unicode 1.0). |
+|  | Unicode1_1 | `1` | Semantica Unicode 1.1. |
+|  | ISO10646_1993 | `2` | Semantica ISO 10646 1993 (deprecata). |
+|  | Unicode2_0 | `3` | Semantica Unicode 2.0 o successive. Solo Unicode BMP. |
+|  | Unicode2_0_Full | `4Unicode 2.0 and onwards semantics (non-BMP characters allowed)` | Repertorio completo Unicode. |

--- a/italian/javascript-cpp/glyph/_index.md
+++ b/italian/javascript-cpp/glyph/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Funzioni dei Font Glyph"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Funzioni per lavorare con i Glyph dei file Font"
+type: docs
+url: /it/javascript-cpp/glyph/
+---
+
+## Glyph Font functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposeFontGetGlyphCount](./asposefontgetglyphcount/) | Ottieni il conteggio dei glifi del font. |
+| [AsposeFontGetMetrics](./asposefontgetmetrics/) | Ottieni le metriche del font. |
+
+
+## Detailed Description
+
+Funzioni per lavorare con i Glyph Font.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/italian/javascript-cpp/glyph/asposefontgetglyphcount/_index.md
+++ b/italian/javascript-cpp/glyph/asposefontgetglyphcount/_index.md
@@ -1,0 +1,72 @@
+---
+title: "AsposeFontGetGlyphCount"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Ottieni informazioni (metadati) da un file Font."
+type: docs
+url: /it/javascript-cpp/glyph/asposefontgetglyphcount/
+---
+## AsposeFontGetGlyphCount function
+
+_Ottieni il conteggio dei glifi del font._
+
+```js
+function AsposeFontGetGlyphCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font sorgente per la conversione. |
+| fileName | stringa | Nome file. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | codice errore (0 nessun errore) |
+|  | errorText | testo errore (\"\" nessun errore) |
+|  | glyphCount | conteggio dei glifi |
+
+### Esempi
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    evt.data == "ready"
+      ? "loaded!"
+      : evt.data.json.errorCode == 0
+      ? "Glyph count: " + evt.data.json.glyphCount
+      : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFontGetGlyphCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get glyph count of font - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontGetGlyphCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+
+**Simple example**:
+```js
+  var ffileFontGetGlyphCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontGetGlyphCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Glyph count: " + json.glyphCount;
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/italian/javascript-cpp/glyph/asposefontgetmetrics/_index.md
+++ b/italian/javascript-cpp/glyph/asposefontgetmetrics/_index.md
@@ -1,0 +1,79 @@
+---
+title: "FontGetFontMetrics"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Ottieni informazioni (metadati) da un file Font."
+type: docs
+url: /it/javascript-cpp/glyph/asposefontgetmetrics/
+---
+## FontGetFontMetrics function
+
+_Ottieni il conteggio dei glifi del font._
+
+```js
+function FontGetFontMetrics(
+    fileBlob,
+    fileName
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font sorgente per la conversione. |
+| fileName | stringa | Nome file. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | codice errore (0 nessun errore) |
+|  | errorText | testo errore (\"\" nessun errore) |
+|  | metriche | oggetto JSON |
+| * ascesa |
+| * discesa |
+| * lineGap |
+| * advanceWidthMax |
+| * minLeftSideBearing |
+| * minRightSideBearing |
+| * xMaxExtent |
+
+### Esempi
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    evt.data == "ready"
+      ? "loaded!"
+      : evt.data.json.errorCode == 0
+      ? JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')
+      : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFontGetMetrics = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get metrics of font - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontGetMetrics', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+
+**Simple example**:
+```js
+  var ffileFontGetGlyphCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = FontGetFontMetrics(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Glyph count: " + json.glyphCount;
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/italian/javascript-cpp/metadata/_index.md
+++ b/italian/javascript-cpp/metadata/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Funzioni dei Font di Metadati"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Funzioni per lavorare con i file Font di Metadati"
+type: docs
+url: /it/javascript-cpp/metadata/
+---
+
+## Metadata Font functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposeFontGetInfo](./asposefontgetinfo/) | Ottieni informazioni (metadati) da un file Font. |
+| [AsposeFontSetInfo](./asposefontsetinfo/) | Imposta le informazioni (metadati) in un file Font. |
+
+## Detailed Description
+
+Funzioni per lavorare con i file Font di Metadati.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/italian/javascript-cpp/metadata/asposefontgetinfo/_index.md
+++ b/italian/javascript-cpp/metadata/asposefontgetinfo/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeFontGetInfo"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Ottieni informazioni (metadati) da un file Font."
+type: docs
+url: /it/javascript-cpp/metadata/asposefontgetinfo/
+---
+## AsposeFontGetInfo function
+
+_Ottieni informazioni (metadati) da un file Font._
+
+```js
+function AsposeFontGetInfo(
+    fileBlob,
+    fileName
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font sorgente per la conversione. |
+| fileName | stringa | Nome file. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | codice errore (0 nessun errore) |
+|  | errorText | testo errore (\"\" nessun errore) |
+|  | record | Array di oggetti JSON : |
+|  | * NameId | identificatore del nome |
+|  | * PlatformId | identificatore della piattaforma |
+|  | * PlatformSpecificId | identificatore specifico della piattaforma |
+|  | * LanguageId | identificatore della lingua |
+|  | * Info | contenuto del record del nome |
+
+### Esempi
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    evt.data == "ready"
+      ? "loaded!"
+      : evt.data.json.errorCode == 0
+      ? "Name records count: " + evt.data.json.records.length + 
+                                            evt.data.json.records.reduce((ret, a) => ret +
+                                            "\nNameId : " + a.NameId
+                                          + "; PlatformId : " + a.PlatformId
+                                          + "; PlatformSpecificId : " + a.PlatformSpecificId
+                                          + "; LanguageId : " + a.LanguageId
+                                          + "; Info : " + a.Info,"")
+      : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFontGetInfo = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get info (metadata) from a Font-file - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontGetInfo', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileFontGetInfo = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontGetInfo(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Name records count: " + json.records.length;
+        for (let recordIndex = 0; recordIndex < json.records.length; recordIndex++) 
+			document.getElementById('output').textContent += " " + "\n"
+                                                         + "NameId : " + json.records[recordIndex].NameId
+                                                         + ";  PlatformId : " + json.records[recordIndex].PlatformId
+                                                         + ";  PlatformSpecificId : " + json.records[recordIndex].PlatformSpecificId
+                                                         + ";  LanguageId : " + json.records[recordIndex].LanguageId
+                                                         + ";  Info : " + json.records[recordIndex].Info;
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/italian/javascript-cpp/metadata/asposefontsetinfo/_index.md
+++ b/italian/javascript-cpp/metadata/asposefontsetinfo/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeFontSetInfo"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Imposta le informazioni (metadati) in un file Font."
+type: docs
+url: /it/javascript-cpp/metadata/asposefontsetinfo/
+---
+## AsposeFontSetInfo function
+
+_Imposta le informazioni (metadati) in un file Font._
+
+```js
+function AsposeFontSetInfo(
+    fileBlob,
+    fileName,
+    nameId, 
+    platformId, 
+    platformSpecificId, 
+    languageId, 
+    text
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font sorgente per la conversione. |
+| fileName | stringa | Nome file. |
+| nameId | TtfNameTableNameId | Identificatore del nome, categoria logica della stringa, specificato dall'enumerazione [`NameId`](../../enumerations/ttfnametablenameid/) |
+|  | platformId | TtfNameTablePlatformId | Identificatore della piattaforma |
+| platformSpecificId | int | Identificatore della codifica specifica della piattaforma. Si prega di utilizzare un valore da una di queste enumerazioni - [`UnicodePlatformSpecificId`](../../enumerations/ttfnametableunicodeplatformspecificid/), [`MacPlatformSpecificId`](../../ttfnametable.macplatformspecificid/), [`MSPlatformSpecificId`](../../enumerations/ttfnametablemsplatformspecificid/). L'enumerazione da utilizzare è definita dal contesto (parametro *platformId*) |
+| languageId | int | Identificatore della lingua. Si prega di utilizzare un valore dalle enumerazioni [`MSLanguageId`](../../enumerations/ttfnametablemslanguageid/) o [`MacLanguageId`](../../enumerations/ttfnametablemaclanguageid/). Le enumerazioni dipendono dal contesto, definito dal parametro *platformId*. |
+|  | testo | stringa | Dati della stringa effettivi |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | codice errore (0 nessun errore) |
+|  | errorText | testo errore (\"\" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    (evt.data == 'ready') ? 'library loaded!' :
+    (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+ 
+ /*Event handler*/
+  const ffileFontSetInfo = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+          const nameId = 'Module.TtfNameTableNameId.' + document.getElementById("NameId").value;
+          //Value will be changed for PlatformId = PlatformId.Microsoft, PlatformSpecificId = MSPlatformSpecificId.Unicode_BMP_UCS2 (1) and languageID = 1033 (English_United_States = 0x0409)
+          const platformId = 'Module.TtfNameTablePlatformId.Microsoft';
+          const platformSpecificId = 'Module.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2';
+          const langID = 'Module.TtfNameTableMSLanguageId.English_United_States';
+          const text = document.getElementById("textValue").value;
+          transfer = [event.target.result];
+          params = [event.target.result, e.target.files[0].name, nameId, platformId, platformSpecificId, langID, text];
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontSetInfo', "params": params }, transfer);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var fFontSetInfo = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+
+      const nameId = new Function("return Module.TtfNameTableNameId." + document.getElementById("NameId").value)();
+      const platformId = Module.TtfNameTablePlatformId.Microsoft;
+      const platformSpecificId = Module.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+      const text = document.getElementById("textValue").value;
+      const langID = 1033;
+
+      const json = AsposeFontSetInfo(blob, file.name, nameId, platformId, platformSpecificId, langID, text);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult);
+        //DownloadFile(file.name);
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(file);
+  }
+```
+
+### Vedi anche
+
+* enum [TtfNameTableNameId](../../enumerations/ttfnametablenameid/)
+* enum [TtfNameTablePlatformId](../../enumerations/ttfnametableplatformid/)
+* enum [TtfNameTableMacPlatformSpecificId](../../enumerations/ttfnametablemacplatformspecificid/)
+* enum [TtfNameTableMSPlatformSpecificId](../../enumerations/ttfnametablemsplatformspecificid/)
+* enum [TtfNameTableUnicodePlatformSpecificId](../../enumerations/ttfnametableunicodeplatformspecificid/)
+* enum [TtfNameTableMacLanguageId](../../enumerations/ttfnametablemaclanguageid/)
+* enum [TtfNameTableMSLanguageId](../../enumerations/ttfnametablemslanguageid/)

--- a/italian/javascript-cpp/misc/_index.md
+++ b/italian/javascript-cpp/misc/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Funzioni varie"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Funzioni secondarie per lavorare con i file Font."
+type: docs
+url: /it/javascript-cpp/misc/
+---
+## Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposeFontAbout](./asposeFontabout/) | Ottieni informazioni sul Prodotto. |
+| [DownloadFile](./downloadfile/) | Crea un collegamento in HTML per scaricare il file. |
+| [DownloadFileAuto](./downloadfileauto/) | Crea un collegamento in HTML per scaricare il file e avvia il download dopo 2 secondi. |
+
+## Detailed Description
+
+Funzioni secondarie per lavorare con i file Font.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/italian/javascript-cpp/misc/asposefontabout/_index.md
+++ b/italian/javascript-cpp/misc/asposefontabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeFontAbout"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Ottieni informazioni sul Prodotto."
+type: docs
+url: /it/javascript-cpp/misc/asposefontabout/
+---
+
+## AsposeFontAbout function
+
+Ottieni informazioni sul Prodotto.
+
+```js
+function AsposeFontAbout()
+```
+
+### Valore restituito
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+| errorCode | codice errore (0 nessun errore) |
+| errorText | testo errore (\"\" nessun errore) |
+| prodotto | Nome prodotto |
+| versione | Versione prodotto |
+| islicensed | Il prodotto è licenziato |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposeFontAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposeFontAbout = function () {
+    /*Get info about Product*/
+    const json = AsposeFontAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/italian/javascript-cpp/misc/downloadfile/_index.md
+++ b/italian/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Crea un collegamento in HTML per scaricare il file."
+type: docs
+url: /it/javascript-cpp/misc/downloadfile/
+---
+
+_Crea un link in HTML per scaricare il file._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/italian/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/italian/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Font per JavaScript via C++"
+description: "Crea un collegamento in HTML per scaricare il file e avvia il download dopo 2 secondi."
+type: docs
+url: /it/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+Crea un collegamento in HTML per scaricare il file e avvia il download dopo 2 secondi.
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### Parametri
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### Osservazioni
+
+Non funziona in Web Worker.


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Italian** (`it`) generated by RDA.

- Pages translated: 30/30
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `italian/javascript-cpp`

🤖 Generated by RDA