### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Spanish

### DIFF
--- a/spanish/javascript-cpp/_index.md
+++ b/spanish/javascript-cpp/_index.md
@@ -1,0 +1,73 @@
+---
+title: "Aspose.Font para JavaScript vía C++"
+description: "Aspose.Font para JavaScript vía C++"
+keywords:  "JavaScript via C++, JavaScript Font toolkit"
+tags: ['font-to-ttf', 'font-to-woff',  'font-to-woff2', 'font-to-svg', 'font-convert', 'font-tools']
+weight: 40
+url: /es/javascript-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.Font for JavaScript via C++ allows developers manipulate them Font files directly in the Web.
+>
+> Such operations are very time consuming, so we recommend using Web Worker. 
+
+
+## Convert functions
+
+| Función | Descripción |
+| -------- | ----------- |
+| [AsposeFontConvert](./convert/) | Convertir una fuente a fuentes TrueType. |
+| [AsposeFontConvertToTTF](./convert/asposefontconverttottf/) | Convertir una fuente al formato TTF. |
+| [AsposeFontConvertToWOFF](./convert/asposefontconverttowoff/) | Convertir una fuente al formato WOFF. |
+| [AsposeFontConvertToWOFF2](./convert/asposefontconverttowoff2/) | Convertir una fuente al formato WOFF2. |
+| [AsposeFontConvertToSVG](./convert/asposefontconverttosvg/) | Convertir una fuente al formato SVG. |
+
+
+## Metadata Font functions
+
+| Función | Descripción |
+| -------- | ----------- |
+| [AsposeFontGetInfo](./metadata/asposefontgetinfo/) | Obtener información (metadatos) de un archivo de fuente. |
+| [AsposeFontSetInfo](./metadata/asposefontsetinfo/) | Establecer información (metadatos) en un archivo de fuente. |
+
+
+## Glyph Font functions
+
+| Función | Descripción |
+| -------- | ----------- |
+| [AsposeFontGetGlyphCount](./glyph/asposefontgetglyphcount/) | Obtener el recuento de glifos de la fuente. |
+| [AsposeFontGetMetrics](./glyph/asposefontgetmetrics/) | Obtener métricas de la fuente. |
+
+
+## Core Functions
+
+| Función | Descripción |
+| -------- | ----------- |
+| [AsposeFontPrepare](./core/asposefontprepare/) | Guardar el BLOB en el FS de memoria para su procesamiento. |
+| [AsposeFontPrepareBase64](./core/asposefontpreparebase64/) | Guardar el BLOB de representación de cadena en el FS de memoria para su procesamiento. |
+
+
+## Miscellaneous
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposeFontAbout](./misc/asposefontabout/) | Obtener información sobre el producto. |
+| [DownloadFile](./misc/downloadfile/) | Crear un enlace en HTML para descargar el archivo. |
+| [DownloadFileAuto](./misc/downloadfileauto) | Crear un enlace en HTML para descargar el archivo y comenzar la descarga después de 2 segundos. |
+
+
+## Enumeraciones
+
+| Enumeración | Descripción |
+| ----------- | ----------- |
+| [FontSavingFormats](./enumerations/fontsavingformats/) | Especifica el tipo de fuente. |
+| [FontStyle](./enumerations/fontstyle/) | Especifica el estilo de fuente. |
+| [TtfNameTableNameId](./enumerations/ttfnametablenameid/) | Especifica NameId. |
+| [TtfNameTablePlatformId](./enumerations/ttfnametableplatformid/) | Representa la enumeración PlatformId. |
+| [TtfNameTableMacPlatformSpecificId](./enumerations/ttfnametablemacplatformspecificid/) | Representa la enumeración de ID específica de la plataforma Macintosh. |
+| [TtfNameTableMSPlatformSpecificId](./enumerations/ttfnametablemsplatformspecificid/) | Representa la enumeración de ID específica de la plataforma Microsoft. |
+| [TtfNameTableUnicodePlatformSpecificId](./enumerations/ttfnametableunicodeplatformspecificid/) | Representa la enumeración de ID específica de la plataforma Unicode. |
+| [TtfNameTableMacLanguageId](./enumerations/ttfnametablemaclanguageid/) | Enumeración MacLanguageId. |
+| [TtfNameTableMSLanguageId](./enumerations/ttfnametablemslanguageid/) | Enumeración MSLanguageId. |

