### PR TITLE
[auto] Translate NODEJS-CPP API Reference to Chinese

### DIFF
--- a/chinese/nodejs-cpp/_index.md
+++ b/chinese/nodejs-cpp/_index.md
@@ -1,0 +1,54 @@
+---
+title: "Aspose.Font 用于 Node.js，通过 C++"
+description: "Aspose.Font 用于 Node.js，通过 C++"
+keywords:  "Node.js via C++, Node.js Font toolkit"
+tags: ['font-to-ttf', 'font-to-woff',  'font-to-woff2', 'font-to-svg', 'font-convert', 'font-tools']
+weight: 40
+url: /zh/nodejs-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.Font for Node.js via C++ allows developers manipulate them Font files on server side web solutions.
+>
+> CommonJS and ECMAScript modules are aviable for any JavaScript solutions. 
+
+
+## Convert functions
+
+| 函数 | 描述 |
+| -------- | ----------- |
+| [AsposeFontConvert](./convert/) | 将字体转换为 TrueType 字体。 |
+| [AsposeFontConvertToTTF](./convert/asposefontconverttottf/) | 将字体转换为 TTF 格式。 |
+| [AsposeFontConvertToWOFF](./convert/asposefontconverttowoff/) | 将字体转换为 WOFF 格式。 |
+| [AsposeFontConvertToWOFF2](./convert/asposefontconverttowoff2/) | 将字体转换为 WOFF2 格式。 |
+| [AsposeFontConvertToSVG](./convert/asposefontconverttosvg/) | 将字体转换为 SVG 格式。 |
+
+
+## Metadata Font functions
+
+| 函数 | 描述 |
+| -------- | ----------- |
+| [AsposeFontGetInfo](./metadata/asposefontgetinfo/) | 从字体文件获取信息（元数据）。 |
+| [AsposeFontSetInfo](./metadata/asposefontsetinfo/) | 在字体文件中设置信息（元数据）。 |
+
+
+## Miscellaneous
+
+| 名称 | 描述 |
+| -------------- | -------------- |
+| [AsposeFontAbout](./misc/asposefontabout/) | 获取关于产品的信息。 |
+
+## 枚举
+
+| 枚举 | 描述 |
+| ----------- | ----------- |
+| [FontSavingFormats](./enumerations/fontsavingformats/) | 指定字体类型。 |
+| [FontStyle](./enumerations/fontstyle/) | 指定字体样式。 |
+| [TtfNameTableNameId](./enumerations/ttfnametablenameid/) | 指定 NameId。 |
+| [TtfNameTablePlatformId](./enumerations/ttfnametableplatformid/) | 表示 PlatformId 枚举。 |
+| [TtfNameTableMacPlatformSpecificId](./enumerations/ttfnametablemacplatformspecificid/) | 表示 Macintosh 平台特定 ID 枚举。 |
+| [TtfNameTableMSPlatformSpecificId](./enumerations/ttfnametablemsplatformspecificid/) | 表示 Microsoft 平台特定 ID 枚举。 |
+| [TtfNameTableUnicodePlatformSpecificId](./enumerations/ttfnametableunicodeplatformspecificid/) | 表示 Unicode 平台特定 ID 枚举。 |
+| [TtfNameTableMacLanguageId](./enumerations/ttfnametablemaclanguageid/) | MacLanguageId 枚举。 |
+| [TtfNameTableMSLanguageId](./enumerations/ttfnametablemslanguageid/) | MSLanguageId 枚举。 |

--- a/chinese/nodejs-cpp/convert/_index.md
+++ b/chinese/nodejs-cpp/convert/_index.md
@@ -1,0 +1,22 @@
+---
+title: "字体转换函数"
+second_title: "Aspose.Font 用于 Node.js，通过 C++"
+description: "将字体转换为 TrueType 格式的函数。"
+type: docs
+url: /zh/nodejs-cpp/convert/
+---
+
+## Convert functions
+
+| 函数 | 描述 |
+| -------- | ----------- |
+| [AsposeFontConvert](./asposefontconvert) | 将字体转换为受支持的格式。 |
+| [AsposeFontConvertToTTF](./asposefontconverttottf/) | 将字体转换为 TTF 格式。 |
+| [AsposeFontConvertToWOFF](./asposefontconverttowoff/) | 将字体转换为 WOFF 格式。 |
+| [AsposeFontConvertToWOFF2](./asposefontconverttowoff2/) | 将字体转换为 WOFF2 格式。 |
+| [AsposeFontConvertToSVG](./asposefontconverttosvg/) | 将字体转换为 SVG 格式。 |
+
+## Detailed Description
+
+将字体转换为 TrueType 格式的函数。
+

