### PR TITLE
[auto] Translate NODEJS-CPP API Reference to German

### DIFF
--- a/german/nodejs-cpp/_index.md
+++ b/german/nodejs-cpp/_index.md
@@ -1,0 +1,54 @@
+---
+title: "Aspose.Font für Node.js via C++"
+description: "Aspose.Font für Node.js via C++"
+keywords:  "Node.js via C++, Node.js Font toolkit"
+tags: ['font-to-ttf', 'font-to-woff',  'font-to-woff2', 'font-to-svg', 'font-convert', 'font-tools']
+weight: 40
+url: /de/nodejs-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.Font for Node.js via C++ allows developers manipulate them Font files on server side web solutions.
+>
+> CommonJS and ECMAScript modules are aviable for any JavaScript solutions. 
+
+
+## Convert functions
+
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [AsposeFontConvert](./convert/) | Konvertiere eine Schriftart in TrueType-Schriftarten. |
+| [AsposeFontConvertToTTF](./convert/asposefontconverttottf/) | Konvertiere eine Schriftart in das TTF-Format. |
+| [AsposeFontConvertToWOFF](./convert/asposefontconverttowoff/) | Konvertiere eine Schriftart in das WOFF-Format. |
+| [AsposeFontConvertToWOFF2](./convert/asposefontconverttowoff2/) | Konvertiere eine Schriftart in das WOFF2-Format. |
+| [AsposeFontConvertToSVG](./convert/asposefontconverttosvg/) | Konvertiere eine Schriftart in das SVG-Format. |
+
+
+## Metadata Font functions
+
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [AsposeFontGetInfo](./metadata/asposefontgetinfo/) | Lese Informationen (Metadaten) aus einer Schriftdatei. |
+| [AsposeFontSetInfo](./metadata/asposefontsetinfo/) | Setze Informationen (Metadaten) in einer Schriftdatei. |
+
+
+## Miscellaneous
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposeFontAbout](./misc/asposefontabout/) | Lese Informationen über das Produkt. |
+
+## Aufzählungen
+
+| Aufzählung | Beschreibung |
+| ----------- | ----------- |
+| [FontSavingFormats](./enumerations/fontsavingformats/) | Gibt den Schriftarttyp an. |
+| [FontStyle](./enumerations/fontstyle/) | Gibt den Schriftstil an. |
+| [TtfNameTableNameId](./enumerations/ttfnametablenameid/) | Gibt die NameId an. |
+| [TtfNameTablePlatformId](./enumerations/ttfnametableplatformid/) | Stellt die PlatformId-Aufzählung dar. |
+| [TtfNameTableMacPlatformSpecificId](./enumerations/ttfnametablemacplatformspecificid/) | Stellt die plattformspezifische ID-Aufzählung für Macintosh dar. |
+| [TtfNameTableMSPlatformSpecificId](./enumerations/ttfnametablemsplatformspecificid/) | Stellt die plattformspezifische ID-Aufzählung für Microsoft dar. |
+| [TtfNameTableUnicodePlatformSpecificId](./enumerations/ttfnametableunicodeplatformspecificid/) | Stellt die plattformspezifische ID-Aufzählung für Unicode dar. |
+| [TtfNameTableMacLanguageId](./enumerations/ttfnametablemaclanguageid/) | MacLanguageId-Aufzählung. |
+| [TtfNameTableMSLanguageId](./enumerations/ttfnametablemslanguageid/) | MSLanguageId-Aufzählung. |

--- a/german/nodejs-cpp/convert/_index.md
+++ b/german/nodejs-cpp/convert/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Schriftart‑Konvertierungsfunktionen"
+second_title: "Aspose.Font für Node.js via C++"
+description: "Funktionen zum Konvertieren von Schriftarten in True‑Type‑Formate."
+type: docs
+url: /de/nodejs-cpp/convert/
+---
+
+## Convert functions
+
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [AsposeFontConvert](./asposefontconvert) | Konvertiere eine Schriftart in unterstützte Formate. |
+| [AsposeFontConvertToTTF](./asposefontconverttottf/) | Konvertiere eine Schriftart in das TTF-Format. |
+| [AsposeFontConvertToWOFF](./asposefontconverttowoff/) | Konvertiere eine Schriftart in das WOFF-Format. |
+| [AsposeFontConvertToWOFF2](./asposefontconverttowoff2/) | Konvertiere eine Schriftart in das WOFF2-Format. |
+| [AsposeFontConvertToSVG](./asposefontconverttosvg/) | Konvertiere eine Schriftart in das SVG-Format. |
+
+## Detailed Description
+
+Funktionen zum Konvertieren von Schriftarten in True‑Type‑Formate.
+

