### PR TITLE
[auto] Translate NODEJS-CPP API Reference to Italian

### DIFF
--- a/italian/nodejs-cpp/_index.md
+++ b/italian/nodejs-cpp/_index.md
@@ -1,0 +1,54 @@
+---
+title: "Aspose.Font per Node.js via C++"
+description: "Aspose.Font per Node.js via C++"
+keywords:  "Node.js via C++, Node.js Font toolkit"
+tags: ['font-to-ttf', 'font-to-woff',  'font-to-woff2', 'font-to-svg', 'font-convert', 'font-tools']
+weight: 40
+url: /it/nodejs-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.Font for Node.js via C++ allows developers manipulate them Font files on server side web solutions.
+>
+> CommonJS and ECMAScript modules are aviable for any JavaScript solutions. 
+
+
+## Convert functions
+
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [AsposeFontConvert](./convert/) | Converti un font in font TrueType. |
+| [AsposeFontConvertToTTF](./convert/asposefontconverttottf/) | Converti un font in formato TTF. |
+| [AsposeFontConvertToWOFF](./convert/asposefontconverttowoff/) | Converti un font in formato WOFF. |
+| [AsposeFontConvertToWOFF2](./convert/asposefontconverttowoff2/) | Converti un font in formato WOFF2. |
+| [AsposeFontConvertToSVG](./convert/asposefontconverttosvg/) | Converti un font in formato SVG. |
+
+
+## Metadata Font functions
+
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [AsposeFontGetInfo](./metadata/asposefontgetinfo/) | Ottieni informazioni (metadati) da un file Font. |
+| [AsposeFontSetInfo](./metadata/asposefontsetinfo/) | Imposta informazioni (metadati) in un file Font. |
+
+
+## Miscellaneous
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposeFontAbout](./misc/asposefontabout/) | Ottieni informazioni sul prodotto. |
+
+## Enumerazioni
+
+| Enumerazione | Descrizione |
+| ----------- | ----------- |
+| [FontSavingFormats](./enumerations/fontsavingformats/) | Specifica il tipo di Font. |
+| [FontStyle](./enumerations/fontstyle/) | Specifica lo stile del Font. |
+| [TtfNameTableNameId](./enumerations/ttfnametablenameid/) | Specifica NameId. |
+| [TtfNameTablePlatformId](./enumerations/ttfnametableplatformid/) | Rappresenta l'enumerazione PlatformId. |
+| [TtfNameTableMacPlatformSpecificId](./enumerations/ttfnametablemacplatformspecificid/) | Rappresenta l'enumerazione dell'ID specifico della piattaforma Macintosh. |
+| [TtfNameTableMSPlatformSpecificId](./enumerations/ttfnametablemsplatformspecificid/) | Rappresenta l'enumerazione dell'ID specifico della piattaforma Microsoft. |
+| [TtfNameTableUnicodePlatformSpecificId](./enumerations/ttfnametableunicodeplatformspecificid/) | Rappresenta l'enumerazione dell'ID specifico della piattaforma Unicode. |
+| [TtfNameTableMacLanguageId](./enumerations/ttfnametablemaclanguageid/) | Enumerazione MacLanguageId. |
+| [TtfNameTableMSLanguageId](./enumerations/ttfnametablemslanguageid/) | Enumerazione MSLanguageId. |

--- a/italian/nodejs-cpp/convert/_index.md
+++ b/italian/nodejs-cpp/convert/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Funzioni di conversione dei font"
+second_title: "Aspose.Font per Node.js via C++"
+description: "Funzioni per convertire i font in formati TrueType."
+type: docs
+url: /it/nodejs-cpp/convert/
+---
+
+## Convert functions
+
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [AsposeFontConvert](./asposefontconvert) | Converti un font nei formati supportati. |
+| [AsposeFontConvertToTTF](./asposefontconverttottf/) | Converti un font in formato TTF. |
+| [AsposeFontConvertToWOFF](./asposefontconverttowoff/) | Converti un font in formato WOFF. |
+| [AsposeFontConvertToWOFF2](./asposefontconverttowoff2/) | Converti un font in formato WOFF2. |
+| [AsposeFontConvertToSVG](./asposefontconverttosvg/) | Converti un font in formato SVG. |
+
+## Detailed Description
+
+Funzioni per convertire i font in formati TrueType.
+