--- a/chinese/nodejs-cpp/convert/asposefontconvert/_index.md
+++ b/chinese/nodejs-cpp/convert/asposefontconvert/_index.md
@@ -1,0 +1,73 @@
+---
+title: "AsposeFontConvert"
+second_title: "Aspose.Font 用于 Node.js，通过 C++"
+description: "将字体转换为其他格式"
+type: docs
+weight: 10
+url: /zh/nodejs-cpp/convert/asposefontconvert/
+---
+## AsposeFontConvert function
+
+将字体转换为其他格式。
+
+```js
+function AsposeFontConvert(
+    fileName,
+    fontType,
+    fontSavingFormat
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileName | string | 文件名。 |
+| fontType | FontType | 要转换的字体类型。 |
+| fontSavingFormat | FontSavingFormats | 要转换成的字体格式。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 代码错误 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
+|  | fileNameResult | 结果文件名 |
+
+### 备注
+
+注意：现在仅支持 TTF 字体类型。
+
+### 示例
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvert to convert font
+    const json = AsposeFontModule.AsposeFontConvert(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvert(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### 另请参见
+
+* enum [FontType](../../enumerations/fonttype/)
+* enum [FontSavingFormats](../../enumerations/fontsavingformats/)

--- a/chinese/nodejs-cpp/convert/asposefontconverttottf/_index.md
+++ b/chinese/nodejs-cpp/convert/asposefontconverttottf/_index.md
@@ -1,0 +1,60 @@
+---
+title: "AsposeFontConvertToTTF"
+second_title: "Aspose.Font 用于 Node.js，通过 C++"
+description: "将字体转换为 ttf 格式"
+type: docs
+weight: 10
+url: /zh/nodejs-cpp/convert/asposefontconverttottf/
+---
+## AsposeFontConvertToTTF function
+
+将字体转换为 TTF 格式。
+
+```js
+function AsposeFontConvertToTTF(
+    fileName,
+    fontType
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileName | string | 文件名。 |
+| fontType | FontType | 要转换的字体类型。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 代码错误 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+const font_file = "./fonts/Lora-Regular.ttf";
+console.log('Aspose.Font for Node.js via C++ example');
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvert to convert font
+    const json = AsposeFontModule.AsposeFontConvertToTTF(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript/ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+const font_file ="./fonts/arial.ttf";
+const AsposeFontModule = await AsposeFont();
+console.log('Aspose.Font for Node.js via C++ example');
+const json = AsposeFontModule.AsposeFontConvertToTTF(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### 另请参见
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/chinese/nodejs-cpp/convert/asposefontconverttowoff/_index.md
+++ b/chinese/nodejs-cpp/convert/asposefontconverttowoff/_index.md
@@ -1,0 +1,67 @@
+---
+title: "AsposeFontConvertToWOFF"
+second_title: "Aspose.Font 用于 Node.js，通过 C++"
+description: "将字体转换为 woff 格式"
+type: docs
+weight: 10
+url: /zh/nodejs-cpp/convert/asposefontconverttowoff/
+---
+## AsposeFontConvertToWOFF function
+
+将字体转换为 WOFF 格式。
+
+```js
+function AsposeFontConvertToWOFF(
+    fileName,
+    fontType
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileName | string | 文件名。 |
+| fontType | FontType | 要转换的字体类型。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 代码错误 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvertToWOFF to convert font
+    const json = AsposeFontModule.AsposeFontConvertToWOFF(font_file,AsposeFontModule.FontType.TTF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvertToWOFF(font_file,AsposeFontModule.FontType.TTF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### 另请参见
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/chinese/nodejs-cpp/convert/asposefontconverttowoff2/_index.md
+++ b/chinese/nodejs-cpp/convert/asposefontconverttowoff2/_index.md
@@ -1,0 +1,67 @@
+---
+title: "AsposeFontConvertToWOFF2"
+second_title: "Aspose.Font 用于 Node.js，通过 C++"
+description: "将字体转换为 woff2 格式"
+type: docs
+weight: 10
+url: /zh/nodejs-cpp/convert/asposefontconverttowoff2/
+---
+## AsposeFontConvertToWOFF2 function
+
+将字体转换为 WOFF2 格式。
+
+```js
+function AsposeFontConvertToWOFF2(
+    fileName,
+    fontType
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileName | string | 文件名。 |
+| fontType | FontType | 要转换的字体类型。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 代码错误 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvertToWOFF2 to convert font
+    const json = AsposeFontModule.AsposeFontConvertToWOFF2(font_file,AsposeFontModule.FontType.TTF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvertToWOFF2(font_file,AsposeFontModule.FontType.TTF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### 另请参见
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/chinese/nodejs-cpp/convert/asposefontconverttowsvg/_index.md
+++ b/chinese/nodejs-cpp/convert/asposefontconverttowsvg/_index.md
@@ -1,0 +1,67 @@
+---
+title: "AsposeFontConvertToSVG"
+second_title: "Aspose.Font 用于 Node.js，通过 C++"
+description: "将字体转换为 svg 格式"
+type: docs
+weight: 10
+url: /zh/nodejs-cpp/convert/asposefontconverttosvg/
+---
+## AsposeFontConvertToSVG function
+
+将字体转换为 SVG 格式。
+
+```js
+function AsposeFontConvertToSVG(
+    fileName,
+    fontType
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileName | string | 文件名。 |
+| fontType | FontType | 要转换的字体类型。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 代码错误 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvertToSVG to convert font
+    const json = AsposeFontModule.AsposeFontConvertToSVG(font_file,AsposeFontModule.FontType.TTF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvertToSVG(font_file,AsposeFontModule.FontType.TTF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### 另请参见
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/chinese/nodejs-cpp/enumerations/_index.md
+++ b/chinese/nodejs-cpp/enumerations/_index.md
@@ -1,0 +1,42 @@
+---
+title: "枚举"
+second_title: "Aspose.Font 用于 Node.js，通过 C++"
+description: "将字体转换为 TrueType 格式的函数。"
+type: docs
+url: /zh/nodejs-cpp/enumerations/
+---
+
+## 枚举
+
+| 枚举 | 描述 |
+| ----------- | ----------- |
+| [FontSavingFormats](./fontsavingformats/) | 指定字体类型。 |
+| [FontType](./fonttype/) | 指定字体类型。 |
+| [TtfNameTableNameId](./ttfnametablenameid/) | 指定 NameId。 |
+| [TtfNameTablePlatformId](./ttfnametableplatformid/) | 表示 PlatformId 枚举。 |
+| [TtfNameTableMSPlatformSpecificId](./ttfnametableMSPlatformSpecificId/) | 表示 MSPlatformSpecificId 枚举。 |
+| [TtfNameTableMacPlatformSpecificId](./ttfnametableMacPlatformSpecificId/) | 表示 MacPlatformSpecificId 枚举。 |
+| [TtfNameTableUnicodePlatformSpecificId](./ttfnametableUnicodePlatformSpecificId/) | 表示 UnicodePlatformSpecificId 枚举。 |
+| [TtfNameTableMacLanguageId](./ttfnametablemaclanguageid/) | Macintosh 平台语言 ID 枚举。 |
+| [TtfNameTableMSLanguageId](./ttfnametablemslanguageid/) | Microsoft 平台语言 ID 枚举。 |
+
+### Example of using enumarations
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    //define parameters for AsposeFontSetInfo
+    const nameId = AsposeFontModule.TtfNameTableNameId.Description;
+    const platformId = AsposeFontModule.TtfNameTablePlatformId.Microsoft;
+    const platformSpecificId = AsposeFontModule.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+    const langID = Module.TtfNameTableMSLanguageId.English_United_States.value;
+    const text = "Updated description";
+    
+    const json = AsposeFontSetInfo(font_file, nameId, platformId, platformSpecificId, langID, text);
+    console.log("AsposeFontSetInfo => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/chinese/nodejs-cpp/enumerations/fontsavingformats/_index.md
+++ b/chinese/nodejs-cpp/enumerations/fontsavingformats/_index.md
@@ -1,0 +1,25 @@
+---
+title: "枚举 FontSavingFormats"
+second_title: "Aspose.Font for .NET API 参考"
+description: "Aspose.Font.FontSavingFormats 枚举。指定字体类型"
+type: docs
+weight: 110
+url: /zh/nodejs-cpp/enumerations/fontsavingformats/
+---
+## FontSavingFormats enumeration
+
+指定字体类型。
+
+```csharp
+public enum FontSavingFormats
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+| TTF | `0` | TTF（TrueType）字体格式 |
+| WOFF | `1` | WOFF（Web Open Font Format） |
+| WOFF2 | `2` | WOFF 文件格式 2.0 |
+| SVG | `3` | SVG（Scalable Vector Graphics）字体格式 |
+| OTF | `4` | OTF（OpenType）字体格式 |

--- a/chinese/nodejs-cpp/enumerations/fonttype/_index.md
+++ b/chinese/nodejs-cpp/enumerations/fonttype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "枚举 FontType"
+second_title: "Aspose.Font for .NET API 参考"
+description: "Aspose.Font.FontType 枚举。指定字体类型"
+type: docs
+weight: 100
+url: /zh/nodejs-cpp/enumerations/fonttype/
+---
+## FontType enumeration
+
+指定字体类型。
+
+```csharp
+public enum FontType
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+| TTF | `0` | TTF（TrueType）字体类型及相关 |
+| Type1 | `1` | Type1 字体类型 |
+| CFF | `2` | CFF（Compact font format）字体类型 |
+| OTF | `3` | OpenType 字体。OpenType 字体格式是 TrueType 字体格式的扩展，增加了对 PostScript 字体数据的支持。 |
+

--- a/chinese/nodejs-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
+++ b/chinese/nodejs-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
@@ -1,0 +1,53 @@
+---
+title: "枚举 TtfNameTableMacPlatformSpecificId"
+second_title: "Aspose.Font for .NET API 参考"
+description: "Aspose.Font.TtfNameTableMacPlatformSpecificId 枚举。指定 MacPlatformSpecificId"
+type: docs
+weight: 131
+url: /zh/nodejs-cpp/enumerations/ttfnametablemacplatformspecificid/
+---
+## TtfNameTableMacPlatformSpecificId enumeration
+
+指定 MacPlatformSpecificId。
+
+```csharp
+ enum TtfNameTableMacPlatformSpecificId
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+|  | Roman | `0` | 罗马平台特定值。 |
+|  | Japanese | `1` | 日语平台特定值。 |
+|  | Traditional_Chinese | `2` | 繁体中文平台特定值。 |
+|  | Korean | `3` | 韩语平台特定值。 |
+|  | Arabic | `4` | 阿拉伯语平台特定值。 |
+|  | Hebrew | `5` | 希伯来语平台特定值。 |
+|  | Greek | `6` | 希腊语平台特定值。 |
+|  | Russian | `7` | 俄语平台特定值。 |
+|  | RSymbol | `8` | RSymbol 平台特定值。 |
+|  | Devanagari | `9` | 天城文平台特定值。 |
+|  | Gurmukhi | `10` | 古鲁穆克文平台特定值。 |
+|  | Gujarati | `11` | 古吉拉特文平台特定值。 |
+|  | Oriya | `12` | 奥里亚文平台特定值。 |
+|  | Bengali | `13` | 孟加拉文平台特定值。 |
+|  | Tamil | `14` | 泰米尔文平台特定值。 |
+|  | Telugu | `15` | 泰卢固语平台特定值。 |
+|  | Kannada | `16` | 卡纳达语平台特定值。 |
+|  | Malayalam | `17` | 马拉雅拉姆语平台特定值。 |
+|  | Sinhalese | `18` | 僧伽罗语平台特定值。 |
+|  | Burmese | `19` | 缅甸语平台特定值。 |
+|  | Khmer | `20` | 高棉语平台特定值。 |
+|  | Thai | `21` | 泰语平台特定值。 |
+|  | Laotian | `22` | 老挝语平台特定值。 |
+|  | Georgian | `23` | 格鲁吉亚语平台特定值。 |
+|  | Armenian | `24` | 亚美尼亚语平台特定值。 |
+|  | Simplified_Chinese | `25` | 简体中文平台特定值。 |
+|  | Tibetan | `26` | 藏语平台特定值。 |
+|  | Mongolian | `27` | 蒙古语平台特定值。 |
+|  | Geez | `28` | 吉兹语平台特定值。 |
+|  | Slavic | `29` | 斯拉夫语平台特定值。 |
+|  | Vietnamese | `30` | 越南语平台特定值。 |
+|  | Sindhi | `31` | 信德语平台特定值。 |
+|  | Uninterpreted | `32` | 未解释的平台特定值。 |

--- a/chinese/nodejs-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
+++ b/chinese/nodejs-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
@@ -1,0 +1,32 @@
+---
+title: "枚举 TtfNameTableMSPlatformSpecificId"
+second_title: "Aspose.Font for .NET API 参考"
+description: "Aspose.Font.TtfNameTableMSPlatformSpecificId 枚举。指定 MSPlatformSpecificId"
+type: docs
+weight: 132
+url: /zh/nodejs-cpp/enumerations/ttfnametablemsplatformspecificid/
+---
+## TtfNameTableMSPlatformSpecificId enumeration
+
+指定 MSPlatformSpecificId。
+
+```csharp
+ enum TtfNameTableMSPlatformSpecificId
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+|  | Symbol | `0` | 符号 MS PlatformSpecificId。 |
+|  | Unicode_BMP_UCS2 | `1` | Unicode BMP (UCS2) MS PlatformSpecificId。 |
+|  | ShiftJIS | `2` | ShiftJIS MS PlatformSpecificId。 |
+|  | PRC | `3` | PRC MS PlatformSpecificId。 |
+|  | Big5 | `4` | Big5 MS PlatformSpecificId。 |
+|  | Wansung | `5` | Wansung MS PlatformSpecificId。 |
+|  | Johab | `6` | Johab MS PlatformSpecificId。 |
+|  | Reserved1 | `7` | Reserved1 MS PlatformSpecificId。 |
+|  | Reserved2 | `8` | Reserved2 MS PlatformSpecificId。 |
+|  | Reserved3 | `9` | Reserved3 MS PlatformSpecificId。 |
+|  | Unicode_UCS4 | `10` | Unicode UCS4 MS PlatformSpecificId。 |
+

--- a/chinese/nodejs-cpp/enumerations/ttfnametablenameid/_index.md
+++ b/chinese/nodejs-cpp/enumerations/ttfnametablenameid/_index.md
@@ -1,0 +1,46 @@
+---
+title: "枚举 TtfNameTableNameId"
+second_title: "Aspose.Font for .NET API 参考"
+description: "Aspose.Font.TtfNameTableNameId 枚举。指定 NameId"
+type: docs
+weight: 120
+url: /zh/nodejs-cpp/enumerations/ttfnametablenameid/
+---
+## TtfNameTableNameId enumeration
+
+指定 NameId。
+
+```csharp
+ enum TtfNameTableNameId
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+|  | CopyrightNotice | `0` | 版权声明。 |
+|  | FontFamily | `1` | 字体族。此字符串是用户在 Macintosh 平台上看到的字体族名称。 |
+|  | FontSubfamily | `2` | 字体子族。此字符串是用户在 Macintosh 平台上看到的字体族。 |
+|  | UniqueFontId | `3` | 唯一子族标识（Apple 规范）。3 唯一字体标识符（MS 规范）。 |
+|  | FullName | `4` | 字体的完整名称。 |
+|  | Version | `5` | 名称表的版本。 |
+|  | PostScriptName | `6` | 字体的 PostScript 名称。注意：一个字体只能有一个 PostScript 名称，并且该名称必须是 ASCII。 |
+|  | TrademarkNotice | `7` | 商标声明。 |
+|  | ManufacturerName | `8` | 制造商名称。 |
+|  | DesignerName | `9` | 设计师；字体设计者的名称。 |
+|  | Description | `10` | 描述；字体的描述。可以包含修订信息、使用建议、历史、特性等。 |
+|  | UrlVendor | `11` | 字体供应商的 URL（带协议，例如 http://、ftp://）。如果 URL 中嵌入唯一序列号，可用于注册该字体。 |
+|  | UrlDesigner | `12` | 字体设计师的 URL（带协议，例如 http://、ftp://） |
+|  | LicenseDescription | `13` | 许可证描述；说明字体的合法使用方式或不同的授权使用示例场景。此字段应使用通俗语言编写，而非法律术语。 |
+|  | LicenseInfoUrl | `14` | 许可证信息 URL，可在此获取更多许可证信息。 |
+|  | PreferredFamily | `16` | `15` 保留 `16` 首选族（仅限 Windows）；在 Windows 中，族名称显示在字体菜单中；子族名称显示为样式名称。出于历史原因，字体族最多包含四种样式，但字体设计师可以将超过四种字体归为同一族。首选族和首选子族 ID 允许设计师包含首选的族/子族分组。仅当这些 ID 与 ID 1 和 2 不同时时才出现。 |
+|  | PreferredSubfamily | `17` | 首选子族（仅限 Windows）；在 Windows 中，族名称显示在字体菜单中；子族名称显示为样式名称。出于历史原因，字体族最多包含四种样式，但字体设计师可以将超过四种字体归为同一族。首选族和首选子族 ID 允许设计师包含首选的族/子族分组。仅当这些 ID 与 ID 1 和 2 不同时时才出现。 |
+|  | CompatibleFull | `18` | 兼容全名（仅限 Macintosh）；在 Macintosh 上，菜单名称使用字体资源构建。通常与完整名称匹配。如果希望字体名称与完整名称不同，可以在 ID 18 中插入兼容全名。该名称不被 macOS 本身使用，但可能被应用程序开发者使用（例如 Adobe）。 |
+|  | SampleText | `19` | 示例文本。这可以是字体名称，或设计师认为最能展示字体外观的任何其他文本。 |
+|  | PostScriptCID | `20` | 它在字体中的存在表示 nameID 6 包含一个 PostScript 字体名称，旨在与 "composefont" 调用一起使用，以在 PostScript 解释器中调用该字体 |
+|  | WwsFamilyName | `21` | 用于在 ID 16 和 17 的条目不符合 WWS 模型时提供符合 WWS 标准的族名称。 |
+|  | WwsSubfamilyName | `22` | 与 ID 21 结合使用时，此 ID 在 ID 16 和 17 的条目不符合 WWS 模型时提供符合 WWS 标准的子族名称（仅反映粗细、宽度和倾斜属性）。 |
+|  | LightBackground | `23` | 如果此 ID 用于 CPAL 表的调色板标签数组，则指定 CPAL 表中对应的颜色调色板适用于在浅色背景（如白色）上显示字体时使用。 |
+|  | DarkBackground | `24` | 如果此 ID 用于 CPAL 表的调色板标签数组，则指定 CPAL 表中对应的颜色调色板适用于在深色背景（如黑色）上显示字体时使用。 |
+|  | VariationsPostScriptNamePrefix | `25` | 如果出现在可变字体中，它可以用作变体字体算法中 PostScript 名称生成的族前缀。 |
+

--- a/chinese/nodejs-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
+++ b/chinese/nodejs-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
@@ -1,0 +1,138 @@
+---
+title: "枚举 TtfNameTableMacLanguageId"
+second_title: "Aspose.Font for .NET API 参考"
+description: "Aspose.Font.TtfNameTableMacLanguageId 枚举。指定 MacLanguageId"
+type: docs
+weight: 140
+url: /zh/nodejs-cpp/enumerations/ttfnametablemaclanguageid/
+---
+## TtfNameTableMacLanguageId enumeration
+
+表示 MacLanguageId 枚举。
+
+```csharp
+ enum TtfNameTableMacLanguageId
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+|  | English | `0` | 英文 LanguageId 值 |
+|  | French | `1` | 法文 LanguageId 值 |
+|  | German | `2` | 德文 LanguageId 值 |
+|  | Italian | `3` | 意大利文 LanguageId 值 |
+|  | Dutch | `4` | 荷兰文 LanguageId 值 |
+|  | Swedish | `5` | 瑞典文 LanguageId 值 |
+|  | Spanish | `6` | 西班牙文 LanguageId 值 |
+|  | Danish | `7` | 丹麦文 LanguageId 值 |
+|  | Portuguese | `8` | 葡萄牙文 LanguageId 值 |
+|  | Norwegian | `9` | 挪威文 LanguageId 值 |
+|  | Hebrew | `10` | 希伯来语 LanguageId 值 |
+|  | Japanese | `11` | 日语 LanguageId 值 |
+|  | Arabic | `12` | 阿拉伯语 LanguageId 值 |
+|  | Finnish | `13` | 芬兰语 LanguageId 值 |
+|  | Greek | `14` | 希腊语 LanguageId 值 |
+|  | Icelandic | `15` | 冰岛语 LanguageId 值 |
+|  | Maltese | `16` | 马耳他语 LanguageId 值 |
+|  | Turkish | `17` | 土耳其语 LanguageId 值 |
+|  | Croatian | `18` | 克罗地亚语 LanguageId 值 |
+|  | Chinese_Traditional | `19` | 中文（繁体） LanguageId 值 |
+|  | Urdu | `20` | 乌尔都语 LanguageId 值 |
+|  | Hindi | `21` | 印地语 LanguageId 值 |
+|  | Thai | `22` | 泰语 LanguageId 值 |
+|  | Korean | `23` | 韩语 LanguageId 值 |
+|  | Lithuanian | `24` | 立陶宛语 LanguageId 值 |
+|  | Polish | `25` | 波兰语 LanguageId 值 |
+|  | Hungarian | `26` | 匈牙利语 LanguageId 值 |
+|  | Estonian | `27` | 爱沙尼亚语 LanguageId 值 |
+|  | Latvian | `28` | 拉脱维亚语 LanguageId 值 |
+|  | Sami | `29` | 萨米语 LanguageId 值 |
+|  | Faroese | `30` | 法罗语 LanguageId 值 |
+|  | Farsi_Persian | `31` | 波斯语/波斯语 LanguageId 值 |
+|  | Russian | `32` | 俄语 LanguageId 值 |
+|  | Chinese_Simplified | `33` | 中文（简体） LanguageId 值 |
+|  | Flemish | `34` | 弗拉芒语 LanguageId 值 |
+|  | Irish_Gaelic | `35` | 爱尔兰盖尔语 LanguageId value |
+|  | Albanian | `36` | 阿尔巴尼亚语 LanguageId value |
+|  | Romanian | `37` | 罗马尼亚语 LanguageId value |
+|  | Czech | `38` | 捷克语 LanguageId value |
+|  | Slovak | `39` | 斯洛伐克语 LanguageId value |
+|  | Slovenian | `40` | 斯洛文尼亚语 LanguageId value |
+|  | Yiddish | `41` | 意第绪语 LanguageId value |
+|  | Serbian | `42` | 塞尔维亚语 LanguageId value |
+|  | Macedonian | `43` | 马其顿语 LanguageId value |
+|  | Bulgarian | `44` | 保加利亚语 LanguageId value |
+|  | Ukrainian | `45` | 乌克兰语 LanguageId value |
+|  | Byelorussian | `46` | 白俄罗斯语 LanguageId value |
+|  | Uzbek | `47` | 乌兹别克语 LanguageId value |
+|  | Kazakh | `48` | 哈萨克语 LanguageId value |
+|  | Azerbaijani_Cyrillic | `49` | 阿塞拜疆语（西里尔文） LanguageId value |
+|  | Azerbaijani_Arabic | `50` | 阿塞拜疆语（阿拉伯文） LanguageId value |
+|  | Armenian | `51` | 亚美尼亚语 LanguageId value |
+|  | Georgian | `52` | 格鲁吉亚语 LanguageId value |
+|  | Moldavian | `53` | 摩尔多瓦语 LanguageId value |
+|  | Kirghiz | `54` | 吉尔吉斯语 LanguageId value |
+|  | Tajiki | `55` | 塔吉克语 LanguageId value |
+|  | Turkmen | `56` | 土库曼语 LanguageId value |
+|  | Mongolian | `57` | 蒙古语（蒙古文） LanguageId value |
+|  | Mongolian_Cyrillic | `58` | 蒙古语（西里尔文） LanguageId value |
+|  | Pashto | `59` | 普什图语 LanguageId value |
+|  | Kurdish | `60` | 普什图语 LanguageId value |
+|  | Kashmiri | `61` | 克什米尔 LanguageId 值 |
+|  | Sindhi | `62` | 信德语 LanguageId 值 |
+|  | Tibetan | `63` | 藏语 LanguageId 值 |
+|  | Nepali | `64` | 尼泊尔语 LanguageId 值 |
+|  | Sanskrit | `65` | 梵语 LanguageId 值 |
+|  | Marathi | `66` | 马拉地语 LanguageId 值 |
+|  | Bengali | `67` | 孟加拉语 LanguageId 值 |
+|  | Assamese | `68` | 阿萨姆语 LanguageId 值 |
+|  | Gujarati | `69` | 古吉拉特语 LanguageId 值 |
+|  | Punjabi | `70` | 旁遮普语 LanguageId 值 |
+|  | Oriya | `71` | 奥里亚语 LanguageId 值 |
+|  | Malayalam | `72` | 马拉雅拉姆语 LanguageId 值 |
+|  | Kannada | `73` | 卡纳达语 LanguageId 值 |
+|  | Tamil | `74` | 泰米尔语 LanguageId 值 |
+|  | Telugu | `75` | 泰卢固语 LanguageId 值 |
+|  | Sinhalese | `76` | 僧伽罗语 LanguageId 值 |
+|  | Burmese | `77` | 缅甸语 LanguageId 值 |
+|  | Khmer | `78` | 高棉语 LanguageId 值 |
+|  | Lao | `79` | 老挝语 LanguageId 值 |
+|  | Vietnamese | `80` | 越南语 LanguageId 值 |
+|  | Indonesian | `81` | 印度尼西亚语 LanguageId 值 |
+|  | Tagalog | `82` | 他加禄语 LanguageId 值 |
+|  | Malay_Roman | `83` | 马来语（罗马字） LanguageId 值 |
+|  | Malay_Arabic | `84` | 马来语（阿拉伯字） LanguageId 值 |
+|  | Amharic | `85` | 阿姆哈拉语 LanguageId 值 |
+|  | Tigrinya | `86` | 提格里尼亚语 LanguageId 值 |
+|  | Galla | `87` | 加拉语 LanguageId 值 |
+|  | Somali | `88` | 索马里语 LanguageId 值 |
+|  | Swahili | `89` | 斯瓦希里语 LanguageId 值 |
+|  | Kinyarwanda_Ruanda | `90` | 基尼亚卢旺达语/卢旺达语 LanguageId 值 |
+|  | Rundi | `91` | 隆迪语 LanguageId 值 |
+|  | Nyanja_Chewa | `92` | 尼扬贾语/切瓦语 LanguageId 值 |
+|  | Malagasy | `93` | 马尔加什语 LanguageId 值 |
+|  | Esperanto | `94` | 世界语 LanguageId 值 |
+|  | Welsh | `128` | 威尔士语 LanguageId 值 |
+|  | Basque | `129` | 巴斯克语 LanguageId 值 |
+|  | Catalan | `130` | 加泰罗尼亚语 LanguageId 值 |
+|  | Latin | `131` | 拉丁语 LanguageId 值 |
+|  | Quechua | `132` | 克丘亚语 LanguageId 值 |
+|  | Guarani | `133` | 瓜拉尼语 LanguageId 值 |
+|  | Aymara | `134` | 艾马拉语 LanguageId 值 |
+|  | Tatar | `135` | 塔塔尔语 LanguageId 值 |
+|  | Uighur | `136` | 维吾尔语 LanguageId 值 |
+|  | Dzongkha | `137` | 宗喀语 LanguageId 值 |
+|  | Javanese | `138` | 爪哇语（罗马字） LanguageId 值 |
+|  | Sundanese | `139` | 巽他语（罗马字） LanguageId 值 |
+|  | Galician | `140` | 加利西亚语 LanguageId 值 |
+|  | Afrikaans | `141` | 阿非利卡语 LanguageId 值 |
+|  | Breton | `142` | 布列塔尼语 LanguageId 值 |
+|  | Inuktitut | `143` | 因纽特语 LanguageId 值 |
+|  | Scottish_Gaelic | `144` | 苏格兰盖尔语 LanguageId 值 |
+|  | Manx_Gaelic | `145` | 曼岛盖尔语 LanguageId 值 |
+|  | Irish_Gaelic_WDA | `146` | 爱尔兰盖尔语（带上点） LanguageId 值 |
+|  | Tongan | `147` | 汤加语 LanguageId 值 |
+|  | Greek_Polytonic | `148` | 希腊语（多音调） LanguageId 值 |
+|  | Greenlandic | `149` | 格陵兰语 LanguageId 值 |
+|  | Azerbaijani_Roman | `150` | 阿塞拜疆语（罗马字） LanguageId 值 |

--- a/chinese/nodejs-cpp/enumerations/ttfnametablenmslanguageid/_index.md
+++ b/chinese/nodejs-cpp/enumerations/ttfnametablenmslanguageid/_index.md
@@ -1,0 +1,225 @@
+---
+title: "枚举 TtfNameTableMSLanguageId"
+second_title: "Aspose.Font for .NET API 参考"
+description: "Aspose.Font.TtfNameTableMSLanguageId 枚举。指定 MSLanguageId"
+type: docs
+weight: 150
+url: /zh/nodejs-cpp/enumerations/ttfnametablemslanguageid/
+---
+## TtfNameTableMSLanguageId enumeration
+
+表示 MSLanguageId 枚举。
+
+```csharp
+ enum TtfNameTableMSLanguageId
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+|  | Afrikaans | `0x0436` | 南非荷兰语（地区：南非，SA）LanguageId 值 |
+|  | Albanian | `0x041c` | 阿尔巴尼亚语（地区：阿尔巴尼亚，SQI）LanguageId 值 |
+|  | Alsatian | `0x0484` | 阿尔萨斯语（地区：法国）LanguageId 值 |
+|  | Amharic | `0x045E` | 阿姆哈拉语（地区：埃塞俄比亚）LanguageId 值 |
+|  | Arabic_Algeria | `0x1401` | 阿拉伯语（地区：阿尔及利亚）LanguageId 值 |
+|  | Arabic_Bahrain | `0x3C01` | 阿拉伯语（地区：巴林）LanguageId 值 |
+|  | Arabic_Egypt | `0x0C01` | 阿拉伯语（地区：埃及）LanguageId 值 |
+|  | Arabic_Iraq | `0x0801` | 阿拉伯语（地区：伊拉克）LanguageId 值 |
+|  | Arabic_Jordan | `0x2C01` | 阿拉伯语（地区：约旦）LanguageId 值 |
+|  | Arabic_Kuwait | `0x3401` | 阿拉伯语（地区：科威特）LanguageId 值 |
+|  | Arabic_Lebanon | `0x3001` | 阿拉伯语（地区：黎巴嫩）LanguageId 值 |
+|  | Arabic_Libya | `0x1001` | 阿拉伯语（地区：利比亚）LanguageId 值 |
+|  | Arabic_Morocco | `0x1801` | 阿拉伯语（地区：摩洛哥）LanguageId 值 |
+|  | Arabic_Oman | `0x2001` | 阿拉伯语（地区：阿曼）LanguageId 值 |
+|  | Arabic_Qatar | `0x4001` | 阿拉伯语（地区：卡塔尔）LanguageId 值 |
+|  | Arabic_Saudi_Arabia | `0x0401` | 阿拉伯语（地区：沙特阿拉伯）LanguageId 值 |
+|  | Arabic_Syria | `0x2801` | 阿拉伯语（地区：叙利亚）LanguageId 值 |
+|  | Arabic_Tunisia | `0x1C01` | 阿拉伯语（地区：突尼斯）LanguageId 值 |
+|  | Arabic_U_A_E | `0x3801` | 阿拉伯语（地区：阿联酋）LanguageId 值 |
+|  | Arabic_Yemen | `0x2401` | 阿拉伯语（地区：也门）LanguageId 值 |
+|  | Armenian | `0x042B` | 亚美尼亚语（地区：亚美尼亚）LanguageId 值 |
+|  | Assamese | `0x044D` | 阿萨姆语（地区：印度）LanguageId 值 |
+|  | Azeri_Cyrillic | `0x082C` | 阿塞拜疆语（西里尔文，地区：阿塞拜疆）LanguageId 值 |
+|  | Azeri_Latin | `0x042C` | 阿塞拜疆语（拉丁文，地区：阿塞拜疆）LanguageId 值 |
+|  | Bashkir | `0x046D` | 巴什基尔语（地区：俄罗斯）LanguageId 值 |
+|  | Basque | `0x042D` | 巴斯克语（地区：巴斯克，EUQ）LanguageId 值 |
+|  | Belarusian | `0x0423` | 白俄罗斯语（地区：白俄罗斯，BEL）LanguageId 值 |
+|  | Bengali_Bangladesh | `0x0845` | 孟加拉语（地区：孟加拉国）LanguageId 值 |
+|  | Bengali_India | `0x0445` | 孟加拉语（地区：印度）LanguageId 值 |
+|  | Bosnian_Cyrillic | `0x201A` | 波斯尼亚语（西里尔文，地区：波斯尼亚和黑塞哥维那）LanguageId 值 |
+|  | Bosnian_Latin | `0x141A` | 波斯尼亚语（拉丁文，地区：波斯尼亚和黑塞哥维那）LanguageId 值 |
+|  | Breton | `0x047E` | 布列塔尼语（地区：法国）LanguageId 值 |
+|  | Bulgarian | `0x0402` | 保加利亚语（地区：保加利亚，BGR）LanguageId 值 |
+|  | Catalan | `0x0403` | 加泰罗尼亚语（地区：加泰罗尼亚，CAT）LanguageId 值 |
+|  | Chinese_Hong_Kong | `0x0C04` | 中文（地区：香港特别行政区）LanguageId 值 |
+|  | Chinese_Macao | `0x1404` | 中文（地区：澳门特别行政区）LanguageId 值 |
+|  | Chinese_PRC | `0x0804` | 中文（地区：中华人民共和国）LanguageId 值 |
+|  | Chinese_Singapore | `0x1004` | 中文（地区：新加坡）LanguageId 值 |
+|  | Chinese_Taiwan | `0x0404` | 中文（地区：台湾）LanguageId 值 |
+|  | Corsican | `0x0483` | 科西嘉语（地区：法国）LanguageId 值 |
+|  | Croatian | `0x041A` | 克罗地亚语（地区：克罗地亚，SHL）LanguageId 值 |
+|  | Croatian_Latin | `0x101A` | 克罗地亚语（拉丁文，地区：波斯尼亚和黑塞哥维那）LanguageId 值 |
+|  | Czech | `0x0405` | 捷克语（地区：捷克共和国，CSY）LanguageId 值 |
+|  | Danish | `0x0406` | 丹麦语（地区：丹麦，DAN）LanguageId 值 |
+|  | Dari | `0x048C` | 达里语（地区：阿富汗）LanguageId 值 |
+|  | Divehi | `0x0465` | 迪维希语（地区：马尔代夫）LanguageId 值 |
+|  | Dutch_Belgium | `0x0813` | 荷兰语（弗拉芒语，地区：比利时，NLB）LanguageId 值 |
+|  | Dutch_Netherlands | `0x0413` | 荷兰语（标准，地区：荷兰，NLD）LanguageId 值 |
+|  | English_Australia | `0x0C09` | 英语（澳大利亚，地区：澳大利亚，ENA）LanguageId 值 |
+|  | English_Belize | `0x2809` | 英语（地区：伯利兹）LanguageId 值 |
+|  | English_Canada | `0x1009` | 英语（加拿大，地区：加拿大，ENC）LanguageId 值 |
+|  | English_Caribbean | `0x2409` | 英语（地区：加勒比海）LanguageId 值 |
+|  | English_India | `0x4009` | 英语 (地区：印度) LanguageId 值 |
+|  | English_Ireland | `0x1809` | 英语 (地区：爱尔兰，ENI) LanguageId 值 |
+|  | English_Jamaica | `0x2009` | 英语 (地区：牙买加) LanguageId 值 |
+|  | English_Malaysia | `0x4409` | 英语 (地区：马来西亚) LanguageId 值 |
+|  | English_New_Zealand | `0x1409` | 英语 (地区：新西兰，ENZ) LanguageId 值 |
+|  | English_ROP | `0x3409` | 英语 (地区：菲律宾共和国，ROP) LanguageId 值 |
+|  | English_Singapore | `0x4809` | 英语 (地区：新加坡) LanguageId 值 |
+|  | English_South_Africa | `0x1C09` | 英语 (地区：南非，SA) LanguageId 值 |
+|  | English_TT | `0x2C09` | 英语 (地区：特立尼达和多巴哥，TT) LanguageId 值 |
+|  | English_United_Kingdom | `0x0809` | 英语 (英式，地区：英国，ENG) LanguageId 值 |
+|  | English_United_States | `0x0409` | 英语 (美式，地区：美国，ENU) LanguageId 值 |
+|  | English_Zimbabwe | `0x3009` | 英语 (地区：津巴布韦) LanguageId 值 |
+|  | Estonian | `0x0425` | 爱沙尼亚语 (地区：爱沙尼亚，ETI) LanguageId 值 |
+|  | Faroese | `0x0438` | 法罗语 (地区：法罗群岛) LanguageId 值 |
+|  | Filipino | `0x0464` | 菲律宾语 (地区：菲律宾) LanguageId 值 |
+|  | Finnish | `0x040B` | 芬兰语 (地区：芬兰，FIN) LanguageId 值 |
+|  | French_Belgium | `0x080C` | 法语 (比利时，地区：比利时，FRB) LanguageId 值 |
+|  | French_Canada | `0x0C0C` | 法语 (加拿大，地区：加拿大，FRC) LanguageId 值 |
+|  | French_France | `0x040C` | 法语 (标准，地区：法国，FRA) LanguageId 值 |
+|  | French_Luxembourg | `0x140c` | 法语 (地区：卢森堡，FRL) LanguageId 值 |
+|  | French_MC | `0x180C` | 法语 (地区：摩纳哥公国，MC) LanguageId 值 |
+|  | French_Switzerland | `0x100C` | 法语 (瑞士，地区：瑞士，FRS) LanguageId 值 |
+|  | Frisian | `0x0462` | 弗里斯兰语 (地区：荷兰，NLD) LanguageId 值 |
+|  | Galician | `0x0456` | 加利西亚语 (地区：加利西亚) LanguageId 值 |
+|  | Georgian | `0x0437` | 格鲁吉亚语 (地区：格鲁吉亚) LanguageId 值 |
+|  | German_Austria | `0x0C07` | 德语（奥地利，地区：奥地利，DEA）LanguageId 值 |
+|  | German_Germany | `0x0407` | 德语（标准，地区：德国，DEU）LanguageId 值 |
+|  | German_Liechtenstein | `0x1407` | 德语（地区：列支敦士登，DEC）LanguageId 值 |
+|  | German_Luxembourg | `0x1007` | 德语（地区：卢森堡，DEL）LanguageId 值 |
+|  | German_Switzerland | `0x0807` | 德语（瑞士，地区：瑞士，DES）LanguageId 值 |
+|  | Greek | `0x0408` | 希腊语（地区：希腊，ELL）LanguageId 值 |
+|  | Greenlandic | `0x046F` | 格陵兰语（地区：格陵兰）LanguageId 值 |
+|  | Gujarati | `0x0447` | 古吉拉特语（地区：印度）LanguageId 值 |
+|  | Hausa | `0x0468` | 豪萨语（拉丁文，地区：尼日利亚）LanguageId 值 |
+|  | Hebrew | `0x040D` | 希伯来语（地区：以色列）LanguageId 值 |
+|  | Hindi | `0x0439` | 印地语（地区：印度）LanguageId 值 |
+|  | Hungarian | `0x040E` | 匈牙利语（地区：匈牙利，HUN）LanguageId 值 |
+|  | Icelandic | `0x040F` | 冰岛语（地区：冰岛，ISL）LanguageId 值 |
+|  | Igbo | `0x0470` | 伊博语（地区：尼日利亚）LanguageId 值 |
+|  | Indonesian | `0x0421` | 印度尼西亚语（地区：印度尼西亚）LanguageId 值 |
+|  | Inuktitut | `0x045D` | 因纽特语（地区：加拿大）LanguageId 值 |
+|  | Inuktitut_Latin | `0x085D` | 因纽特语（拉丁文，地区：加拿大）LanguageId 值 |
+|  | Irish | `0x083C` | 爱尔兰语（地区：爱尔兰）LanguageId 值 |
+|  | isiXhosa | `0x0434` | isiXhosa（地区：南非，SA）LanguageId 值 |
+|  | isiZulu | `0x0435` | isiZulu（地区：南非，SA）LanguageId 值 |
+|  | Italian_Italy | `0x0410` | 意大利语（标准，地区：意大利，ITA）LanguageId 值 |
+|  | Italian_Switzerland | `0x0810` | 意大利语（瑞士，地区：瑞士，ITS）LanguageId 值 |
+|  | Japanese | `0x0411` | 日语（地区：日本）LanguageId 值 |
+|  | Kannada | `0x044B` | 卡纳达语（地区：印度）LanguageId 值 |
+|  | Kazakh | `0x043F` | 哈萨克语（地区：哈萨克斯坦）LanguageId 值 |
+|  | Khmer | `0x0453` | 高棉语 (地区: 柬埔寨) LanguageId 值 |
+|  | Kiche | `0x0486` | 基切语 (地区: 危地马拉) LanguageId 值 |
+|  | Kinyarwanda | `0x0487` | 卢旺达语 (地区: 卢旺达) LanguageId 值 |
+|  | Kiswahili | `0x0441` | 斯瓦希里语 (地区: 肯尼亚) LanguageId 值 |
+|  | Konkani | `0x0457` | 孔卡尼语 (地区: 印度) LanguageId 值 |
+|  | Korean | `0x0412` | 韩语 (地区: 韩国) LanguageId 值 |
+|  | Kyrgyz | `0x0440` | 吉尔吉斯语 (地区: 吉尔吉斯斯坦) LanguageId 值 |
+|  | Lao | `0x0454` | 老挝语 (地区: 老挝人民民主共和国) LanguageId 值 |
+|  | Latvian | `0x0426` | 拉脱维亚语 (地区: 拉脱维亚, LVI) LanguageId 值 |
+|  | Lithuanian | `0x0427` | 立陶宛语 (地区: 立陶宛, LTH) LanguageId 值 |
+|  | Lower_Sorbian | `0x082E` | 下索布语 (地区: 德国) LanguageId 值 |
+|  | Luxembourgish | `0x046E` | 卢森堡语 (地区: 卢森堡) LanguageId 值 |
+|  | Macedonian | `0x042F` | 马其顿语 (地区: 北马其顿) LanguageId 值 |
+|  | Malay_Brunei_Darussalam | `0x083E` | 马来语 (地区: 文莱达鲁萨兰国) LanguageId 值 |
+|  | Malay_Malaysia | `0x043E` | 马来语 (地区: 马来西亚) LanguageId 值 |
+|  | Malayalam | `0x044C` | 马拉雅拉姆语 (地区: 印度) LanguageId 值 |
+|  | Maltese | `0x043A` | 马耳他语 (地区: 马耳他) LanguageId 值 |
+|  | Maori | `0x0481` | 毛利语 (地区: 新西兰) LanguageId 值 |
+|  | Mapudungun | `0x047A` | 马普杜贡语 (地区: 智利) LanguageId 值 |
+|  | Marathi | `0x044E` | 马拉地语 (地区: 印度) LanguageId 值 |
+|  | Mohawk | `0x047C` | 莫霍克语 (地区: 莫霍克) LanguageId 值 |
+|  | Mongolian_Cyrillic | `0x0450` | 蒙古语 (西里尔文, 地区: 蒙古) LanguageId 值 |
+|  | Mongolian_Traditional | `0x0850` | 蒙古语 (传统, 地区: 中华人民共和国) LanguageId 值 |
+|  | Nepali | `0x0461` | 尼泊尔语 (地区: 尼泊尔) LanguageId 值 |
+|  | Norwegian_Bokmal | `0x0414` | 挪威语 (博克马尔, 地区: 挪威, NOR) LanguageId 值 |
+|  | Norwegian_Nynorsk | `0x0814` | 挪威语 (Nynorsk, 地区: 挪威, NON) LanguageId 值 |
+|  | Occitan | `0x0482` | 奥克语 (地区: 法国) LanguageId 值 |
+|  | Odia | `0x0448` | 奥迪亚语 (原名 Oriya, 地区: 印度) LanguageId 值 |
+|  | Pashto | `0x0463` | 普什图语 (地区: 阿富汗) LanguageId 值 |
+|  | Polish | `0x0415` | 波兰语 (地区: 波兰, PLK) LanguageId 值 |
+|  | Portuguese_Brazil | `0x0416` | 葡萄牙语 (巴西, 地区: 巴西, PTB) LanguageId 值 |
+|  | Portuguese_Portugal | `0x0816` | 葡萄牙语 (标准, 地区: 葡萄牙, PTG) LanguageId 值 |
+|  | Punjabi | `0x0446` | 旁遮普语 (地区: 印度) LanguageId 值 |
+|  | Quechua_Bolivia | `0x046B` | 克丘亚语 (地区: 玻利维亚) LanguageId 值 |
+|  | Quechua_Ecuador | `0x086B` | 克丘亚语 (地区: 厄瓜多尔) LanguageId 值 |
+|  | Quechua_Peru | `0x0C6B` | 克丘亚语 (地区: 秘鲁) LanguageId 值 |
+|  | Romanian | `0x0418` | 罗马尼亚语 (地区: 罗马尼亚, ROM) LanguageId 值 |
+|  | Romansh | `0x0417` | 罗曼什语 (地区: 瑞士) LanguageId 值 |
+|  | Russian | `0x0419` | 俄语 (地区: 俄罗斯, RUS) LanguageId 值 |
+|  | Sami_Inari | `0x243B` | 萨米语 (Inari, 地区: 芬兰) LanguageId 值 |
+|  | Sami_Lule_Norway | `0x103B` | 萨米语 (Lule, 地区: 挪威) LanguageId 值 |
+|  | Sami_Lule_Sweden | `0x143B` | 萨米语 (Lule, 地区: 瑞典) LanguageId 值 |
+|  | Sami_Northern_Finland | `0x0C3B` | 萨米语 (北部, 地区: 芬兰) LanguageId 值 |
+|  | Sami_Northern_Norway | `0x043B` | 萨米语 (北部, 地区: 挪威) LanguageId 值 |
+|  | Sami_Northern_Sweden | `0x083B` | 萨米语 (北部, 地区: 挪威) LanguageId 值 |
+|  | Sami_Skolt | `0x203B` | 萨米语 (Skolt, 地区: 芬兰) LanguageId 值 |
+|  | Sami_Southern_Norway | `0x183B` | 萨米语 (南部, 地区: 挪威) LanguageId 值 |
+|  | Sami_Southern_Sweden | `0x1C3B` | 萨米语 (南部, 地区: 瑞典) LanguageId 值 |
+|  | Sanskrit | `0x044F` | 梵语 (地区: 印度) LanguageId 值 |
+|  | Serbian_Cyrillic_BIH | `0x1C1A` | 塞尔维亚语 (西里尔文, 地区: 波斯尼亚和黑塞哥维那) LanguageId 值 |
+|  | Serbian_Cyrillic_Serbia | `0x0C1A` | 塞尔维亚语 (西里尔文, 地区: 塞尔维亚) LanguageId 值 |
+|  | Serbian_Latin_BIH | `0x181A` | 塞尔维亚语（拉丁文，地区：波斯尼亚和黑塞哥维那）LanguageId 值 |
+|  | Serbian_Latin_Serbia | `0x081A` | 塞尔维亚语（拉丁文，地区：塞尔维亚）LanguageId 值 |
+|  | Sesotho_Sa_Leboa | `0x046C` | 塞索托语（北索托，地区：南非，SA）LanguageId 值 |
+|  | Setswana | `0x0432` | 茨瓦纳语（地区：南非，SA）LanguageId 值 |
+|  | Sinhala | `0x045B` | 僧伽罗语（地区：斯里兰卡）LanguageId 值 |
+|  | Slovak | `0x041B` | 斯洛伐克语（地区：斯洛伐克，SKY）LanguageId 值 |
+|  | Slovenian | `0x0424` | 斯洛文尼亚语（地区：斯洛文尼亚，SLV）LanguageId 值 |
+|  | Spanish_Argentina | `0x2C0A` | 西班牙语（地区：阿根廷）LanguageId 值 |
+|  | Spanish_Bolivia | `0x400A` | 西班牙语（地区：玻利维亚）LanguageId 值 |
+|  | Spanish_Chile | `0x340A` | 西班牙语（地区：智利）LanguageId 值 |
+|  | Spanish_Colombia | `0x240A` | 西班牙语（地区：哥伦比亚）LanguageId 值 |
+|  | Spanish_Costa_Rica | `0x140A` | 西班牙语（地区：哥斯达黎加）LanguageId 值 |
+|  | Spanish_Dominican_Republic | `0x1C0A` | 西班牙语（地区：多米尼加共和国）LanguageId 值 |
+|  | Spanish_Ecuador | `0x300A` | 西班牙语（地区：多米尼加共和国）LanguageId 值 |
+|  | Spanish_El_Salvador | `0x440A` | 西班牙语（地区：多米尼加共和国）LanguageId 值 |
+|  | Spanish_Guatemala | `0x100A` | 西班牙语（地区：危地马拉）LanguageId 值 |
+|  | Spanish_Honduras | `0x480A` | 西班牙语（地区：洪都拉斯）LanguageId 值 |
+|  | Spanish_Mexico | `0x080A` | 西班牙语（墨西哥语，地区：墨西哥，ESM）LanguageId 值 |
+|  | Spanish_Nicaragua | `0x4C0A` | 西班牙语（地区：尼加拉瓜）LanguageId 值 |
+|  | Spanish_Panama | `0x180A` | 西班牙语（地区：巴拿马）LanguageId 值 |
+|  | Spanish_Paraguay | `0x3C0A` | 西班牙语（地区：巴拉圭）LanguageId 值 |
+|  | Spanish_Peru | `0x280A` | 西班牙语（地区：秘鲁）LanguageId 值 |
+|  | Spanish_Puerto_Rico | `0x500A` | 西班牙语（地区：波多黎各）LanguageId 值 |
+|  | Spanish_Modern_Sort | `0x0C0A` | 西班牙语（现代排序，地区：西班牙，ESN）LanguageId 值 |
+|  | Spanish_Traditional_Sort | `0x040A` | 西班牙语（传统排序，地区：西班牙，ESP）LanguageId 值 |
+|  | Spanish_United_States | `0x540A` | 西班牙语（地区：美国）LanguageId 值 |
+|  | Spanish_Uruguay | `0x380A` | 西班牙语（地区：乌拉圭）LanguageId 值 |
+|  | Spanish_Venezuela | `0x200A` | 西班牙语 (地区：委内瑞拉) LanguageId 值 |
+|  | Swedish_Finland | `0x081D` | 瑞典语 (地区：芬兰) LanguageId 值 |
+|  | Swedish_Sweden | `0x041D` | 瑞典语 (地区：瑞典，SVE) LanguageId 值 |
+|  | Syriac | `0x045A` | 叙利亚语 (地区：叙利亚) LanguageId 值 |
+|  | Tajik | `0x0428` | 塔吉克语 (西里尔文，地区：塔吉克斯坦) LanguageId 值 |
+|  | Tamazight | `0x085F` | 塔马齐格特语  (拉丁文，地区：阿尔及利亚) LanguageId 值 |
+|  | Tamil | `0x0449` | 泰米尔语 (地区：印度) LanguageId 值 |
+|  | Tatar | `0x0444` | 鞑靼语 (地区：俄罗斯) LanguageId 值 |
+|  | Telugu | `0x044A` | 泰卢固语 (地区：印度) LanguageId 值 |
+|  | Thai | `0x041E` | 泰语 (地区：泰国) LanguageId 值 |
+|  | Tibetan | `0x0451` | 藏语 (地区：中国) LanguageId 值 |
+|  | Turkish | `0x041F` | 土耳其语 (地区：土耳其，TRK) LanguageId 值 |
+|  | Turkmen | `0x0442` | 土库曼语 (地区：土库曼斯坦) LanguageId 值 |
+|  | Uighur | `0x0480` | 维吾尔语 (地区：中国) LanguageId 值 |
+|  | Ukrainian | `0x0422` | 乌克兰语 (地区：乌克兰，UKR) LanguageId 值 |
+|  | Upper_Sorbian | `0x042E` | 上索布语 (地区：德国) LanguageId 值 |
+|  | Urdu | `0x0420` | 乌尔都语 (地区：巴基斯坦伊斯兰共和国) LanguageId 值 |
+|  | Uzbek_Cyrillic | `0x0843` | 乌兹别克语 (西里尔文，地区：乌兹别克斯坦) LanguageId 值 |
+|  | Uzbek_Latin | `0x0443` | 乌兹别克语 (拉丁文，地区：乌兹别克斯坦) LanguageId 值 |
+|  | Vietnamese | `0x042A` | 越南语 (地区：越南) LanguageId 值 |
+|  | Welsh | `0x0452` | 威尔士语 (地区：英国) LanguageId 值 |
+|  | Wolof | `0x0488` | 沃洛夫语 (地区：塞内加尔) LanguageId 值 |
+|  | Yakut | `0x0485` | 雅库特语 (地区：俄罗斯) LanguageId 值 |
+|  | Yi | `0x0478` | 彝语 (地区：中国) LanguageId 值 |
+| Yoruba | `0x046A` | 约鲁巴语 (地区：尼日利亚) LanguageId 值 |

--- a/chinese/nodejs-cpp/enumerations/ttfnametableplatformid/_index.md
+++ b/chinese/nodejs-cpp/enumerations/ttfnametableplatformid/_index.md
@@ -1,0 +1,24 @@
+---
+title: "枚举 TtfNameTablePlatformId"
+second_title: "Aspose.Font for .NET API 参考"
+description: "Aspose.Font.TtfNameTablePlatformId 枚举。指定 PlatformId"
+type: docs
+weight: 130
+url: /zh/nodejs-cpp/enumerations/ttfnametableplatformid/
+---
+## TtfNameTablePlatformId enumeration
+
+指定 PlatformId
+
+```cssharp
+ enum TtfNameTablePlatformId
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+|  | Unicode | `0` | Unicode |
+|  | Macintosh | `1` | Macintosh 脚本管理器代码。 |
+|  | ISO | `2` | Apple 规范: (保留; 请勿使用) MS 规范: ISO 编码。注意，自 OpenType Specification v1.3 起，平台 ID 2 (ISO) 已被弃用。它原本用于表示 ISO/IEC 10646，而不是 Unicode；两者的字符编码分配完全相同。 |
+|  | Microsoft | `3` | Microsoft 编码。 |

--- a/chinese/nodejs-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
+++ b/chinese/nodejs-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
@@ -1,0 +1,25 @@
+---
+title: "枚举 TtfNameTableUnicodePlatformSpecificId"
+second_title: "Aspose.Font for .NET API 参考"
+description: "Aspose.Font.TtfNameTableUnicodePlatformSpecificId 枚举。指定 UnicodePlatformSpecificId"
+type: docs
+weight: 133
+url: /zh/nodejs-cpp/enumerations/ttfnametableunicodeplatformspecificid/
+---
+## TtfNameTableUnicodePlatformSpecificId enumeration
+
+指定 UnicodePlatformSpecificId
+
+```csharp
+ enum TtfNameTableUnicodePlatformSpecificId
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| --- | --- | --- |
+|  | Default | `0` | 默认语义（Unicode 1.0） |
+|  | Unicode1_1 | `1` | Unicode 1.1 语义 |
+|  | ISO10646_1993 | `2` | ISO 10646 1993 语义（已弃用） |
+|  | Unicode2_0 | `3` | Unicode 2.0 或更高语义。仅限 Unicode BMP。 |
+|  | Unicode2_0_Full | `4Unicode 2.0 and onwards semantics (non-BMP characters allowed)` | Unicode 完整字符集 |

--- a/chinese/nodejs-cpp/metadata/_index.md
+++ b/chinese/nodejs-cpp/metadata/_index.md
@@ -1,0 +1,19 @@
+---
+title: "元数据字体函数"
+second_title: "Aspose.Font 用于 Node.js，通过 C++"
+description: "用于处理元数据字体文件的函数"
+type: docs
+url: /zh/nodejs-cpp/metadata/
+---
+
+## Metadata Font functions
+
+| 名称 | 描述 |
+| -------------- | -------------- |
+| [AsposeFontGetInfo](./asposefontgetinfo/) | 从字体文件获取信息（元数据）。 |
+| [AsposeFontSetInfo](./asposefontsetinfo/) | 将信息（元数据）写入字体文件。 |
+
+## Detailed Description
+
+用于处理元数据字体文件的函数。
+

--- a/chinese/nodejs-cpp/metadata/asposefontgetinfo/_index.md
+++ b/chinese/nodejs-cpp/metadata/asposefontgetinfo/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposeFontGetInfo"
+second_title: "Aspose.Font 用于 Node.js，通过 C++"
+description: "从字体文件获取信息（元数据）。"
+type: docs
+url: /zh/nodejs-cpp/metadata/asposefontgetinfo/
+---
+## AsposeFontGetInfo function
+
+_获取信息（元数据）自字体文件._
+
+```js
+function AsposeFontGetInfo(
+    fileName
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileName | string | 文件名。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 代码错误 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
+|  | 记录 | JSON 对象数组 : |
+|  | * NameId | 名称标识符 |
+|  | * PlatformId | 平台标识符 |
+|  | * PlatformSpecificId | 平台特定标识符 |
+|  | * LanguageId | 语言标识符 |
+|  | * 信息 | 名称记录的内容 |
+
+### 示例
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    //AsposeFontGetInfo - get metadata information
+    const json = AsposeFontModule.AsposeFontGetInfo(font_file);
+    console.log("AsposeFontGetInfo => %O",  json.errorCode == 0 ? json.records.reduce((ret, a) => ret +
+        "\nNameId : " + a.NameId
+        + "; PlatformId : " + a.PlatformId
+        + "; PlatformSpecificId : " + a.PlatformSpecificId
+        + "; LanguageId : " + a.LanguageId
+        + "; Info : " + a.Info,"") : json.errorText);
+
+});
+```
+**ECMAScript\ES6 js modules:**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+//AsposeFontGetInfo - get metadata font information
+json = AsposeFontModule.AsposeFontGetInfo(font_file);
+console.log("AsposeFontGetInfo => %O",  json.errorCode == 0 ? json.records.reduce((ret, a) => ret +
+    "\nNameId : " + a.NameId
+  + "; PlatformId : " + a.PlatformId
+  + "; PlatformSpecificId : " + a.PlatformSpecificId
+  + "; LanguageId : " + a.LanguageId
+  + "; Info : " + a.Info,"") : json.errorText);
+```

--- a/chinese/nodejs-cpp/metadata/asposefontsetinfo/_index.md
+++ b/chinese/nodejs-cpp/metadata/asposefontsetinfo/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeFontSetInfo"
+second_title: "Aspose.Font 用于 Node.js，通过 C++"
+description: "将信息（元数据）写入字体文件。"
+type: docs
+url: /zh/nodejs-cpp/metadata/asposefontsetinfo/
+---
+## AsposeFontSetInfo function
+
+_将信息（元数据）写入字体文件。_
+
+```js
+function AsposeFontSetInfo(
+    fileName,
+    nameId, 
+    platformId, 
+    platformSpecificId, 
+    languageId, 
+    text
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileName | string | 文件名。 |
+| nameId | TtfNameTableNameId | 名称标识符，逻辑字符串类别，由[`NameId`](../../enumerations/ttfnametablenameid/) 枚举指定 |
+|  | platformId | TtfNameTablePlatformId | 平台标识符 |
+| platformSpecificId | int | 平台特定的编码标识符。请使用以下枚举之一的值 - [`UnicodePlatformSpecificId`](../../enumerations/ttfnametableunicodeplatformspecificid/)、[`MacPlatformSpecificId`](../../ttfnametable.macplatformspecificid/)、[`MSPlatformSpecificId`](../../enumerations/ttfnametablemsplatformspecificid/)。使用哪种枚举取决于上下文（*platformId* 参数）。 |
+| languageId | int | 语言标识符。请根据上下文使用 [`MSLanguageId`](../../enumerations/ttfnametablemslanguageid/) 或 [`MacLanguageId`](../../enumerations/ttfnametablemaclanguageid/) 枚举的值，*platformId* 参数定义了上下文。 |
+|  | 文本 | string | 实际字符串数据 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 代码错误 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    //AsposeSetInfo - set metadata info into font
+    const nameId = AsposeFontModule.TtfNameTableNameId.Description;
+    const platformId = AsposeFontModule.TtfNameTablePlatformId.Microsoft;
+    const platformSpecificId = AsposeFontModule.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+    const langID = Module.TtfNameTableMSLanguageId.English_United_States.value;
+    const text = "Updated description";
+    
+    const json = AsposeFontSetInfo(font_file, nameId, platformId, platformSpecificId, langID, text);
+    console.log("AsposeFontSetInfo => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules:**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+//AsposeSetInfo - set metadata info into font
+const nameId = AsposeFontModule.TtfNameTableNameId.Description;
+const platformId = AsposeFontModule.TtfNameTablePlatformId.Microsoft;
+const platformSpecificId = AsposeFontModule.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+const langID = Module.TtfNameTableMSLanguageId.English_United_States.value;
+const text = "Updated description";
+
+const json = AsposeFontModule.AsposeFontSetInfo(font_file, nameId, platformId, platformSpecificId, langID, text);
+console.log("AsposeFontSetInfo => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### 另请参见
+
+* enum [TtfNameTableNameId](../../enumerations/ttfnametablenameid/)
+* enum [TtfNameTablePlatformId](../../enumerations/ttfnametableplatformid/)
+* enum [TtfNameTableMacPlatformSpecificId](../../enumerations/ttfnametablemacplatformspecificid/)
+* enum [TtfNameTableMSPlatformSpecificId](../../enumerations/ttfnametablemsplatformspecificid/)
+* enum [TtfNameTableUnicodePlatformSpecificId](../../enumerations/ttfnametableunicodeplatformspecificid/)
+* enum [TtfNameTableMacLanguageId](../../enumerations/ttfnametablemaclanguageid/)
+* enum [TtfNameTableMSLanguageId](../../enumerations/ttfnametablemslanguageid/)

--- a/chinese/nodejs-cpp/misc/_index.md
+++ b/chinese/nodejs-cpp/misc/_index.md
@@ -1,0 +1,17 @@
+---
+title: "杂项函数"
+second_title: "Aspose.Font 用于 Node.js，通过 C++"
+description: "用于处理字体文件的次要函数。"
+type: docs
+url: /zh/nodejs-cpp/misc/
+---
+## Functions
+
+| 名称 | 描述 |
+| -------------- | -------------- |
+| [AsposeFontAbout](./asposefontabout/) | 获取关于产品的信息。 |
+
+## Detailed Description
+
+用于处理字体文件的次要函数。
+

--- a/chinese/nodejs-cpp/misc/asposefontabout/_index.md
+++ b/chinese/nodejs-cpp/misc/asposefontabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeFontAbout"
+second_title: "Aspose.Font 用于 Node.js，通过 C++"
+description: "获取关于产品的信息。"
+type: docs
+url: /zh/nodejs-cpp/misc/AsposeFontAbout/
+---
+
+## AsposeFontAbout function
+
+获取关于产品的信息。
+
+```js
+function AsposeFontAbout()
+```
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+| errorCode | 代码错误 (0 无错误) |
+| errorText | 文本错误 (\"\" 无错误) |
+| 产品 | 产品名称 |
+| 版本 | 产品版本 |
+| islicensed | 产品已授权 |
+
+
+## 示例
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    json = AsposeFontModule.AsposeFontAbout();
+    console.log("AsposeFontAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules:**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+//AsposeFontAbout - Get info about Product
+const json = AsposeFontModule.AsposeFontAbout();
+console.log("AsposeFontAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+```


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **Chinese** (`zh`) generated by RDA.

- Pages translated: 22/22
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `chinese/nodejs-cpp`

🤖 Generated by RDA