### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Swedish

### DIFF
--- a/swedish/javascript-cpp/_index.md
+++ b/swedish/javascript-cpp/_index.md
@@ -1,0 +1,73 @@
+---
+title: "Aspose.Font för JavaScript via C++"
+description: "Aspose.Font för JavaScript via C++"
+keywords:  "JavaScript via C++, JavaScript Font toolkit"
+tags: ['font-to-ttf', 'font-to-woff',  'font-to-woff2', 'font-to-svg', 'font-convert', 'font-tools']
+weight: 40
+url: /sv/javascript-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.Font for JavaScript via C++ allows developers manipulate them Font files directly in the Web.
+>
+> Such operations are very time consuming, so we recommend using Web Worker. 
+
+
+## Convert functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposeFontConvert](./convert/) | Konvertera ett teckensnitt till TrueType-teckensnitt. |
+| [AsposeFontConvertToTTF](./convert/asposefontconverttottf/) | Konvertera ett teckensnitt till TTF-format. |
+| [AsposeFontConvertToWOFF](./convert/asposefontconverttowoff/) | Konvertera ett teckensnitt till WOFF-format. |
+| [AsposeFontConvertToWOFF2](./convert/asposefontconverttowoff2/) | Konvertera ett teckensnitt till WOFF2-format. |
+| [AsposeFontConvertToSVG](./convert/asposefontconverttosvg/) | Konvertera ett teckensnitt till SVG-format. |
+
+
+## Metadata Font functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposeFontGetInfo](./metadata/asposefontgetinfo/) | Hämta information (metadata) från en teckensnittsfil. |
+| [AsposeFontSetInfo](./metadata/asposefontsetinfo/) | Ange information (metadata) i en teckensnittsfil. |
+
+
+## Glyph Font functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposeFontGetGlyphCount](./glyph/asposefontgetglyphcount/) | Hämta antalet glyfer i teckensnittet. |
+| [AsposeFontGetMetrics](./glyph/asposefontgetmetrics/) | Hämta mått för teckensnittet. |
+
+
+## Core Functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposeFontPrepare](./core/asposefontprepare/) | Spara BLOB:en i minnes‑FS för bearbetning. |
+| [AsposeFontPrepareBase64](./core/asposefontpreparebase64/) | Spara BLOB:en med strängrepresentation i minnes‑FS för bearbetning. |
+
+
+## Miscellaneous
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposeFontAbout](./misc/asposefontabout/) | Hämta information om produkten. |
+| [DownloadFile](./misc/downloadfile/) | Skapa en länk i HTML för att ladda ner filen. |
+| [DownloadFileAuto](./misc/downloadfileauto) | Skapa en länk i HTML för att ladda ner filen och starta nedladdning efter 2 sekunder. |
+
+
+## Enumerationer
+
+| Enumeration | Beskrivning |
+| ----------- | ----------- |
+| [FontSavingFormats](./enumerations/fontsavingformats/) | Anger teckensnittstyp. |
+| [FontStyle](./enumerations/fontstyle/) | Anger teckensnittsstil. |
+| [TtfNameTableNameId](./enumerations/ttfnametablenameid/) | Anger NameId. |
+| [TtfNameTablePlatformId](./enumerations/ttfnametableplatformid/) | Representerar PlatformId-enumeration. |
+| [TtfNameTableMacPlatformSpecificId](./enumerations/ttfnametablemacplatformspecificid/) | Representerar Macintosh-plattformsspecifik id-enumeration. |
+| [TtfNameTableMSPlatformSpecificId](./enumerations/ttfnametablemsplatformspecificid/) | Representerar Microsoft-plattformsspecifik id-enumeration. |
+| [TtfNameTableUnicodePlatformSpecificId](./enumerations/ttfnametableunicodeplatformspecificid/) | Representerar Unicode-plattformsspecifik id-enumeration. |
+| [TtfNameTableMacLanguageId](./enumerations/ttfnametablemaclanguageid/) | MacLanguageId-enumeration. |
+| [TtfNameTableMSLanguageId](./enumerations/ttfnametablemslanguageid/) | MSLanguageId-enumeration. |