--- a/spanish/javascript-cpp/convert/_index.md
+++ b/spanish/javascript-cpp/convert/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Funciones de conversión de fuente"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Funciones para convertir fuentes a formatos TrueType."
+type: docs
+url: /es/javascript-cpp/convert/
+---
+
+## Convert functions
+
+| Función | Descripción |
+| -------- | ----------- |
+| [AsposeFontConvert](./asposefontconvert) | Convertir una fuente a formatos compatibles. |
+| [AsposeFontConvertToTTF](./asposefontconverttottf/) | Convertir una fuente al formato TTF. |
+| [AsposeFontConvertToWOFF](./asposefontconverttowoff/) | Convertir una fuente al formato WOFF. |
+| [AsposeFontConvertToWOFF2](./asposefontconverttowoff2/) | Convertir una fuente al formato WOFF2. |
+| [AsposeFontConvertToSVG](./asposefontconverttosvg/) | Convertir una fuente al formato SVG. |
+
+## Detailed Description
+
+Funciones para convertir fuentes a formatos TrueType.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```
+

--- a/spanish/javascript-cpp/convert/asposefontconvert/_index.md
+++ b/spanish/javascript-cpp/convert/asposefontconvert/_index.md
@@ -1,0 +1,94 @@
+---
+title: "AsposeFontConvert"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Convierte la fuente a otro formato"
+type: docs
+weight: 10
+url: /es/javascript-cpp/convert/asposefontconvert/
+---
+## AsposeFontConvert function
+
+Convierte la fuente a otro formato.
+
+```js
+function AsposeFontConvert(
+    fileBlob,
+    fileName,
+    fontType,
+    fontSavingFormat
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente de origen para convertir. |
+| fileName | string | Nombre de archivo. |
+| fontType | FontType | Tipo de fuente a convertir. |
+| fontSavingFormat | FontSavingFormats | Formato de fuente al que convertir. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | fileNameResult | nombre de archivo resultante |
+
+### Observaciones
+
+Nota: ahora solo se admite el tipo de fuente TTF.
+
+### Ejemplos
+
+```js
+  var fTTF2WOFF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvert(event.target.result, e.target.files[0].name, Module.FontType.TTF, Module.FontSavingFormats.WOFF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "woff");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoTTF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to TTF and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvert', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF', 'Module.FontSavingFormats.TTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* enum [FontType](../../enumerations/fonttype/)
+* enum [FontSavingFormats](../../enumerations/fontsavingformats/)

--- a/spanish/javascript-cpp/convert/asposefontconverttottf/_index.md
+++ b/spanish/javascript-cpp/convert/asposefontconverttottf/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToTTF"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Convierte la fuente al formato ttf"
+type: docs
+weight: 10
+url: /es/javascript-cpp/convert/asposefontconverttottf/
+---
+## AsposeFontConvertToTTF function
+
+Convierte la fuente al formato TTF.
+
+```js
+function AsposeFontConvertToTTF(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente de origen para convertir. |
+| fileName | string | Nombre de archivo. |
+| fontType | FontType | Tipo de fuente a convertir. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | fileNameResult | nombre de archivo resultante |
+
+### Ejemplos
+
+```js
+  var fEOT2TTF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToTTF(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoTTF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to TTF and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToTTF', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/spanish/javascript-cpp/convert/asposefontconverttowoff/_index.md
+++ b/spanish/javascript-cpp/convert/asposefontconverttowoff/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToWOFF"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Convierte la fuente al formato woff"
+type: docs
+weight: 10
+url: /es/javascript-cpp/convert/asposefontconverttowoff/
+---
+## AsposeFontConvertToWOFF function
+
+Convierte la fuente al formato WOFF.
+
+```js
+function AsposeFontConvertToWOFF(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente de origen para convertir. |
+| fileName | string | Nombre de archivo. |
+| fontType | FontType | Tipo de fuente a convertir. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | fileNameResult | nombre de archivo resultante |
+
+### Ejemplos
+
+```js
+  var fEOT2WOFF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToWOFF(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoWOFF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to WOFF and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToWOFF', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/spanish/javascript-cpp/convert/asposefontconverttowoff2/_index.md
+++ b/spanish/javascript-cpp/convert/asposefontconverttowoff2/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToWOFF2"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Convierte la fuente al formato woff2"
+type: docs
+weight: 10
+url: /es/javascript-cpp/convert/asposefontconverttowoff2/
+---
+## AsposeFontConvertToWOFF2 function
+
+Convierte la fuente al formato WOFF2.
+
+```js
+function AsposeFontConvertToWOFF2(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente de origen para convertir. |
+| fileName | string | Nombre de archivo. |
+| fontType | FontType | Tipo de fuente a convertir. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | fileNameResult | nombre de archivo resultante |
+
+### Ejemplos
+
+```js
+  var fEOT2WOFF2 = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToWOFF2(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoWOFF2 = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to WOFF2 and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToWOFF2', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/spanish/javascript-cpp/convert/asposefontconverttowsvg/_index.md
+++ b/spanish/javascript-cpp/convert/asposefontconverttowsvg/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToSVG"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Convierte la fuente al formato svg"
+type: docs
+weight: 10
+url: /es/javascript-cpp/convert/asposefontconverttosvg/
+---
+## AsposeFontConvertToSVG function
+
+Convierte la fuente al formato SVG.
+
+```js
+function AsposeFontConvertToSVG(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente de origen para convertir. |
+| fileName | string | Nombre de archivo. |
+| fontType | FontType | Tipo de fuente a convertir. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | fileNameResult | nombre de archivo resultante |
+
+### Ejemplos
+
+```js
+  var fEOT2SVG = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToSVG(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoSVG = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to SVG and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToSVG', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/spanish/javascript-cpp/core/_index.md
+++ b/spanish/javascript-cpp/core/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Funciones principales"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Funciones principales para trabajar con archivos de fuente."
+type: docs
+url: /es/javascript-cpp/core/
+---
+
+## Core Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposeFontPrepare](./asposefontprepare/) | Guardar el BLOB en el FS de memoria para su procesamiento. |
+| [AsposeFontPrepareBase64](./asposefontpreparebase64/) | Guardar el BLOB de representación de cadena en el FS de memoria para su procesamiento. |
+
+## Detailed Description
+
+Funciones principales para trabajar con archivos de fuente.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/spanish/javascript-cpp/core/asposefontprepare/_index.md
+++ b/spanish/javascript-cpp/core/asposefontprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposeFontPrepare"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Guardar el BLOB en el FS de memoria para su procesamiento."
+type: docs
+url: /es/javascript-cpp/core/asposefontprepare/
+---
+
+_Guarda el BLOB en el Memory FS para su procesamiento._
+
+```js
+function AsposeFontPrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+Objeto JSON
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposeFontPrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposeFontAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposeFontWebWorker.postMessage(
+        { "operation": 'AsposeFontPrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposeFontPrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/spanish/javascript-cpp/core/asposefontpreparebase64/_index.md
+++ b/spanish/javascript-cpp/core/asposefontpreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposeFontPrepareBase64"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Guardar el BLOB de representación de cadena en el FS de memoria para su procesamiento."
+type: docs
+url: /es/javascript-cpp/core/asposefontpreparebase64/
+---
+## AsposeFontPrepareBase64 function
+_Guarda la representación en cadena BLOB en el Memory FS para su procesamiento._
+
+```js
+function AsposeFontPrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### Observaciones
+**AsposeFontPrepareBase64** doesn't work in Web Worker mode, use AsposeFontPrepare
+
+### Ejemplos
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposeFontPrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposeFontPrepareBase64 for Web Worker*/
+  const AsposeFontPrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposeFontWebWorker.postMessage(
+                 { "operation": 'AsposeFontPrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposeFontPrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/Font");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/spanish/javascript-cpp/enumerations/_index.md
+++ b/spanish/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Enumeraciones"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Funciones para convertir fuentes a formatos TrueType."
+type: docs
+url: /es/javascript-cpp/enumerations/
+---
+
+## Enumeraciones
+
+| Enumeración | Descripción |
+| ----------- | ----------- |
+| [FontSavingFormats](./fontsavingformats/) | Especifica el tipo de fuente. |
+| [FontType](./fonttype/) | Especifica el tipo de fuente. |
+| [TtfNameTableNameId](./ttfnametablenameid/) | Especifica NameId. |
+| [TtfNameTablePlatformId](./ttfnametableplatformid/) | Representa la enumeración PlatformId. |
+| [TtfNameTableMSPlatformSpecificId](./ttfnametableMSPlatformSpecificId/) | Representa la enumeración MSPlatformSpecificId. |
+| [TtfNameTableMacPlatformSpecificId](./ttfnametableMacPlatformSpecificId/) | Representa la enumeración MacPlatformSpecificId. |
+| [TtfNameTableUnicodePlatformSpecificId](./ttfnametableUnicodePlatformSpecificId/) | Representa la enumeración UnicodePlatformSpecificId. |
+| [TtfNameTableMacLanguageId](./ttfnametablemaclanguageid/) | Enumeración del id de idioma de la plataforma Macintosh. |
+| [TtfNameTableMSLanguageId](./ttfnametablemslanguageid/) | Enumeración del id de idioma de la plataforma Microsoft. |
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```
+

--- a/spanish/javascript-cpp/enumerations/fontsavingformats/_index.md
+++ b/spanish/javascript-cpp/enumerations/fontsavingformats/_index.md
@@ -1,0 +1,26 @@
+---
+title: "Enum FontSavingFormats"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Aspose.Font.FontSavingFormats enum. Especifica el tipo de fuente"
+type: docs
+weight: 110
+url: /es/javascript-cpp/enumerations/fontsavingformats/
+---
+## FontSavingFormats enumeration
+
+Especifica el tipo de fuente.
+
+```csharp
+public enum FontSavingFormats
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+| TTF | `0` | Formato de fuente TTF (TrueType). |
+| WOFF | `1` | WOFF (Web Open Font Format). |
+| WOFF2 | `2` | Formato de archivo WOFF 2.0 |
+| SVG | `3` | Formato de fuente SVG (Scalable Vector Graphics) |
+| OTF | `4` | Formato de fuente OTF (OpenType) |
+

--- a/spanish/javascript-cpp/enumerations/fonttype/_index.md
+++ b/spanish/javascript-cpp/enumerations/fonttype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum FontType"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Aspose.Font.FontType enum. Especifica el tipo de fuente"
+type: docs
+weight: 100
+url: /es/javascript-cpp/enumerations/fonttype/
+---
+## FontType enumeration
+
+Especifica el tipo de fuente.
+
+```csharp
+public enum FontType
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+| TTF | `0` | Tipo de fuente TTF (TrueType) y relacionados. |
+| Type1 | `1` | Tipo de fuente Type1. |
+| CFF | `2` | Tipo de fuente CFF (Compact font format). |
+| OTF | `3` | Fuente OpenType. El formato de fuente OpenType es una extensión del formato de fuente TrueType, añadiendo soporte para datos de fuente PostScript. |
+

--- a/spanish/javascript-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
+++ b/spanish/javascript-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
@@ -1,0 +1,53 @@
+---
+title: "Enumeración TtfNameTableMacPlatformSpecificId"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Aspose.Font.TtfNameTableMacPlatformSpecificId enumeración. Especifica MacPlatformSpecificId"
+type: docs
+weight: 131
+url: /es/javascript-cpp/enumerations/ttfnametablemacplatformspecificid/
+---
+## TtfNameTableMacPlatformSpecificId enumeration
+
+Especifica MacPlatformSpecificId.
+
+```csharp
+ enum TtfNameTableMacPlatformSpecificId
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+|  | Roman | `0` | Valor específico de plataforma Roman. |
+|  | Japanese | `1` | Valor específico de plataforma Japanese. |
+|  | Traditional_Chinese | `2` | Valor específico de plataforma Traditional Chinese. |
+|  | Korean | `3` | Valor específico de plataforma Korean. |
+|  | Arabic | `4` | Valor específico de plataforma Arabic. |
+|  | Hebrew | `5` | Valor específico de plataforma Hebreo. |
+|  | Greek | `6` | Valor específico de plataforma Griego. |
+|  | Russian | `7` | Valor específico de plataforma Ruso. |
+|  | RSymbol | `8` | Valor específico de plataforma RSymbol. |
+|  | Devanagari | `9` | Valor específico de plataforma Devanagari. |
+|  | Gurmukhi | `10` | Valor específico de plataforma Gurmukhi. |
+|  | Gujarati | `11` | Valor específico de plataforma Gujarati. |
+|  | Oriya | `12` | Valor específico de plataforma Oriya. |
+|  | Bengali | `13` | Valor específico de plataforma Bengali. |
+|  | Tamil | `14` | Valor específico de plataforma Tamil. |
+|  | Telugu | `15` | Valor específico de plataforma Telugu. |
+|  | Kannada | `16` | Valor específico de plataforma Kannada. |
+|  | Malayalam | `17` | Valor específico de la plataforma Malayalam. |
+|  | Sinhalese | `18` | Valor específico de la plataforma Cingalés. |
+|  | Burmese | `19` | Valor específico de la plataforma Birmano. |
+|  | Khmer | `20` | Valor específico de la plataforma Jemer. |
+|  | Thai | `21` | Valor específico de la plataforma Tailandés. |
+|  | Laotian | `22` | Valor específico de la plataforma Laosiano. |
+|  | Georgian | `23` | Valor específico de la plataforma Georgiano. |
+|  | Armenian | `24` | Valor específico de la plataforma Armenio. |
+|  | Simplified_Chinese | `25` | Valor específico de la plataforma Chino simplificado. |
+|  | Tibetan | `26` | Valor específico de la plataforma Tibetano. |
+|  | Mongolian | `27` | Valor específico de la plataforma mongola. |
+|  | Geez | `28` | Valor específico de la plataforma Geez. |
+|  | Slavic | `29` | Valor específico de la plataforma eslava. |
+|  | Vietnamese | `30` | Valor específico de la plataforma vietnamita. |
+|  | Sindhi | `31` | Valor específico de la plataforma sindhi. |
+|  | Uninterpreted | `32` | Valor específico de la plataforma no interpretado. |

--- a/spanish/javascript-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
+++ b/spanish/javascript-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Enumeración TtfNameTableMSPlatformSpecificId"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Aspose.Font.TtfNameTableMSPlatformSpecificId enum. Especifica MSPlatformSpecificId"
+type: docs
+weight: 132
+url: /es/javascript-cpp/enumerations/ttfnametablemsplatformspecificid/
+---
+## TtfNameTableMSPlatformSpecificId enumeration
+
+Especifica MSPlatformSpecificId.
+
+```csharp
+ enum TtfNameTableMSPlatformSpecificId
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+|  | Symbol | `0` | Símbolo MS PlatformSpecificId. |
+|  | Unicode_BMP_UCS2 | `1` | Unicode BMP (UCS2) MS PlatformSpecificId. |
+|  | ShiftJIS | `2` | ShiftJIS MS PlatformSpecificId. |
+|  | PRC | `3` | PRC MS PlatformSpecificId. |
+|  | Big5 | `4` | Big5 MS PlatformSpecificId. |
+|  | Wansung | `5` | Wansung MS PlatformSpecificId. |
+|  | Johab | `6` | Johab MS PlatformSpecificId. |
+|  | Reserved1 | `7` | Reserved1 MS PlatformSpecificId. |
+|  | Reserved2 | `8` | Reserved2 MS PlatformSpecificId. |
+|  | Reserved3 | `9` | Reserved3 MS PlatformSpecificId. |
+|  | Unicode_UCS4 | `10` | Unicode UCS4 MS PlatformSpecificId. |
+

--- a/spanish/javascript-cpp/enumerations/ttfnametablenameid/_index.md
+++ b/spanish/javascript-cpp/enumerations/ttfnametablenameid/_index.md
@@ -1,0 +1,46 @@
+---
+title: "Enumeración TtfNameTableNameId"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Aspose.Font.TtfNameTableNameId enumeración. Especifica NameId"
+type: docs
+weight: 120
+url: /es/javascript-cpp/enumerations/ttfnametablenameid/
+---
+## TtfNameTableNameId enumeration
+
+Especifica NameId.
+
+```csharp
+ enum TtfNameTableNameId
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+|  | CopyrightNotice | `0` | Aviso de derechos de autor. |
+|  | FontFamily | `1` | Familia de fuente. Esta cadena es el nombre de la familia de fuentes que el usuario ve en plataformas Macintosh. |
+|  | FontSubfamily | `2` | Subfamilia de fuente. Esta cadena es la familia de fuentes que el usuario ve en plataformas Macintosh. |
+|  | UniqueFontId | `3` | Identificación única de subfamilia (especificación de Apple). 3 Identificador único de fuente (especificación de MS). |
+|  | FullName | `4` | Nombre completo de la fuente. |
+|  | Version | `5` | Versión de la tabla de nombres. |
+|  | PostScriptName | `6` | Nombre PostScript de la fuente. Nota: Una fuente puede tener solo un nombre PostScript y ese nombre debe ser ASCII. |
+|  | TrademarkNotice | `7` | Aviso de marca registrada. |
+|  | ManufacturerName | `8` | Nombre del fabricante. |
+|  | DesignerName | `9` | Diseñador; nombre del diseñador del tipo de letra. |
+|  | Description | `10` | Descripción; descripción del tipo de letra. Puede contener información de revisión, recomendaciones de uso, historia, características, etc. |
+|  | UrlVendor | `11` | URL del proveedor de la fuente (con protocolo, p. ej., http://, ftp://). Si un número de serie único está incrustado en la URL, puede usarse para registrar la fuente. |
+|  | UrlDesigner | `12` | URL del diseñador de la fuente (con protocolo, p. ej., http://, ftp://) |
+|  | LicenseDescription | `13` | Descripción de la licencia; descripción de cómo puede usarse legalmente la fuente, o diferentes escenarios de ejemplo para uso con licencia. Este campo debe escribirse en lenguaje sencillo, no en jerga legal. |
+|  | LicenseInfoUrl | `14` | URL de información de la licencia, donde se puede encontrar información adicional de licencias. |
+|  | PreferredFamily | `16` | `15` Reservado `16` Familia preferida (solo Windows); En Windows, el nombre de la familia se muestra en el menú de fuentes; el nombre de la subfamilia se presenta como el nombre del estilo. Por razones históricas, las familias de fuentes han contenido un máximo de cuatro estilos, pero los diseñadores de fuentes pueden agrupar más de cuatro fuentes en una sola familia. Los IDs de Familia preferida y Subfamilia preferida permiten a los diseñadores de fuentes incluir los agrupamientos de familia/subfamilia preferidos. Estos IDs solo están presentes si son diferentes de los IDs 1 y 2. |
+|  | PreferredSubfamily | `17` | Subfamilia preferida (solo Windows); En Windows, el nombre de la familia se muestra en el menú de fuentes; el nombre de la subfamilia se presenta como el nombre del estilo. Por razones históricas, las familias de fuentes han contenido un máximo de cuatro estilos, pero los diseñadores de fuentes pueden agrupar más de cuatro fuentes en una sola familia. Los IDs de Familia preferida y Subfamilia preferida permiten a los diseñadores de fuentes incluir los agrupamientos de familia/subfamilia preferidos. Estos IDs solo están presentes si son diferentes de los IDs 1 y 2. |
+|  | CompatibleFull | `18` | Completo compatible (solo Macintosh); En Macintosh, el nombre del menú se construye usando el recurso de fuente. Esto suele coincidir con el Nombre completo. Si deseas que el nombre de la fuente aparezca diferente al Nombre completo, puedes insertar el Nombre completo compatible en el ID 18. Este nombre no lo usa el propio Mac OS, pero puede ser usado por desarrolladores de aplicaciones (p. ej., Adobe). |
+|  | SampleText | `19` | Texto de muestra. Esto puede ser el nombre de la fuente, o cualquier otro texto que el diseñador considere el mejor ejemplo para mostrar cómo se ve la fuente. |
+|  | PostScriptCID | `20` | Su presencia en una fuente significa que el nameID 6 contiene un nombre de fuente PostScript que está destinado a usarse con la invocación "composefont" para invocar la fuente en un intérprete PostScript. |
+|  | WwsFamilyName | `21` | Se utiliza para proporcionar un nombre de familia conforme a WWS en caso de que las entradas de los IDs 16 y 17 no se ajusten al modelo WWS. |
+|  | WwsSubfamilyName | `22` | Usado junto con el ID 21, este ID proporciona un nombre de subfamilia conforme a WWS (reflejando solo los atributos de peso, anchura y pendiente) en caso de que las entradas de los IDs 16 y 17 no se ajusten al modelo WWS. |
+|  | LightBackground | `23` | Este ID, si se usa en la matriz de etiquetas de paleta de la tabla CPAL, especifica que la paleta de colores correspondiente en la tabla CPAL es adecuada para usar con la fuente al mostrarla sobre un fondo claro como blanco. |
+|  | DarkBackground | `24` | Este ID, si se usa en la matriz de etiquetas de paleta de la tabla CPAL, especifica que la paleta de colores correspondiente en la tabla CPAL es adecuada para usar con la fuente al mostrarla sobre un fondo oscuro como negro. |
+|  | VariationsPostScriptNamePrefix | `25` | Si está presente en una fuente variable, puede usarse como prefijo de familia en el algoritmo de generación de nombres PostScript para fuentes de variación. |
+

--- a/spanish/javascript-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
+++ b/spanish/javascript-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
@@ -1,0 +1,138 @@
+---
+title: "Enumeración TtfNameTableMacLanguageId"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Enumeración Aspose.Font.TtfNameTableMacLanguageId. Especifica MacLanguageId"
+type: docs
+weight: 140
+url: /es/javascript-cpp/enumerations/ttfnametablemaclanguageid/
+---
+## TtfNameTableMacLanguageId enumeration
+
+Representa la enumeración MacLanguageId.
+
+```csharp
+ enum TtfNameTableMacLanguageId
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+|  | English | `0` | Valor LanguageId en inglés |
+|  | French | `1` | Valor LanguageId en francés |
+|  | German | `2` | Valor LanguageId en alemán |
+|  | Italian | `3` | Valor LanguageId en italiano |
+|  | Dutch | `4` | Valor LanguageId en holandés |
+|  | Swedish | `5` | Valor LanguageId en sueco |
+|  | Spanish | `6` | Valor LanguageId en español |
+|  | Danish | `7` | Valor LanguageId en danés |
+|  | Portuguese | `8` | Valor LanguageId en portugués |
+|  | Norwegian | `9` | Valor LanguageId en noruego |
+|  | Hebrew | `10` | Valor LanguageId en hebreo |
+|  | Japanese | `11` | Valor LanguageId en japonés |
+|  | Arabic | `12` | Valor LanguageId en árabe |
+|  | Finnish | `13` | Valor LanguageId en finlandés |
+|  | Greek | `14` | Valor LanguageId en griego |
+|  | Icelandic | `15` | Valor LanguageId en islandés |
+|  | Maltese | `16` | Valor LanguageId en maltés |
+|  | Turkish | `17` | Valor LanguageId en turco |
+|  | Croatian | `18` | Valor LanguageId en croata |
+|  | Chinese_Traditional | `19` | Valor LanguageId en chino (tradicional) |
+|  | Urdu | `20` | Valor LanguageId en urdu |
+|  | Hindi | `21` | Valor LanguageId en hindi |
+|  | Thai | `22` | tailandés LanguageId valor |
+|  | Korean | `23` | coreano LanguageId valor |
+|  | Lithuanian | `24` | lituano LanguageId valor |
+|  | Polish | `25` | polaco LanguageId valor |
+|  | Hungarian | `26` | húngaro LanguageId valor |
+|  | Estonian | `27` | estonio LanguageId valor |
+|  | Latvian | `28` | letón LanguageId valor |
+|  | Sami | `29` | sami LanguageId valor |
+|  | Faroese | `30` | feroés LanguageId valor |
+|  | Farsi_Persian | `31` | Farsi/Persa LanguageId valor |
+|  | Russian | `32` | ruso LanguageId valor |
+|  | Chinese_Simplified | `33` | chino (simplificado) LanguageId valor |
+|  | Flemish | `34` | flamenco LanguageId valor |
+|  | Irish_Gaelic | `35` | gaélico irlandés LanguageId valor |
+|  | Albanian | `36` | albanés LanguageId valor |
+|  | Romanian | `37` | rumano LanguageId valor |
+|  | Czech | `38` | checo LanguageId valor |
+|  | Slovak | `39` | eslovaco LanguageId valor |
+|  | Slovenian | `40` | esloveno LanguageId valor |
+|  | Yiddish | `41` | yidis LanguageId valor |
+|  | Serbian | `42` | serbio LanguageId valor |
+|  | Macedonian | `43` | macedonio LanguageId valor |
+|  | Bulgarian | `44` | búlgaro LanguageId valor |
+|  | Ukrainian | `45` | ucraniano LanguageId valor |
+|  | Byelorussian | `46` | bielorruso LanguageId valor |
+|  | Uzbek | `47` | uzbeko LanguageId valor |
+|  | Kazakh | `48` | kazajo LanguageId valor |
+|  | Azerbaijani_Cyrillic | `49` | azerbaiyano (alfabeto cirílico) LanguageId valor |
+|  | Azerbaijani_Arabic | `50` | azerbaiyano (alfabeto árabe) LanguageId valor |
+|  | Armenian | `51` | armenio LanguageId valor |
+|  | Georgian | `52` | georgiano LanguageId valor |
+|  | Moldavian | `53` | moldavo LanguageId valor |
+|  | Kirghiz | `54` | kirguís LanguageId valor |
+|  | Tajiki | `55` | tayiko LanguageId valor |
+|  | Turkmen | `56` | turcomano LanguageId valor |
+|  | Mongolian | `57` | mongol (alfabeto mongol) LanguageId valor |
+|  | Mongolian_Cyrillic | `58` | mongol (alfabeto cirílico) LanguageId valor |
+|  | Pashto | `59` | pastún LanguageId valor |
+|  | Kurdish | `60` | pastún LanguageId valor |
+|  | Kashmiri | `61` | cachemiro LanguageId valor |
+|  | Sindhi | `62` | sindhi LanguageId valor |
+|  | Tibetan | `63` | tibetano LanguageId valor |
+|  | Nepali | `64` | nepalí LanguageId valor |
+|  | Sanskrit | `65` | sánscrito LanguageId valor |
+|  | Marathi | `66` | maratí LanguageId valor |
+|  | Bengali | `67` | bengalí LanguageId valor |
+|  | Assamese | `68` | asamés LanguageId valor |
+|  | Gujarati | `69` | gujarati LanguageId valor |
+|  | Punjabi | `70` | punyabí LanguageId valor |
+|  | Oriya | `71` | oriya LanguageId valor |
+|  | Malayalam | `72` | malayalam LanguageId valor |
+|  | Kannada | `73` | Kannada valor de LanguageId |
+|  | Tamil | `74` | Tamil valor de LanguageId |
+|  | Telugu | `75` | Telugu valor de LanguageId |
+|  | Sinhalese | `76` | Sinhalese valor de LanguageId |
+|  | Burmese | `77` | Burmese valor de LanguageId |
+|  | Khmer | `78` | Khmer valor de LanguageId |
+|  | Lao | `79` | Lao valor de LanguageId |
+|  | Vietnamese | `80` | Vietnamese valor de LanguageId |
+|  | Indonesian | `81` | Indonesian valor de LanguageId |
+|  | Tagalog | `82` | Tagalog valor de LanguageId |
+|  | Malay_Roman | `83` | Malay (Roman script) valor de LanguageId |
+|  | Malay_Arabic | `84` | Malay (Arabic script) valor de LanguageId |
+|  | Amharic | `85` | Amharic valor de LanguageId |
+|  | Tigrinya | `86` | Tigrinya valor de LanguageId |
+|  | Galla | `87` | Galla valor de LanguageId |
+|  | Somali | `88` | Somali valor de LanguageId |
+|  | Swahili | `89` | Swahili valor de LanguageId |
+|  | Kinyarwanda_Ruanda | `90` | Kinyarwanda/Ruanda valor de LanguageId |
+|  | Rundi | `91` | Rundi valor de LanguageId |
+|  | Nyanja_Chewa | `92` | Nyanja/Chewa valor de LanguageId |
+|  | Malagasy | `93` | Malagasy valor de LanguageId |
+|  | Esperanto | `94` | Esperanto valor de LanguageId |
+|  | Welsh | `128` | Welsh valor de LanguageId |
+|  | Basque | `129` | Basque valor de LanguageId |
+|  | Catalan | `130` | Catalan valor de LanguageId |
+|  | Latin | `131` | Latin LanguageId valor |
+|  | Quechua | `132` | Quechua LanguageId valor |
+|  | Guarani | `133` | Guarani LanguageId valor |
+|  | Aymara | `134` | Aymara LanguageId valor |
+|  | Tatar | `135` | Tatar LanguageId valor |
+|  | Uighur | `136` | Uighur LanguageId valor |
+|  | Dzongkha | `137` | Dzongkha LanguageId valor |
+|  | Javanese | `138` | Javanese (Roman script) LanguageId valor |
+|  | Sundanese | `139` | Sundanese (Roman script) LanguageId valor |
+|  | Galician | `140` | Galician LanguageId valor |
+|  | Afrikaans | `141` | Afrikaans LanguageId valor |
+|  | Breton | `142` | Breton LanguageId valor |
+|  | Inuktitut | `143` | Inuktitut LanguageId valor |
+|  | Scottish_Gaelic | `144` | Scottish Gaelic LanguageId valor |
+|  | Manx_Gaelic | `145` | Manx Gaelic LanguageId valor |
+|  | Irish_Gaelic_WDA | `146` | Irish Gaelic (with dot above) LanguageId valor |
+|  | Tongan | `147` | Tongan LanguageId valor |
+|  | Greek_Polytonic | `148` | Greek (polytonic) LanguageId valor |
+|  | Greenlandic | `149` | Greenlandic LanguageId valor |
+|  | Azerbaijani_Roman | `150` | Azerbaijani (Roman script) LanguageId valor |

--- a/spanish/javascript-cpp/enumerations/ttfnametablenmslanguageid/_index.md
+++ b/spanish/javascript-cpp/enumerations/ttfnametablenmslanguageid/_index.md
@@ -1,0 +1,225 @@
+---
+title: "Enumeración TtfNameTableMSLanguageId"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Enumeración Aspose.Font.TtfNameTableMSLanguageId. Especifica MSLanguageId"
+type: docs
+weight: 150
+url: /es/javascript-cpp/enumerations/ttfnametablemslanguageid/
+---
+## TtfNameTableMSLanguageId enumeration
+
+Representa la enumeración MSLanguageId.
+
+```csharp
+ enum TtfNameTableMSLanguageId
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+|  | Afrikaans | `0x0436` | Afrikaans (Región: Sudáfrica, SA) valor de LanguageId |
+|  | Albanian | `0x041c` | Albanés (Región: Albania, SQI) valor de LanguageId |
+|  | Alsatian | `0x0484` | Alsaciano (Región: Francia) valor de LanguageId |
+|  | Amharic | `0x045E` | Amhárico (Región: Etiopía) valor de LanguageId |
+|  | Arabic_Algeria | `0x1401` | Árabe (Región: Argelia) valor de LanguageId |
+|  | Arabic_Bahrain | `0x3C01` | Árabe (Región: Baréin) valor de LanguageId |
+|  | Arabic_Egypt | `0x0C01` | Árabe (Región: Egipto) valor de LanguageId |
+|  | Arabic_Iraq | `0x0801` | Árabe (Región: Irak) valor de LanguageId |
+|  | Arabic_Jordan | `0x2C01` | Árabe (Región: Jordania) valor de LanguageId |
+|  | Arabic_Kuwait | `0x3401` | Árabe (Región: Kuwait) valor de LanguageId |
+|  | Arabic_Lebanon | `0x3001` | Árabe (Región: Líbano) valor de LanguageId |
+|  | Arabic_Libya | `0x1001` | Árabe (Región: Libia) valor de LanguageId |
+|  | Arabic_Morocco | `0x1801` | Árabe (Región: Marruecos) valor de LanguageId |
+|  | Arabic_Oman | `0x2001` | Árabe (Región: Omán) valor de LanguageId |
+|  | Arabic_Qatar | `0x4001` | Árabe (Región: Catar) valor de LanguageId |
+|  | Arabic_Saudi_Arabia | `0x0401` | Árabe (Región: Arabia Saudita) valor de LanguageId |
+|  | Arabic_Syria | `0x2801` | Árabe (Región: Siria) valor de LanguageId |
+|  | Arabic_Tunisia | `0x1C01` | Árabe (Región: Túnez) valor de LanguageId |
+|  | Arabic_U_A_E | `0x3801` | Árabe (Región: EAU) valor de LanguageId |
+|  | Arabic_Yemen | `0x2401` | Árabe (Región: Yemen) valor de LanguageId |
+|  | Armenian | `0x042B` | Armenio (Región: Armenia) valor de LanguageId |
+|  | Assamese | `0x044D` | Asamés (Región: India) valor de LanguageId |
+|  | Azeri_Cyrillic | `0x082C` | Azerí (Cirílico, Región: Azerbaiyán) valor de LanguageId |
+|  | Azeri_Latin | `0x042C` | Azerí (Latín, Región: Azerbaiyán) valor de LanguageId |
+|  | Bashkir | `0x046D` | Bashkir (Región: Rusia) valor de LanguageId |
+|  | Basque | `0x042D` | Vasco (Región: Vasco, EUQ) valor de LanguageId |
+|  | Belarusian | `0x0423` | Belaruso (Región: Bielorrusia, BEL) valor de LanguageId |
+|  | Bengali_Bangladesh | `0x0845` | Bengalí (Región: Bangladesh) valor de LanguageId |
+|  | Bengali_India | `0x0445` | Bengalí (Región: India) valor de LanguageId |
+|  | Bosnian_Cyrillic | `0x201A` | Bosnio (Cirílico, Región: Bosnia y Herzegovina) valor de LanguageId |
+|  | Bosnian_Latin | `0x141A` | Bosnio (Latín, Región: Bosnia y Herzegovina) valor de LanguageId |
+|  | Breton | `0x047E` | Bretón (Región: Francia) valor de LanguageId |
+|  | Bulgarian | `0x0402` | Búlgaro (Región: Bulgaria, BGR) valor de LanguageId |
+|  | Catalan | `0x0403` | Catalán (Región: Catalán, CAT) valor de LanguageId |
+|  | Chinese_Hong_Kong | `0x0C04` | Chino (Región: Hong Kong RAE) valor de LanguageId |
+|  | Chinese_Macao | `0x1404` | Chino (Región: Macao RAE) valor de LanguageId |
+|  | Chinese_PRC | `0x0804` | Chino (Región: República Popular de China) valor de LanguageId |
+|  | Chinese_Singapore | `0x1004` | Chino (Región: Singapur) valor de LanguageId |
+|  | Chinese_Taiwan | `0x0404` | Chino (Región: Taiwán) valor de LanguageId |
+|  | Corsican | `0x0483` | Corsés (Región: Francia) valor de LanguageId |
+|  | Croatian | `0x041A` | Croata (Región: Croacia, SHL) valor de LanguageId |
+|  | Croatian_Latin | `0x101A` | Croata (Latín, Región: Bosnia y Herzegovina) valor de LanguageId |
+|  | Czech | `0x0405` | Checo (Región: República Checa, CSY) valor de LanguageId |
+|  | Danish | `0x0406` | Danés (Región: Dinamarca, DAN) valor de LanguageId |
+|  | Dari | `0x048C` | Dari (Región: Afganistán) valor de LanguageId |
+|  | Divehi | `0x0465` | Dhivehi (Región: Maldivas) valor de LanguageId |
+|  | Dutch_Belgium | `0x0813` | Holandés (Flamenco, Región: Bélgica, NLB) valor de LanguageId |
+|  | Dutch_Netherlands | `0x0413` | Holandés (Estándar, Región: Países Bajos, NLD) valor de LanguageId |
+|  | English_Australia | `0x0C09` | Inglés (Australiano, Región: Australia, ENA) valor de LanguageId |
+|  | English_Belize | `0x2809` | Inglés (Región: Belice) valor de LanguageId |
+|  | English_Canada | `0x1009` | Inglés (Canadiense, Región: Canadá, ENC) valor de LanguageId |
+|  | English_Caribbean | `0x2409` | Inglés (Región: Caribe) valor de LanguageId |
+|  | English_India | `0x4009` | Inglés (Región: India) valor de LanguageId |
+|  | English_Ireland | `0x1809` | Inglés (Región: Irlanda, ENI) valor de LanguageId |
+|  | English_Jamaica | `0x2009` | Inglés (Región: Jamaica) valor de LanguageId |
+|  | English_Malaysia | `0x4409` | Inglés (Región: Malasia) valor de LanguageId |
+|  | English_New_Zealand | `0x1409` | Inglés (Región: Nueva Zelanda, ENZ) valor de LanguageId |
+|  | English_ROP | `0x3409` | Inglés (Región: República de Filipinas, ROP) valor de LanguageId |
+|  | English_Singapore | `0x4809` | Inglés (Región: Singapur) valor de LanguageId |
+|  | English_South_Africa | `0x1C09` | Inglés (Región: Sudáfrica, SA) valor de LanguageId |
+|  | English_TT | `0x2C09` | Inglés (Región: Trinidad y Tobago, TT) valor de LanguageId |
+|  | English_United_Kingdom | `0x0809` | Inglés (Británico, Región: Reino Unido, ENG) valor de LanguageId |
+|  | English_United_States | `0x0409` | Inglés (Estadounidense, Región: Estados Unidos, ENU) valor de LanguageId |
+|  | English_Zimbabwe | `0x3009` | Inglés (Región: Zimbabue) valor de LanguageId |
+|  | Estonian | `0x0425` | Estonio (Región: Estonia, ETI) valor de LanguageId |
+|  | Faroese | `0x0438` | Feroés (Región: Islas Feroe) valor de LanguageId |
+|  | Filipino | `0x0464` | Filipino (Región: Filipinas) valor de LanguageId |
+|  | Finnish | `0x040B` | Finlandés (Región: Finlandia, FIN) valor de LanguageId |
+|  | French_Belgium | `0x080C` | Francés (Belga, Región: Bélgica, FRB) valor de LanguageId |
+|  | French_Canada | `0x0C0C` | Francés (Canadiense, Región: Canadá, FRC) valor de LanguageId |
+|  | French_France | `0x040C` | Francés (Estándar, Región: Francia, FRA) valor de LanguageId |
+|  | French_Luxembourg | `0x140c` | Francés (Región: Luxemburgo, FRL) valor de LanguageId |
+|  | French_MC | `0x180C` | Francés (Región: Principado de Mónaco, MC) valor de LanguageId |
+|  | French_Switzerland | `0x100C` | Francés (Suizo, Región: Suiza, FRS) valor de LanguageId |
+|  | Frisian | `0x0462` | Frisio (Región: Países Bajos, NLD) valor de LanguageId |
+|  | Galician | `0x0456` | Gallego (Región: Gallego) valor de LanguageId |
+|  | Georgian | `0x0437` | Georgiano (Región: Georgia) valor de LanguageId |
+|  | German_Austria | `0x0C07` | Alemán (Austríaco, Región: Austria, DEA) valor de LanguageId |
+|  | German_Germany | `0x0407` | Alemán (Estándar, Región: Alemania, DEU) valor de LanguageId |
+|  | German_Liechtenstein | `0x1407` | Alemán (Región: Liechtenstein, DEC) valor de LanguageId |
+|  | German_Luxembourg | `0x1007` | Alemán (Región: Luxemburgo, DEL) valor de LanguageId |
+|  | German_Switzerland | `0x0807` | Alemán (Suizo, Región: Suiza, DES) valor de LanguageId |
+|  | Greek | `0x0408` | Griego (Región: Grecia, ELL) valor de LanguageId |
+|  | Greenlandic | `0x046F` | Groenlandés (Región: Groenlandia) valor de LanguageId |
+|  | Gujarati | `0x0447` | Guyaratí (Región: India) valor de LanguageId |
+|  | Hausa | `0x0468` | Hausa (Latín, Región: Nigeria) valor de LanguageId |
+|  | Hebrew | `0x040D` | Hebreo (Región: Israel) valor de LanguageId |
+|  | Hindi | `0x0439` | Hindi (Región: India) valor de LanguageId |
+|  | Hungarian | `0x040E` | Húngaro (Región: Hungría, HUN) valor de LanguageId |
+|  | Icelandic | `0x040F` | Islandés (Región: Islandia, ISL) valor de LanguageId |
+|  | Igbo | `0x0470` | Igbo (Región: Nigeria) valor de LanguageId |
+|  | Indonesian | `0x0421` | Indonesio (Región: Indonesia) valor de LanguageId |
+|  | Inuktitut | `0x045D` | Inuktitut (Región: Canadá) valor de LanguageId |
+|  | Inuktitut_Latin | `0x085D` | Inuktitut (Latín, Región: Canadá) valor de LanguageId |
+|  | Irish | `0x083C` | Irlandés (Región: Irlanda) valor de LanguageId |
+|  | isiXhosa | `0x0434` | Valor de LanguageId de isiXhosa (Región: Sudáfrica, SA) |
+|  | isiZulu | `0x0435` | Valor de LanguageId de isiZulu (Región: Sudáfrica, SA) |
+|  | Italian_Italy | `0x0410` | Italiano (Estándar, Región: Italia, ITA) valor de LanguageId |
+|  | Italian_Switzerland | `0x0810` | Italiano (Suizo, Región: Suiza, ITS) valor de LanguageId |
+|  | Japanese | `0x0411` | Japonés (Región: Japón) valor de LanguageId |
+|  | Kannada | `0x044B` | Canarés (Región: India) valor de LanguageId |
+|  | Kazakh | `0x043F` | Kazajo (Región: Kazajistán) valor de LanguageId |
+|  | Khmer | `0x0453` | Khmer (Región: Camboya) valor de LanguageId |
+|  | Kiche | `0x0486` | K�iche (Región: Guatemala) valor de LanguageId |
+|  | Kinyarwanda | `0x0487` | Kinyarwanda (Región: Ruanda) valor de LanguageId |
+|  | Kiswahili | `0x0441` | Kiswahili (Región: Kenia) valor de LanguageId |
+|  | Konkani | `0x0457` | Konkani (Región: India) valor de LanguageId |
+|  | Korean | `0x0412` | Korean (Región: Corea) valor de LanguageId |
+|  | Kyrgyz | `0x0440` | Kyrgyz (Región: Kirguistán) valor de LanguageId |
+|  | Lao | `0x0454` | Lao (Región: Lao P.D.R.) valor de LanguageId |
+|  | Latvian | `0x0426` | Latvian (Región: Letonia, LVI) valor de LanguageId |
+|  | Lithuanian | `0x0427` | Lithuanian (Región: Lituania, LTH) valor de LanguageId |
+|  | Lower_Sorbian | `0x082E` | Lower Sorbian (Región: Alemania) valor de LanguageId |
+|  | Luxembourgish | `0x046E` | Luxembourgish (Región: Luxemburgo) valor de LanguageId |
+|  | Macedonian | `0x042F` | Macedonian (Región: Macedonia del Norte) valor de LanguageId |
+|  | Malay_Brunei_Darussalam | `0x083E` | Malay (Región: Brunéi Darussalam) valor de LanguageId |
+|  | Malay_Malaysia | `0x043E` | Malay (Región: Malasia) valor de LanguageId |
+|  | Malayalam | `0x044C` | Malayalam (Región: India) valor de LanguageId |
+|  | Maltese | `0x043A` | Maltese (Región: Malta) valor de LanguageId |
+|  | Maori | `0x0481` | Maori (Región: Nueva Zelanda) valor de LanguageId |
+|  | Mapudungun | `0x047A` | Mapudungun (Región: Chile) valor de LanguageId |
+|  | Marathi | `0x044E` | Marathi (Región: India) valor de LanguageId |
+|  | Mohawk | `0x047C` | Mohawk (Región: Mohawk) valor de LanguageId |
+|  | Mongolian_Cyrillic | `0x0450` | Mongolian (Cirílico, Región: Mongolia) valor de LanguageId |
+|  | Mongolian_Traditional | `0x0850` | Mongolian (Tradicional, Región: República Popular de China) valor de LanguageId |
+|  | Nepali | `0x0461` | Nepali (Región: Nepal) valor de LanguageId |
+|  | Norwegian_Bokmal | `0x0414` | Norwegian (Bokmal, Región: Noruega, NOR) valor de LanguageId |
+|  | Norwegian_Nynorsk | `0x0814` | Noruego (Nynorsk, Región: Norway, NON) valor de LanguageId |
+|  | Occitan | `0x0482` | Occitano (Región: France) valor de LanguageId |
+|  | Odia | `0x0448` | Odia (anteriormente Oriya, Región: India) valor de LanguageId |
+|  | Pashto | `0x0463` | Pastún (Región: Afghanistan) valor de LanguageId |
+|  | Polish | `0x0415` | Polaco (Región: Poland, PLK) valor de LanguageId |
+|  | Portuguese_Brazil | `0x0416` | Portugués (brasileño, Región: Brazil, PTB) valor de LanguageId |
+|  | Portuguese_Portugal | `0x0816` | Portugués (estándar, Región: Portugal, PTG) valor de LanguageId |
+|  | Punjabi | `0x0446` | Punjabi (Región: India) valor de LanguageId |
+|  | Quechua_Bolivia | `0x046B` | Quechua (Región: Bolivia) valor de LanguageId |
+|  | Quechua_Ecuador | `0x086B` | Quechua (Región: Ecuador) valor de LanguageId |
+|  | Quechua_Peru | `0x0C6B` | Quechua (Región: Peru) valor de LanguageId |
+|  | Romanian | `0x0418` | Rumano (Región: Romania, ROM) valor de LanguageId |
+|  | Romansh | `0x0417` | Romanche (Región: Switzerland) valor de LanguageId |
+|  | Russian | `0x0419` | Ruso (Región: Russia, RUS) valor de LanguageId |
+|  | Sami_Inari | `0x243B` | Sami (Inari, Región: Finland) valor de LanguageId |
+|  | Sami_Lule_Norway | `0x103B` | Sami (Lule, Región: Norway) valor de LanguageId |
+|  | Sami_Lule_Sweden | `0x143B` | Sami (Lule, Región: Sweden) valor de LanguageId |
+|  | Sami_Northern_Finland | `0x0C3B` | Sami (norte, Región: Finland) valor de LanguageId |
+|  | Sami_Northern_Norway | `0x043B` | Sami (norte, Región: Norway) valor de LanguageId |
+|  | Sami_Northern_Sweden | `0x083B` | Sami (norte, Región: Norway) valor de LanguageId |
+|  | Sami_Skolt | `0x203B` | Sami (Skolt, Región: Finland) valor de LanguageId |
+|  | Sami_Southern_Norway | `0x183B` | Sami (sur, Región: Norway) valor de LanguageId |
+|  | Sami_Southern_Sweden | `0x1C3B` | Sami (sur, Región: Sweden) valor de LanguageId |
+|  | Sanskrit | `0x044F` | Sánscrito (Región: India) valor de LanguageId |
+|  | Serbian_Cyrillic_BIH | `0x1C1A` | Serbio (Cirílico, Región: Bosnia and Herzegovina) valor de LanguageId |
+|  | Serbian_Cyrillic_Serbia | `0x0C1A` | Serbio (Cirílico, Región: Serbia) valor de LanguageId |
+|  | Serbian_Latin_BIH | `0x181A` | Serbio (Latín, Región: Bosnia y Herzegovina) valor de LanguageId |
+|  | Serbian_Latin_Serbia | `0x081A` | Serbio (Latín, Región: Serbia) valor de LanguageId |
+|  | Sesotho_Sa_Leboa | `0x046C` | Sesotho sa Leboa (Sotho del Norte, Región: Sudáfrica, SA) valor de LanguageId |
+|  | Setswana | `0x0432` | Setswana (Región: Sudáfrica, SA) valor de LanguageId |
+|  | Sinhala | `0x045B` | Cingalés (Región: Sri Lanka) valor de LanguageId |
+|  | Slovak | `0x041B` | Eslovaco (Región: Eslovaquia, SKY) valor de LanguageId |
+|  | Slovenian | `0x0424` | Esloveno (Región: Eslovenia, SLV) valor de LanguageId |
+|  | Spanish_Argentina | `0x2C0A` | Español (Región: Argentina) valor de LanguageId |
+|  | Spanish_Bolivia | `0x400A` | Español (Región: Bolivia) valor de LanguageId |
+|  | Spanish_Chile | `0x340A` | Español (Región: Chile) valor de LanguageId |
+|  | Spanish_Colombia | `0x240A` | Español (Región: Colombia) valor de LanguageId |
+|  | Spanish_Costa_Rica | `0x140A` | Español (Región: Costa Rica) valor de LanguageId |
+|  | Spanish_Dominican_Republic | `0x1C0A` | Español (Región: República Dominicana) valor de LanguageId |
+|  | Spanish_Ecuador | `0x300A` | Español (Región: República Dominicana) valor de LanguageId |
+|  | Spanish_El_Salvador | `0x440A` | Español (Región: República Dominicana) valor de LanguageId |
+|  | Spanish_Guatemala | `0x100A` | Español (Región: Guatemala) valor de LanguageId |
+|  | Spanish_Honduras | `0x480A` | Español (Región: Honduras) valor de LanguageId |
+|  | Spanish_Mexico | `0x080A` | Español (Mexicano, Región: México, ESM) valor de LanguageId |
+|  | Spanish_Nicaragua | `0x4C0A` | Español (Región: Nicaragua) valor de LanguageId |
+|  | Spanish_Panama | `0x180A` | Español (Región: Panamá) valor de LanguageId |
+|  | Spanish_Paraguay | `0x3C0A` | Español (Región: Paraguay) valor de LanguageId |
+|  | Spanish_Peru | `0x280A` | Español (Región: Perú) valor de LanguageId |
+|  | Spanish_Puerto_Rico | `0x500A` | Español (Región: Puerto Rico) valor de LanguageId |
+|  | Spanish_Modern_Sort | `0x0C0A` | Español (Orden Moderno, Región: España, ESN) valor de LanguageId |
+|  | Spanish_Traditional_Sort | `0x040A` | Español (Orden Tradicional, Región: España, ESP) valor de LanguageId |
+|  | Spanish_United_States | `0x540A` | Español (Región: Estados Unidos) valor de LanguageId |
+|  | Spanish_Uruguay | `0x380A` | Español (Región: Uruguay) valor de LanguageId |
+|  | Spanish_Venezuela | `0x200A` | Español (Región: Venezuela) valor de LanguageId |
+|  | Swedish_Finland | `0x081D` | Sueco (Región: Finlandia) valor de LanguageId |
+|  | Swedish_Sweden | `0x041D` | Sueco (Región: Suecia, SVE) valor de LanguageId |
+|  | Syriac | `0x045A` | Siríaco (Región: Siria) valor de LanguageId |
+|  | Tajik | `0x0428` | Tayiko (Cirílico, Región: Tayikistán) valor de LanguageId |
+|  | Tamazight | `0x085F` | Tamazight (Latín, Región: Argelia) valor de LanguageId |
+|  | Tamil | `0x0449` | Tamil (Región: India) valor de LanguageId |
+|  | Tatar | `0x0444` | Tártaro (Región: Rusia) valor de LanguageId |
+|  | Telugu | `0x044A` | Telugu (Región: India) valor de LanguageId |
+|  | Thai | `0x041E` | Tailandés (Región: Tailandia) valor de LanguageId |
+|  | Tibetan | `0x0451` | Tibetano (Región: RPC) valor de LanguageId |
+|  | Turkish | `0x041F` | Turco (Región: Turquía, TRK) valor de LanguageId |
+|  | Turkmen | `0x0442` | Turcomano (Región: Turkmenistán) valor de LanguageId |
+|  | Uighur | `0x0480` | Uigur (Región: RPC) valor de LanguageId |
+|  | Ukrainian | `0x0422` | Ucraniano (Región: Ucrania, UKR) valor de LanguageId |
+|  | Upper_Sorbian | `0x042E` | Alto sorabo (Región: Alemania) valor de LanguageId |
+|  | Urdu | `0x0420` | Urdu (Región: República Islámica de Pakistán) valor de LanguageId |
+|  | Uzbek_Cyrillic | `0x0843` | Uzbeko (Cirílico, Región: Uzbekistán) valor de LanguageId |
+|  | Uzbek_Latin | `0x0443` | Uzbeko (Latín, Región: Uzbekistán) valor de LanguageId |
+|  | Vietnamese | `0x042A` | Vietnamita (Región: Vietnam) valor de LanguageId |
+|  | Welsh | `0x0452` | Galés (Región: Reino Unido) valor de LanguageId |
+|  | Wolof | `0x0488` | Wólof (Región: Senegal) valor de LanguageId |
+|  | Yakut | `0x0485` | Yakuto (Región: Rusia) valor de LanguageId |
+|  | Yi | `0x0478` | Yi (Región: RPC) valor de LanguageId |
+| Yoruba | `0x046A` | Yoruba (Región: Nigeria) valor de LanguageId |

--- a/spanish/javascript-cpp/enumerations/ttfnametableplatformid/_index.md
+++ b/spanish/javascript-cpp/enumerations/ttfnametableplatformid/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Enum TtfNameTablePlatformId"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Aspose.Font.TtfNameTablePlatformId enum. Especifica PlatformId"
+type: docs
+weight: 130
+url: /es/javascript-cpp/enumerations/ttfnametableplatformid/
+---
+## TtfNameTablePlatformId enumeration
+
+Especifica PlatformId.
+
+```cssharp
+ enum TtfNameTablePlatformId
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+|  | Unicode | `0` | Unicode |
+|  | Macintosh | `1` | Código del Script Manager de Macintosh. |
+|  | ISO | `2` | Especificación de Apple: (reservado; no usar) Especificación de MS: codificación ISO. Tenga en cuenta que la ID de plataforma 2 (ISO) ha sido desaprobada a partir de la Especificación OpenType v1.3. Se pretendía representar ISO/IEC 10646, en contraste con Unicode; ambos estándares tienen asignaciones de códigos de caracteres idénticas |
+|  | Microsoft | `3` | Codificación de Microsoft. |

--- a/spanish/javascript-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
+++ b/spanish/javascript-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum TtfNameTableUnicodePlatformSpecificId"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Aspose.Font.TtfNameTableUnicodePlatformSpecificId enum. Especifica UnicodePlatformSpecificId"
+type: docs
+weight: 133
+url: /es/javascript-cpp/enumerations/ttfnametableunicodeplatformspecificid/
+---
+## TtfNameTableUnicodePlatformSpecificId enumeration
+
+Especifica UnicodePlatformSpecificId.
+
+```csharp
+ enum TtfNameTableUnicodePlatformSpecificId
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+|  | Default | `0` | Semántica predeterminada (Unicode 1.0). |
+|  | Unicode1_1 | `1` | Semántica Unicode 1.1. |
+|  | ISO10646_1993 | `2` | Semántica ISO 10646 1993 (obsoleta). |
+|  | Unicode2_0 | `3` | Semántica Unicode 2.0 o posterior. Solo BMP de Unicode. |
+|  | Unicode2_0_Full | `4Unicode 2.0 and onwards semantics (non-BMP characters allowed)` | Repertorio completo de Unicode. |

--- a/spanish/javascript-cpp/glyph/_index.md
+++ b/spanish/javascript-cpp/glyph/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Funciones de fuente de glifos"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Funciones para trabajar con glifos de archivos de fuente"
+type: docs
+url: /es/javascript-cpp/glyph/
+---
+
+## Glyph Font functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposeFontGetGlyphCount](./asposefontgetglyphcount/) | Obtener el recuento de glifos de la fuente. |
+| [AsposeFontGetMetrics](./asposefontgetmetrics/) | Obtener métricas de la fuente. |
+
+
+## Detailed Description
+
+Funciones para trabajar con glifos de fuente.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/spanish/javascript-cpp/glyph/asposefontgetglyphcount/_index.md
+++ b/spanish/javascript-cpp/glyph/asposefontgetglyphcount/_index.md
@@ -1,0 +1,72 @@
+---
+title: "AsposeFontGetGlyphCount"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Obtener información (metadatos) de un archivo de fuente."
+type: docs
+url: /es/javascript-cpp/glyph/asposefontgetglyphcount/
+---
+## AsposeFontGetGlyphCount function
+
+_Obtener el recuento de glifos de la fuente._
+
+```js
+function AsposeFontGetGlyphCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente de origen para convertir. |
+| fileName | string | Nombre de archivo. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | glyphCount | recuento de glifos |
+
+### Ejemplos
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    evt.data == "ready"
+      ? "loaded!"
+      : evt.data.json.errorCode == 0
+      ? "Glyph count: " + evt.data.json.glyphCount
+      : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFontGetGlyphCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get glyph count of font - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontGetGlyphCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+
+**Simple example**:
+```js
+  var ffileFontGetGlyphCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontGetGlyphCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Glyph count: " + json.glyphCount;
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/spanish/javascript-cpp/glyph/asposefontgetmetrics/_index.md
+++ b/spanish/javascript-cpp/glyph/asposefontgetmetrics/_index.md
@@ -1,0 +1,79 @@
+---
+title: "FontGetFontMetrics"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Obtener información (metadatos) de un archivo de fuente."
+type: docs
+url: /es/javascript-cpp/glyph/asposefontgetmetrics/
+---
+## FontGetFontMetrics function
+
+_Obtener el recuento de glifos de la fuente._
+
+```js
+function FontGetFontMetrics(
+    fileBlob,
+    fileName
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente de origen para convertir. |
+| fileName | string | Nombre de archivo. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | métricas | Objeto JSON |
+| * ascenso |
+| * descenso |
+| * espacio entre líneas |
+| * anchoAvanceMáximo |
+| * margenIzquierdoMínimo |
+| * margenDerechoMínimo |
+| * extensiónXMáxima |
+
+### Ejemplos
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    evt.data == "ready"
+      ? "loaded!"
+      : evt.data.json.errorCode == 0
+      ? JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')
+      : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFontGetMetrics = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get metrics of font - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontGetMetrics', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+
+**Simple example**:
+```js
+  var ffileFontGetGlyphCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = FontGetFontMetrics(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Glyph count: " + json.glyphCount;
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/spanish/javascript-cpp/metadata/_index.md
+++ b/spanish/javascript-cpp/metadata/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Funciones de fuente de metadatos"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Funciones para trabajar con archivos de fuente de metadatos"
+type: docs
+url: /es/javascript-cpp/metadata/
+---
+
+## Metadata Font functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposeFontGetInfo](./asposefontgetinfo/) | Obtener información (metadatos) de un archivo de fuente. |
+| [AsposeFontSetInfo](./asposefontsetinfo/) | Establecer información (metadatos) en un archivo de fuente. |
+
+## Detailed Description
+
+Funciones para trabajar con archivos de fuente de metadatos.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/spanish/javascript-cpp/metadata/asposefontgetinfo/_index.md
+++ b/spanish/javascript-cpp/metadata/asposefontgetinfo/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeFontGetInfo"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Obtener información (metadatos) de un archivo de fuente."
+type: docs
+url: /es/javascript-cpp/metadata/asposefontgetinfo/
+---
+## AsposeFontGetInfo function
+
+_Obtener información (metadatos) de un archivo de fuente._
+
+```js
+function AsposeFontGetInfo(
+    fileBlob,
+    fileName
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente de origen para convertir. |
+| fileName | string | Nombre de archivo. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | registros | Matriz de objetos JSON : |
+|  | * NameId | identificador de nombre |
+|  | * PlatformId | identificador de plataforma |
+|  | * PlatformSpecificId | identificador específico de la plataforma |
+|  | * LanguageId | identificador de idioma |
+|  | * Info | contenido del registro de nombre |
+
+### Ejemplos
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    evt.data == "ready"
+      ? "loaded!"
+      : evt.data.json.errorCode == 0
+      ? "Name records count: " + evt.data.json.records.length + 
+                                            evt.data.json.records.reduce((ret, a) => ret +
+                                            "\nNameId : " + a.NameId
+                                          + "; PlatformId : " + a.PlatformId
+                                          + "; PlatformSpecificId : " + a.PlatformSpecificId
+                                          + "; LanguageId : " + a.LanguageId
+                                          + "; Info : " + a.Info,"")
+      : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFontGetInfo = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get info (metadata) from a Font-file - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontGetInfo', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileFontGetInfo = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontGetInfo(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Name records count: " + json.records.length;
+        for (let recordIndex = 0; recordIndex < json.records.length; recordIndex++) 
+			document.getElementById('output').textContent += " " + "\n"
+                                                         + "NameId : " + json.records[recordIndex].NameId
+                                                         + ";  PlatformId : " + json.records[recordIndex].PlatformId
+                                                         + ";  PlatformSpecificId : " + json.records[recordIndex].PlatformSpecificId
+                                                         + ";  LanguageId : " + json.records[recordIndex].LanguageId
+                                                         + ";  Info : " + json.records[recordIndex].Info;
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/spanish/javascript-cpp/metadata/asposefontsetinfo/_index.md
+++ b/spanish/javascript-cpp/metadata/asposefontsetinfo/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeFontSetInfo"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Establecer información (metadatos) en un archivo de fuente."
+type: docs
+url: /es/javascript-cpp/metadata/asposefontsetinfo/
+---
+## AsposeFontSetInfo function
+
+_Establecer información (metadatos) en un archivo de fuente._
+
+```js
+function AsposeFontSetInfo(
+    fileBlob,
+    fileName,
+    nameId, 
+    platformId, 
+    platformSpecificId, 
+    languageId, 
+    text
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente de origen para convertir. |
+| fileName | string | Nombre de archivo. |
+| nameId | TtfNameTableNameId | Identificador de nombre, categoría lógica de cadena, especificado por la enumeración [`NameId`](../../enumerations/ttfnametablenameid/) |
+|  | platformId | TtfNameTablePlatformId | Identificador de plataforma |
+| platformSpecificId | int | Identificador de codificación específico de la plataforma. Por favor, use un valor de una de estas enumeraciones - [`UnicodePlatformSpecificId`](../../enumerations/ttfnametableunicodeplatformspecificid/), [`MacPlatformSpecificId`](../../ttfnametable.macplatformspecificid/), [`MSPlatformSpecificId`](../../enumerations/ttfnametablemsplatformspecificid/). La enumeración a usar se define por el contexto (parámetro *platformId*) |
+| languageId | int | Identificador de idioma. Por favor, use un valor de las enumeraciones [`MSLanguageId`](../../enumerations/ttfnametablemslanguageid/) o [`MacLanguageId`](../../enumerations/ttfnametablemaclanguageid/). Las enumeraciones dependen del contexto, definido por el parámetro *platformId*. |
+|  | texto | string | Datos de cadena reales |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | fileNameResult | nombre de archivo resultante |
+
+### Ejemplos
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    (evt.data == 'ready') ? 'library loaded!' :
+    (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+ 
+ /*Event handler*/
+  const ffileFontSetInfo = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+          const nameId = 'Module.TtfNameTableNameId.' + document.getElementById("NameId").value;
+          //Value will be changed for PlatformId = PlatformId.Microsoft, PlatformSpecificId = MSPlatformSpecificId.Unicode_BMP_UCS2 (1) and languageID = 1033 (English_United_States = 0x0409)
+          const platformId = 'Module.TtfNameTablePlatformId.Microsoft';
+          const platformSpecificId = 'Module.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2';
+          const langID = 'Module.TtfNameTableMSLanguageId.English_United_States';
+          const text = document.getElementById("textValue").value;
+          transfer = [event.target.result];
+          params = [event.target.result, e.target.files[0].name, nameId, platformId, platformSpecificId, langID, text];
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontSetInfo', "params": params }, transfer);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var fFontSetInfo = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+
+      const nameId = new Function("return Module.TtfNameTableNameId." + document.getElementById("NameId").value)();
+      const platformId = Module.TtfNameTablePlatformId.Microsoft;
+      const platformSpecificId = Module.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+      const text = document.getElementById("textValue").value;
+      const langID = 1033;
+
+      const json = AsposeFontSetInfo(blob, file.name, nameId, platformId, platformSpecificId, langID, text);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult);
+        //DownloadFile(file.name);
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(file);
+  }
+```
+
+### Ver también
+
+* enum [TtfNameTableNameId](../../enumerations/ttfnametablenameid/)
+* enum [TtfNameTablePlatformId](../../enumerations/ttfnametableplatformid/)
+* enum [TtfNameTableMacPlatformSpecificId](../../enumerations/ttfnametablemacplatformspecificid/)
+* enum [TtfNameTableMSPlatformSpecificId](../../enumerations/ttfnametablemsplatformspecificid/)
+* enum [TtfNameTableUnicodePlatformSpecificId](../../enumerations/ttfnametableunicodeplatformspecificid/)
+* enum [TtfNameTableMacLanguageId](../../enumerations/ttfnametablemaclanguageid/)
+* enum [TtfNameTableMSLanguageId](../../enumerations/ttfnametablemslanguageid/)

--- a/spanish/javascript-cpp/misc/_index.md
+++ b/spanish/javascript-cpp/misc/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Funciones misceláneas"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Funciones secundarias para trabajar con archivos de fuente."
+type: docs
+url: /es/javascript-cpp/misc/
+---
+## Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposeFontAbout](./asposeFontabout/) | Obtener información sobre el producto. |
+| [DownloadFile](./downloadfile/) | Crear un enlace en HTML para descargar el archivo. |
+| [DownloadFileAuto](./downloadfileauto/) | Crear un enlace en HTML para descargar el archivo y comenzar la descarga después de 2 segundos. |
+
+## Detailed Description
+
+Funciones secundarias para trabajar con archivos de fuente.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/spanish/javascript-cpp/misc/asposefontabout/_index.md
+++ b/spanish/javascript-cpp/misc/asposefontabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeFontAbout"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Obtener información sobre el producto."
+type: docs
+url: /es/javascript-cpp/misc/asposefontabout/
+---
+
+## AsposeFontAbout function
+
+Obtener información sobre el producto.
+
+```js
+function AsposeFontAbout()
+```
+
+### Valor devuelto
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+| errorCode | código de error (0 sin error) |
+| errorText | texto de error ("" sin error) |
+| producto | Nombre del producto |
+| versión | Versión del producto |
+| islicensed | El producto está licenciado |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposeFontAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposeFontAbout = function () {
+    /*Get info about Product*/
+    const json = AsposeFontAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/spanish/javascript-cpp/misc/downloadfile/_index.md
+++ b/spanish/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Crear un enlace en HTML para descargar el archivo."
+type: docs
+url: /es/javascript-cpp/misc/downloadfile/
+---
+
+_Crea un enlace en HTML para descargar el archivo._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/spanish/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/spanish/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Font para JavaScript vía C++"
+description: "Crear un enlace en HTML para descargar el archivo y comenzar la descarga después de 2 segundos."
+type: docs
+url: /es/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+Crear un enlace en HTML para descargar el archivo y comenzar la descarga después de 2 segundos.
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### Parámetros
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### Observaciones
+
+No funciona en Web Worker.


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Spanish** (`es`) generated by RDA.

- Pages translated: 30/30
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `spanish/javascript-cpp`

🤖 Generated by RDA