--- a/german/nodejs-cpp/convert/asposefontconvert/_index.md
+++ b/german/nodejs-cpp/convert/asposefontconvert/_index.md
@@ -1,0 +1,73 @@
+---
+title: "AsposeFontConvert"
+second_title: "Aspose.Font für Node.js via C++"
+description: "Konvertiert die Schrift in ein anderes Format"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/convert/asposefontconvert/
+---
+## AsposeFontConvert function
+
+Konvertiert die Schrift in ein anderes Format.
+
+```js
+function AsposeFontConvert(
+    fileName,
+    fontType,
+    fontSavingFormat
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileName | string | Dateiname. |
+| fontType | FontType | Schrifttyp zum Konvertieren. |
+| fontSavingFormat | FontSavingFormats | Schriftformat, in das konvertiert werden soll. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Hinweise
+
+Hinweis: Der TTF-Schrifttyp wird derzeit nur unterstützt.
+
+### Beispiele
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvert to convert font
+    const json = AsposeFontModule.AsposeFontConvert(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvert(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Siehe auch
+
+* enum [FontType](../../enumerations/fonttype/)
+* enum [FontSavingFormats](../../enumerations/fontsavingformats/)

--- a/german/nodejs-cpp/convert/asposefontconverttottf/_index.md
+++ b/german/nodejs-cpp/convert/asposefontconverttottf/_index.md
@@ -1,0 +1,60 @@
+---
+title: "AsposeFontConvertToTTF"
+second_title: "Aspose.Font für Node.js via C++"
+description: "Konvertiert die Schrift in das ttf-Format"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/convert/asposefontconverttottf/
+---
+## AsposeFontConvertToTTF function
+
+Konvertiert die Schrift in das TTF-Format.
+
+```js
+function AsposeFontConvertToTTF(
+    fileName,
+    fontType
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileName | string | Dateiname. |
+| fontType | FontType | Schrifttyp zum Konvertieren. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+const font_file = "./fonts/Lora-Regular.ttf";
+console.log('Aspose.Font for Node.js via C++ example');
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvert to convert font
+    const json = AsposeFontModule.AsposeFontConvertToTTF(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript/ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+const font_file ="./fonts/arial.ttf";
+const AsposeFontModule = await AsposeFont();
+console.log('Aspose.Font for Node.js via C++ example');
+const json = AsposeFontModule.AsposeFontConvertToTTF(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Siehe auch
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/german/nodejs-cpp/convert/asposefontconverttowoff/_index.md
+++ b/german/nodejs-cpp/convert/asposefontconverttowoff/_index.md
@@ -1,0 +1,67 @@
+---
+title: "AsposeFontConvertToWOFF"
+second_title: "Aspose.Font für Node.js via C++"
+description: "Konvertiert die Schrift in das woff-Format"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/convert/asposefontconverttowoff/
+---
+## AsposeFontConvertToWOFF function
+
+Konvertiert die Schrift in das WOFF-Format.
+
+```js
+function AsposeFontConvertToWOFF(
+    fileName,
+    fontType
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileName | string | Dateiname. |
+| fontType | FontType | Schrifttyp zum Konvertieren. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvertToWOFF to convert font
+    const json = AsposeFontModule.AsposeFontConvertToWOFF(font_file,AsposeFontModule.FontType.TTF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvertToWOFF(font_file,AsposeFontModule.FontType.TTF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Siehe auch
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/german/nodejs-cpp/convert/asposefontconverttowoff2/_index.md
+++ b/german/nodejs-cpp/convert/asposefontconverttowoff2/_index.md
@@ -1,0 +1,67 @@
+---
+title: "AsposeFontConvertToWOFF2"
+second_title: "Aspose.Font für Node.js via C++"
+description: "Konvertiert die Schrift in das woff2-Format"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/convert/asposefontconverttowoff2/
+---
+## AsposeFontConvertToWOFF2 function
+
+Konvertiert die Schrift in das WOFF2-Format.
+
+```js
+function AsposeFontConvertToWOFF2(
+    fileName,
+    fontType
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileName | string | Dateiname. |
+| fontType | FontType | Schrifttyp zum Konvertieren. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvertToWOFF2 to convert font
+    const json = AsposeFontModule.AsposeFontConvertToWOFF2(font_file,AsposeFontModule.FontType.TTF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvertToWOFF2(font_file,AsposeFontModule.FontType.TTF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Siehe auch
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/german/nodejs-cpp/convert/asposefontconverttowsvg/_index.md
+++ b/german/nodejs-cpp/convert/asposefontconverttowsvg/_index.md
@@ -1,0 +1,67 @@
+---
+title: "AsposeFontConvertToSVG"
+second_title: "Aspose.Font für Node.js via C++"
+description: "Konvertiert die Schrift in das svg-Format"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/convert/asposefontconverttosvg/
+---
+## AsposeFontConvertToSVG function
+
+Konvertiert die Schrift in das SVG-Format.
+
+```js
+function AsposeFontConvertToSVG(
+    fileName,
+    fontType
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileName | string | Dateiname. |
+| fontType | FontType | Schrifttyp zum Konvertieren. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvertToSVG to convert font
+    const json = AsposeFontModule.AsposeFontConvertToSVG(font_file,AsposeFontModule.FontType.TTF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvertToSVG(font_file,AsposeFontModule.FontType.TTF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Siehe auch
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/german/nodejs-cpp/enumerations/_index.md
+++ b/german/nodejs-cpp/enumerations/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Aufzählungen"
+second_title: "Aspose.Font für Node.js via C++"
+description: "Funktionen zum Konvertieren von Schriftarten in True‑Type‑Formate."
+type: docs
+url: /de/nodejs-cpp/enumerations/
+---
+
+## Aufzählungen
+
+| Aufzählung | Beschreibung |
+| ----------- | ----------- |
+| [FontSavingFormats](./fontsavingformats/) | Gibt den Schriftarttyp an. |
+| [FontType](./fonttype/) | Gibt den Schriftarttyp an. |
+| [TtfNameTableNameId](./ttfnametablenameid/) | Gibt die NameId an. |
+| [TtfNameTablePlatformId](./ttfnametableplatformid/) | Stellt die PlatformId-Aufzählung dar. |
+| [TtfNameTableMSPlatformSpecificId](./ttfnametableMSPlatformSpecificId/) | Stellt die Aufzählung MSPlatformSpecificId dar. |
+| [TtfNameTableMacPlatformSpecificId](./ttfnametableMacPlatformSpecificId/) | Stellt die Aufzählung MacPlatformSpecificId dar. |
+| [TtfNameTableUnicodePlatformSpecificId](./ttfnametableUnicodePlatformSpecificId/) | Stellt die Aufzählung UnicodePlatformSpecificId dar. |
+| [TtfNameTableMacLanguageId](./ttfnametablemaclanguageid/) | Macintosh-Plattform-Sprach‑ID‑Aufzählung. |
+| [TtfNameTableMSLanguageId](./ttfnametablemslanguageid/) | Microsoft-Plattform-Sprach‑ID‑Aufzählung. |
+
+### Example of using enumarations
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    //define parameters for AsposeFontSetInfo
+    const nameId = AsposeFontModule.TtfNameTableNameId.Description;
+    const platformId = AsposeFontModule.TtfNameTablePlatformId.Microsoft;
+    const platformSpecificId = AsposeFontModule.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+    const langID = Module.TtfNameTableMSLanguageId.English_United_States.value;
+    const text = "Updated description";
+    
+    const json = AsposeFontSetInfo(font_file, nameId, platformId, platformSpecificId, langID, text);
+    console.log("AsposeFontSetInfo => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/german/nodejs-cpp/enumerations/fontsavingformats/_index.md
+++ b/german/nodejs-cpp/enumerations/fontsavingformats/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum FontSavingFormats"
+second_title: "Aspose.Font für .NET API-Referenz"
+description: "Aspose.Font.FontSavingFormats enum. Gibt den Font-Typ an"
+type: docs
+weight: 110
+url: /de/nodejs-cpp/enumerations/fontsavingformats/
+---
+## FontSavingFormats enumeration
+
+Gibt den Schriftarttyp an.
+
+```csharp
+public enum FontSavingFormats
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+| TTF | `0` | TTF (TrueType) Font-Format. |
+| WOFF | `1` | WOFF(Web Open Font Format). |
+| WOFF2 | `2` | WOFF-Dateiformat 2.0 |
+| SVG | `3` | SVG(Scalable Vector Graphics) Font-Format |
+| OTF | `4` | OTF (OpenType) Font-Format |

--- a/german/nodejs-cpp/enumerations/fonttype/_index.md
+++ b/german/nodejs-cpp/enumerations/fonttype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum FontType"
+second_title: "Aspose.Font für .NET API-Referenz"
+description: "Aspose.Font.FontType enum. Gibt den Font-Typ an"
+type: docs
+weight: 100
+url: /de/nodejs-cpp/enumerations/fonttype/
+---
+## FontType enumeration
+
+Gibt den Schriftarttyp an.
+
+```csharp
+public enum FontType
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+| TTF | `0` | TTF (TrueType) Font-Typ und Verwandtes. |
+| Type1 | `1` | Type1 Font-Typ. |
+| CFF | `2` | CFF (Compact font format) Font-Typ. |
+| OTF | `3` | OpenType Font. Das OpenType Font-Format ist eine Erweiterung des TrueType Font-Formats und fügt Unterstützung für PostScript Font-Daten hinzu. |
+

--- a/german/nodejs-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
+++ b/german/nodejs-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
@@ -1,0 +1,53 @@
+---
+title: "Aufzählung TtfNameTableMacPlatformSpecificId"
+second_title: "Aspose.Font für .NET API-Referenz"
+description: "Aspose.Font.TtfNameTableMacPlatformSpecificId enum. Gibt MacPlatformSpecificId an"
+type: docs
+weight: 131
+url: /de/nodejs-cpp/enumerations/ttfnametablemacplatformspecificid/
+---
+## TtfNameTableMacPlatformSpecificId enumeration
+
+Gibt MacPlatformSpecificId an.
+
+```csharp
+ enum TtfNameTableMacPlatformSpecificId
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+|  | Roman | `0` | Römischer plattformspezifischer Wert. |
+|  | Japanese | `1` | Japanischer plattformspezifischer Wert. |
+|  | Traditional_Chinese | `2` | Traditioneller chinesischer plattformspezifischer Wert. |
+|  | Korean | `3` | Koreanischer plattformspezifischer Wert. |
+|  | Arabic | `4` | Arabischer plattformspezifischer Wert. |
+|  | Hebrew | `5` | Hebräischer plattformspezifischer Wert. |
+|  | Greek | `6` | Griechischer plattformspezifischer Wert. |
+|  | Russian | `7` | Russischer plattformspezifischer Wert. |
+|  | RSymbol | `8` | RSymbol plattformspezifischer Wert. |
+|  | Devanagari | `9` | Devanagari plattformspezifischer Wert. |
+|  | Gurmukhi | `10` | Gurmukhi plattformspezifischer Wert. |
+|  | Gujarati | `11` | Gujarati plattformspezifischer Wert. |
+|  | Oriya | `12` | Oriya plattformspezifischer Wert. |
+|  | Bengali | `13` | Bengalisch plattformspezifischer Wert. |
+|  | Tamil | `14` | Tamil plattformspezifischer Wert. |
+|  | Telugu | `15` | Telugu plattformspezifischer Wert. |
+|  | Kannada | `16` | Kannada plattformspezifischer Wert. |
+|  | Malayalam | `17` | Malayalam plattformspezifischer Wert. |
+|  | Sinhalese | `18` | Singhalesisch plattformspezifischer Wert. |
+|  | Burmese | `19` | Burmesisch plattformspezifischer Wert. |
+|  | Khmer | `20` | Khmer plattformspezifischer Wert. |
+|  | Thai | `21` | Thai plattformspezifischer Wert. |
+|  | Laotian | `22` | Laotisch plattformspezifischer Wert. |
+|  | Georgian | `23` | Georgisch plattformspezifischer Wert. |
+|  | Armenian | `24` | Armenisch plattformspezifischer Wert. |
+|  | Simplified_Chinese | `25` | Vereinfachtes Chinesisch plattformspezifischer Wert. |
+|  | Tibetan | `26` | Tibetisch plattformspezifischer Wert. |
+|  | Mongolian | `27` | Mongolisch plattformspezifischer Wert. |
+|  | Geez | `28` | Geez plattformspezifischer Wert. |
+|  | Slavic | `29` | Slawisch plattformspezifischer Wert. |
+|  | Vietnamese | `30` | Vietnamesisch plattformspezifischer Wert. |
+|  | Sindhi | `31` | Sindhi plattformspezifischer Wert. |
+|  | Uninterpreted | `32` | Nicht interpretierter plattformspezifischer Wert. |

--- a/german/nodejs-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
+++ b/german/nodejs-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Enum TtfNameTableMSPlatformSpecificId"
+second_title: "Aspose.Font für .NET API-Referenz"
+description: "Aspose.Font.TtfNameTableMSPlatformSpecificId enum. Gibt MSPlatformSpecificId an."
+type: docs
+weight: 132
+url: /de/nodejs-cpp/enumerations/ttfnametablemsplatformspecificid/
+---
+## TtfNameTableMSPlatformSpecificId enumeration
+
+Gibt MSPlatformSpecificId an.
+
+```csharp
+ enum TtfNameTableMSPlatformSpecificId
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+|  | Symbol | `0` | Symbol MS PlatformSpecificId. |
+|  | Unicode_BMP_UCS2 | `1` | Unicode BMP (UCS2) MS PlatformSpecificId. |
+|  | ShiftJIS | `2` | ShiftJIS MS PlatformSpecificId. |
+|  | PRC | `3` | PRC MS PlatformSpecificId. |
+|  | Big5 | `4` | Big5 MS PlatformSpecificId. |
+|  | Wansung | `5` | Wansung MS PlatformSpecificId. |
+|  | Johab | `6` | Johab MS PlatformSpecificId. |
+|  | Reserved1 | `7` | Reserved1 MS PlatformSpecificId. |
+|  | Reserved2 | `8` | Reserved2 MS PlatformSpecificId. |
+|  | Reserved3 | `9` | Reserved3 MS PlatformSpecificId. |
+|  | Unicode_UCS4 | `10` | Unicode UCS4 MS PlatformSpecificId. |
+

--- a/german/nodejs-cpp/enumerations/ttfnametablenameid/_index.md
+++ b/german/nodejs-cpp/enumerations/ttfnametablenameid/_index.md
@@ -1,0 +1,46 @@
+---
+title: "Aufzählung TtfNameTableNameId"
+second_title: "Aspose.Font für .NET API-Referenz"
+description: "Aspose.Font.TtfNameTableNameId Enum. Gibt NameId an"
+type: docs
+weight: 120
+url: /de/nodejs-cpp/enumerations/ttfnametablenameid/
+---
+## TtfNameTableNameId enumeration
+
+Gibt die NameId an.
+
+```csharp
+ enum TtfNameTableNameId
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+|  | CopyrightNotice | `0` | Copyright-Hinweis. |
+|  | FontFamily | `1` | Schriftfamilie. Dieser String ist der Schriftfamilienname, den der Benutzer auf Macintosh-Plattformen sieht. |
+|  | FontSubfamily | `2` | Schriftunterfamilie. Dieser String ist die Schriftfamilie, die der Benutzer auf Macintosh-Plattformen sieht. |
+|  | UniqueFontId | `3` | Eindeutige Unterfamilienidentifikation (Apple-Spezifikation). 3 eindeutiger Schrift-Identifikator (MS-Spezifikation). |
+|  | FullName | `4` | Vollständiger Name der Schrift. |
+|  | Version | `5` | Version der Namens‑tabelle. |
+|  | PostScriptName | `6` | PostScript‑Name der Schrift. Hinweis: Eine Schrift darf nur einen PostScript‑Namen haben und dieser Name muss ASCII sein. |
+|  | TrademarkNotice | `7` | Markenhinweis. |
+|  | ManufacturerName | `8` | Herstellername. |
+|  | DesignerName | `9` | Designer; Name des Designers der Schriftart. |
+|  | Description | `10` | Beschreibung; Beschreibung der Schriftart. Kann Versionsinformationen, Nutzungsempfehlungen, Geschichte, Merkmale usw. enthalten. |
+|  | UrlVendor | `11` | URL des Schriftanbieters (mit Protokoll, z. B. http://, ftp://). Wenn eine eindeutige Seriennummer in der URL eingebettet ist, kann sie zur Registrierung der Schrift verwendet werden. |
+|  | UrlDesigner | `12` | URL des Schrift‑Designers (mit Protokoll, z. B. http://, ftp://). |
+|  | LicenseDescription | `13` | Lizenzbeschreibung; Beschreibung, wie die Schrift rechtlich verwendet werden darf, oder verschiedene Beispielszenarien für lizenzierte Nutzung. Dieses Feld sollte in klarer Sprache verfasst sein, nicht in Rechtssprache. |
+|  | LicenseInfoUrl | `14` | URL zu Lizenzinformationen, wo zusätzliche Lizenzinformationen gefunden werden können. |
+|  | PreferredFamily | `16` | `15` Reserviert `16` Bevorzugte Familie (nur Windows); In Windows wird der Familienname im Schriftmenü angezeigt; der Unterfamilienname wird als Stilname präsentiert. Aus historischen Gründen enthielten Schriftfamilien maximal vier Stile, aber Schriftgestalter können mehr als vier Schriften zu einer einzigen Familie gruppieren. Die IDs für bevorzugte Familie und bevorzugte Unterfamilie ermöglichen es Schriftgestaltern, die bevorzugten Familien-/Untergruppierungen einzubeziehen. Diese IDs sind nur vorhanden, wenn sie sich von den IDs 1 und 2 unterscheiden. |
+|  | PreferredSubfamily | `17` | Bevorzugte Unterfamilie (nur Windows); In Windows wird der Familienname im Schriftmenü angezeigt; der Unterfamilienname wird als Stilname präsentiert. Aus historischen Gründen enthielten Schriftfamilien maximal vier Stile, aber Schriftgestalter können mehr als vier Schriften zu einer einzigen Familie gruppieren. Die IDs für bevorzugte Familie und bevorzugte Unterfamilie ermöglichen es Schriftgestaltern, die bevorzugten Familien-/Untergruppierungen einzubeziehen. Diese IDs sind nur vorhanden, wenn sie sich von den IDs 1 und 2 unterscheiden. |
+|  | CompatibleFull | `18` | Kompatibler Vollname (nur Macintosh); Auf dem Macintosh wird der Menüname mithilfe der Schriftressource erstellt. Dieser entspricht normalerweise dem Vollnamen. Wenn der Name der Schrift anders als der Vollname angezeigt werden soll, kann der kompatible Vollname in ID 18 eingefügt werden. Dieser Name wird vom Mac‑OS selbst nicht verwendet, kann aber von Anwendungsentwicklern (z. B. Adobe) genutzt werden. |
+|  | SampleText | `19` | Beispieltext. Dies kann der Schriftname sein oder jeder andere Text, den der Designer für den besten Beispieltext hält, um zu zeigen, wie die Schrift aussieht. |
+|  | PostScriptCID | `20` | Seine Anwesenheit in einer Schrift bedeutet, dass nameID 6 einen PostScript-Schriftnamen enthält, der mit dem Aufruf "composefont" verwendet werden soll, um die Schrift in einem PostScript‑Interpreter zu aktivieren. |
+|  | WwsFamilyName | `21` | Wird verwendet, um einen WWS-konformen Familiennamen bereitzustellen, falls die Einträge für IDs 16 und 17 nicht dem WWS‑Modell entsprechen. |
+|  | WwsSubfamilyName | `22` | In Kombination mit ID 21 liefert diese ID einen WWS-konformen Unterfamiliennamen (der nur Gewicht-, Breiten- und Neigungsattribute widerspiegelt), falls die Einträge für IDs 16 und 17 nicht dem WWS‑Modell entsprechen. |
+|  | LightBackground | `23` | Diese ID gibt, wenn sie im Palette‑Labels‑Array der CPAL‑Tabelle verwendet wird, an, dass die entsprechende Farbpalette in der CPAL‑Tabelle für die Verwendung mit der Schrift geeignet ist, wenn sie auf einem hellen Hintergrund wie Weiß angezeigt wird. |
+|  | DarkBackground | `24` | Diese ID gibt, wenn sie im Palette‑Labels‑Array der CPAL‑Tabelle verwendet wird, an, dass die entsprechende Farbpalette in der CPAL‑Tabelle für die Verwendung mit der Schrift geeignet ist, wenn sie auf einem dunklen Hintergrund wie Schwarz angezeigt wird. |
+|  | VariationsPostScriptNamePrefix | `25` | Falls in einer variablen Schrift vorhanden, kann sie als Familienpräfix im Algorithmus zur PostScript‑Namensgenerierung für Variationsschriften verwendet werden. |
+

--- a/german/nodejs-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
+++ b/german/nodejs-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
@@ -1,0 +1,138 @@
+---
+title: "Enum TtfNameTableMacLanguageId"
+second_title: "Aspose.Font für .NET API-Referenz"
+description: "Aspose.Font.TtfNameTableMacLanguageId enum. Gibt MacLanguageId an"
+type: docs
+weight: 140
+url: /de/nodejs-cpp/enumerations/ttfnametablemaclanguageid/
+---
+## TtfNameTableMacLanguageId enumeration
+
+Stellt die MacLanguageId-Aufzählung dar.
+
+```csharp
+ enum TtfNameTableMacLanguageId
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+|  | English | `0` | Englischer LanguageId-Wert |
+|  | French | `1` | Französischer LanguageId-Wert |
+|  | German | `2` | Deutscher LanguageId-Wert |
+|  | Italian | `3` | Italienischer LanguageId-Wert |
+|  | Dutch | `4` | Niederländischer LanguageId-Wert |
+|  | Swedish | `5` | Schwedischer LanguageId-Wert |
+|  | Spanish | `6` | Spanischer LanguageId-Wert |
+|  | Danish | `7` | Dänischer LanguageId-Wert |
+|  | Portuguese | `8` | Portugiesischer LanguageId-Wert |
+|  | Norwegian | `9` | Norwegischer LanguageId-Wert |
+|  | Hebrew | `10` | Hebräisch LanguageId Wert |
+|  | Japanese | `11` | Japanisch LanguageId Wert |
+|  | Arabic | `12` | Arabisch LanguageId Wert |
+|  | Finnish | `13` | Finnisch LanguageId Wert |
+|  | Greek | `14` | Griechisch LanguageId Wert |
+|  | Icelandic | `15` | Isländisch LanguageId Wert |
+|  | Maltese | `16` | Maltesisch LanguageId Wert |
+|  | Turkish | `17` | Türkisch LanguageId Wert |
+|  | Croatian | `18` | Kroatisch LanguageId Wert |
+|  | Chinese_Traditional | `19` | Chinesisch (Traditionell) LanguageId Wert |
+|  | Urdu | `20` | Urdu LanguageId Wert |
+|  | Hindi | `21` | Hindi LanguageId Wert |
+|  | Thai | `22` | Thailändisch LanguageId Wert |
+|  | Korean | `23` | Koreanisch LanguageId Wert |
+|  | Lithuanian | `24` | Litauisch LanguageId Wert |
+|  | Polish | `25` | Polnisch LanguageId Wert |
+|  | Hungarian | `26` | Ungarisch LanguageId Wert |
+|  | Estonian | `27` | Estnisch LanguageId Wert |
+|  | Latvian | `28` | Lettisch LanguageId Wert |
+|  | Sami | `29` | Samisch LanguageId Wert |
+|  | Faroese | `30` | Färöisch LanguageId Wert |
+|  | Farsi_Persian | `31` | Farsi/Persisch LanguageId Wert |
+|  | Russian | `32` | Russisch LanguageId Wert |
+|  | Chinese_Simplified | `33` | Chinesisch (Vereinfacht) LanguageId Wert |
+|  | Flemish | `34` | Flämisch LanguageId Wert |
+|  | Irish_Gaelic | `35` | Irisch-Gälisch LanguageId-Wert |
+|  | Albanian | `36` | Albanisch LanguageId-Wert |
+|  | Romanian | `37` | Rumänisch LanguageId-Wert |
+|  | Czech | `38` | Tschechisch LanguageId-Wert |
+|  | Slovak | `39` | Slowakisch LanguageId-Wert |
+|  | Slovenian | `40` | Slowenisch LanguageId-Wert |
+|  | Yiddish | `41` | Jiddisch LanguageId-Wert |
+|  | Serbian | `42` | Serbisch LanguageId-Wert |
+|  | Macedonian | `43` | Mazedonisch LanguageId-Wert |
+|  | Bulgarian | `44` | Bulgarisch LanguageId-Wert |
+|  | Ukrainian | `45` | Ukrainisch LanguageId-Wert |
+|  | Byelorussian | `46` | Belarussisch LanguageId-Wert |
+|  | Uzbek | `47` | Usbekisch LanguageId-Wert |
+|  | Kazakh | `48` | Kasachisch LanguageId-Wert |
+|  | Azerbaijani_Cyrillic | `49` | Aserbaidschanisch (kyrillisches Skript) LanguageId-Wert |
+|  | Azerbaijani_Arabic | `50` | Aserbaidschanisch (arabisches Skript) LanguageId-Wert |
+|  | Armenian | `51` | Armenisch LanguageId-Wert |
+|  | Georgian | `52` | Georgisch LanguageId-Wert |
+|  | Moldavian | `53` | Moldauisch LanguageId-Wert |
+|  | Kirghiz | `54` | Kirgisisch LanguageId-Wert |
+|  | Tajiki | `55` | Tadschikisch LanguageId-Wert |
+|  | Turkmen | `56` | Turkmenisch LanguageId-Wert |
+|  | Mongolian | `57` | Mongolisch (mongolisches Skript) LanguageId-Wert |
+|  | Mongolian_Cyrillic | `58` | Mongolisch (kyrillisches Skript) LanguageId-Wert |
+|  | Pashto | `59` | Paschtunisch LanguageId-Wert |
+|  | Kurdish | `60` | Paschtunisch LanguageId-Wert |
+|  | Kashmiri | `61` | Kashmiri LanguageId-Wert |
+|  | Sindhi | `62` | Sindhi LanguageId-Wert |
+|  | Tibetan | `63` | Tibetan LanguageId-Wert |
+|  | Nepali | `64` | Nepali LanguageId-Wert |
+|  | Sanskrit | `65` | Sanskrit LanguageId-Wert |
+|  | Marathi | `66` | Marathi LanguageId-Wert |
+|  | Bengali | `67` | Bengali LanguageId-Wert |
+|  | Assamese | `68` | Assamese LanguageId-Wert |
+|  | Gujarati | `69` | Gujarati LanguageId-Wert |
+|  | Punjabi | `70` | Punjabi LanguageId-Wert |
+|  | Oriya | `71` | Oriya LanguageId-Wert |
+|  | Malayalam | `72` | Malayalam LanguageId-Wert |
+|  | Kannada | `73` | Kannada LanguageId-Wert |
+|  | Tamil | `74` | Tamil LanguageId-Wert |
+|  | Telugu | `75` | Telugu LanguageId-Wert |
+|  | Sinhalese | `76` | Sinhalese LanguageId-Wert |
+|  | Burmese | `77` | Burmese LanguageId-Wert |
+|  | Khmer | `78` | Khmer LanguageId-Wert |
+|  | Lao | `79` | Lao LanguageId-Wert |
+|  | Vietnamese | `80` | Vietnamese LanguageId-Wert |
+|  | Indonesian | `81` | Indonesian LanguageId-Wert |
+|  | Tagalog | `82` | Tagalog LanguageId-Wert |
+|  | Malay_Roman | `83` | Malay (Roman script) LanguageId-Wert |
+|  | Malay_Arabic | `84` | Malay (Arabic script) LanguageId-Wert |
+|  | Amharic | `85` | Amharic LanguageId-Wert |
+|  | Tigrinya | `86` | Tigrinya LanguageId Wert |
+|  | Galla | `87` | Galla LanguageId Wert |
+|  | Somali | `88` | Somali LanguageId Wert |
+|  | Swahili | `89` | Swahili LanguageId Wert |
+|  | Kinyarwanda_Ruanda | `90` | Kinyarwanda/Ruanda LanguageId Wert |
+|  | Rundi | `91` | Rundi LanguageId Wert |
+|  | Nyanja_Chewa | `92` | Nyanja/Chewa LanguageId Wert |
+|  | Malagasy | `93` | Malagasy LanguageId Wert |
+|  | Esperanto | `94` | Esperanto LanguageId Wert |
+|  | Welsh | `128` | Walisisch LanguageId Wert |
+|  | Basque | `129` | Baskisch LanguageId Wert |
+|  | Catalan | `130` | Katalanisch LanguageId Wert |
+|  | Latin | `131` | Latein LanguageId Wert |
+|  | Quechua | `132` | Quechua LanguageId Wert |
+|  | Guarani | `133` | Guarani LanguageId Wert |
+|  | Aymara | `134` | Aymara LanguageId Wert |
+|  | Tatar | `135` | Tatarisch LanguageId Wert |
+|  | Uighur | `136` | Uigurisch LanguageId Wert |
+|  | Dzongkha | `137` | Dzongkha LanguageId Wert |
+|  | Javanese | `138` | Javanisch (römische Schrift) LanguageId Wert |
+|  | Sundanese | `139` | Sundanesisch (römische Schrift) LanguageId Wert |
+|  | Galician | `140` | Galicisch LanguageId Wert |
+|  | Afrikaans | `141` | Afrikaans LanguageId Wert |
+|  | Breton | `142` | Bretonisch LanguageId Wert |
+|  | Inuktitut | `143` | Inuktitut LanguageId Wert |
+|  | Scottish_Gaelic | `144` | Schottisch-Gälisch LanguageId-Wert |
+|  | Manx_Gaelic | `145` | Manx-Gälisch LanguageId-Wert |
+|  | Irish_Gaelic_WDA | `146` | Irisch-Gälisch (mit Punkt darüber) LanguageId-Wert |
+|  | Tongan | `147` | Tongaisch LanguageId-Wert |
+|  | Greek_Polytonic | `148` | Griechisch (polytonisch) LanguageId-Wert |
+|  | Greenlandic | `149` | Grönländisch LanguageId-Wert |
+|  | Azerbaijani_Roman | `150` | Aserbaidschanisch (römisches Skript) LanguageId-Wert |

--- a/german/nodejs-cpp/enumerations/ttfnametablenmslanguageid/_index.md
+++ b/german/nodejs-cpp/enumerations/ttfnametablenmslanguageid/_index.md
@@ -1,0 +1,225 @@
+---
+title: "Enum TtfNameTableMSLanguageId"
+second_title: "Aspose.Font für .NET API-Referenz"
+description: "Aspose.Font.TtfNameTableMSLanguageId‑Enum. Gibt MSLanguageId an."
+type: docs
+weight: 150
+url: /de/nodejs-cpp/enumerations/ttfnametablemslanguageid/
+---
+## TtfNameTableMSLanguageId enumeration
+
+Stellt die MSLanguageId‑Aufzählung dar.
+
+```csharp
+ enum TtfNameTableMSLanguageId
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+|  | Afrikaans | `0x0436` | Afrikaans (Region: Südafrika, SA) LanguageId‑Wert |
+|  | Albanian | `0x041c` | Albanisch (Region: Albanien, SQI) LanguageId‑Wert |
+|  | Alsatian | `0x0484` | Elsässisch (Region: Frankreich) LanguageId Wert |
+|  | Amharic | `0x045E` | Amharisch (Region: Äthiopien) LanguageId Wert |
+|  | Arabic_Algeria | `0x1401` | Arabisch (Region: Algerien) LanguageId Wert |
+|  | Arabic_Bahrain | `0x3C01` | Arabisch (Region: Bahrain) LanguageId Wert |
+|  | Arabic_Egypt | `0x0C01` | Arabisch (Region: Ägypten) LanguageId Wert |
+|  | Arabic_Iraq | `0x0801` | Arabisch (Region: Irak) LanguageId Wert |
+|  | Arabic_Jordan | `0x2C01` | Arabisch (Region: Jordanien) LanguageId Wert |
+|  | Arabic_Kuwait | `0x3401` | Arabisch (Region: Kuwait) LanguageId Wert |
+|  | Arabic_Lebanon | `0x3001` | Arabisch (Region: Libanon) LanguageId Wert |
+|  | Arabic_Libya | `0x1001` | Arabisch (Region: Libyen) LanguageId Wert |
+|  | Arabic_Morocco | `0x1801` | Arabisch (Region: Marokko) LanguageId Wert |
+|  | Arabic_Oman | `0x2001` | Arabisch (Region: Oman) LanguageId Wert |
+|  | Arabic_Qatar | `0x4001` | Arabisch (Region: Katar) LanguageId Wert |
+|  | Arabic_Saudi_Arabia | `0x0401` | Arabisch (Region: Saudi-Arabien) LanguageId Wert |
+|  | Arabic_Syria | `0x2801` | Arabisch (Region: Syrien) LanguageId Wert |
+|  | Arabic_Tunisia | `0x1C01` | Arabisch (Region: Tunesien) LanguageId Wert |
+|  | Arabic_U_A_E | `0x3801` | Arabisch (Region: VAE) LanguageId Wert |
+|  | Arabic_Yemen | `0x2401` | Arabisch (Region: Jemen) LanguageId Wert |
+|  | Armenian | `0x042B` | Armenisch (Region: Armenien) LanguageId Wert |
+|  | Assamese | `0x044D` | Assamesisch (Region: Indien) LanguageId Wert |
+|  | Azeri_Cyrillic | `0x082C` | Aserbaidschanisch (Kyrillisch, Region: Aserbaidschan) LanguageId Wert |
+|  | Azeri_Latin | `0x042C` | Aserbaidschanisch (Lateinisch, Region: Aserbaidschan) LanguageId Wert |
+|  | Bashkir | `0x046D` | Baschkirisch (Region: Russland) LanguageId Wert |
+|  | Basque | `0x042D` | Baskisch (Region: Baskenland, EUQ) LanguageId Wert |
+|  | Belarusian | `0x0423` | Belarussisch (Region: Belarus,  BEL) LanguageId Wert |
+|  | Bengali_Bangladesh | `0x0845` | Bengalisch (Region: Bangladesch) LanguageId Wert |
+|  | Bengali_India | `0x0445` | Bengalisch (Region: Indien) LanguageId Wert |
+|  | Bosnian_Cyrillic | `0x201A` | Bosnisch (Kyrillisch, Region: Bosnien und Herzegowina) LanguageId Wert |
+|  | Bosnian_Latin | `0x141A` | Bosnisch (Lateinisch, Region: Bosnien und Herzegowina) LanguageId Wert |
+|  | Breton | `0x047E` | Bretonisch (Region: Frankreich) LanguageId Wert |
+|  | Bulgarian | `0x0402` | Bulgarisch (Region: Bulgarien, BGR) LanguageId Wert |
+|  | Catalan | `0x0403` | Katalanisch (Region: Katalonien, CAT) LanguageId Wert |
+|  | Chinese_Hong_Kong | `0x0C04` | Chinesisch (Region: Hongkong S.A.R.) LanguageId Wert |
+|  | Chinese_Macao | `0x1404` | Chinesisch (Region: Macau S.A.R.) LanguageId Wert |
+|  | Chinese_PRC | `0x0804` | Chinesisch (Region: Volksrepublik China) LanguageId Wert |
+|  | Chinese_Singapore | `0x1004` | Chinesisch (Region: Singapur) LanguageId Wert |
+|  | Chinese_Taiwan | `0x0404` | Chinesisch (Region: Taiwan) LanguageId Wert |
+|  | Corsican | `0x0483` | Korsisch (Region: Frankreich) LanguageId Wert |
+|  | Croatian | `0x041A` | Kroatisch (Region: Kroatien, SHL) LanguageId Wert |
+|  | Croatian_Latin | `0x101A` | Kroatisch (Lateinisch, Region: Bosnien und Herzegowina) LanguageId Wert |
+|  | Czech | `0x0405` | Tschechisch (Region: Tschechien, CSY) LanguageId Wert |
+|  | Danish | `0x0406` | Dänisch (Region: Dänemark, DAN) LanguageId Wert |
+|  | Dari | `0x048C` | Dari (Region: Afghanistan) LanguageId Wert |
+|  | Divehi | `0x0465` | Divehi (Region: Malediven) LanguageId Wert |
+|  | Dutch_Belgium | `0x0813` | Niederländisch (Flämisch, Region: Belgien, NLB) LanguageId Wert |
+|  | Dutch_Netherlands | `0x0413` | Niederländisch (Standard, Region: Niederlande, NLD) LanguageId Wert |
+|  | English_Australia | `0x0C09` | Englisch (Australisch, Region: Australien, ENA) LanguageId Wert |
+|  | English_Belize | `0x2809` | Englisch (Region: Belize) LanguageId Wert |
+|  | English_Canada | `0x1009` | Englisch (Kanadisch, Region: Kanada, ENC) LanguageId Wert |
+|  | English_Caribbean | `0x2409` | Englisch (Region: Karibik) LanguageId Wert |
+|  | English_India | `0x4009` | Englisch (Region: Indien) LanguageId Wert |
+|  | English_Ireland | `0x1809` | Englisch (Region: Irland, ENI) LanguageId Wert |
+|  | English_Jamaica | `0x2009` | Englisch (Region: Jamaika) LanguageId Wert |
+|  | English_Malaysia | `0x4409` | Englisch (Region: Malaysia) LanguageId Wert |
+|  | English_New_Zealand | `0x1409` | Englisch (Region: Neuseeland, ENZ) LanguageId Wert |
+|  | English_ROP | `0x3409` | Englisch (Region: Republik der Philippinen, ROP) LanguageId Wert |
+|  | English_Singapore | `0x4809` | Englisch (Region: Singapur) LanguageId Wert |
+|  | English_South_Africa | `0x1C09` | Englisch (Region: Südafrika, SA) LanguageId Wert |
+|  | English_TT | `0x2C09` | Englisch (Region: Trinidad und Tobago, TT) LanguageId Wert |
+|  | English_United_Kingdom | `0x0809` | Englisch (Britisch, Region: Vereinigtes Königreich, ENG) LanguageId Wert |
+|  | English_United_States | `0x0409` | Englisch (Amerikanisch, Region: Vereinigte Staaten, ENU) LanguageId Wert |
+|  | English_Zimbabwe | `0x3009` | Englisch (Region: Simbabwe) LanguageId Wert |
+|  | Estonian | `0x0425` | Estnisch (Region: Estland, ETI) LanguageId Wert |
+|  | Faroese | `0x0438` | Färöisch (Region: Färöer-Inseln) LanguageId Wert |
+|  | Filipino | `0x0464` | Filipino (Region: Philippinen) LanguageId Wert |
+|  | Finnish | `0x040B` | Finnisch (Region: Finnland, FIN) LanguageId Wert |
+|  | French_Belgium | `0x080C` | Französisch (Belgisch, Region: Belgien, FRB) LanguageId Wert |
+|  | French_Canada | `0x0C0C` | Französisch (Kanadisch, Region: Kanada, FRC) LanguageId Wert |
+|  | French_France | `0x040C` | Französisch (Standard, Region: Frankreich, FRA) LanguageId Wert |
+|  | French_Luxembourg | `0x140c` | Französisch (Region: Luxemburg, FRL) LanguageId Wert |
+|  | French_MC | `0x180C` | Französisch (Region: Fürstentum Monaco, MC) LanguageId Wert |
+|  | French_Switzerland | `0x100C` | Französisch (Schweizerisch, Region: Schweiz, FRS) LanguageId Wert |
+|  | Frisian | `0x0462` | Friesisch (Region: Niederlande, NLD) LanguageId Wert |
+|  | Galician | `0x0456` | Galicisch (Region: Galicien) LanguageId Wert |
+|  | Georgian | `0x0437` | Georgisch (Region: Georgien) LanguageId Wert |
+|  | German_Austria | `0x0C07` | Deutsch (österreichisch, Region: Österreich, DEA) LanguageId Wert |
+|  | German_Germany | `0x0407` | Deutsch (Standard, Region: Deutschland, DEU) LanguageId Wert |
+|  | German_Liechtenstein | `0x1407` | Deutsch (Region: Liechtenstein, DEC) LanguageId Wert |
+|  | German_Luxembourg | `0x1007` | Deutsch (Region: Luxemburg, DEL) LanguageId Wert |
+|  | German_Switzerland | `0x0807` | Deutsch (schweizerisch, Region: Schweiz, DES) LanguageId Wert |
+|  | Greek | `0x0408` | Griechisch (Region: Griechenland, ELL) LanguageId Wert |
+|  | Greenlandic | `0x046F` | Grönländisch (Region: Grönland) LanguageId Wert |
+|  | Gujarati | `0x0447` | Gujarati (Region: Indien) LanguageId Wert |
+|  | Hausa | `0x0468` | Hausa (Lateinisch, Region: Nigeria) LanguageId Wert |
+|  | Hebrew | `0x040D` | Hebräisch (Region: Israel) LanguageId Wert |
+|  | Hindi | `0x0439` | Hindi (Region: Indien) LanguageId Wert |
+|  | Hungarian | `0x040E` | Ungarisch (Region: Ungarn, HUN) LanguageId Wert |
+|  | Icelandic | `0x040F` | Isländisch (Region: Island, ISL) LanguageId Wert |
+|  | Igbo | `0x0470` | Igbo (Region: Nigeria) LanguageId Wert |
+|  | Indonesian | `0x0421` | Indonesisch (Region: Indonesien) LanguageId Wert |
+|  | Inuktitut | `0x045D` | Inuktitut (Region: Kanada) LanguageId Wert |
+|  | Inuktitut_Latin | `0x085D` | Inuktitut (Lateinisch, Region: Kanada) LanguageId Wert |
+|  | Irish | `0x083C` | Irisch (Region: Irland) LanguageId Wert |
+|  | isiXhosa | `0x0434` | isiXhosa (Region: Südafrika, SA) LanguageId Wert |
+|  | isiZulu | `0x0435` | isiZulu (Region: Südafrika, SA) LanguageId Wert |
+|  | Italian_Italy | `0x0410` | Italienisch (Standard, Region: Italien, ITA) LanguageId Wert |
+|  | Italian_Switzerland | `0x0810` | Italienisch (schweizerisch, Region: Schweiz, ITS) LanguageId Wert |
+|  | Japanese | `0x0411` | Japanisch (Region: Japan) LanguageId Wert |
+|  | Kannada | `0x044B` | Kannada (Region: Indien) LanguageId Wert |
+|  | Kazakh | `0x043F` | Kasachisch (Region: Kasachstan) LanguageId Wert |
+|  | Khmer | `0x0453` | Khmer (Region: Kambodscha) LanguageId Wert |
+|  | Kiche | `0x0486` | K�iche (Region: Guatemala) LanguageId Wert |
+|  | Kinyarwanda | `0x0487` | Kinyarwanda (Region: Ruanda) LanguageId Wert |
+|  | Kiswahili | `0x0441` | Kiswahili (Region: Kenia) LanguageId Wert |
+|  | Konkani | `0x0457` | Konkani (Region: Indien) LanguageId Wert |
+|  | Korean | `0x0412` | Korean (Region: Korea) LanguageId Wert |
+|  | Kyrgyz | `0x0440` | Kyrgyz (Region: Kirgisistan) LanguageId Wert |
+|  | Lao | `0x0454` | Lao (Region: Lao P.D.R.) LanguageId Wert |
+|  | Latvian | `0x0426` | Latvian (Region: Lettland, LVI) LanguageId Wert |
+|  | Lithuanian | `0x0427` | Lithuanian (Region: Litauen, LTH) LanguageId Wert |
+|  | Lower_Sorbian | `0x082E` | Lower Sorbian (Region: Deutschland) LanguageId Wert |
+|  | Luxembourgish | `0x046E` | Luxembourgish (Region: Luxemburg) LanguageId Wert |
+|  | Macedonian | `0x042F` | Macedonian (Region: Nordmazedonien) LanguageId Wert |
+|  | Malay_Brunei_Darussalam | `0x083E` | Malay (Region: Brunei Darussalam) LanguageId Wert |
+|  | Malay_Malaysia | `0x043E` | Malay (Region: Malaysia) LanguageId Wert |
+|  | Malayalam | `0x044C` | Malayalam (Region: Indien) LanguageId Wert |
+|  | Maltese | `0x043A` | Maltese (Region: Malta) LanguageId Wert |
+|  | Maori | `0x0481` | Maori (Region: Neuseeland) LanguageId Wert |
+|  | Mapudungun | `0x047A` | Mapudungun (Region: Chile) LanguageId Wert |
+|  | Marathi | `0x044E` | Marathi (Region: Indien) LanguageId Wert |
+|  | Mohawk | `0x047C` | Mohawk (Region: Mohawk) LanguageId Wert |
+|  | Mongolian_Cyrillic | `0x0450` | Mongolian (Cyrillic, Region: Mongolei) LanguageId Wert |
+|  | Mongolian_Traditional | `0x0850` | Mongolian (Traditional, Region: Volksrepublik China) LanguageId Wert |
+|  | Nepali | `0x0461` | Nepali (Region: Nepal) LanguageId Wert |
+|  | Norwegian_Bokmal | `0x0414` | Norwegian (Bokmal, Region: Norwegen, NOR) LanguageId Wert |
+|  | Norwegian_Nynorsk | `0x0814` | Norwegisch (Nynorsk, Region: Norway, NON) LanguageId-Wert |
+|  | Occitan | `0x0482` | Okzitanisch (Region: France) LanguageId-Wert |
+|  | Odia | `0x0448` | Odia (früher Oriya, Region: India) LanguageId-Wert |
+|  | Pashto | `0x0463` | Paschtunisch (Region: Afghanistan) LanguageId-Wert |
+|  | Polish | `0x0415` | Polnisch (Region: Poland, PLK) LanguageId-Wert |
+|  | Portuguese_Brazil | `0x0416` | Portugiesisch (Brasilianisch, Region: Brazil, PTB) LanguageId-Wert |
+|  | Portuguese_Portugal | `0x0816` | Portugiesisch (Standard, Region: Portugal, PTG) LanguageId-Wert |
+|  | Punjabi | `0x0446` | Punjabi (Region: India) LanguageId-Wert |
+|  | Quechua_Bolivia | `0x046B` | Quechua (Region: Bolivia) LanguageId-Wert |
+|  | Quechua_Ecuador | `0x086B` | Quechua (Region: Ecuador) LanguageId-Wert |
+|  | Quechua_Peru | `0x0C6B` | Quechua (Region: Peru) LanguageId-Wert |
+|  | Romanian | `0x0418` | Rumänisch (Region: Romania, ROM) LanguageId-Wert |
+|  | Romansh | `0x0417` | Rätoromanisch (Region: Switzerland) LanguageId-Wert |
+|  | Russian | `0x0419` | Russisch (Region: Russia, RUS) LanguageId-Wert |
+|  | Sami_Inari | `0x243B` | Samisch (Inari, Region: Finland) LanguageId-Wert |
+|  | Sami_Lule_Norway | `0x103B` | Samisch (Lule, Region: Norway) LanguageId-Wert |
+|  | Sami_Lule_Sweden | `0x143B` | Samisch (Lule, Region: Sweden) LanguageId-Wert |
+|  | Sami_Northern_Finland | `0x0C3B` | Samisch (Nördlich, Region: Finland) LanguageId-Wert |
+|  | Sami_Northern_Norway | `0x043B` | Samisch (Nördlich, Region: Norway) LanguageId-Wert |
+|  | Sami_Northern_Sweden | `0x083B` | Samisch (Nördlich, Region: Norway) LanguageId-Wert |
+|  | Sami_Skolt | `0x203B` | Samisch (Skolt, Region: Finland) LanguageId-Wert |
+|  | Sami_Southern_Norway | `0x183B` | Samisch (Südlich, Region: Norway) LanguageId-Wert |
+|  | Sami_Southern_Sweden | `0x1C3B` | Samisch (Südlich, Region: Sweden) LanguageId-Wert |
+|  | Sanskrit | `0x044F` | Sanskrit (Region: India) LanguageId-Wert |
+|  | Serbian_Cyrillic_BIH | `0x1C1A` | Serbisch (Kyrillisch, Region: Bosnia and Herzegovina) LanguageId-Wert |
+|  | Serbian_Cyrillic_Serbia | `0x0C1A` | Serbisch (Kyrillisch, Region: Serbia) LanguageId-Wert |
+|  | Serbian_Latin_BIH | `0x181A` | Serbisch (Lateinisch, Region: Bosnien und Herzegowina) LanguageId-Wert |
+|  | Serbian_Latin_Serbia | `0x081A` | Serbisch (Lateinisch, Region: Serbien) LanguageId-Wert |
+|  | Sesotho_Sa_Leboa | `0x046C` | Sesotho sa Leboa (Nord-Sotho, Region: Südafrika, SA) LanguageId-Wert |
+|  | Setswana | `0x0432` | Setswana (Region: Südafrika, SA) LanguageId-Wert |
+|  | Sinhala | `0x045B` | Singhalesisch (Region: Sri Lanka) LanguageId-Wert |
+|  | Slovak | `0x041B` | Slowakisch (Region: Slowakei, SKY) LanguageId-Wert |
+|  | Slovenian | `0x0424` | Slowenisch (Region: Slowenien, SLV) LanguageId-Wert |
+|  | Spanish_Argentina | `0x2C0A` | Spanisch (Region: Argentinien) LanguageId-Wert |
+|  | Spanish_Bolivia | `0x400A` | Spanisch (Region: Bolivien) LanguageId-Wert |
+|  | Spanish_Chile | `0x340A` | Spanisch (Region: Chile) LanguageId-Wert |
+|  | Spanish_Colombia | `0x240A` | Spanisch (Region: Kolumbien) LanguageId-Wert |
+|  | Spanish_Costa_Rica | `0x140A` | Spanisch (Region: Costa Rica) LanguageId-Wert |
+|  | Spanish_Dominican_Republic | `0x1C0A` | Spanisch (Region: Dominikanische Republik) LanguageId-Wert |
+|  | Spanish_Ecuador | `0x300A` | Spanisch (Region: Dominikanische Republik) LanguageId-Wert |
+|  | Spanish_El_Salvador | `0x440A` | Spanisch (Region: Dominikanische Republik) LanguageId-Wert |
+|  | Spanish_Guatemala | `0x100A` | Spanisch (Region: Guatemala) LanguageId-Wert |
+|  | Spanish_Honduras | `0x480A` | Spanisch (Region: Honduras) LanguageId-Wert |
+|  | Spanish_Mexico | `0x080A` | Spanisch (Mexikanisch, Region: Mexiko, ESM) LanguageId-Wert |
+|  | Spanish_Nicaragua | `0x4C0A` | Spanisch (Region: Nicaragua) LanguageId-Wert |
+|  | Spanish_Panama | `0x180A` | Spanisch (Region: Panama) LanguageId-Wert |
+|  | Spanish_Paraguay | `0x3C0A` | Spanisch (Region: Paraguay) LanguageId-Wert |
+|  | Spanish_Peru | `0x280A` | Spanisch (Region: Peru) LanguageId-Wert |
+|  | Spanish_Puerto_Rico | `0x500A` | Spanisch (Region: Puerto Rico) LanguageId-Wert |
+|  | Spanish_Modern_Sort | `0x0C0A` | Spanisch (Moderne Sortierung, Region: Spanien, ESN) LanguageId-Wert |
+|  | Spanish_Traditional_Sort | `0x040A` | Spanisch (Traditionelle Sortierung, Region: Spanien, ESP) LanguageId-Wert |
+|  | Spanish_United_States | `0x540A` | Spanisch (Region: Vereinigte Staaten) LanguageId-Wert |
+|  | Spanish_Uruguay | `0x380A` | Spanisch (Region: Uruguay) LanguageId-Wert |
+|  | Spanish_Venezuela | `0x200A` | Spanisch (Region: Venezuela) LanguageId value |
+|  | Swedish_Finland | `0x081D` | Schwedisch (Region: Finnland) LanguageId value |
+|  | Swedish_Sweden | `0x041D` | Schwedisch (Region: Schweden, SVE) LanguageId value |
+|  | Syriac | `0x045A` | Syrisch (Region: Syrien) LanguageId value |
+|  | Tajik | `0x0428` | Tadschikisch (Kyrillisch, Region: Tadschikistan) LanguageId value |
+|  | Tamazight | `0x085F` | Tamazight  (Lateinisch, Region: Algerien) LanguageId value |
+|  | Tamil | `0x0449` | Tamilisch (Region: Indien) LanguageId value |
+|  | Tatar | `0x0444` | Tatarisch (Region: Russland) LanguageId value |
+|  | Telugu | `0x044A` | Telugu (Region: Indien) LanguageId value |
+|  | Thai | `0x041E` | Thailändisch (Region: Thailand) LanguageId value |
+|  | Tibetan | `0x0451` | Tibetisch (Region: PRC) LanguageId value |
+|  | Turkish | `0x041F` | Türkisch (Region: Türkei, TRK) LanguageId value |
+|  | Turkmen | `0x0442` | Turkmenisch (Region: Turkmenistan) LanguageId value |
+|  | Uighur | `0x0480` | Uigurisch (Region: PRC) LanguageId value |
+|  | Ukrainian | `0x0422` | Ukrainisch (Region: Ukraine, UKR) LanguageId value |
+|  | Upper_Sorbian | `0x042E` | Obersorbisch (Region: Deutschland) LanguageId value |
+|  | Urdu | `0x0420` | Urdu (Region: Islamische Republik Pakistan) LanguageId value |
+|  | Uzbek_Cyrillic | `0x0843` | Usbekisch (Kyrillisch, Region: Usbekistan) LanguageId value |
+|  | Uzbek_Latin | `0x0443` | Usbekisch (Lateinisch, Region: Usbekistan) LanguageId value |
+|  | Vietnamese | `0x042A` | Vietnamesisch (Region: Vietnam) LanguageId value |
+|  | Welsh | `0x0452` | Walisisch (Region: Vereinigtes Königreich) LanguageId value |
+|  | Wolof | `0x0488` | Wolof (Region: Senegal) LanguageId value |
+|  | Yakut | `0x0485` | Jakutisch (Region: Russland) LanguageId value |
+|  | Yi | `0x0478` | Yi (Region: PRC) LanguageId value |
+| Yoruba | `0x046A` | Yoruba (Region: Nigeria) LanguageId value |

--- a/german/nodejs-cpp/enumerations/ttfnametableplatformid/_index.md
+++ b/german/nodejs-cpp/enumerations/ttfnametableplatformid/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Enum TtfNameTablePlatformId"
+second_title: "Aspose.Font für .NET API-Referenz"
+description: "Aspose.Font.TtfNameTablePlatformId enum. Gibt PlatformId an"
+type: docs
+weight: 130
+url: /de/nodejs-cpp/enumerations/ttfnametableplatformid/
+---
+## TtfNameTablePlatformId enumeration
+
+Gibt PlatformId an.
+
+```cssharp
+ enum TtfNameTablePlatformId
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+|  | Unicode | `0` | Unicode |
+|  | Macintosh | `1` | Macintosh Script Manager-Code. |
+|  | ISO | `2` | Apple-Spezifikation: (reserviert; nicht verwenden) MS-Spezifikation: ISO-Codierung. Hinweis: Die Plattform-ID 2 (ISO) wurde mit der OpenType-Spezifikation v1.3 veraltet. Sie sollte ISO/IEC 10646 darstellen, im Gegensatz zu Unicode; beide Standards haben identische Zeichenkodierungszuweisungen. |
+|  | Microsoft | `3` | Microsoft-Codierung. |

--- a/german/nodejs-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
+++ b/german/nodejs-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum TtfNameTableUnicodePlatformSpecificId"
+second_title: "Aspose.Font für .NET API-Referenz"
+description: "Aspose.Font.TtfNameTableUnicodePlatformSpecificId enum. Gibt UnicodePlatformSpecificId an"
+type: docs
+weight: 133
+url: /de/nodejs-cpp/enumerations/ttfnametableunicodeplatformspecificid/
+---
+## TtfNameTableUnicodePlatformSpecificId enumeration
+
+Gibt UnicodePlatformSpecificId an.
+
+```csharp
+ enum TtfNameTableUnicodePlatformSpecificId
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| --- | --- | --- |
+|  | Default | `0` | Standardsemantik (Unicode 1.0). |
+|  | Unicode1_1 | `1` | Unicode 1.1 Semantik. |
+|  | ISO10646_1993 | `2` | ISO 10646 1993 Semantik (veraltet). |
+|  | Unicode2_0 | `3` | Unicode 2.0 oder spätere Semantik. Nur Unicode BMP. |
+|  | Unicode2_0_Full | `4Unicode 2.0 and onwards semantics (non-BMP characters allowed)` | Vollständiges Unicode-Repertoire. |

--- a/german/nodejs-cpp/metadata/_index.md
+++ b/german/nodejs-cpp/metadata/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Metadaten-Schriftfunktionen"
+second_title: "Aspose.Font für Node.js via C++"
+description: "Funktionen zum Arbeiten mit Metadaten-Schriftdateien"
+type: docs
+url: /de/nodejs-cpp/metadata/
+---
+
+## Metadata Font functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposeFontGetInfo](./asposefontgetinfo/) | Lese Informationen (Metadaten) aus einer Schriftdatei. |
+| [AsposeFontSetInfo](./asposefontsetinfo/) | Setze Informationen (Metadaten) in eine Font-Datei. |
+
+## Detailed Description
+
+Funktionen zum Arbeiten mit Metadaten‑Font‑Dateien.
+

--- a/german/nodejs-cpp/metadata/asposefontgetinfo/_index.md
+++ b/german/nodejs-cpp/metadata/asposefontgetinfo/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposeFontGetInfo"
+second_title: "Aspose.Font für Node.js via C++"
+description: "Lese Informationen (Metadaten) aus einer Schriftdatei."
+type: docs
+url: /de/nodejs-cpp/metadata/asposefontgetinfo/
+---
+## AsposeFontGetInfo function
+
+_Informationen (Metadaten) aus einer Schriftdatei erhalten._
+
+```js
+function AsposeFontGetInfo(
+    fileName
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileName | string | Dateiname. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | Datensätze | Array von JSON-Objekten : |
+|  | * NameId | Namensbezeichner |
+|  | * PlatformId | Plattformbezeichner |
+|  | * PlatformSpecificId | plattform-spezifischer Bezeichner |
+|  | * LanguageId | Sprachbezeichner |
+|  | * Info | Inhalt des Namensdatensatzes |
+
+### Beispiele
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    //AsposeFontGetInfo - get metadata information
+    const json = AsposeFontModule.AsposeFontGetInfo(font_file);
+    console.log("AsposeFontGetInfo => %O",  json.errorCode == 0 ? json.records.reduce((ret, a) => ret +
+        "\nNameId : " + a.NameId
+        + "; PlatformId : " + a.PlatformId
+        + "; PlatformSpecificId : " + a.PlatformSpecificId
+        + "; LanguageId : " + a.LanguageId
+        + "; Info : " + a.Info,"") : json.errorText);
+
+});
+```
+**ECMAScript\ES6 js modules:**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+//AsposeFontGetInfo - get metadata font information
+json = AsposeFontModule.AsposeFontGetInfo(font_file);
+console.log("AsposeFontGetInfo => %O",  json.errorCode == 0 ? json.records.reduce((ret, a) => ret +
+    "\nNameId : " + a.NameId
+  + "; PlatformId : " + a.PlatformId
+  + "; PlatformSpecificId : " + a.PlatformSpecificId
+  + "; LanguageId : " + a.LanguageId
+  + "; Info : " + a.Info,"") : json.errorText);
+```

--- a/german/nodejs-cpp/metadata/asposefontsetinfo/_index.md
+++ b/german/nodejs-cpp/metadata/asposefontsetinfo/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeFontSetInfo"
+second_title: "Aspose.Font für Node.js via C++"
+description: "Setze Informationen (Metadaten) in eine Font-Datei."
+type: docs
+url: /de/nodejs-cpp/metadata/asposefontsetinfo/
+---
+## AsposeFontSetInfo function
+
+_Setze Informationen (Metadaten) in eine Font-Datei._
+
+```js
+function AsposeFontSetInfo(
+    fileName,
+    nameId, 
+    platformId, 
+    platformSpecificId, 
+    languageId, 
+    text
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileName | string | Dateiname. |
+| nameId | TtfNameTableNameId | Namensidentifikator, logische Zeichenkettenkategorie, angegeben durch die Aufzählung [`NameId`](../../enumerations/ttfnametablenameid/) |
+|  | platformId | TtfNameTablePlatformId | Plattform‑Identifikator |
+| platformSpecificId | int | Plattform-spezifischer Codierungsidentifikator. Bitte verwenden Sie einen Wert aus einer der folgenden Aufzählungen – [`UnicodePlatformSpecificId`](../../enumerations/ttfnametableunicodeplatformspecificid/), [`MacPlatformSpecificId`](../../ttfnametable.macplatformspecificid/), [`MSPlatformSpecificId`](../../enumerations/ttfnametablemsplatformspecificid/). Welche Aufzählung zu verwenden ist, wird durch den Kontext (*platformId*‑Parameter) bestimmt. |
+| languageId | int | Sprachidentifikator. Bitte verwenden Sie einen Wert aus der Aufzählung [`MSLanguageId`](../../enumerations/ttfnametablemslanguageid/) oder [`MacLanguageId`](../../enumerations/ttfnametablemaclanguageid/), abhängig vom Kontext, definiert durch den *platformId*‑Parameter. |
+|  | Text | string | Tatsächliche Zeichenkettendaten |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    //AsposeSetInfo - set metadata info into font
+    const nameId = AsposeFontModule.TtfNameTableNameId.Description;
+    const platformId = AsposeFontModule.TtfNameTablePlatformId.Microsoft;
+    const platformSpecificId = AsposeFontModule.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+    const langID = Module.TtfNameTableMSLanguageId.English_United_States.value;
+    const text = "Updated description";
+    
+    const json = AsposeFontSetInfo(font_file, nameId, platformId, platformSpecificId, langID, text);
+    console.log("AsposeFontSetInfo => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules:**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+//AsposeSetInfo - set metadata info into font
+const nameId = AsposeFontModule.TtfNameTableNameId.Description;
+const platformId = AsposeFontModule.TtfNameTablePlatformId.Microsoft;
+const platformSpecificId = AsposeFontModule.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+const langID = Module.TtfNameTableMSLanguageId.English_United_States.value;
+const text = "Updated description";
+
+const json = AsposeFontModule.AsposeFontSetInfo(font_file, nameId, platformId, platformSpecificId, langID, text);
+console.log("AsposeFontSetInfo => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Siehe auch
+
+* enum [TtfNameTableNameId](../../enumerations/ttfnametablenameid/)
+* enum [TtfNameTablePlatformId](../../enumerations/ttfnametableplatformid/)
+* enum [TtfNameTableMacPlatformSpecificId](../../enumerations/ttfnametablemacplatformspecificid/)
+* enum [TtfNameTableMSPlatformSpecificId](../../enumerations/ttfnametablemsplatformspecificid/)
+* enum [TtfNameTableUnicodePlatformSpecificId](../../enumerations/ttfnametableunicodeplatformspecificid/)
+* enum [TtfNameTableMacLanguageId](../../enumerations/ttfnametablemaclanguageid/)
+* enum [TtfNameTableMSLanguageId](../../enumerations/ttfnametablemslanguageid/)

--- a/german/nodejs-cpp/misc/_index.md
+++ b/german/nodejs-cpp/misc/_index.md
@@ -1,0 +1,17 @@
+---
+title: "Verschiedene Funktionen"
+second_title: "Aspose.Font für Node.js via C++"
+description: "Sekundäre Funktionen zum Arbeiten mit Font‑Dateien."
+type: docs
+url: /de/nodejs-cpp/misc/
+---
+## Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposeFontAbout](./asposefontabout/) | Lese Informationen über das Produkt. |
+
+## Detailed Description
+
+Sekundäre Funktionen zum Arbeiten mit Font‑Dateien.
+

--- a/german/nodejs-cpp/misc/asposefontabout/_index.md
+++ b/german/nodejs-cpp/misc/asposefontabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeFontAbout"
+second_title: "Aspose.Font für Node.js via C++"
+description: "Lese Informationen über das Produkt."
+type: docs
+url: /de/nodejs-cpp/misc/AsposeFontAbout/
+---
+
+## AsposeFontAbout function
+
+Lese Informationen über das Produkt.
+
+```js
+function AsposeFontAbout()
+```
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+| errorCode | Fehlercode (0 kein Fehler) |
+| errorText | Textfehler ("" kein Fehler) |
+| Produkt | Produktname |
+| Version | Produktversion |
+| islicensed | Produkt ist lizenziert |
+
+
+## Beispiel
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    json = AsposeFontModule.AsposeFontAbout();
+    console.log("AsposeFontAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules:**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+//AsposeFontAbout - Get info about Product
+const json = AsposeFontModule.AsposeFontAbout();
+console.log("AsposeFontAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+```


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **German** (`de`) generated by RDA.

- Pages translated: 22/22
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `german/nodejs-cpp`

🤖 Generated by RDA