--- a/swedish/javascript-cpp/convert/_index.md
+++ b/swedish/javascript-cpp/convert/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Konvertera font-funktioner"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Funktioner för att konvertera font till TrueType-format."
+type: docs
+url: /sv/javascript-cpp/convert/
+---
+
+## Convert functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposeFontConvert](./asposefontconvert) | Konvertera ett font till stödjade format. |
+| [AsposeFontConvertToTTF](./asposefontconverttottf/) | Konvertera ett teckensnitt till TTF-format. |
+| [AsposeFontConvertToWOFF](./asposefontconverttowoff/) | Konvertera ett teckensnitt till WOFF-format. |
+| [AsposeFontConvertToWOFF2](./asposefontconverttowoff2/) | Konvertera ett teckensnitt till WOFF2-format. |
+| [AsposeFontConvertToSVG](./asposefontconverttosvg/) | Konvertera ett teckensnitt till SVG-format. |
+
+## Detailed Description
+
+Funktioner för att konvertera font till TrueType-format.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```
+

--- a/swedish/javascript-cpp/convert/asposefontconvert/_index.md
+++ b/swedish/javascript-cpp/convert/asposefontconvert/_index.md
@@ -1,0 +1,94 @@
+---
+title: "AsposeFontConvert"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Konverterar teckensnittet till ett annat format"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/convert/asposefontconvert/
+---
+## AsposeFontConvert function
+
+Konverterar teckensnittet till ett annat format.
+
+```js
+function AsposeFontConvert(
+    fileBlob,
+    fileName,
+    fontType,
+    fontSavingFormat
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfont för konvertering. |
+| fileName | string | Filnamn. |
+| fontType | FontType | Teckensnittstyp att konvertera. |
+| fontSavingFormat | FontSavingFormats | Teckensnittformat att konvertera till. |
+
+### Returvärde
+
+JSON‑objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel (\"\" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Anmärkningar
+
+Obs: TTF-teckensnittstyp stöds nu endast.
+
+### Exempel
+
+```js
+  var fTTF2WOFF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvert(event.target.result, e.target.files[0].name, Module.FontType.TTF, Module.FontSavingFormats.WOFF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "woff");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoTTF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to TTF and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvert', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF', 'Module.FontSavingFormats.TTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* enum [FontType](../../enumerations/fonttype/)
+* enum [FontSavingFormats](../../enumerations/fontsavingformats/)

--- a/swedish/javascript-cpp/convert/asposefontconverttottf/_index.md
+++ b/swedish/javascript-cpp/convert/asposefontconverttottf/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToTTF"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Konverterar teckensnittet till ttf-format"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/convert/asposefontconverttottf/
+---
+## AsposeFontConvertToTTF function
+
+Konverterar teckensnittet till TTF-format.
+
+```js
+function AsposeFontConvertToTTF(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfont för konvertering. |
+| fileName | string | Filnamn. |
+| fontType | FontType | Teckensnittstyp att konvertera. |
+
+### Returvärde
+
+JSON‑objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel (\"\" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fEOT2TTF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToTTF(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoTTF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to TTF and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToTTF', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/swedish/javascript-cpp/convert/asposefontconverttowoff/_index.md
+++ b/swedish/javascript-cpp/convert/asposefontconverttowoff/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToWOFF"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Konverterar teckensnittet till woff-format"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/convert/asposefontconverttowoff/
+---
+## AsposeFontConvertToWOFF function
+
+Konverterar teckensnittet till WOFF-format.
+
+```js
+function AsposeFontConvertToWOFF(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfont för konvertering. |
+| fileName | string | Filnamn. |
+| fontType | FontType | Teckensnittstyp att konvertera. |
+
+### Returvärde
+
+JSON‑objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel (\"\" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fEOT2WOFF = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToWOFF(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoWOFF = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to WOFF and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToWOFF', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/swedish/javascript-cpp/convert/asposefontconverttowoff2/_index.md
+++ b/swedish/javascript-cpp/convert/asposefontconverttowoff2/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToWOFF2"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Konverterar teckensnittet till woff2-format"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/convert/asposefontconverttowoff2/
+---
+## AsposeFontConvertToWOFF2 function
+
+Konverterar teckensnittet till WOFF2-format.
+
+```js
+function AsposeFontConvertToWOFF2(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfont för konvertering. |
+| fileName | string | Filnamn. |
+| fontType | FontType | Teckensnittstyp att konvertera. |
+
+### Returvärde
+
+JSON‑objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel (\"\" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fEOT2WOFF2 = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToWOFF2(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoWOFF2 = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to WOFF2 and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToWOFF2', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/swedish/javascript-cpp/convert/asposefontconverttowsvg/_index.md
+++ b/swedish/javascript-cpp/convert/asposefontconverttowsvg/_index.md
@@ -1,0 +1,88 @@
+---
+title: "AsposeFontConvertToSVG"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Konverterar teckensnittet till svg-format"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/convert/asposefontconverttosvg/
+---
+## AsposeFontConvertToSVG function
+
+Konverterar teckensnittet till SVG-format.
+
+```js
+function AsposeFontConvertToSVG(
+    fileBlob,
+    fileName,
+    fontType
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfont för konvertering. |
+| fileName | string | Filnamn. |
+| fontType | FontType | Teckensnittstyp att konvertera. |
+
+### Returvärde
+
+JSON‑objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel (\"\" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fEOT2SVG = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontConvertToSVG(event.target.result, e.target.files[0].name, Module.FontType.OTF);
+      if (json.errorCode == 0) document.getElementById('output').textContent = json.fileNameResult;
+      else document.getElementById('output').textContent = json.errorText;
+      DownloadFile(json.fileNameResult, "font/ttf");
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fOTFtoSVG = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a OTF fonts to SVG and save - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontConvertToSVG', "params": [event.target.result, e.target.files[0].name, 'Module.FontType.OTF'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/swedish/javascript-cpp/core/_index.md
+++ b/swedish/javascript-cpp/core/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Kärnfunktioner"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Kärnfunktioner för att arbeta med Font-filer."
+type: docs
+url: /sv/javascript-cpp/core/
+---
+
+## Core Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposeFontPrepare](./asposefontprepare/) | Spara BLOB:en i minnes‑FS för bearbetning. |
+| [AsposeFontPrepareBase64](./asposefontpreparebase64/) | Spara BLOB:en med strängrepresentation i minnes‑FS för bearbetning. |
+
+## Detailed Description
+
+Kärnfunktioner för att arbeta med Font-filer.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/swedish/javascript-cpp/core/asposefontprepare/_index.md
+++ b/swedish/javascript-cpp/core/asposefontprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposeFontPrepare"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Spara BLOB:en i minnes‑FS för bearbetning."
+type: docs
+url: /sv/javascript-cpp/core/asposefontprepare/
+---
+
+_Spara BLOB i Memory FS för bearbetning._
+
+```js
+function AsposeFontPrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+JSON‑objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposeFontPrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposeFontAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposeFontWebWorker.postMessage(
+        { "operation": 'AsposeFontPrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposeFontPrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/core/asposefontpreparebase64/_index.md
+++ b/swedish/javascript-cpp/core/asposefontpreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposeFontPrepareBase64"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Spara BLOB:en med strängrepresentation i minnes‑FS för bearbetning."
+type: docs
+url: /sv/javascript-cpp/core/asposefontpreparebase64/
+---
+## AsposeFontPrepareBase64 function
+_Spara strängrepresentationen BLOB i Memory FS för bearbetning._
+
+```js
+function AsposeFontPrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### Anmärkningar
+**AsposeFontPrepareBase64** doesn't work in Web Worker mode, use AsposeFontPrepare
+
+### Exempel
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposeFontPrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposeFontPrepareBase64 for Web Worker*/
+  const AsposeFontPrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposeFontWebWorker.postMessage(
+                 { "operation": 'AsposeFontPrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposeFontPrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/Font");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/enumerations/_index.md
+++ b/swedish/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Enumerationer"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Funktioner för att konvertera font till TrueType-format."
+type: docs
+url: /sv/javascript-cpp/enumerations/
+---
+
+## Enumerationer
+
+| Enumeration | Beskrivning |
+| ----------- | ----------- |
+| [FontSavingFormats](./fontsavingformats/) | Anger teckensnittstyp. |
+| [FontType](./fonttype/) | Anger teckensnittstyp. |
+| [TtfNameTableNameId](./ttfnametablenameid/) | Anger NameId. |
+| [TtfNameTablePlatformId](./ttfnametableplatformid/) | Representerar PlatformId-enumeration. |
+| [TtfNameTableMSPlatformSpecificId](./ttfnametableMSPlatformSpecificId/) | Representerar MSPlatformSpecificId-enumeration. |
+| [TtfNameTableMacPlatformSpecificId](./ttfnametableMacPlatformSpecificId/) | Representerar MacPlatformSpecificId-enumeration. |
+| [TtfNameTableUnicodePlatformSpecificId](./ttfnametableUnicodePlatformSpecificId/) | Representerar UnicodePlatformSpecificId-enumeration. |
+| [TtfNameTableMacLanguageId](./ttfnametablemaclanguageid/) | Macintosh-plattformens språk‑id‑uppräkning. |
+| [TtfNameTableMSLanguageId](./ttfnametablemslanguageid/) | Microsoft-plattformens språk‑id‑uppräkning. |
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```
+

--- a/swedish/javascript-cpp/enumerations/fontsavingformats/_index.md
+++ b/swedish/javascript-cpp/enumerations/fontsavingformats/_index.md
@@ -1,0 +1,26 @@
+---
+title: "Enum FontSavingFormats"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Aspose.Font.FontSavingFormats enum. Anger teckensnittstyp"
+type: docs
+weight: 110
+url: /sv/javascript-cpp/enumerations/fontsavingformats/
+---
+## FontSavingFormats enumeration
+
+Anger teckensnittstyp.
+
+```csharp
+public enum FontSavingFormats
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+| TTF | `0` | TTF (TrueType) teckensnittformat. |
+| WOFF | `1` | WOFF (Web Open Font Format). |
+| WOFF2 | `2` | WOFF-filformat 2.0 |
+| SVG | `3` | SVG (Scalable Vector Graphics) teckensnittformat |
+| OTF | `4` | OTF (OpenType) teckensnittformat |
+

--- a/swedish/javascript-cpp/enumerations/fonttype/_index.md
+++ b/swedish/javascript-cpp/enumerations/fonttype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum FontType"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Aspose.Font.FontType enum. Anger teckensnittstyp"
+type: docs
+weight: 100
+url: /sv/javascript-cpp/enumerations/fonttype/
+---
+## FontType enumeration
+
+Anger teckensnittstyp.
+
+```csharp
+public enum FontType
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+| TTF | `0` | TTF (TrueType) teckensnittstyp och relaterat. |
+| Type1 | `1` | Type1 teckensnittstyp. |
+| CFF | `2` | CFF (Compact font format) teckensnittstyp. |
+| OTF | `3` | OpenType Font. OpenType Font-format är en utökning av TrueType Font-formatet och lägger till stöd för PostScript Font-data. |
+

--- a/swedish/javascript-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
+++ b/swedish/javascript-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
@@ -1,0 +1,53 @@
+---
+title: "Enum TtfNameTableMacPlatformSpecificId"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Aspose.Font.TtfNameTableMacPlatformSpecificId enum. Anger MacPlatformSpecificId"
+type: docs
+weight: 131
+url: /sv/javascript-cpp/enumerations/ttfnametablemacplatformspecificid/
+---
+## TtfNameTableMacPlatformSpecificId enumeration
+
+Anger MacPlatformSpecificId.
+
+```csharp
+ enum TtfNameTableMacPlatformSpecificId
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+|  | Roman | `0` | Roman plattformspecifikt värde. |
+|  | Japanese | `1` | Japansk plattformspecifikt värde. |
+|  | Traditional_Chinese | `2` | Traditionell kinesisk plattformspecifikt värde. |
+|  | Korean | `3` | Koreansk plattformspecifikt värde. |
+|  | Arabic | `4` | Arabisk plattformspecifikt värde. |
+|  | Hebrew | `5` | Hebrew plattformspecifikt värde. |
+|  | Greek | `6` | Greek plattformspecifikt värde. |
+|  | Russian | `7` | Russian plattformspecifikt värde. |
+|  | RSymbol | `8` | RSymbol plattformspecifikt värde. |
+|  | Devanagari | `9` | Devanagari plattformspecifikt värde. |
+|  | Gurmukhi | `10` | Gurmukhi plattformspecifikt värde. |
+|  | Gujarati | `11` | Gujarati plattformspecifikt värde. |
+|  | Oriya | `12` | Oriya plattformspecifikt värde. |
+|  | Bengali | `13` | Bengali plattformspecifikt värde. |
+|  | Tamil | `14` | Tamil plattformspecifikt värde. |
+|  | Telugu | `15` | Telugu plattformspecifikt värde. |
+|  | Kannada | `16` | Kannada plattformspecifikt värde. |
+|  | Malayalam | `17` | Malayalam plattformsspecifikt värde. |
+|  | Sinhalese | `18` | Sinhalese plattformsspecifikt värde. |
+|  | Burmese | `19` | Burmese plattformsspecifikt värde. |
+|  | Khmer | `20` | Khmer plattformsspecifikt värde. |
+|  | Thai | `21` | Thai plattformsspecifikt värde. |
+|  | Laotian | `22` | Laotian plattformsspecifikt värde. |
+|  | Georgian | `23` | Georgian plattformsspecifikt värde. |
+|  | Armenian | `24` | Armenian plattformsspecifikt värde. |
+|  | Simplified_Chinese | `25` | Simplified Chinese plattformsspecifikt värde. |
+|  | Tibetan | `26` | Tibetan plattformsspecifikt värde. |
+|  | Mongolian | `27` | Mongoliskt plattformspecifikt värde. |
+|  | Geez | `28` | Geez plattformspecifikt värde. |
+|  | Slavic | `29` | Slavisk plattformspecifikt värde. |
+|  | Vietnamese | `30` | Vietnamesiskt plattformspecifikt värde. |
+|  | Sindhi | `31` | Sindhi plattformspecifikt värde. |
+|  | Uninterpreted | `32` | Otolkat plattformspecifikt värde. |

--- a/swedish/javascript-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
+++ b/swedish/javascript-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Enum TtfNameTableMSPlatformSpecificId"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Aspose.Font.TtfNameTableMSPlatformSpecificId enum. Anger MSPlatformSpecificId"
+type: docs
+weight: 132
+url: /sv/javascript-cpp/enumerations/ttfnametablemsplatformspecificid/
+---
+## TtfNameTableMSPlatformSpecificId enumeration
+
+Anger MSPlatformSpecificId.
+
+```csharp
+ enum TtfNameTableMSPlatformSpecificId
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+|  | Symbol | `0` | Symbol MS PlatformSpecificId. |
+|  | Unicode_BMP_UCS2 | `1` | Unicode BMP (UCS2) MS PlatformSpecificId. |
+|  | ShiftJIS | `2` | ShiftJIS MS PlatformSpecificId. |
+|  | PRC | `3` | PRC MS PlatformSpecificId. |
+|  | Big5 | `4` | Big5 MS PlatformSpecificId. |
+|  | Wansung | `5` | Wansung MS PlatformSpecificId. |
+|  | Johab | `6` | Johab MS PlatformSpecificId. |
+|  | Reserved1 | `7` | Reserved1 MS PlatformSpecificId. |
+|  | Reserved2 | `8` | Reserved2 MS PlatformSpecificId. |
+|  | Reserved3 | `9` | Reserved3 MS PlatformSpecificId. |
+|  | Unicode_UCS4 | `10` | Unicode UCS4 MS PlatformSpecificId. |
+

--- a/swedish/javascript-cpp/enumerations/ttfnametablenameid/_index.md
+++ b/swedish/javascript-cpp/enumerations/ttfnametablenameid/_index.md
@@ -1,0 +1,46 @@
+---
+title: "Enum TtfNameTableNameId"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Aspose.Font.TtfNameTableNameId enum. Anger NameId"
+type: docs
+weight: 120
+url: /sv/javascript-cpp/enumerations/ttfnametablenameid/
+---
+## TtfNameTableNameId enumeration
+
+Anger NameId.
+
+```csharp
+ enum TtfNameTableNameId
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+|  | CopyrightNotice | `0` | Upphovsrättsmeddelande. |
+|  | FontFamily | `1` | Typsnittsfamilj. Denna sträng är typsnittsfamiljens namn som användaren ser på Macintosh-plattformar. |
+|  | FontSubfamily | `2` | Typsnittssubfamilj. Denna sträng är typsnittsfamiljen som användaren ser på Macintosh-plattformar. |
+|  | UniqueFontId | `3` | Unik subfamiljeidentifiering (Apple-spec). 3 Unik typsnittsidentifierare (MS-spec). |
+|  | FullName | `4` | Fullständigt namn på typsnittet. |
+|  | Version | `5` | Version av namntabellen. |
+|  | PostScriptName | `6` | PostScript-namn för typsnittet. Obs: Ett typsnitt kan bara ha ett PostScript-namn och det namnet måste vara ASCII. |
+|  | TrademarkNotice | `7` | Varumärkesmeddelande. |
+|  | ManufacturerName | `8` | Tillverkarens namn. |
+|  | DesignerName | `9` | Designer; namn på typsnittets designer. |
+|  | Description | `10` | Beskrivning; beskrivning av typsnittet. Kan innehålla revisionsinformation, användningsrekommendationer, historik, funktioner med mera. |
+|  | UrlVendor | `11` | URL för typsnittleverantören (med protokoll, t.ex. http://, ftp://). Om ett unikt serienummer är inbäddat i URL:en kan det användas för att registrera typsnittet. |
+|  | UrlDesigner | `12` | URL för typsnittdesignern (med protokoll, t.ex. http://, ftp://) |
+|  | LicenseDescription | `13` | Licensbeskrivning; beskrivning av hur typsnittet får användas lagligt, eller olika exempel på licensierad användning. Detta fält bör skrivas på enkelt språk, inte juridiskt språkbruk. |
+|  | LicenseInfoUrl | `14` | URL för licensinformation, där ytterligare licensinformation kan hittas. |
+|  | PreferredFamily | `16` | `15` Reserverad `16` Föredragen familj (endast Windows); I Windows visas familjenamnet i typsnittmenyn; subfamiljenamnet visas som stilnamn. Av historiska skäl har typsnittsfamiljer innehållit högst fyra stilar, men typsnittsdesigners kan gruppera fler än fyra typsnitt i en enda familj. ID:n för föredragen familj och föredragen subfamilj låter typsnittsdesigners inkludera de föredragna familje-/subfamiljegrupperingarna. Dessa ID:n finns bara om de skiljer sig från ID:n 1 och 2. |
+|  | PreferredSubfamily | `17` | Föredragen subfamilj (endast Windows); I Windows visas familjenamnet i typsnittmenyn; subfamiljenamnet visas som stilnamn. Av historiska skäl har typsnittsfamiljer innehållit högst fyra stilar, men typsnittsdesigners kan gruppera fler än fyra typsnitt i en enda familj. ID:n för föredragen familj och föredragen subfamilj låter typsnittsdesigners inkludera de föredragna familje-/subfamiljegrupperingarna. Dessa ID:n finns bara om de skiljer sig från ID:n 1 och 2. |
+|  | CompatibleFull | `18` | Kompatibel full (endast Macintosh); På Macintosh konstrueras menynamnet med hjälp av typsnittresursen. Detta matchar vanligtvis det fullständiga namnet. Om du vill att typsnittets namn ska visas annorlunda än det fullständiga namnet kan du infoga det kompatibla fullständiga namnet i ID 18. Detta namn används inte av själva Mac OS, men kan användas av programutvecklare (t.ex. Adobe). |
+|  | SampleText | `19` | Exempeltext. Detta kan vara typsnittets namn, eller någon annan text som designern anser vara den bästa exempeltexten för att visa hur typsnittet ser ut. |
+|  | PostScriptCID | `20` | Dess närvaro i ett typsnitt betyder att nameID 6 innehåller ett PostScript-typsnittnamn som är avsett att användas med "composefont"-anropet för att aktivera typsnittet i en PostScript-tolk. |
+|  | WwsFamilyName | `21` | Används för att tillhandahålla ett WWS‑konformt familjenamn om posterna för ID‑n 16 och 17 inte följer WWS‑modellen. |
+|  | WwsSubfamilyName | `22` | Används i kombination med ID 21, detta ID tillhandahåller ett WWS‑konformt subfamiljenamn (som endast återspeglar vikt-, bredd- och lutningsattribut) om posterna för ID‑n 16 och 17 inte följer WWS‑modellen. |
+|  | LightBackground | `23` | Detta ID, om det används i CPAL-tabellens Palette Labels Array, anger att den motsvarande färgpaletten i CPAL-tabellen är lämplig att använda med typsnittet när det visas på en ljus bakgrund, såsom vit. |
+|  | DarkBackground | `24` | Detta ID, om det används i CPAL-tabellens Palette Labels Array, anger att den motsvarande färgpaletten i CPAL-tabellen är lämplig att använda med typsnittet när det visas på en mörk bakgrund, såsom svart. |
+|  | VariationsPostScriptNamePrefix | `25` | Om den finns i ett variabelt teckensnitt kan den användas som familjeprefix i algoritmen för PostScript‑namngenerering för variationsfonter. |
+

--- a/swedish/javascript-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
+++ b/swedish/javascript-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
@@ -1,0 +1,138 @@
+---
+title: "Enum TtfNameTableMacLanguageId"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Aspose.Font.TtfNameTableMacLanguageId enum. Anger MacLanguageId"
+type: docs
+weight: 140
+url: /sv/javascript-cpp/enumerations/ttfnametablemaclanguageid/
+---
+## TtfNameTableMacLanguageId enumeration
+
+Representerar MacLanguageId enumeration.
+
+```csharp
+ enum TtfNameTableMacLanguageId
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+|  | English | `0` | Engelsk LanguageId värde |
+|  | French | `1` | Fransk LanguageId värde |
+|  | German | `2` | Tysk LanguageId värde |
+|  | Italian | `3` | Italiensk LanguageId värde |
+|  | Dutch | `4` | Nederländsk LanguageId värde |
+|  | Swedish | `5` | Svensk LanguageId värde |
+|  | Spanish | `6` | Spansk LanguageId värde |
+|  | Danish | `7` | Dansk LanguageId värde |
+|  | Portuguese | `8` | Portugisisk LanguageId värde |
+|  | Norwegian | `9` | Norsk LanguageId värde |
+|  | Hebrew | `10` | Hebreisk LanguageId värde |
+|  | Japanese | `11` | Japansk LanguageId värde |
+|  | Arabic | `12` | Arabisk LanguageId värde |
+|  | Finnish | `13` | Finsk LanguageId värde |
+|  | Greek | `14` | Grekisk LanguageId värde |
+|  | Icelandic | `15` | Isländsk LanguageId värde |
+|  | Maltese | `16` | Maltesisk LanguageId värde |
+|  | Turkish | `17` | Turkisk LanguageId värde |
+|  | Croatian | `18` | Kroatisk LanguageId värde |
+|  | Chinese_Traditional | `19` | Kinesisk (traditionell) LanguageId värde |
+|  | Urdu | `20` | Urdu LanguageId värde |
+|  | Hindi | `21` | Hindi LanguageId värde |
+|  | Thai | `22` | thailändska LanguageId värde |
+|  | Korean | `23` | koreanska LanguageId värde |
+|  | Lithuanian | `24` | litauiska LanguageId värde |
+|  | Polish | `25` | polska LanguageId värde |
+|  | Hungarian | `26` | ungerska LanguageId värde |
+|  | Estonian | `27` | estniska LanguageId värde |
+|  | Latvian | `28` | lettiska LanguageId värde |
+|  | Sami | `29` | samiska LanguageId värde |
+|  | Faroese | `30` | färöiska LanguageId värde |
+|  | Farsi_Persian | `31` | Farsi/persiska LanguageId värde |
+|  | Russian | `32` | ryska LanguageId värde |
+|  | Chinese_Simplified | `33` | kinesiska (förenklad) LanguageId värde |
+|  | Flemish | `34` | flamländska LanguageId värde |
+|  | Irish_Gaelic | `35` | iriska gaeliska LanguageId värde |
+|  | Albanian | `36` | albanska LanguageId värde |
+|  | Romanian | `37` | rumänska LanguageId värde |
+|  | Czech | `38` | tjeckiska LanguageId värde |
+|  | Slovak | `39` | slovakiska LanguageId värde |
+|  | Slovenian | `40` | slovenska LanguageId värde |
+|  | Yiddish | `41` | jiddisch LanguageId värde |
+|  | Serbian | `42` | serbiska LanguageId värde |
+|  | Macedonian | `43` | makedonska LanguageId värde |
+|  | Bulgarian | `44` | bulgariska LanguageId värde |
+|  | Ukrainian | `45` | ukrainska LanguageId värde |
+|  | Byelorussian | `46` | belarusiska LanguageId värde |
+|  | Uzbek | `47` | Uzbek LanguageId värde |
+|  | Kazakh | `48` | Kazakh LanguageId värde |
+|  | Azerbaijani_Cyrillic | `49` | Azerbaijani (kyrilliskt skript) LanguageId värde |
+|  | Azerbaijani_Arabic | `50` | Azerbaijani (arabiskt skript) LanguageId värde |
+|  | Armenian | `51` | Armenian LanguageId värde |
+|  | Georgian | `52` | Georgian LanguageId värde |
+|  | Moldavian | `53` | Moldavian LanguageId värde |
+|  | Kirghiz | `54` | Kirghiz LanguageId värde |
+|  | Tajiki | `55` | Tajiki LanguageId värde |
+|  | Turkmen | `56` | Turkmen LanguageId värde |
+|  | Mongolian | `57` | Mongolian (mongoliskt skript) LanguageId värde |
+|  | Mongolian_Cyrillic | `58` | Mongolian (kyrilliskt skript) LanguageId värde |
+|  | Pashto | `59` | Pashto LanguageId värde |
+|  | Kurdish | `60` | Pashto LanguageId värde |
+|  | Kashmiri | `61` | Kashmiri LanguageId värde |
+|  | Sindhi | `62` | Sindhi LanguageId värde |
+|  | Tibetan | `63` | Tibetan LanguageId värde |
+|  | Nepali | `64` | Nepali LanguageId värde |
+|  | Sanskrit | `65` | Sanskrit LanguageId värde |
+|  | Marathi | `66` | Marathi LanguageId värde |
+|  | Bengali | `67` | Bengali LanguageId värde |
+|  | Assamese | `68` | Assamese LanguageId värde |
+|  | Gujarati | `69` | Gujarati LanguageId värde |
+|  | Punjabi | `70` | Punjabi LanguageId värde |
+|  | Oriya | `71` | Oriya LanguageId värde |
+|  | Malayalam | `72` | Malayalam LanguageId värde |
+|  | Kannada | `73` | Kannada LanguageId värde |
+|  | Tamil | `74` | Tamil LanguageId värde |
+|  | Telugu | `75` | Telugu LanguageId värde |
+|  | Sinhalese | `76` | Sinhalese LanguageId värde |
+|  | Burmese | `77` | Burmese LanguageId värde |
+|  | Khmer | `78` | Khmer LanguageId värde |
+|  | Lao | `79` | Lao LanguageId värde |
+|  | Vietnamese | `80` | Vietnamese LanguageId värde |
+|  | Indonesian | `81` | Indonesian LanguageId värde |
+|  | Tagalog | `82` | Tagalog LanguageId värde |
+|  | Malay_Roman | `83` | Malay (Roman script) LanguageId värde |
+|  | Malay_Arabic | `84` | Malay (Arabic script) LanguageId värde |
+|  | Amharic | `85` | Amharic LanguageId värde |
+|  | Tigrinya | `86` | Tigrinya LanguageId värde |
+|  | Galla | `87` | Galla LanguageId värde |
+|  | Somali | `88` | Somali LanguageId värde |
+|  | Swahili | `89` | Swahili LanguageId värde |
+|  | Kinyarwanda_Ruanda | `90` | Kinyarwanda/Ruanda LanguageId värde |
+|  | Rundi | `91` | Rundi LanguageId värde |
+|  | Nyanja_Chewa | `92` | Nyanja/Chewa LanguageId värde |
+|  | Malagasy | `93` | Malagasy LanguageId värde |
+|  | Esperanto | `94` | Esperanto LanguageId värde |
+|  | Welsh | `128` | Welsh LanguageId värde |
+|  | Basque | `129` | Basque LanguageId värde |
+|  | Catalan | `130` | Catalan LanguageId värde |
+|  | Latin | `131` | Latin LanguageId värde |
+|  | Quechua | `132` | Quechua LanguageId värde |
+|  | Guarani | `133` | Guarani LanguageId värde |
+|  | Aymara | `134` | Aymara LanguageId värde |
+|  | Tatar | `135` | Tatar LanguageId värde |
+|  | Uighur | `136` | Uigur LanguageId värde |
+|  | Dzongkha | `137` | Dzongkha LanguageId värde |
+|  | Javanese | `138` | Javanesiska (romanskt skript) LanguageId värde |
+|  | Sundanese | `139` | Sundanesiska (romanskt skript) LanguageId värde |
+|  | Galician | `140` | Galiciska LanguageId värde |
+|  | Afrikaans | `141` | Afrikaans LanguageId värde |
+|  | Breton | `142` | Bretonska LanguageId värde |
+|  | Inuktitut | `143` | Inuktitut LanguageId värde |
+|  | Scottish_Gaelic | `144` | Skotsk gaeliska LanguageId värde |
+|  | Manx_Gaelic | `145` | Manx-gaeliska LanguageId värde |
+|  | Irish_Gaelic_WDA | `146` | Irländsk gaeliska (med prick ovan) LanguageId värde |
+|  | Tongan | `147` | Tonganska LanguageId värde |
+|  | Greek_Polytonic | `148` | Grekiska (polytonisk) LanguageId värde |
+|  | Greenlandic | `149` | Grönländska LanguageId värde |
+|  | Azerbaijani_Roman | `150` | Azerbajdzjanska (romanskt skript) LanguageId värde |

--- a/swedish/javascript-cpp/enumerations/ttfnametablenmslanguageid/_index.md
+++ b/swedish/javascript-cpp/enumerations/ttfnametablenmslanguageid/_index.md
@@ -1,0 +1,225 @@
+---
+title: "Enum TtfNameTableMSLanguageId"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Aspose.Font.TtfNameTableMSLanguageId enum. Anger MSLanguageId"
+type: docs
+weight: 150
+url: /sv/javascript-cpp/enumerations/ttfnametablemslanguageid/
+---
+## TtfNameTableMSLanguageId enumeration
+
+Representerar MSLanguageId‑enumerationen.
+
+```csharp
+ enum TtfNameTableMSLanguageId
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+|  | Afrikaans | `0x0436` | Afrikaans (Region: South Africa, SA) LanguageId värde |
+|  | Albanian | `0x041c` | Albanian (Region: Albania,  SQI) LanguageId värde |
+|  | Alsatian | `0x0484` | Alsatian (Region: France) LanguageId värde |
+|  | Amharic | `0x045E` | Amharic (Region: Ethiopia) LanguageId värde |
+|  | Arabic_Algeria | `0x1401` | Arabic (Region: Algeria) LanguageId värde |
+|  | Arabic_Bahrain | `0x3C01` | Arabic (Region: Bahrain) LanguageId värde |
+|  | Arabic_Egypt | `0x0C01` | Arabic (Region: Egypt) LanguageId värde |
+|  | Arabic_Iraq | `0x0801` | Arabic (Region: Iraq) LanguageId värde |
+|  | Arabic_Jordan | `0x2C01` | Arabic (Region: Jordan) LanguageId värde |
+|  | Arabic_Kuwait | `0x3401` | Arabic (Region: Kuwait) LanguageId värde |
+|  | Arabic_Lebanon | `0x3001` | Arabic (Region: Lebanon) LanguageId värde |
+|  | Arabic_Libya | `0x1001` | Arabic (Region: Libya) LanguageId värde |
+|  | Arabic_Morocco | `0x1801` | Arabic (Region: Morocco) LanguageId värde |
+|  | Arabic_Oman | `0x2001` | Arabic (Region: Oman) LanguageId värde |
+|  | Arabic_Qatar | `0x4001` | Arabic (Region: Qatar) LanguageId värde |
+|  | Arabic_Saudi_Arabia | `0x0401` | Arabic (Region: Saudi Arabia) LanguageId värde |
+|  | Arabic_Syria | `0x2801` | Arabic (Region: Syria) LanguageId värde |
+|  | Arabic_Tunisia | `0x1C01` | Arabic (Region: Tunisia) LanguageId värde |
+|  | Arabic_U_A_E | `0x3801` | Arabic (Region: U.A.E.) LanguageId värde |
+|  | Arabic_Yemen | `0x2401` | Arabic (Region: Yemen) LanguageId värde |
+|  | Armenian | `0x042B` | Armenian (Region: Armenia) LanguageId värde |
+|  | Assamese | `0x044D` | Assamese (Region: India) LanguageId värde |
+|  | Azeri_Cyrillic | `0x082C` | Azeri (Cyrillic, Region: Azerbaijan) LanguageId värde |
+|  | Azeri_Latin | `0x042C` | Azeri (Latin, Region: Azerbaijan) LanguageId värde |
+|  | Bashkir | `0x046D` | Bashkir (Region: Russia) LanguageId värde |
+|  | Basque | `0x042D` | Baskiska (Region: Basque, EUQ) LanguageId-värde |
+|  | Belarusian | `0x0423` | Vitryska (Region: Belarus, BEL) LanguageId-värde |
+|  | Bengali_Bangladesh | `0x0845` | Bengali (Region: Bangladesh) LanguageId-värde |
+|  | Bengali_India | `0x0445` | Bengali (Region: India) LanguageId-värde |
+|  | Bosnian_Cyrillic | `0x201A` | Bosniska (Cyrillic, Region: Bosnia and Herzegovina) LanguageId-värde |
+|  | Bosnian_Latin | `0x141A` | Bosniska (Latin, Region: Bosnia and Herzegovina) LanguageId-värde |
+|  | Breton | `0x047E` | Bretonska (Region: France) LanguageId-värde |
+|  | Bulgarian | `0x0402` | Bulgariska (Region: Bulgaria, BGR) LanguageId-värde |
+|  | Catalan | `0x0403` | Katalanska (Region: Catalan, CAT) LanguageId-värde |
+|  | Chinese_Hong_Kong | `0x0C04` | Kinesiska (Region: Hong Kong S.A.R.) LanguageId-värde |
+|  | Chinese_Macao | `0x1404` | Kinesiska (Region: Macao S.A.R.) LanguageId-värde |
+|  | Chinese_PRC | `0x0804` | Kinesiska (Region: People�s Republic of China) LanguageId-värde |
+|  | Chinese_Singapore | `0x1004` | Kinesiska (Region: Singapore) LanguageId-värde |
+|  | Chinese_Taiwan | `0x0404` | Kinesiska (Region: Taiwan) LanguageId-värde |
+|  | Corsican | `0x0483` | Korsikanska (Region: France) LanguageId-värde |
+|  | Croatian | `0x041A` | Kroatiska (Region: Croatia, SHL) LanguageId-värde |
+|  | Croatian_Latin | `0x101A` | Kroatiska (Latin, Region: Bosnia and Herzegovina) LanguageId-värde |
+|  | Czech | `0x0405` | Tjeckiska (Region: Czech Republic, CSY) LanguageId-värde |
+|  | Danish | `0x0406` | Danska (Region: Denmark, DAN) LanguageId-värde |
+|  | Dari | `0x048C` | Dari (Region: Afghanistan) LanguageId-värde |
+|  | Divehi | `0x0465` | Divehi (Region: Maldives) LanguageId-värde |
+|  | Dutch_Belgium | `0x0813` | Nederländska (Flemish, Region: Belgium, NLB) LanguageId-värde |
+|  | Dutch_Netherlands | `0x0413` | Nederländska (Standard, Region: Netherlands, NLD) LanguageId-värde |
+|  | English_Australia | `0x0C09` | Engelska (Australian, Region: Australia, ENA) LanguageId-värde |
+|  | English_Belize | `0x2809` | Engelska (Region: Belize) LanguageId-värde |
+|  | English_Canada | `0x1009` | engelska (kanadensisk, region: Kanada, ENC) LanguageId‑värde |
+|  | English_Caribbean | `0x2409` | engelska (region: Karibien) LanguageId‑värde |
+|  | English_India | `0x4009` | engelska (region: Indien) LanguageId‑värde |
+|  | English_Ireland | `0x1809` | engelska (region: Irland, ENI) LanguageId‑värde |
+|  | English_Jamaica | `0x2009` | engelska (region: Jamaica) LanguageId‑värde |
+|  | English_Malaysia | `0x4409` | engelska (region: Malaysia) LanguageId‑värde |
+|  | English_New_Zealand | `0x1409` | engelska (region: Nya Zeeland, ENZ) LanguageId‑värde |
+|  | English_ROP | `0x3409` | engelska (region: Filippinernas republiken, ROP) LanguageId‑värde |
+|  | English_Singapore | `0x4809` | engelska (region: Singapore) LanguageId‑värde |
+|  | English_South_Africa | `0x1C09` | engelska (region: Sydafrika, SA) LanguageId‑värde |
+|  | English_TT | `0x2C09` | engelska (region: Trinidad och Tobago, TT) LanguageId‑värde |
+|  | English_United_Kingdom | `0x0809` | engelska (brittisk, region: Storbritannien, ENG) LanguageId‑värde |
+|  | English_United_States | `0x0409` | engelska (amerikansk, region: USA, ENU) LanguageId‑värde |
+|  | English_Zimbabwe | `0x3009` | engelska (region: Zimbabwe) LanguageId‑värde |
+|  | Estonian | `0x0425` | estniska (region: Estland, ETI) LanguageId‑värde |
+|  | Faroese | `0x0438` | faröisk (region: Färöarna) LanguageId‑värde |
+|  | Filipino | `0x0464` | filippinsk (region: Filippinerna) LanguageId‑värde |
+|  | Finnish | `0x040B` | finska (region: Finland, FIN) LanguageId‑värde |
+|  | French_Belgium | `0x080C` | franska (belgisk, region: Belgien, FRB) LanguageId‑värde |
+|  | French_Canada | `0x0C0C` | franska (kanadensisk, region: Kanada, FRC) LanguageId‑värde |
+|  | French_France | `0x040C` | franska (standard, region: Frankrike, FRA) LanguageId‑värde |
+|  | French_Luxembourg | `0x140c` | franska (region: Luxemburg, FRL) LanguageId‑värde |
+|  | French_MC | `0x180C` | franska (region: Furstendömet Monaco, MC) LanguageId‑värde |
+|  | French_Switzerland | `0x100C` | franska (schweizisk, region: Schweiz, FRS) LanguageId‑värde |
+|  | Frisian | `0x0462` | frisiska (region: Nederländerna, NLD) LanguageId‑värde |
+|  | Galician | `0x0456` | Galiciska (Region: Galiciska) LanguageId värde |
+|  | Georgian | `0x0437` | Georgiska (Region: Georgien) LanguageId värde |
+|  | German_Austria | `0x0C07` | Tyska (österrikisk, Region: Österrike, DEA) LanguageId värde |
+|  | German_Germany | `0x0407` | Tyska (Standard, Region: Tyskland, DEU) LanguageId värde |
+|  | German_Liechtenstein | `0x1407` | Tyska (Region: Liechtenstein, DEC) LanguageId värde |
+|  | German_Luxembourg | `0x1007` | Tyska (Region: Luxemburg, DEL) LanguageId värde |
+|  | German_Switzerland | `0x0807` | Tyska (schweizisk, Region: Schweiz, DES) LanguageId värde |
+|  | Greek | `0x0408` | Grekiska (Region: Grekland, ELL) LanguageId värde |
+|  | Greenlandic | `0x046F` | Grönländska (Region: Grönland) LanguageId värde |
+|  | Gujarati | `0x0447` | Gujarati (Region: Indien) LanguageId värde |
+|  | Hausa | `0x0468` | Hausa (Latin, Region: Nigeria) LanguageId värde |
+|  | Hebrew | `0x040D` | Hebreiska (Region: Israel) LanguageId värde |
+|  | Hindi | `0x0439` | Hindi (Region: Indien) LanguageId värde |
+|  | Hungarian | `0x040E` | Ungerska (Region: Ungern, HUN) LanguageId värde |
+|  | Icelandic | `0x040F` | Isländska (Region: Island, ISL) LanguageId värde |
+|  | Igbo | `0x0470` | Igbo (Region: Nigeria) LanguageId värde |
+|  | Indonesian | `0x0421` | Indonesiska (Region: Indonesien) LanguageId värde |
+|  | Inuktitut | `0x045D` | Inuktitut (Region: Kanada) LanguageId värde |
+|  | Inuktitut_Latin | `0x085D` | Inuktitut (Latin, Region: Kanada) LanguageId värde |
+|  | Irish | `0x083C` | Iriska (Region: Irland) LanguageId värde |
+|  | isiXhosa | `0x0434` | isiXhosa (Region: Sydafrika, SA) LanguageId-värde |
+|  | isiZulu | `0x0435` | isiZulu (Region: Sydafrika, SA) LanguageId-värde |
+|  | Italian_Italy | `0x0410` | Italienska (Standard, Region: Italien, ITA) LanguageId värde |
+|  | Italian_Switzerland | `0x0810` | Italienska (schweizisk, Region: Schweiz, ITS) LanguageId värde |
+|  | Japanese | `0x0411` | Japanska (Region: Japan) LanguageId värde |
+|  | Kannada | `0x044B` | Kannada (Region: Indien) LanguageId värde |
+|  | Kazakh | `0x043F` | Kazakiska (Region: Kazakstan) LanguageId värde |
+|  | Khmer | `0x0453` | Khmer (Region: Kambodja) LanguageId värde |
+|  | Kiche | `0x0486` | K�iche (Region: Guatemala) LanguageId värde |
+|  | Kinyarwanda | `0x0487` | Kinyarwanda (Region: Rwanda) LanguageId värde |
+|  | Kiswahili | `0x0441` | Kiswahili (Region: Kenya) LanguageId värde |
+|  | Konkani | `0x0457` | Konkani (Region: Indien) LanguageId värde |
+|  | Korean | `0x0412` | Koreanska (Region: Korea) LanguageId värde |
+|  | Kyrgyz | `0x0440` | Kirgiziska (Region: Kirgizistan) LanguageId värde |
+|  | Lao | `0x0454` | Lao (Region: Lao P.D.R.) LanguageId värde |
+|  | Latvian | `0x0426` | Lettiska (Region: Lettland, LVI) LanguageId värde |
+|  | Lithuanian | `0x0427` | Litauiska (Region: Litauen, LTH) LanguageId värde |
+|  | Lower_Sorbian | `0x082E` | Nedre sorbiska (Region: Tyskland) LanguageId värde |
+|  | Luxembourgish | `0x046E` | Luxemburgiska (Region: Luxemburg) LanguageId värde |
+|  | Macedonian | `0x042F` | Makedonska (Region: Nordmakedonien) LanguageId värde |
+|  | Malay_Brunei_Darussalam | `0x083E` | Malajiska (Region: Brunei Darussalam) LanguageId värde |
+|  | Malay_Malaysia | `0x043E` | Malajiska (Region: Malaysia) LanguageId värde |
+|  | Malayalam | `0x044C` | Malayalam (Region: Indien) LanguageId värde |
+|  | Maltese | `0x043A` | Maltesiska (Region: Malta) LanguageId värde |
+|  | Maori | `0x0481` | Maori (Region: Nya Zeeland) LanguageId värde |
+|  | Mapudungun | `0x047A` | Mapudungun (Region: Chile) LanguageId värde |
+|  | Marathi | `0x044E` | Marathi (Region: Indien) LanguageId värde |
+|  | Mohawk | `0x047C` | Mohawk (Region: Mohawk) LanguageId värde |
+|  | Mongolian_Cyrillic | `0x0450` | Mongoliska (Kyrillisk, Region: Mongoliet) LanguageId värde |
+|  | Mongolian_Traditional | `0x0850` | Mongoliska (Traditionell, Region: Folkrepubliken Kina) LanguageId värde |
+|  | Nepali | `0x0461` | Nepali (Region: Nepal) LanguageId värde |
+|  | Norwegian_Bokmal | `0x0414` | Norska (Bokmål, Region: Norge, NOR) LanguageId värde |
+|  | Norwegian_Nynorsk | `0x0814` | Norska (Nynorsk, Region: Norge, NON) LanguageId värde |
+|  | Occitan | `0x0482` | Occitanska (Region: Frankrike) LanguageId värde |
+|  | Odia | `0x0448` | Odia (tidigare Oriya, Region: Indien) LanguageId värde |
+|  | Pashto | `0x0463` | Pashto (Region: Afghanistan) LanguageId värde |
+|  | Polish | `0x0415` | Polska (Region: Polen, PLK) LanguageId värde |
+|  | Portuguese_Brazil | `0x0416` | Portugisiska (brasiliansk, Region: Brasilien, PTB) LanguageId värde |
+|  | Portuguese_Portugal | `0x0816` | Portugisiska (standard, Region: Portugal, PTG) LanguageId värde |
+|  | Punjabi | `0x0446` | Punjabi (Region: Indien) LanguageId värde |
+|  | Quechua_Bolivia | `0x046B` | Quechua (Region: Bolivia) LanguageId värde |
+|  | Quechua_Ecuador | `0x086B` | Quechua (Region: Ecuador) LanguageId värde |
+|  | Quechua_Peru | `0x0C6B` | Quechua (Region: Peru) LanguageId värde |
+|  | Romanian | `0x0418` | Rumänska (Region: Rumänien, ROM) LanguageId värde |
+|  | Romansh | `0x0417` | Rätoromanska (Region: Schweiz) LanguageId värde |
+|  | Russian | `0x0419` | Ryska (Region: Ryssland, RUS) LanguageId värde |
+|  | Sami_Inari | `0x243B` | samiska (Inari, Region: Finland) LanguageId värde |
+|  | Sami_Lule_Norway | `0x103B` | samiska (Lule, Region: Norge) LanguageId värde |
+|  | Sami_Lule_Sweden | `0x143B` | samiska (Lule, Region: Sverige) LanguageId värde |
+|  | Sami_Northern_Finland | `0x0C3B` | samiska (nordlig, Region: Finland) LanguageId värde |
+|  | Sami_Northern_Norway | `0x043B` | samiska (nordlig, Region: Norge) LanguageId värde |
+|  | Sami_Northern_Sweden | `0x083B` | samiska (nordlig, Region: Norge) LanguageId värde |
+|  | Sami_Skolt | `0x203B` | samiska (Skolt, Region: Finland) LanguageId värde |
+|  | Sami_Southern_Norway | `0x183B` | samiska (södra, Region: Norge) LanguageId värde |
+|  | Sami_Southern_Sweden | `0x1C3B` | samiska (södra, Region: Sverige) LanguageId värde |
+|  | Sanskrit | `0x044F` | Sanskrit (Region: Indien) LanguageId värde |
+|  | Serbian_Cyrillic_BIH | `0x1C1A` | Serbiska (kyrillisk, Region: Bosnien och Hercegovina) LanguageId värde |
+|  | Serbian_Cyrillic_Serbia | `0x0C1A` | Serbiska (kyrillisk, Region: Serbien) LanguageId värde |
+|  | Serbian_Latin_BIH | `0x181A` | Serbiska (Latin, Region: Bosnien och Hercegovina) LanguageId-värde |
+|  | Serbian_Latin_Serbia | `0x081A` | Serbiska (Latin, Region: Serbien) LanguageId-värde |
+|  | Sesotho_Sa_Leboa | `0x046C` | Sesotho sa Leboa (Norra Sotho, Region: Sydafrika, SA) LanguageId-värde |
+|  | Setswana | `0x0432` | Setswana (Region: Sydafrika, SA) LanguageId-värde |
+|  | Sinhala | `0x045B` | Sinhala (Region: Sri Lanka) LanguageId-värde |
+|  | Slovak | `0x041B` | Slovakiska (Region: Slovakien, SKY) LanguageId-värde |
+|  | Slovenian | `0x0424` | Slovenska (Region: Slovenien, SLV) LanguageId-värde |
+|  | Spanish_Argentina | `0x2C0A` | Spanska (Region: Argentina) LanguageId-värde |
+|  | Spanish_Bolivia | `0x400A` | Spanska (Region: Bolivia) LanguageId-värde |
+|  | Spanish_Chile | `0x340A` | Spanska (Region: Chile) LanguageId-värde |
+|  | Spanish_Colombia | `0x240A` | Spanska (Region: Colombia) LanguageId-värde |
+|  | Spanish_Costa_Rica | `0x140A` | Spanska (Region: Costa Rica) LanguageId-värde |
+|  | Spanish_Dominican_Republic | `0x1C0A` | Spanska (Region: Dominikanska republiken) LanguageId-värde |
+|  | Spanish_Ecuador | `0x300A` | Spanska (Region: Dominikanska republiken) LanguageId-värde |
+|  | Spanish_El_Salvador | `0x440A` | Spanska (Region: Dominikanska republiken) LanguageId-värde |
+|  | Spanish_Guatemala | `0x100A` | Spanska (Region: Guatemala) LanguageId-värde |
+|  | Spanish_Honduras | `0x480A` | Spanska (Region: Honduras) LanguageId-värde |
+|  | Spanish_Mexico | `0x080A` | Spanska (mexikansk, Region: Mexiko, ESM) LanguageId-värde |
+|  | Spanish_Nicaragua | `0x4C0A` | Spanska (Region: Nicaragua) LanguageId-värde |
+|  | Spanish_Panama | `0x180A` | Spanska (Region: Panama) LanguageId-värde |
+|  | Spanish_Paraguay | `0x3C0A` | Spanska (Region: Paraguay) LanguageId-värde |
+|  | Spanish_Peru | `0x280A` | Spanska (Region: Peru) LanguageId-värde |
+|  | Spanish_Puerto_Rico | `0x500A` | Spanska (Region: Puerto Rico) LanguageId-värde |
+|  | Spanish_Modern_Sort | `0x0C0A` | Spanska (Modern sortering, Region: Spanien, ESN) LanguageId-värde |
+|  | Spanish_Traditional_Sort | `0x040A` | Spanska (Traditionell sortering, Region: Spanien, ESP) LanguageId-värde |
+|  | Spanish_United_States | `0x540A` | Spanska (Region: USA) LanguageId-värde |
+|  | Spanish_Uruguay | `0x380A` | Spanska (Region: Uruguay) LanguageId-värde |
+|  | Spanish_Venezuela | `0x200A` | Spanska (Region: Venezuela) LanguageId värde |
+|  | Swedish_Finland | `0x081D` | Svenska (Region: Finland) LanguageId värde |
+|  | Swedish_Sweden | `0x041D` | Svenska (Region: Sverige, SVE) LanguageId värde |
+|  | Syriac | `0x045A` | Syrianska (Region: Syrien) LanguageId värde |
+|  | Tajik | `0x0428` | Tadzjikiska (Cyrillic, Region: Tadzjikistan) LanguageId värde |
+|  | Tamazight | `0x085F` | Tamazight (Latin, Region: Algeriet) LanguageId värde |
+|  | Tamil | `0x0449` | Tamil (Region: Indien) LanguageId värde |
+|  | Tatar | `0x0444` | Tatariska (Region: Ryssland) LanguageId värde |
+|  | Telugu | `0x044A` | Telugu (Region: Indien) LanguageId värde |
+|  | Thai | `0x041E` | Thailändska (Region: Thailand) LanguageId värde |
+|  | Tibetan | `0x0451` | Tibetanska (Region: Kina) LanguageId värde |
+|  | Turkish | `0x041F` | Turkiska (Region: Turkiet, TRK) LanguageId värde |
+|  | Turkmen | `0x0442` | Turkmeniska (Region: Turkmenistan) LanguageId värde |
+|  | Uighur | `0x0480` | Uiguriska (Region: Kina) LanguageId värde |
+|  | Ukrainian | `0x0422` | Ukrainska (Region: Ukraina, UKR) LanguageId värde |
+|  | Upper_Sorbian | `0x042E` | Övre sorbiska (Region: Tyskland) LanguageId värde |
+|  | Urdu | `0x0420` | Urdu (Region: Islamiska republiken Pakistan) LanguageId värde |
+|  | Uzbek_Cyrillic | `0x0843` | Uzbekiska (Cyrillic, Region: Uzbekistan) LanguageId värde |
+|  | Uzbek_Latin | `0x0443` | Uzbekiska (Latin, Region: Uzbekistan) LanguageId värde |
+|  | Vietnamese | `0x042A` | Vietnamesiska (Region: Vietnam) LanguageId värde |
+|  | Welsh | `0x0452` | Walesiska (Region: Storbritannien) LanguageId värde |
+|  | Wolof | `0x0488` | Wolof (Region: Senegal) LanguageId värde |
+|  | Yakut | `0x0485` | Jakutiska (Region: Ryssland) LanguageId värde |
+|  | Yi | `0x0478` | Yi (Region: Kina) LanguageId värde |
+| Yoruba | `0x046A` | Yoruba (Region: Nigeria) LanguageId värde |

--- a/swedish/javascript-cpp/enumerations/ttfnametableplatformid/_index.md
+++ b/swedish/javascript-cpp/enumerations/ttfnametableplatformid/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Enum TtfNameTablePlatformId"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Aspose.Font.TtfNameTablePlatformId enum. Anger PlatformId"
+type: docs
+weight: 130
+url: /sv/javascript-cpp/enumerations/ttfnametableplatformid/
+---
+## TtfNameTablePlatformId enumeration
+
+Anger PlatformId.
+
+```cssharp
+ enum TtfNameTablePlatformId
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+|  | Unicode | `0` | Unicode |
+|  | Macintosh | `1` | Macintosh Script Manager-kod. |
+|  | ISO | `2` | Apple-spec: (reserverad; använd inte) MS-spec: ISO-kodning. Observera att plattforms-ID 2 (ISO) har avskrivits sedan OpenType Specification v1.3. Det var avsett att representera ISO/IEC 10646, i motsats till Unicode; båda standarderna har identiska teckenkodstilldelningar |
+|  | Microsoft | `3` | Microsoft-kodning. |

--- a/swedish/javascript-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
+++ b/swedish/javascript-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum TtfNameTableUnicodePlatformSpecificId"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Aspose.Font.TtfNameTableUnicodePlatformSpecificId enum. Anger UnicodePlatformSpecificId"
+type: docs
+weight: 133
+url: /sv/javascript-cpp/enumerations/ttfnametableunicodeplatformspecificid/
+---
+## TtfNameTableUnicodePlatformSpecificId enumeration
+
+Anger UnicodePlatformSpecificId.
+
+```csharp
+ enum TtfNameTableUnicodePlatformSpecificId
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+|  | Default | `0` | Standardsemantik (Unicode 1.0). |
+|  | Unicode1_1 | `1` | Unicode 1.1-semantik. |
+|  | ISO10646_1993 | `2` | ISO 10646 1993-semantik (föråldrad). |
+|  | Unicode2_0 | `3` | Unicode 2.0 eller senare semantik. Endast Unicode BMP. |
+|  | Unicode2_0_Full | `4Unicode 2.0 and onwards semantics (non-BMP characters allowed)` | Unicode fullständigt repertoar. |

--- a/swedish/javascript-cpp/glyph/_index.md
+++ b/swedish/javascript-cpp/glyph/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Glyph Font-funktioner"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Funktioner för att arbeta med Glyphs i Font-filer"
+type: docs
+url: /sv/javascript-cpp/glyph/
+---
+
+## Glyph Font functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposeFontGetGlyphCount](./asposefontgetglyphcount/) | Hämta antalet glyfer i teckensnittet. |
+| [AsposeFontGetMetrics](./asposefontgetmetrics/) | Hämta mått för teckensnittet. |
+
+
+## Detailed Description
+
+Funktioner för att arbeta med Font-Glyphs.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/swedish/javascript-cpp/glyph/asposefontgetglyphcount/_index.md
+++ b/swedish/javascript-cpp/glyph/asposefontgetglyphcount/_index.md
@@ -1,0 +1,72 @@
+---
+title: "AsposeFontGetGlyphCount"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Hämta information (metadata) från en teckensnittsfil."
+type: docs
+url: /sv/javascript-cpp/glyph/asposefontgetglyphcount/
+---
+## AsposeFontGetGlyphCount function
+
+_Hämta teckenantal för teckensnitt._
+
+```js
+function AsposeFontGetGlyphCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfont för konvertering. |
+| fileName | string | Filnamn. |
+
+### Returvärde
+
+JSON‑objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel (\"\" inget fel) |
+|  | glyphCount | antal tecken |
+
+### Exempel
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    evt.data == "ready"
+      ? "loaded!"
+      : evt.data.json.errorCode == 0
+      ? "Glyph count: " + evt.data.json.glyphCount
+      : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFontGetGlyphCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get glyph count of font - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontGetGlyphCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+
+**Simple example**:
+```js
+  var ffileFontGetGlyphCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontGetGlyphCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Glyph count: " + json.glyphCount;
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/glyph/asposefontgetmetrics/_index.md
+++ b/swedish/javascript-cpp/glyph/asposefontgetmetrics/_index.md
@@ -1,0 +1,79 @@
+---
+title: "FontGetFontMetrics"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Hämta information (metadata) från en teckensnittsfil."
+type: docs
+url: /sv/javascript-cpp/glyph/asposefontgetmetrics/
+---
+## FontGetFontMetrics function
+
+_Hämta teckenantal för teckensnitt._
+
+```js
+function FontGetFontMetrics(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfont för konvertering. |
+| fileName | string | Filnamn. |
+
+### Returvärde
+
+JSON‑objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel (\"\" inget fel) |
+|  | mått | JSON‑objekt |
+| * höjd |
+| * nedstigning |
+| * radavstånd |
+| * maximal framstegsbredd |
+| * minsta vänstra sidobäring |
+| * minsta högra sidobäring |
+| * maximal x-utsträckning |
+
+### Exempel
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    evt.data == "ready"
+      ? "loaded!"
+      : evt.data.json.errorCode == 0
+      ? JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')
+      : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFontGetMetrics = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get metrics of font - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontGetMetrics', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+
+**Simple example**:
+```js
+  var ffileFontGetGlyphCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = FontGetFontMetrics(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Glyph count: " + json.glyphCount;
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/metadata/_index.md
+++ b/swedish/javascript-cpp/metadata/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Metadata Font-funktioner"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Funktioner för att arbeta med Metadata Font-filer"
+type: docs
+url: /sv/javascript-cpp/metadata/
+---
+
+## Metadata Font functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposeFontGetInfo](./asposefontgetinfo/) | Hämta information (metadata) från en teckensnittsfil. |
+| [AsposeFontSetInfo](./asposefontsetinfo/) | Sätt information (metadata) i en Font-fil. |
+
+## Detailed Description
+
+Funktioner för att arbeta med Metadata Font-filer.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/swedish/javascript-cpp/metadata/asposefontgetinfo/_index.md
+++ b/swedish/javascript-cpp/metadata/asposefontgetinfo/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeFontGetInfo"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Hämta information (metadata) från en teckensnittsfil."
+type: docs
+url: /sv/javascript-cpp/metadata/asposefontgetinfo/
+---
+## AsposeFontGetInfo function
+
+_Hämta information (metadata) från en Font-fil._
+
+```js
+function AsposeFontGetInfo(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfont för konvertering. |
+| fileName | string | Filnamn. |
+
+### Returvärde
+
+JSON‑objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel (\"\" inget fel) |
+|  | poster | Array av JSON‑objekt : |
+|  | * NameId | namnidentifierare |
+|  | * PlatformId | plattformidentifierare |
+|  | * PlatformSpecificId | plattformsspecifik identifierare |
+|  | * LanguageId | språkidentifierare |
+|  | * Info | innehåll i namnpost |
+
+### Exempel
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    evt.data == "ready"
+      ? "loaded!"
+      : evt.data.json.errorCode == 0
+      ? "Name records count: " + evt.data.json.records.length + 
+                                            evt.data.json.records.reduce((ret, a) => ret +
+                                            "\nNameId : " + a.NameId
+                                          + "; PlatformId : " + a.PlatformId
+                                          + "; PlatformSpecificId : " + a.PlatformSpecificId
+                                          + "; LanguageId : " + a.LanguageId
+                                          + "; Info : " + a.Info,"")
+      : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileFontGetInfo = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Get info (metadata) from a Font-file - Ask Web Worker*/
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontGetInfo', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileFontGetInfo = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeFontGetInfo(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Name records count: " + json.records.length;
+        for (let recordIndex = 0; recordIndex < json.records.length; recordIndex++) 
+			document.getElementById('output').textContent += " " + "\n"
+                                                         + "NameId : " + json.records[recordIndex].NameId
+                                                         + ";  PlatformId : " + json.records[recordIndex].PlatformId
+                                                         + ";  PlatformSpecificId : " + json.records[recordIndex].PlatformSpecificId
+                                                         + ";  LanguageId : " + json.records[recordIndex].LanguageId
+                                                         + ";  Info : " + json.records[recordIndex].Info;
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```

--- a/swedish/javascript-cpp/metadata/asposefontsetinfo/_index.md
+++ b/swedish/javascript-cpp/metadata/asposefontsetinfo/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeFontSetInfo"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Sätt information (metadata) i en Font-fil."
+type: docs
+url: /sv/javascript-cpp/metadata/asposefontsetinfo/
+---
+## AsposeFontSetInfo function
+
+_Sätt information (metadata) i en Font-fil._
+
+```js
+function AsposeFontSetInfo(
+    fileBlob,
+    fileName,
+    nameId, 
+    platformId, 
+    platformSpecificId, 
+    languageId, 
+    text
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfont för konvertering. |
+| fileName | string | Filnamn. |
+| nameId | TtfNameTableNameId | Namnidentifierare, logisk strängkategori, specificerad av [`NameId`](../../enumerations/ttfnametablenameid/) enumeration |
+|  | platformId | TtfNameTablePlatformId | Plattformsidentifierare |
+| platformSpecificId | int | Plattformspecifik kodningsidentifierare. Använd värde från någon av dessa enumerationer – [`UnicodePlatformSpecificId`](../../enumerations/ttfnametableunicodeplatformspecificid/), [`MacPlatformSpecificId`](../../ttfnametable.macplatformspecificid/), [`MSPlatformSpecificId`](../../enumerations/ttfnametablemsplatformspecificid/). Vilken enumeration som ska användas definieras av kontexten (*platformId*-parameter). |
+| languageId | int | Språkidentifierare. Använd värde från [`MSLanguageId`](../../enumerations/ttfnametablemslanguageid/) eller [`MacLanguageId`](../../enumerations/ttfnametablemaclanguageid/) enumerationer beroende på kontext, definierad av *platformId*-parameter. |
+|  | text | string | Faktisk strängdata |
+
+### Returvärde
+
+JSON‑objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel (\"\" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = (evt) => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = (evt) => document.getElementById("output").textContent =
+    (evt.data == 'ready') ? 'library loaded!' :
+    (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "font/ttf", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+ 
+ /*Event handler*/
+  const ffileFontSetInfo = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+          const nameId = 'Module.TtfNameTableNameId.' + document.getElementById("NameId").value;
+          //Value will be changed for PlatformId = PlatformId.Microsoft, PlatformSpecificId = MSPlatformSpecificId.Unicode_BMP_UCS2 (1) and languageID = 1033 (English_United_States = 0x0409)
+          const platformId = 'Module.TtfNameTablePlatformId.Microsoft';
+          const platformSpecificId = 'Module.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2';
+          const langID = 'Module.TtfNameTableMSLanguageId.English_United_States';
+          const text = document.getElementById("textValue").value;
+          transfer = [event.target.result];
+          params = [event.target.result, e.target.files[0].name, nameId, platformId, platformSpecificId, langID, text];
+      AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontSetInfo', "params": params }, transfer);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var fFontSetInfo = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+
+      const nameId = new Function("return Module.TtfNameTableNameId." + document.getElementById("NameId").value)();
+      const platformId = Module.TtfNameTablePlatformId.Microsoft;
+      const platformSpecificId = Module.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+      const text = document.getElementById("textValue").value;
+      const langID = 1033;
+
+      const json = AsposeFontSetInfo(blob, file.name, nameId, platformId, platformSpecificId, langID, text);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult);
+        //DownloadFile(file.name);
+      }
+      else document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(file);
+  }
+```
+
+### Se även
+
+* enum [TtfNameTableNameId](../../enumerations/ttfnametablenameid/)
+* enum [TtfNameTablePlatformId](../../enumerations/ttfnametableplatformid/)
+* enum [TtfNameTableMacPlatformSpecificId](../../enumerations/ttfnametablemacplatformspecificid/)
+* enum [TtfNameTableMSPlatformSpecificId](../../enumerations/ttfnametablemsplatformspecificid/)
+* enum [TtfNameTableUnicodePlatformSpecificId](../../enumerations/ttfnametableunicodeplatformspecificid/)
+* enum [TtfNameTableMacLanguageId](../../enumerations/ttfnametablemaclanguageid/)
+* enum [TtfNameTableMSLanguageId](../../enumerations/ttfnametablemslanguageid/)

--- a/swedish/javascript-cpp/misc/_index.md
+++ b/swedish/javascript-cpp/misc/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Övriga funktioner"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Sekundära funktioner för att arbeta med Font-filer."
+type: docs
+url: /sv/javascript-cpp/misc/
+---
+## Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposeFontAbout](./asposeFontabout/) | Hämta information om produkten. |
+| [DownloadFile](./downloadfile/) | Skapa en länk i HTML för att ladda ner filen. |
+| [DownloadFileAuto](./downloadfileauto/) | Skapa en länk i HTML för att ladda ner filen och starta nedladdning efter 2 sekunder. |
+
+## Detailed Description
+
+Sekundära funktioner för att arbeta med Font-filer.
+
+```js
+/* Web Worker*/
+const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Font for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposeFontforJS.js"></script>
+```

--- a/swedish/javascript-cpp/misc/asposefontabout/_index.md
+++ b/swedish/javascript-cpp/misc/asposefontabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeFontAbout"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Hämta information om produkten."
+type: docs
+url: /sv/javascript-cpp/misc/asposefontabout/
+---
+
+## AsposeFontAbout function
+
+Hämta information om produkten.
+
+```js
+function AsposeFontAbout()
+```
+
+### Returvärde
+
+JSON‑objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+| errorCode | kodfel (0 inget fel) |
+| errorText | textfel (\"\" inget fel) |
+| produkt | Produktnamn |
+| version | Produktversion |
+| islicensed | Produkten är licensierad |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposeFontWebWorker = new Worker("AsposeFontforJS.js");
+  AsposeFontWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposeFontWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposeFontAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposeFontWebWorker.postMessage({ "operation": 'AsposeFontAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposeFontAbout = function () {
+    /*Get info about Product*/
+    const json = AsposeFontAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/swedish/javascript-cpp/misc/downloadfile/_index.md
+++ b/swedish/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Skapa en länk i HTML för att ladda ner filen."
+type: docs
+url: /sv/javascript-cpp/misc/downloadfile/
+---
+
+_Skapa en länk i HTML för att ladda ner filen._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/swedish/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/swedish/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Font för JavaScript via C++"
+description: "Skapa en länk i HTML för att ladda ner filen och starta nedladdning efter 2 sekunder."
+type: docs
+url: /sv/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+Skapa en länk i HTML för att ladda ner filen och starta nedladdning efter 2 sekunder.
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### Parametrar
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### Anmärkningar
+
+Fungerar inte i Web Worker.


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Swedish** (`sv`) generated by RDA.

- Pages translated: 30/30
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `swedish/javascript-cpp`

🤖 Generated by RDA