--- a/italian/nodejs-cpp/convert/asposefontconvert/_index.md
+++ b/italian/nodejs-cpp/convert/asposefontconvert/_index.md
@@ -1,0 +1,73 @@
+---
+title: "AsposeFontConvert"
+second_title: "Aspose.Font per Node.js via C++"
+description: "Converte il Font in un altro formato"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/convert/asposefontconvert/
+---
+## AsposeFontConvert function
+
+Converte il Font in un altro formato.
+
+```js
+function AsposeFontConvert(
+    fileName,
+    fontType,
+    fontSavingFormat
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileName | string | Nome file. |
+| fontType | FontType | Tipo di Font da convertire. |
+| fontSavingFormat | FontSavingFormats | Formato del Font in cui convertire. |
+
+### Valore restituito
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | codice errore (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Osservazioni
+
+Nota: il tipo di Font TTF è ora supportato solo.
+
+### Esempi
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvert to convert font
+    const json = AsposeFontModule.AsposeFontConvert(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvert(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Vedi anche
+
+* enum [FontType](../../enumerations/fonttype/)
+* enum [FontSavingFormats](../../enumerations/fontsavingformats/)

--- a/italian/nodejs-cpp/convert/asposefontconverttottf/_index.md
+++ b/italian/nodejs-cpp/convert/asposefontconverttottf/_index.md
@@ -1,0 +1,60 @@
+---
+title: "AsposeFontConvertToTTF"
+second_title: "Aspose.Font per Node.js via C++"
+description: "Converte il Font nel formato ttf"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/convert/asposefontconverttottf/
+---
+## AsposeFontConvertToTTF function
+
+Converte il Font nel formato TTF.
+
+```js
+function AsposeFontConvertToTTF(
+    fileName,
+    fontType
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileName | string | Nome file. |
+| fontType | FontType | Tipo di Font da convertire. |
+
+### Valore restituito
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | codice errore (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+const font_file = "./fonts/Lora-Regular.ttf";
+console.log('Aspose.Font for Node.js via C++ example');
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvert to convert font
+    const json = AsposeFontModule.AsposeFontConvertToTTF(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript/ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+const font_file ="./fonts/arial.ttf";
+const AsposeFontModule = await AsposeFont();
+console.log('Aspose.Font for Node.js via C++ example');
+const json = AsposeFontModule.AsposeFontConvertToTTF(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Vedi anche
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/italian/nodejs-cpp/convert/asposefontconverttowoff/_index.md
+++ b/italian/nodejs-cpp/convert/asposefontconverttowoff/_index.md
@@ -1,0 +1,67 @@
+---
+title: "AsposeFontConvertToWOFF"
+second_title: "Aspose.Font per Node.js via C++"
+description: "Converte il Font nel formato woff"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/convert/asposefontconverttowoff/
+---
+## AsposeFontConvertToWOFF function
+
+Converte il Font nel formato WOFF.
+
+```js
+function AsposeFontConvertToWOFF(
+    fileName,
+    fontType
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileName | string | Nome file. |
+| fontType | FontType | Tipo di Font da convertire. |
+
+### Valore restituito
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | codice errore (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvertToWOFF to convert font
+    const json = AsposeFontModule.AsposeFontConvertToWOFF(font_file,AsposeFontModule.FontType.TTF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvertToWOFF(font_file,AsposeFontModule.FontType.TTF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Vedi anche
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/italian/nodejs-cpp/convert/asposefontconverttowoff2/_index.md
+++ b/italian/nodejs-cpp/convert/asposefontconverttowoff2/_index.md
@@ -1,0 +1,67 @@
+---
+title: "AsposeFontConvertToWOFF2"
+second_title: "Aspose.Font per Node.js via C++"
+description: "Converte il Font nel formato woff2"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/convert/asposefontconverttowoff2/
+---
+## AsposeFontConvertToWOFF2 function
+
+Converte il Font nel formato WOFF2.
+
+```js
+function AsposeFontConvertToWOFF2(
+    fileName,
+    fontType
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileName | string | Nome file. |
+| fontType | FontType | Tipo di Font da convertire. |
+
+### Valore restituito
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | codice errore (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvertToWOFF2 to convert font
+    const json = AsposeFontModule.AsposeFontConvertToWOFF2(font_file,AsposeFontModule.FontType.TTF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvertToWOFF2(font_file,AsposeFontModule.FontType.TTF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Vedi anche
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/italian/nodejs-cpp/convert/asposefontconverttowsvg/_index.md
+++ b/italian/nodejs-cpp/convert/asposefontconverttowsvg/_index.md
@@ -1,0 +1,67 @@
+---
+title: "AsposeFontConvertToSVG"
+second_title: "Aspose.Font per Node.js via C++"
+description: "Converte il Font nel formato svg"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/convert/asposefontconverttosvg/
+---
+## AsposeFontConvertToSVG function
+
+Converte il Font nel formato SVG.
+
+```js
+function AsposeFontConvertToSVG(
+    fileName,
+    fontType
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileName | string | Nome file. |
+| fontType | FontType | Tipo di Font da convertire. |
+
+### Valore restituito
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | codice errore (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvertToSVG to convert font
+    const json = AsposeFontModule.AsposeFontConvertToSVG(font_file,AsposeFontModule.FontType.TTF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvertToSVG(font_file,AsposeFontModule.FontType.TTF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Vedi anche
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/italian/nodejs-cpp/enumerations/_index.md
+++ b/italian/nodejs-cpp/enumerations/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Enumerazioni"
+second_title: "Aspose.Font per Node.js via C++"
+description: "Funzioni per convertire i font in formati TrueType."
+type: docs
+url: /it/nodejs-cpp/enumerations/
+---
+
+## Enumerazioni
+
+| Enumerazione | Descrizione |
+| ----------- | ----------- |
+| [FontSavingFormats](./fontsavingformats/) | Specifica il tipo di Font. |
+| [FontType](./fonttype/) | Specifica il tipo di Font. |
+| [TtfNameTableNameId](./ttfnametablenameid/) | Specifica NameId. |
+| [TtfNameTablePlatformId](./ttfnametableplatformid/) | Rappresenta l'enumerazione PlatformId. |
+| [TtfNameTableMSPlatformSpecificId](./ttfnametableMSPlatformSpecificId/) | Rappresenta l'enumerazione MSPlatformSpecificId. |
+| [TtfNameTableMacPlatformSpecificId](./ttfnametableMacPlatformSpecificId/) | Rappresenta l'enumerazione MacPlatformSpecificId. |
+| [TtfNameTableUnicodePlatformSpecificId](./ttfnametableUnicodePlatformSpecificId/) | Rappresenta l'enumerazione UnicodePlatformSpecificId. |
+| [TtfNameTableMacLanguageId](./ttfnametablemaclanguageid/) | Enumerazione degli ID lingua della piattaforma Macintosh. |
+| [TtfNameTableMSLanguageId](./ttfnametablemslanguageid/) | Enumerazione degli ID lingua della piattaforma Microsoft. |
+
+### Example of using enumarations
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    //define parameters for AsposeFontSetInfo
+    const nameId = AsposeFontModule.TtfNameTableNameId.Description;
+    const platformId = AsposeFontModule.TtfNameTablePlatformId.Microsoft;
+    const platformSpecificId = AsposeFontModule.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+    const langID = Module.TtfNameTableMSLanguageId.English_United_States.value;
+    const text = "Updated description";
+    
+    const json = AsposeFontSetInfo(font_file, nameId, platformId, platformSpecificId, langID, text);
+    console.log("AsposeFontSetInfo => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/italian/nodejs-cpp/enumerations/fontsavingformats/_index.md
+++ b/italian/nodejs-cpp/enumerations/fontsavingformats/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum FontSavingFormats"
+second_title: "Riferimento API di Aspose.Font per .NET"
+description: "Aspose.Font.FontSavingFormats enum. Specifica il tipo di carattere"
+type: docs
+weight: 110
+url: /it/nodejs-cpp/enumerations/fontsavingformats/
+---
+## FontSavingFormats enumeration
+
+Specifica il tipo di Font.
+
+```csharp
+public enum FontSavingFormats
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+| TTF | `0` | Formato di carattere TTF (TrueType). |
+| WOFF | `1` | WOFF (Web Open Font Format). |
+| WOFF2 | `2` | Formato file WOFF 2.0 |
+| SVG | `3` | Formato di carattere SVG (Scalable Vector Graphics) |
+| OTF | `4` | Formato di carattere OTF (OpenType) |

--- a/italian/nodejs-cpp/enumerations/fonttype/_index.md
+++ b/italian/nodejs-cpp/enumerations/fonttype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum FontType"
+second_title: "Riferimento API di Aspose.Font per .NET"
+description: "Aspose.Font.FontType enum. Specifica il tipo di carattere"
+type: docs
+weight: 100
+url: /it/nodejs-cpp/enumerations/fonttype/
+---
+## FontType enumeration
+
+Specifica il tipo di Font.
+
+```csharp
+public enum FontType
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+| TTF | `0` | Tipo di carattere TTF (TrueType) e correlati. |
+| Type1 | `1` | Tipo di carattere Type1. |
+| CFF | `2` | Tipo di carattere CFF (Compact font format). |
+| OTF | `3` | OpenType Font. Il formato di carattere OpenType è un'estensione del formato di carattere TrueType, aggiungendo il supporto per i dati dei caratteri PostScript. |
+

--- a/italian/nodejs-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
+++ b/italian/nodejs-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
@@ -1,0 +1,53 @@
+---
+title: "Enum TtfNameTableMacPlatformSpecificId"
+second_title: "Riferimento API di Aspose.Font per .NET"
+description: "Enum Aspose.Font.TtfNameTableMacPlatformSpecificId. Specifica MacPlatformSpecificId"
+type: docs
+weight: 131
+url: /it/nodejs-cpp/enumerations/ttfnametablemacplatformspecificid/
+---
+## TtfNameTableMacPlatformSpecificId enumeration
+
+Specifică MacPlatformSpecificId.
+
+```csharp
+ enum TtfNameTableMacPlatformSpecificId
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+|  | Roman | `0` | Valore specifico della piattaforma Roman. |
+|  | Japanese | `1` | Valore specifico della piattaforma giapponese. |
+|  | Traditional_Chinese | `2` | Valore specifico della piattaforma cinese tradizionale. |
+|  | Korean | `3` | Valore specifico della piattaforma coreana. |
+|  | Arabic | `4` | Valore specifico della piattaforma araba. |
+|  | Hebrew | `5` | Valore specifico della piattaforma ebraica. |
+|  | Greek | `6` | Valore specifico della piattaforma greca. |
+|  | Russian | `7` | Valore specifico della piattaforma russa. |
+|  | RSymbol | `8` | Valore specifico della piattaforma RSymbol. |
+|  | Devanagari | `9` | Valore specifico della piattaforma Devanagari. |
+|  | Gurmukhi | `10` | Valore specifico della piattaforma Gurmukhi. |
+|  | Gujarati | `11` | Valore specifico della piattaforma Gujarati. |
+|  | Oriya | `12` | Valore specifico della piattaforma Oriya. |
+|  | Bengali | `13` | Valore specifico della piattaforma bengalese. |
+|  | Tamil | `14` | Valore specifico della piattaforma tamil. |
+|  | Telugu | `15` | Valore specifico della piattaforma Telugu. |
+|  | Kannada | `16` | Valore specifico della piattaforma Kannada. |
+|  | Malayalam | `17` | Valore specifico della piattaforma Malayalam. |
+|  | Sinhalese | `18` | Valore specifico della piattaforma Sinhalese. |
+|  | Burmese | `19` | Valore specifico della piattaforma Burmese. |
+|  | Khmer | `20` | Valore specifico della piattaforma Khmer. |
+|  | Thai | `21` | Valore specifico della piattaforma Thai. |
+|  | Laotian | `22` | Valore specifico della piattaforma Laotian. |
+|  | Georgian | `23` | Valore specifico della piattaforma Georgian. |
+|  | Armenian | `24` | Valore specifico della piattaforma Armenian. |
+|  | Simplified_Chinese | `25` | Valore specifico della piattaforma cinese semplificato. |
+|  | Tibetan | `26` | Valore specifico della piattaforma tibetana. |
+|  | Mongolian | `27` | Valore specifico della piattaforma mongola. |
+|  | Geez | `28` | Valore specifico della piattaforma Geez. |
+|  | Slavic | `29` | Valore specifico della piattaforma Slavic. |
+|  | Vietnamese | `30` | Valore specifico della piattaforma vietnamita. |
+|  | Sindhi | `31` | Valore specifico della piattaforma Sindhi. |
+|  | Uninterpreted | `32` | Valore specifico della piattaforma Uninterpreted. |

--- a/italian/nodejs-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
+++ b/italian/nodejs-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Enum TtfNameTableMSPlatformSpecificId"
+second_title: "Riferimento API di Aspose.Font per .NET"
+description: "Enum Aspose.Font.TtfNameTableMSPlatformSpecificId. Specifica MSPlatformSpecificId"
+type: docs
+weight: 132
+url: /it/nodejs-cpp/enumerations/ttfnametablemsplatformspecificid/
+---
+## TtfNameTableMSPlatformSpecificId enumeration
+
+Specifica MSPlatformSpecificId.
+
+```csharp
+ enum TtfNameTableMSPlatformSpecificId
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+|  | Symbol | `0` | Symbol MS PlatformSpecificId. |
+|  | Unicode_BMP_UCS2 | `1` | Unicode BMP (UCS2) MS PlatformSpecificId. |
+|  | ShiftJIS | `2` | ShiftJIS MS PlatformSpecificId. |
+|  | PRC | `3` | PRC MS PlatformSpecificId. |
+|  | Big5 | `4` | Big5 MS PlatformSpecificId. |
+|  | Wansung | `5` | Wansung MS PlatformSpecificId. |
+|  | Johab | `6` | Johab MS PlatformSpecificId. |
+|  | Reserved1 | `7` | Reserved1 MS PlatformSpecificId. |
+|  | Reserved2 | `8` | Reserved2 MS PlatformSpecificId. |
+|  | Reserved3 | `9` | Reserved3 MS PlatformSpecificId. |
+|  | Unicode_UCS4 | `10` | Unicode UCS4 MS PlatformSpecificId. |
+

--- a/italian/nodejs-cpp/enumerations/ttfnametablenameid/_index.md
+++ b/italian/nodejs-cpp/enumerations/ttfnametablenameid/_index.md
@@ -1,0 +1,46 @@
+---
+title: "Enum TtfNameTableNameId"
+second_title: "Riferimento API di Aspose.Font per .NET"
+description: "Aspose.Font.TtfNameTableNameId enum. Specifica NameId"
+type: docs
+weight: 120
+url: /it/nodejs-cpp/enumerations/ttfnametablenameid/
+---
+## TtfNameTableNameId enumeration
+
+Specifica NameId.
+
+```csharp
+ enum TtfNameTableNameId
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+|  | CopyrightNotice | `0` | Avviso di copyright. |
+|  | FontFamily | `1` | Famiglia Font. Questa stringa è il nome della famiglia del Font che l'utente vede sulle piattaforme Macintosh. |
+|  | FontSubfamily | `2` | Sottofamiglia Font. Questa stringa è la famiglia del Font che l'utente vede sulle piattaforme Macintosh. |
+|  | UniqueFontId | `3` | Identificazione unica della sottofamiglia (specifica Apple). 3 Identificatore unico del Font (specifica MS). |
+|  | FullName | `4` | Nome completo del Font. |
+|  | Version | `5` | Versione della tabella dei nomi. |
+|  | PostScriptName | `6` | Nome PostScript del Font. Nota: un Font può avere un solo nome PostScript e tale nome deve essere ASCII. |
+|  | TrademarkNotice | `7` | Avviso di marchio. |
+|  | ManufacturerName | `8` | Nome del produttore. |
+|  | DesignerName | `9` | Designer; nome del designer del carattere. |
+|  | Description | `10` | Descrizione; descrizione del carattere. Può contenere informazioni di revisione, raccomandazioni d'uso, storia, funzionalità, ecc. |
+|  | UrlVendor | `11` | URL del fornitore del Font (con protocollo, ad es., http://, ftp://). Se un numero di serie unico è incorporato nell'URL, può essere usato per registrare il Font. |
+|  | UrlDesigner | `12` | URL del designer del Font (con protocollo, ad es., http://, ftp://) |
+|  | LicenseDescription | `13` | Descrizione della licenza; descrizione di come il Font può essere usato legalmente, o diversi scenari di esempio per l'uso con licenza. Questo campo dovrebbe essere scritto in linguaggio semplice, non in gergo legale. |
+|  | LicenseInfoUrl | `14` | URL delle informazioni sulla licenza, dove è possibile trovare ulteriori informazioni sulla licenza. |
+|  | PreferredFamily | `16` | `15` Riservato `16` Famiglia Preferita (solo Windows); In Windows, il nome Famiglia è visualizzato nel menu Font; il nome Sottofamiglia è presentato come nome Stile. Per ragioni storiche, le famiglie di Font hanno contenuto un massimo di quattro stili, ma i designer di Font possono raggruppare più di quattro font in una singola famiglia. Gli ID di Famiglia Preferita e Sottofamiglia Preferita consentono ai designer di Font di includere i raggruppamenti di famiglia/sottofamiglia preferiti. Questi ID sono presenti solo se sono diversi dagli ID 1 e 2. |
+|  | PreferredSubfamily | `17` | Sottofamiglia Preferita (solo Windows); In Windows, il nome Famiglia è visualizzato nel menu Font; il nome Sottofamiglia è presentato come nome Stile. Per ragioni storiche, le famiglie di Font hanno contenuto un massimo di quattro stili, ma i designer di Font possono raggruppare più di quattro font in una singola famiglia. Gli ID di Famiglia Preferita e Sottofamiglia Preferita consentono ai designer di Font di includere i raggruppamenti di famiglia/sottofamiglia preferiti. Questi ID sono presenti solo se sono diversi dagli ID 1 e 2. |
+|  | CompatibleFull | `18` | Compatibile Completo (solo Macintosh); Su Macintosh, il nome del menu è costruito usando la risorsa Font. Questo di solito corrisponde al Nome Completo. Se desideri che il nome del Font appaia diversamente dal Nome Completo, puoi inserire il Nome Compatibile Completo nell'ID 18. Questo nome non è usato dal Mac OS stesso, ma può essere usato dagli sviluppatori di applicazioni (ad es., Adobe). |
+|  | SampleText | `19` | Testo di esempio. Può essere il nome del Font, o qualsiasi altro testo che il designer ritiene sia il miglior esempio per mostrare l'aspetto del Font. |
+|  | PostScriptCID | `20` | La sua presenza in un font indica che il nameID 6 contiene un nome font PostScript destinato ad essere usato con l'invocazione "composefont" per richiamare il font in un interprete PostScript. |
+|  | WwsFamilyName | `21` | Usato per fornire un nome di famiglia conforme al modello WWS nel caso in cui le voci per gli ID 16 e 17 non siano conformi al modello WWS. |
+|  | WwsSubfamilyName | `22` | Usato in combinazione con l'ID 21, questo ID fornisce un nome di sottofamiglia conforme al modello WWS (che riflette solo gli attributi di peso, larghezza e inclinazione) nel caso in cui le voci per gli ID 16 e 17 non siano conformi al modello WWS. |
+|  | LightBackground | `23` | Questo ID, se usato nell'Array delle Etichette della Palette della tabella CPAL, specifica che la palette di colori corrispondente nella tabella CPAL è appropriata per l'uso con il font quando viene visualizzato su uno sfondo chiaro come il bianco. |
+|  | DarkBackground | `24` | Questo ID, se usato nell'Array delle Etichette della Palette della tabella CPAL, specifica che la palette di colori corrispondente nella tabella CPAL è appropriata per l'uso con il font quando viene visualizzato su uno sfondo scuro come il nero. |
+|  | VariationsPostScriptNamePrefix | `25` | Se presente in un font variabile, può essere usato come prefisso di famiglia nella generazione del nome PostScript per l'algoritmo dei Font a Variazione. |
+

--- a/italian/nodejs-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
+++ b/italian/nodejs-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
@@ -1,0 +1,138 @@
+---
+title: "Enum TtfNameTableMacLanguageId"
+second_title: "Riferimento API di Aspose.Font per .NET"
+description: "Enum Aspose.Font.TtfNameTableMacLanguageId. Specifica MacLanguageId"
+type: docs
+weight: 140
+url: /it/nodejs-cpp/enumerations/ttfnametablemaclanguageid/
+---
+## TtfNameTableMacLanguageId enumeration
+
+Rappresenta l'enumerazione MacLanguageId.
+
+```csharp
+ enum TtfNameTableMacLanguageId
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+|  | English | `0` | Valore LanguageId inglese |
+|  | French | `1` | Valore LanguageId francese |
+|  | German | `2` | Valore LanguageId tedesco |
+|  | Italian | `3` | Valore LanguageId italiano |
+|  | Dutch | `4` | Valore LanguageId olandese |
+|  | Swedish | `5` | Valore LanguageId svedese |
+|  | Spanish | `6` | Valore LanguageId spagnolo |
+|  | Danish | `7` | Valore LanguageId danese |
+|  | Portuguese | `8` | Valore LanguageId portoghese |
+|  | Norwegian | `9` | Valore LanguageId norvegese |
+|  | Hebrew | `10` | Ebraico LanguageId valore |
+|  | Japanese | `11` | Giapponese LanguageId valore |
+|  | Arabic | `12` | Arabo LanguageId valore |
+|  | Finnish | `13` | Finlandese LanguageId valore |
+|  | Greek | `14` | Greco LanguageId valore |
+|  | Icelandic | `15` | Islandese LanguageId valore |
+|  | Maltese | `16` | Maltese LanguageId valore |
+|  | Turkish | `17` | Turco LanguageId valore |
+|  | Croatian | `18` | Croato LanguageId valore |
+|  | Chinese_Traditional | `19` | Cinese (Tradizionale) LanguageId valore |
+|  | Urdu | `20` | Urdu LanguageId valore |
+|  | Hindi | `21` | Hindi LanguageId valore |
+|  | Thai | `22` | Thai LanguageId valore |
+|  | Korean | `23` | Coreano LanguageId valore |
+|  | Lithuanian | `24` | Lituano LanguageId valore |
+|  | Polish | `25` | Polacco LanguageId valore |
+|  | Hungarian | `26` | Ungherese LanguageId valore |
+|  | Estonian | `27` | Estone LanguageId valore |
+|  | Latvian | `28` | Lettone LanguageId valore |
+|  | Sami | `29` | Sami LanguageId valore |
+|  | Faroese | `30` | Faroese LanguageId valore |
+|  | Farsi_Persian | `31` | Farsi/Persiano LanguageId valore |
+|  | Russian | `32` | Russo LanguageId valore |
+|  | Chinese_Simplified | `33` | Cinese (Semplificato) LanguageId valore |
+|  | Flemish | `34` | Fiammingo LanguageId valore |
+|  | Irish_Gaelic | `35` | Gaelico irlandese LanguageId valore |
+|  | Albanian | `36` | Albanese LanguageId valore |
+|  | Romanian | `37` | Rumeno LanguageId valore |
+|  | Czech | `38` | Ceco LanguageId valore |
+|  | Slovak | `39` | Slovacco LanguageId valore |
+|  | Slovenian | `40` | Sloveno LanguageId valore |
+|  | Yiddish | `41` | Yiddish LanguageId valore |
+|  | Serbian | `42` | Serbo LanguageId valore |
+|  | Macedonian | `43` | Macedone LanguageId valore |
+|  | Bulgarian | `44` | Bulgaro LanguageId valore |
+|  | Ukrainian | `45` | Ucraino LanguageId valore |
+|  | Byelorussian | `46` | Bielorusso LanguageId valore |
+|  | Uzbek | `47` | Uzbeko LanguageId valore |
+|  | Kazakh | `48` | Kazako LanguageId valore |
+|  | Azerbaijani_Cyrillic | `49` | Azero (scrittura cirillica) LanguageId valore |
+|  | Azerbaijani_Arabic | `50` | Azero (scrittura araba) LanguageId valore |
+|  | Armenian | `51` | Armeno LanguageId valore |
+|  | Georgian | `52` | Georgiano LanguageId valore |
+|  | Moldavian | `53` | Moldavo LanguageId valore |
+|  | Kirghiz | `54` | Kirghiso LanguageId valore |
+|  | Tajiki | `55` | Tagico LanguageId valore |
+|  | Turkmen | `56` | Turkmeno LanguageId valore |
+|  | Mongolian | `57` | Mongolo (scrittura mongola) LanguageId valore |
+|  | Mongolian_Cyrillic | `58` | Mongolo (scrittura cirillica) LanguageId valore |
+|  | Pashto | `59` | Pashto LanguageId valore |
+|  | Kurdish | `60` | Pashto LanguageId valore |
+|  | Kashmiri | `61` | Kashmiri LanguageId valore |
+|  | Sindhi | `62` | Sindhi LanguageId valore |
+|  | Tibetan | `63` | Tibetan LanguageId valore |
+|  | Nepali | `64` | Nepali LanguageId valore |
+|  | Sanskrit | `65` | Sanskrit LanguageId valore |
+|  | Marathi | `66` | Marathi LanguageId valore |
+|  | Bengali | `67` | Bengali LanguageId valore |
+|  | Assamese | `68` | Assamese LanguageId valore |
+|  | Gujarati | `69` | Gujarati LanguageId valore |
+|  | Punjabi | `70` | Punjabi LanguageId valore |
+|  | Oriya | `71` | Oriya LanguageId valore |
+|  | Malayalam | `72` | Malayalam LanguageId valore |
+|  | Kannada | `73` | Kannada LanguageId valore |
+|  | Tamil | `74` | Tamil LanguageId valore |
+|  | Telugu | `75` | Telugu LanguageId valore |
+|  | Sinhalese | `76` | Sinhalese LanguageId valore |
+|  | Burmese | `77` | Burmese LanguageId valore |
+|  | Khmer | `78` | Khmer LanguageId valore |
+|  | Lao | `79` | Lao LanguageId valore |
+|  | Vietnamese | `80` | Vietnamese LanguageId valore |
+|  | Indonesian | `81` | Indonesian LanguageId valore |
+|  | Tagalog | `82` | Tagalog LanguageId valore |
+|  | Malay_Roman | `83` | Malay (Roman script) LanguageId valore |
+|  | Malay_Arabic | `84` | Malay (Arabic script) LanguageId valore |
+|  | Amharic | `85` | Amharic LanguageId valore |
+|  | Tigrinya | `86` | Tigrinya LanguageId valore |
+|  | Galla | `87` | Galla LanguageId valore |
+|  | Somali | `88` | Somali LanguageId valore |
+|  | Swahili | `89` | Swahili LanguageId valore |
+|  | Kinyarwanda_Ruanda | `90` | Kinyarwanda/Ruanda LanguageId valore |
+|  | Rundi | `91` | Rundi LanguageId valore |
+|  | Nyanja_Chewa | `92` | Nyanja/Chewa LanguageId valore |
+|  | Malagasy | `93` | Malagasy LanguageId valore |
+|  | Esperanto | `94` | Esperanto LanguageId valore |
+|  | Welsh | `128` | Welsh LanguageId valore |
+|  | Basque | `129` | Basque LanguageId valore |
+|  | Catalan | `130` | Catalan LanguageId valore |
+|  | Latin | `131` | Latin LanguageId valore |
+|  | Quechua | `132` | Quechua LanguageId valore |
+|  | Guarani | `133` | Guarani LanguageId valore |
+|  | Aymara | `134` | Aymara LanguageId valore |
+|  | Tatar | `135` | Tatar LanguageId valore |
+|  | Uighur | `136` | Uighur LanguageId valore |
+|  | Dzongkha | `137` | Dzongkha LanguageId valore |
+|  | Javanese | `138` | Javanese (Roman script) LanguageId valore |
+|  | Sundanese | `139` | Sundanese (Roman script) LanguageId valore |
+|  | Galician | `140` | Galician LanguageId valore |
+|  | Afrikaans | `141` | Afrikaans LanguageId valore |
+|  | Breton | `142` | Breton LanguageId valore |
+|  | Inuktitut | `143` | Inuktitut LanguageId valore |
+|  | Scottish_Gaelic | `144` | Valore LanguageId del gaelico scozzese |
+|  | Manx_Gaelic | `145` | Valore LanguageId del gaelico di Man |
+|  | Irish_Gaelic_WDA | `146` | Valore LanguageId del gaelico irlandese (con punto sopra) |
+|  | Tongan | `147` | Valore LanguageId tongano |
+|  | Greek_Polytonic | `148` | Valore LanguageId greco (politonico) |
+|  | Greenlandic | `149` | Valore LanguageId groenlandese |
+|  | Azerbaijani_Roman | `150` | Valore LanguageId azero (scrittura latina) |

--- a/italian/nodejs-cpp/enumerations/ttfnametablenmslanguageid/_index.md
+++ b/italian/nodejs-cpp/enumerations/ttfnametablenmslanguageid/_index.md
@@ -1,0 +1,225 @@
+---
+title: "Enum TtfNameTableMSLanguageId"
+second_title: "Riferimento API di Aspose.Font per .NET"
+description: "Aspose.Font.TtfNameTableMSLanguageId enum. Specifica MSLanguageId"
+type: docs
+weight: 150
+url: /it/nodejs-cpp/enumerations/ttfnametablemslanguageid/
+---
+## TtfNameTableMSLanguageId enumeration
+
+Rappresenta l'enumerazione MSLanguageId.
+
+```csharp
+ enum TtfNameTableMSLanguageId
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+|  | Afrikaans | `0x0436` | Valore LanguageId per Afrikaans (Regione: Sud Africa, SA) |
+|  | Albanian | `0x041c` | Valore LanguageId per Albanian (Regione: Albania, SQI) |
+|  | Alsatian | `0x0484` | Alsaziano (Regione: Francia) valore LanguageId |
+|  | Amharic | `0x045E` | Amarico (Regione: Etiopia) valore LanguageId |
+|  | Arabic_Algeria | `0x1401` | Arabo (Regione: Algeria) valore LanguageId |
+|  | Arabic_Bahrain | `0x3C01` | Arabo (Regione: Bahrain) valore LanguageId |
+|  | Arabic_Egypt | `0x0C01` | Arabo (Regione: Egitto) valore LanguageId |
+|  | Arabic_Iraq | `0x0801` | Arabo (Regione: Iraq) valore LanguageId |
+|  | Arabic_Jordan | `0x2C01` | Arabo (Regione: Giordania) valore LanguageId |
+|  | Arabic_Kuwait | `0x3401` | Arabo (Regione: Kuwait) valore LanguageId |
+|  | Arabic_Lebanon | `0x3001` | Arabo (Regione: Libano) valore LanguageId |
+|  | Arabic_Libya | `0x1001` | Arabo (Regione: Libia) valore LanguageId |
+|  | Arabic_Morocco | `0x1801` | Arabo (Regione: Marocco) valore LanguageId |
+|  | Arabic_Oman | `0x2001` | Arabo (Regione: Oman) valore LanguageId |
+|  | Arabic_Qatar | `0x4001` | Arabo (Regione: Qatar) valore LanguageId |
+|  | Arabic_Saudi_Arabia | `0x0401` | Arabo (Regione: Arabia Saudita) valore LanguageId |
+|  | Arabic_Syria | `0x2801` | Arabo (Regione: Siria) valore LanguageId |
+|  | Arabic_Tunisia | `0x1C01` | Arabo (Regione: Tunisia) valore LanguageId |
+|  | Arabic_U_A_E | `0x3801` | Arabo (Regione: Emirati Arabi Uniti) valore LanguageId |
+|  | Arabic_Yemen | `0x2401` | Arabo (Regione: Yemen) valore LanguageId |
+|  | Armenian | `0x042B` | Armeno (Regione: Armenia) valore LanguageId |
+|  | Assamese | `0x044D` | Assamese (Regione: India) valore LanguageId |
+|  | Azeri_Cyrillic | `0x082C` | Azero (Cirillico, Regione: Azerbaigian) valore LanguageId |
+|  | Azeri_Latin | `0x042C` | Azero (Latino, Regione: Azerbaigian) valore LanguageId |
+|  | Bashkir | `0x046D` | Bashkir (Regione: Russia) valore LanguageId |
+|  | Basque | `0x042D` | Basco (Regione: Paesi Baschi, EUQ) valore LanguageId |
+|  | Belarusian | `0x0423` | Bielorusso (Regione: Bielorussia,  BEL) valore LanguageId |
+|  | Bengali_Bangladesh | `0x0845` | Bengali (Regione: Bangladesh) valore LanguageId |
+|  | Bengali_India | `0x0445` | Bengali (Regione: India) valore LanguageId |
+|  | Bosnian_Cyrillic | `0x201A` | Bosnian (Cirillico, Regione: Bosnia ed Erzegovina) valore LanguageId |
+|  | Bosnian_Latin | `0x141A` | Bosnian (Latino, Regione: Bosnia ed Erzegovina) valore LanguageId |
+|  | Breton | `0x047E` | Breton (Regione: Francia) valore LanguageId |
+|  | Bulgarian | `0x0402` | Bulgarian (Regione: Bulgaria, BGR) valore LanguageId |
+|  | Catalan | `0x0403` | Catalan (Regione: Catalan, CAT) valore LanguageId |
+|  | Chinese_Hong_Kong | `0x0C04` | Chinese (Regione: Hong Kong S.A.R.) valore LanguageId |
+|  | Chinese_Macao | `0x1404` | Chinese (Regione: Macao S.A.R.) valore LanguageId |
+|  | Chinese_PRC | `0x0804` | Chinese (Regione: People�s Republic of China) valore LanguageId |
+|  | Chinese_Singapore | `0x1004` | Chinese (Regione: Singapore) valore LanguageId |
+|  | Chinese_Taiwan | `0x0404` | Chinese (Regione: Taiwan) valore LanguageId |
+|  | Corsican | `0x0483` | Corsican (Regione: Francia) valore LanguageId |
+|  | Croatian | `0x041A` | Croatian (Regione: Croazia, SHL) valore LanguageId |
+|  | Croatian_Latin | `0x101A` | Croatian (Latino, Regione: Bosnia ed Erzegovina) valore LanguageId |
+|  | Czech | `0x0405` | Czech (Regione: Repubblica Ceca, CSY) valore LanguageId |
+|  | Danish | `0x0406` | Danish (Regione: Danimarca, DAN) valore LanguageId |
+|  | Dari | `0x048C` | Dari (Regione: Afghanistan) valore LanguageId |
+|  | Divehi | `0x0465` | Divehi (Regione: Maldive) valore LanguageId |
+|  | Dutch_Belgium | `0x0813` | Dutch (Fiammingo, Regione: Belgio, NLB) valore LanguageId |
+|  | Dutch_Netherlands | `0x0413` | Dutch (Standard, Regione: Paesi Bassi, NLD) valore LanguageId |
+|  | English_Australia | `0x0C09` | English (Australiano, Regione: Australia, ENA) valore LanguageId |
+|  | English_Belize | `0x2809` | English (Regione: Belize) valore LanguageId |
+|  | English_Canada | `0x1009` | English (Canadese, Regione: Canada, ENC) valore LanguageId |
+|  | English_Caribbean | `0x2409` | English (Regione: Caraibi) valore LanguageId |
+|  | English_India | `0x4009` | Inglese (Regione: India) LanguageId valore |
+|  | English_Ireland | `0x1809` | Inglese (Regione: Ireland, ENI) LanguageId valore |
+|  | English_Jamaica | `0x2009` | Inglese (Regione: Jamaica) LanguageId valore |
+|  | English_Malaysia | `0x4409` | Inglese (Regione: Malaysia) LanguageId valore |
+|  | English_New_Zealand | `0x1409` | Inglese (Regione: New Zealand, ENZ) LanguageId valore |
+|  | English_ROP | `0x3409` | Inglese (Regione: Republic of the Philippines, ROP) LanguageId valore |
+|  | English_Singapore | `0x4809` | Inglese (Regione: Singapore) LanguageId valore |
+|  | English_South_Africa | `0x1C09` | Inglese (Regione: South Africa, SA) LanguageId valore |
+|  | English_TT | `0x2C09` | Inglese (Regione: Trinidad and Tobago, TT) LanguageId valore |
+|  | English_United_Kingdom | `0x0809` | Inglese (Britannico, Regione: United Kingdom, ENG) LanguageId valore |
+|  | English_United_States | `0x0409` | Inglese (Americano, Regione: United States, ENU) LanguageId valore |
+|  | English_Zimbabwe | `0x3009` | Inglese (Regione: Zimbabwe) LanguageId valore |
+|  | Estonian | `0x0425` | Estone (Regione: Estonia, ETI) LanguageId valore |
+|  | Faroese | `0x0438` | Faroese (Regione: Faroe Islands) LanguageId valore |
+|  | Filipino | `0x0464` | Filippino (Regione: Philippines) LanguageId valore |
+|  | Finnish | `0x040B` | Finlandese (Regione: Finland, FIN) LanguageId valore |
+|  | French_Belgium | `0x080C` | Francese (Belga, Regione: Belgium, FRB) LanguageId valore |
+|  | French_Canada | `0x0C0C` | Francese (Canadese, Regione: Canada, FRC) LanguageId valore |
+|  | French_France | `0x040C` | Francese (Standard, Regione: France, FRA) LanguageId valore |
+|  | French_Luxembourg | `0x140c` | Francese (Regione: Luxembourg, FRL) LanguageId valore |
+|  | French_MC | `0x180C` | Francese (Regione: Principality of Monaco, MC) LanguageId valore |
+|  | French_Switzerland | `0x100C` | Francese (Svizzero, Regione: Switzerland, FRS) LanguageId valore |
+|  | Frisian | `0x0462` | Frisone (Regione: Netherlands, NLD) LanguageId valore |
+|  | Galician | `0x0456` | Galiziano (Regione: Galician) LanguageId valore |
+|  | Georgian | `0x0437` | Georgiano (Regione: Georgia) LanguageId valore |
+|  | German_Austria | `0x0C07` | Tedesco (austriaco, Regione: Austria, DEA) valore LanguageId |
+|  | German_Germany | `0x0407` | Tedesco (standard, Regione: Germania, DEU) valore LanguageId |
+|  | German_Liechtenstein | `0x1407` | Tedesco (Regione: Liechtenstein, DEC) valore LanguageId |
+|  | German_Luxembourg | `0x1007` | Tedesco (Regione: Lussemburgo, DEL) valore LanguageId |
+|  | German_Switzerland | `0x0807` | Tedesco (svizzero, Regione: Svizzera, DES) valore LanguageId |
+|  | Greek | `0x0408` | Greco (Regione: Grecia, ELL) valore LanguageId |
+|  | Greenlandic | `0x046F` | Groenlandese (Regione: Groenlandia) valore LanguageId |
+|  | Gujarati | `0x0447` | Gujarati (Regione: India) valore LanguageId |
+|  | Hausa | `0x0468` | Hausa (latino, Regione: Nigeria) valore LanguageId |
+|  | Hebrew | `0x040D` | Ebraico (Regione: Israele) valore LanguageId |
+|  | Hindi | `0x0439` | Hindi (Regione: India) valore LanguageId |
+|  | Hungarian | `0x040E` | Ungherese (Regione: Ungheria, HUN) valore LanguageId |
+|  | Icelandic | `0x040F` | Islandese (Regione: Islanda, ISL) valore LanguageId |
+|  | Igbo | `0x0470` | Igbo (Regione: Nigeria) valore LanguageId |
+|  | Indonesian | `0x0421` | Indonesiano (Regione: Indonesia) valore LanguageId |
+|  | Inuktitut | `0x045D` | Inuktitut (Regione: Canada) valore LanguageId |
+|  | Inuktitut_Latin | `0x085D` | Inuktitut (latino, Regione: Canada) valore LanguageId |
+|  | Irish | `0x083C` | Irlandese (Regione: Irlanda) valore LanguageId |
+|  | isiXhosa | `0x0434` | isiXhosa (Regione: Sudafrica, SA) valore LanguageId |
+|  | isiZulu | `0x0435` | isiZulu (Regione: Sudafrica, SA) valore LanguageId |
+|  | Italian_Italy | `0x0410` | Italiano (standard, Regione: Italia, ITA) valore LanguageId |
+|  | Italian_Switzerland | `0x0810` | Italiano (svizzero, Regione: Svizzera, ITS) valore LanguageId |
+|  | Japanese | `0x0411` | Giapponese (Regione: Giappone) valore LanguageId |
+|  | Kannada | `0x044B` | Kannada (Regione: India) valore LanguageId |
+|  | Kazakh | `0x043F` | Kazako (Regione: Kazakistan) valore LanguageId |
+|  | Khmer | `0x0453` | Khmer (Regione: Cambogia) valore LanguageId |
+|  | Kiche | `0x0486` | K'iche (Regione: Guatemala) valore LanguageId |
+|  | Kinyarwanda | `0x0487` | Kinyarwanda (Regione: Ruanda) valore LanguageId |
+|  | Kiswahili | `0x0441` | Kiswahili (Regione: Kenya) valore LanguageId |
+|  | Konkani | `0x0457` | Konkani (Regione: India) valore LanguageId |
+|  | Korean | `0x0412` | Coreano (Regione: Corea) valore LanguageId |
+|  | Kyrgyz | `0x0440` | Kirghiso (Regione: Kirghizistan) valore LanguageId |
+|  | Lao | `0x0454` | Lao (Regione: Lao P.D.R.) valore LanguageId |
+|  | Latvian | `0x0426` | Lettone (Regione: Lettonia, LVI) valore LanguageId |
+|  | Lithuanian | `0x0427` | Lituano (Regione: Lituania, LTH) valore LanguageId |
+|  | Lower_Sorbian | `0x082E` | Sorabo inferiore (Regione: Germania) valore LanguageId |
+|  | Luxembourgish | `0x046E` | Lussemburghese (Regione: Lussemburgo) valore LanguageId |
+|  | Macedonian | `0x042F` | Macedone (Regione: Macedonia del Nord) valore LanguageId |
+|  | Malay_Brunei_Darussalam | `0x083E` | Malese (Regione: Brunei Darussalam) valore LanguageId |
+|  | Malay_Malaysia | `0x043E` | Malese (Regione: Malesia) valore LanguageId |
+|  | Malayalam | `0x044C` | Malayalam (Regione: India) valore LanguageId |
+|  | Maltese | `0x043A` | Maltese (Regione: Malta) valore LanguageId |
+|  | Maori | `0x0481` | Maori (Regione: Nuova Zelanda) valore LanguageId |
+|  | Mapudungun | `0x047A` | Mapudungun (Regione: Cile) valore LanguageId |
+|  | Marathi | `0x044E` | Marathi (Regione: India) valore LanguageId |
+|  | Mohawk | `0x047C` | Mohawk (Regione: Mohawk) valore LanguageId |
+|  | Mongolian_Cyrillic | `0x0450` | Mongolo (Cirillico, Regione: Mongolia) valore LanguageId |
+|  | Mongolian_Traditional | `0x0850` | Mongolo (Tradizionale, Regione: Repubblica Popolare Cinese) valore LanguageId |
+|  | Nepali | `0x0461` | Nepali (Regione: Nepal) valore LanguageId |
+|  | Norwegian_Bokmal | `0x0414` | Norvegese (Bokmål, Regione: Norvegia, NOR) valore LanguageId |
+|  | Norwegian_Nynorsk | `0x0814` | Norvegese (Nynorsk, Regione: Norvegia, NON) valore LanguageId |
+|  | Occitan | `0x0482` | Occitano (Regione: Francia) valore LanguageId |
+|  | Odia | `0x0448` | Odia (precedentemente Oriya, Regione: India) valore LanguageId |
+|  | Pashto | `0x0463` | Pashto (Regione: Afghanistan) valore LanguageId |
+|  | Polish | `0x0415` | Polacco (Regione: Polonia, PLK) valore LanguageId |
+|  | Portuguese_Brazil | `0x0416` | Portoghese (Brasiliana, Regione: Brasile, PTB) valore LanguageId |
+|  | Portuguese_Portugal | `0x0816` | Portoghese (Standard, Regione: Portogallo, PTG) valore LanguageId |
+|  | Punjabi | `0x0446` | Punjabi (Regione: India) valore LanguageId |
+|  | Quechua_Bolivia | `0x046B` | Quechua (Regione: Bolivia) valore LanguageId |
+|  | Quechua_Ecuador | `0x086B` | Quechua (Regione: Ecuador) valore LanguageId |
+|  | Quechua_Peru | `0x0C6B` | Quechua (Regione: Perù) valore LanguageId |
+|  | Romanian | `0x0418` | Rumeno (Regione: Romania, ROM) valore LanguageId |
+|  | Romansh | `0x0417` | Romancio (Regione: Svizzera) valore LanguageId |
+|  | Russian | `0x0419` | Russo (Regione: Russia, RUS) valore LanguageId |
+|  | Sami_Inari | `0x243B` | Sami (Inari, Regione: Finlandia) valore LanguageId |
+|  | Sami_Lule_Norway | `0x103B` | Sami (Lule, Regione: Norvegia) valore LanguageId |
+|  | Sami_Lule_Sweden | `0x143B` | Sami (Lule, Regione: Svezia) valore LanguageId |
+|  | Sami_Northern_Finland | `0x0C3B` | Sami (Settentrionale, Regione: Finlandia) valore LanguageId |
+|  | Sami_Northern_Norway | `0x043B` | Sami (Settentrionale, Regione: Norvegia) valore LanguageId |
+|  | Sami_Northern_Sweden | `0x083B` | Sami (Settentrionale, Regione: Norvegia) valore LanguageId |
+|  | Sami_Skolt | `0x203B` | Sami (Skolt, Regione: Finlandia) valore LanguageId |
+|  | Sami_Southern_Norway | `0x183B` | Sami (Meridionale, Regione: Norvegia) valore LanguageId |
+|  | Sami_Southern_Sweden | `0x1C3B` | Sami (Meridionale, Regione: Svezia) valore LanguageId |
+|  | Sanskrit | `0x044F` | Sanskrito (Regione: India) valore LanguageId |
+|  | Serbian_Cyrillic_BIH | `0x1C1A` | Serbo (Cirillico, Regione: Bosnia ed Erzegovina) valore LanguageId |
+|  | Serbian_Cyrillic_Serbia | `0x0C1A` | Serbo (Cirillico, Regione: Serbia) valore LanguageId |
+|  | Serbian_Latin_BIH | `0x181A` | Serbo (Latino, Regione: Bosnia ed Erzegovina) valore LanguageId |
+|  | Serbian_Latin_Serbia | `0x081A` | Serbo (Latino, Regione: Serbia) valore LanguageId |
+|  | Sesotho_Sa_Leboa | `0x046C` | Sesotho sa Leboa (Northern Sotho, Regione: Sudafrica, SA) valore LanguageId |
+|  | Setswana | `0x0432` | Setswana (Regione: Sudafrica, SA) valore LanguageId |
+|  | Sinhala | `0x045B` | Sinhala (Regione: Sri Lanka) valore LanguageId |
+|  | Slovak | `0x041B` | Slovacco (Regione: Slovacchia, SKY) valore LanguageId |
+|  | Slovenian | `0x0424` | Sloveno (Regione: Slovenia, SLV) valore LanguageId |
+|  | Spanish_Argentina | `0x2C0A` | Spagnolo (Regione: Argentina) valore LanguageId |
+|  | Spanish_Bolivia | `0x400A` | Spagnolo (Regione: Bolivia) valore LanguageId |
+|  | Spanish_Chile | `0x340A` | Spagnolo (Regione: Cile) valore LanguageId |
+|  | Spanish_Colombia | `0x240A` | Spagnolo (Regione: Colombia) valore LanguageId |
+|  | Spanish_Costa_Rica | `0x140A` | Spagnolo (Regione: Costa Rica) valore LanguageId |
+|  | Spanish_Dominican_Republic | `0x1C0A` | Spagnolo (Regione: Repubblica Dominicana) valore LanguageId |
+|  | Spanish_Ecuador | `0x300A` | Spagnolo (Regione: Repubblica Dominicana) valore LanguageId |
+|  | Spanish_El_Salvador | `0x440A` | Spagnolo (Regione: Repubblica Dominicana) valore LanguageId |
+|  | Spanish_Guatemala | `0x100A` | Spagnolo (Regione: Guatemala) valore LanguageId |
+|  | Spanish_Honduras | `0x480A` | Spagnolo (Regione: Honduras) valore LanguageId |
+|  | Spanish_Mexico | `0x080A` | Spagnolo (Messicano, Regione: Messico, ESM) valore LanguageId |
+|  | Spanish_Nicaragua | `0x4C0A` | Spagnolo (Regione: Nicaragua) valore LanguageId |
+|  | Spanish_Panama | `0x180A` | Spagnolo (Regione: Panama) valore LanguageId |
+|  | Spanish_Paraguay | `0x3C0A` | Spagnolo (Regione: Paraguay) valore LanguageId |
+|  | Spanish_Peru | `0x280A` | Spagnolo (Regione: Perù) valore LanguageId |
+|  | Spanish_Puerto_Rico | `0x500A` | Spagnolo (Regione: Porto Rico) valore LanguageId |
+|  | Spanish_Modern_Sort | `0x0C0A` | Spagnolo (Ordinamento Moderno, Regione: Spagna, ESN) valore LanguageId |
+|  | Spanish_Traditional_Sort | `0x040A` | Spagnolo (Ordinamento Tradizionale, Regione: Spagna, ESP) valore LanguageId |
+|  | Spanish_United_States | `0x540A` | Spagnolo (Regione: Stati Uniti) valore LanguageId |
+|  | Spanish_Uruguay | `0x380A` | Spagnolo (Regione: Uruguay) valore LanguageId |
+|  | Spanish_Venezuela | `0x200A` | Spagnolo (Regione: Venezuela) valore LanguageId |
+|  | Swedish_Finland | `0x081D` | Svedese (Regione: Finlandia) valore LanguageId |
+|  | Swedish_Sweden | `0x041D` | Svedese (Regione: Svezia, SVE) valore LanguageId |
+|  | Syriac | `0x045A` | Siriano (Regione: Siria) valore LanguageId |
+|  | Tajik | `0x0428` | Tagico (Cirillico, Regione: Tagikistan) valore LanguageId |
+|  | Tamazight | `0x085F` | Tamazight (Latino, Regione: Algeria) valore LanguageId |
+|  | Tamil | `0x0449` | Tamil (Regione: India) valore LanguageId |
+|  | Tatar | `0x0444` | Tatar (Regione: Russia) valore LanguageId |
+|  | Telugu | `0x044A` | Telugu (Regione: India) valore LanguageId |
+|  | Thai | `0x041E` | Thai (Regione: Thailandia) valore LanguageId |
+|  | Tibetan | `0x0451` | Tibetano (Regione: RPC) valore LanguageId |
+|  | Turkish | `0x041F` | Turco (Regione: Turchia, TRK) valore LanguageId |
+|  | Turkmen | `0x0442` | Turkmeno (Regione: Turkmenistan) valore LanguageId |
+|  | Uighur | `0x0480` | Uiguro (Regione: RPC) valore LanguageId |
+|  | Ukrainian | `0x0422` | Ucraino (Regione: Ucraina, UKR) valore LanguageId |
+|  | Upper_Sorbian | `0x042E` | Sorabo Superiore (Regione: Germania) valore LanguageId |
+|  | Urdu | `0x0420` | Urdu (Regione: Repubblica Islamica del Pakistan) valore LanguageId |
+|  | Uzbek_Cyrillic | `0x0843` | Uzbeko (Cirillico, Regione: Uzbekistan) valore LanguageId |
+|  | Uzbek_Latin | `0x0443` | Uzbeko (Latino, Regione: Uzbekistan) valore LanguageId |
+|  | Vietnamese | `0x042A` | Vietnamita (Regione: Vietnam) valore LanguageId |
+|  | Welsh | `0x0452` | Gallese (Regione: Regno Unito) valore LanguageId |
+|  | Wolof | `0x0488` | Wolof (Regione: Senegal) valore LanguageId |
+|  | Yakut | `0x0485` | Yakut (Regione: Russia) valore LanguageId |
+|  | Yi | `0x0478` | Yi (Regione: RPC) valore LanguageId |
+| Yoruba | `0x046A` | Yoruba (Regione: Nigeria) valore LanguageId |

--- a/italian/nodejs-cpp/enumerations/ttfnametableplatformid/_index.md
+++ b/italian/nodejs-cpp/enumerations/ttfnametableplatformid/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Enum TtfNameTablePlatformId"
+second_title: "Riferimento API di Aspose.Font per .NET"
+description: "Aspose.Font.TtfNameTablePlatformId enum. Specifica PlatformId"
+type: docs
+weight: 130
+url: /it/nodejs-cpp/enumerations/ttfnametableplatformid/
+---
+## TtfNameTablePlatformId enumeration
+
+Specifica PlatformId.
+
+```cssharp
+ enum TtfNameTablePlatformId
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+|  | Unicode | `0` | Unicode |
+|  | Macintosh | `1` | Codice del Macintosh Script Manager. |
+|  | ISO | `2` | Specifiche Apple: (riservato; non utilizzare) Specifiche MS: codifica ISO. Nota che l'ID piattaforma 2 (ISO) è stato deprecato a partire dalla Specifica OpenType v1.3. Era destinato a rappresentare ISO/IEC 10646, in contrapposizione a Unicode; entrambi gli standard hanno assegnazioni di codici carattere identiche |
+|  | Microsoft | `3` | Codifica Microsoft. |

--- a/italian/nodejs-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
+++ b/italian/nodejs-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum TtfNameTableUnicodePlatformSpecificId"
+second_title: "Riferimento API di Aspose.Font per .NET"
+description: "Aspose.Font.TtfNameTableUnicodePlatformSpecificId enum. Specifica UnicodePlatformSpecificId"
+type: docs
+weight: 133
+url: /it/nodejs-cpp/enumerations/ttfnametableunicodeplatformspecificid/
+---
+## TtfNameTableUnicodePlatformSpecificId enumeration
+
+Specifica UnicodePlatformSpecificId.
+
+```csharp
+ enum TtfNameTableUnicodePlatformSpecificId
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+|  | Default | `0` | Semantica predefinita (Unicode 1.0). |
+|  | Unicode1_1 | `1` | Semantica Unicode 1.1. |
+|  | ISO10646_1993 | `2` | Semantica ISO 10646 1993 (deprecata). |
+|  | Unicode2_0 | `3` | Semantica Unicode 2.0 o successive. Solo BMP Unicode. |
+|  | Unicode2_0_Full | `4Unicode 2.0 and onwards semantics (non-BMP characters allowed)` | Repertorio completo Unicode. |

--- a/italian/nodejs-cpp/metadata/_index.md
+++ b/italian/nodejs-cpp/metadata/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Funzioni dei metadati del Font"
+second_title: "Aspose.Font per Node.js via C++"
+description: "Funzioni per lavorare con i file di metadati del Font"
+type: docs
+url: /it/nodejs-cpp/metadata/
+---
+
+## Metadata Font functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposeFontGetInfo](./asposefontgetinfo/) | Ottieni informazioni (metadati) da un file Font. |
+| [AsposeFontSetInfo](./asposefontsetinfo/) | Imposta le informazioni (metadata) in un file Font. |
+
+## Detailed Description
+
+Funzioni per lavorare con file Font di metadata.
+

--- a/italian/nodejs-cpp/metadata/asposefontgetinfo/_index.md
+++ b/italian/nodejs-cpp/metadata/asposefontgetinfo/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposeFontGetInfo"
+second_title: "Aspose.Font per Node.js via C++"
+description: "Ottieni informazioni (metadati) da un file Font."
+type: docs
+url: /it/nodejs-cpp/metadata/asposefontgetinfo/
+---
+## AsposeFontGetInfo function
+
+_Ottieni informazioni (metadata) da un file Font._
+
+```js
+function AsposeFontGetInfo(
+    fileName
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileName | string | Nome file. |
+
+### Valore restituito
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | codice errore (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | record | Array di oggetti JSON : |
+|  | * NameId | identificatore del nome |
+|  | * PlatformId | identificatore della piattaforma |
+|  | * PlatformSpecificId | identificatore specifico della piattaforma |
+|  | * LanguageId | identificatore della lingua |
+|  | * Informazioni | contenuto del record del nome |
+
+### Esempi
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    //AsposeFontGetInfo - get metadata information
+    const json = AsposeFontModule.AsposeFontGetInfo(font_file);
+    console.log("AsposeFontGetInfo => %O",  json.errorCode == 0 ? json.records.reduce((ret, a) => ret +
+        "\nNameId : " + a.NameId
+        + "; PlatformId : " + a.PlatformId
+        + "; PlatformSpecificId : " + a.PlatformSpecificId
+        + "; LanguageId : " + a.LanguageId
+        + "; Info : " + a.Info,"") : json.errorText);
+
+});
+```
+**ECMAScript\ES6 js modules:**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+//AsposeFontGetInfo - get metadata font information
+json = AsposeFontModule.AsposeFontGetInfo(font_file);
+console.log("AsposeFontGetInfo => %O",  json.errorCode == 0 ? json.records.reduce((ret, a) => ret +
+    "\nNameId : " + a.NameId
+  + "; PlatformId : " + a.PlatformId
+  + "; PlatformSpecificId : " + a.PlatformSpecificId
+  + "; LanguageId : " + a.LanguageId
+  + "; Info : " + a.Info,"") : json.errorText);
+```

--- a/italian/nodejs-cpp/metadata/asposefontsetinfo/_index.md
+++ b/italian/nodejs-cpp/metadata/asposefontsetinfo/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeFontSetInfo"
+second_title: "Aspose.Font per Node.js via C++"
+description: "Imposta le informazioni (metadata) in un file Font."
+type: docs
+url: /it/nodejs-cpp/metadata/asposefontsetinfo/
+---
+## AsposeFontSetInfo function
+
+_Imposta le informazioni (metadata) in un file Font._
+
+```js
+function AsposeFontSetInfo(
+    fileName,
+    nameId, 
+    platformId, 
+    platformSpecificId, 
+    languageId, 
+    text
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileName | string | Nome file. |
+| nameId | TtfNameTableNameId | Identificatore del nome, categoria logica della stringa, specificata dall'enumerazione [`NameId`](../../enumerations/ttfnametablenameid/) |
+|  | platformId | TtfNameTablePlatformId | Identificatore della piattaforma |
+| platformSpecificId | int | Identificatore di codifica specifico della piattaforma. Si prega di utilizzare un valore da una delle seguenti enumerazioni - [`UnicodePlatformSpecificId`](../../enumerations/ttfnametableunicodeplatformspecificid/), [`MacPlatformSpecificId`](../../ttfnametable.macplatformspecificid/), [`MSPlatformSpecificId`](../../enumerations/ttfnametablemsplatformspecificid/). L'enumerazione da utilizzare è definita dal contesto (parametro *platformId*) |
+| languageId | int | Identificatore della lingua. Si prega di utilizzare un valore dalle enumerazioni [`MSLanguageId`](../../enumerations/ttfnametablemslanguageid/) o [`MacLanguageId`](../../enumerations/ttfnametablemaclanguageid/) a seconda del contesto, definito dal parametro *platformId*. |
+|  | testo | string | Dati della stringa effettivi |
+
+### Valore restituito
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | codice errore (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    //AsposeSetInfo - set metadata info into font
+    const nameId = AsposeFontModule.TtfNameTableNameId.Description;
+    const platformId = AsposeFontModule.TtfNameTablePlatformId.Microsoft;
+    const platformSpecificId = AsposeFontModule.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+    const langID = Module.TtfNameTableMSLanguageId.English_United_States.value;
+    const text = "Updated description";
+    
+    const json = AsposeFontSetInfo(font_file, nameId, platformId, platformSpecificId, langID, text);
+    console.log("AsposeFontSetInfo => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules:**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+//AsposeSetInfo - set metadata info into font
+const nameId = AsposeFontModule.TtfNameTableNameId.Description;
+const platformId = AsposeFontModule.TtfNameTablePlatformId.Microsoft;
+const platformSpecificId = AsposeFontModule.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+const langID = Module.TtfNameTableMSLanguageId.English_United_States.value;
+const text = "Updated description";
+
+const json = AsposeFontModule.AsposeFontSetInfo(font_file, nameId, platformId, platformSpecificId, langID, text);
+console.log("AsposeFontSetInfo => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Vedi anche
+
+* enum [TtfNameTableNameId](../../enumerations/ttfnametablenameid/)
+* enum [TtfNameTablePlatformId](../../enumerations/ttfnametableplatformid/)
+* enum [TtfNameTableMacPlatformSpecificId](../../enumerations/ttfnametablemacplatformspecificid/)
+* enum [TtfNameTableMSPlatformSpecificId](../../enumerations/ttfnametablemsplatformspecificid/)
+* enum [TtfNameTableUnicodePlatformSpecificId](../../enumerations/ttfnametableunicodeplatformspecificid/)
+* enum [TtfNameTableMacLanguageId](../../enumerations/ttfnametablemaclanguageid/)
+* enum [TtfNameTableMSLanguageId](../../enumerations/ttfnametablemslanguageid/)

--- a/italian/nodejs-cpp/misc/_index.md
+++ b/italian/nodejs-cpp/misc/_index.md
@@ -1,0 +1,17 @@
+---
+title: "Funzioni varie"
+second_title: "Aspose.Font per Node.js via C++"
+description: "Funzioni secondarie per lavorare con file Font."
+type: docs
+url: /it/nodejs-cpp/misc/
+---
+## Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposeFontAbout](./asposefontabout/) | Ottieni informazioni sul prodotto. |
+
+## Detailed Description
+
+Funzioni secondarie per lavorare con file Font.
+

--- a/italian/nodejs-cpp/misc/asposefontabout/_index.md
+++ b/italian/nodejs-cpp/misc/asposefontabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeFontAbout"
+second_title: "Aspose.Font per Node.js via C++"
+description: "Ottieni informazioni sul prodotto."
+type: docs
+url: /it/nodejs-cpp/misc/AsposeFontAbout/
+---
+
+## AsposeFontAbout function
+
+Ottieni informazioni sul prodotto.
+
+```js
+function AsposeFontAbout()
+```
+
+### Valore restituito
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+| errorCode | codice errore (0 nessun errore) |
+| errorText | errore di testo ("" nessun errore) |
+| prodotto | Nome prodotto |
+| versione | Versione prodotto |
+| islicensed | Il prodotto è licenziato |
+
+
+## Esempio
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    json = AsposeFontModule.AsposeFontAbout();
+    console.log("AsposeFontAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules:**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+//AsposeFontAbout - Get info about Product
+const json = AsposeFontModule.AsposeFontAbout();
+console.log("AsposeFontAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+```


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **Italian** (`it`) generated by RDA.

- Pages translated: 22/22
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `italian/nodejs-cpp`

🤖 Generated by RDA