### PR TITLE
[auto] Translate NODEJS-CPP API Reference to Spanish

### DIFF
--- a/spanish/nodejs-cpp/_index.md
+++ b/spanish/nodejs-cpp/_index.md
@@ -1,0 +1,54 @@
+---
+title: "Aspose.Font para Node.js mediante C++"
+description: "Aspose.Font para Node.js mediante C++"
+keywords:  "Node.js via C++, Node.js Font toolkit"
+tags: ['font-to-ttf', 'font-to-woff',  'font-to-woff2', 'font-to-svg', 'font-convert', 'font-tools']
+weight: 40
+url: /es/nodejs-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.Font for Node.js via C++ allows developers manipulate them Font files on server side web solutions.
+>
+> CommonJS and ECMAScript modules are aviable for any JavaScript solutions. 
+
+
+## Convert functions
+
+| Función | Descripción |
+| -------- | ----------- |
+| [AsposeFontConvert](./convert/) | Convertir una fuente a fuentes TrueType. |
+| [AsposeFontConvertToTTF](./convert/asposefontconverttottf/) | Convertir una fuente al formato TTF. |
+| [AsposeFontConvertToWOFF](./convert/asposefontconverttowoff/) | Convertir una fuente al formato WOFF. |
+| [AsposeFontConvertToWOFF2](./convert/asposefontconverttowoff2/) | Convertir una fuente al formato WOFF2. |
+| [AsposeFontConvertToSVG](./convert/asposefontconverttosvg/) | Convertir una fuente al formato SVG. |
+
+
+## Metadata Font functions
+
+| Función | Descripción |
+| -------- | ----------- |
+| [AsposeFontGetInfo](./metadata/asposefontgetinfo/) | Obtener información (metadatos) de un archivo de fuente. |
+| [AsposeFontSetInfo](./metadata/asposefontsetinfo/) | Establecer información (metadatos) en un archivo de fuente. |
+
+
+## Miscellaneous
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposeFontAbout](./misc/asposefontabout/) | Obtener información sobre el producto. |
+
+## Enumeraciones
+
+| Enumeración | Descripción |
+| ----------- | ----------- |
+| [FontSavingFormats](./enumerations/fontsavingformats/) | Especifica el tipo de fuente. |
+| [FontStyle](./enumerations/fontstyle/) | Especifica el estilo de fuente. |
+| [TtfNameTableNameId](./enumerations/ttfnametablenameid/) | Especifica NameId. |
+| [TtfNameTablePlatformId](./enumerations/ttfnametableplatformid/) | Representa la enumeración PlatformId. |
+| [TtfNameTableMacPlatformSpecificId](./enumerations/ttfnametablemacplatformspecificid/) | Representa la enumeración de ID específica de la plataforma Macintosh. |
+| [TtfNameTableMSPlatformSpecificId](./enumerations/ttfnametablemsplatformspecificid/) | Representa la enumeración de ID específica de la plataforma Microsoft. |
+| [TtfNameTableUnicodePlatformSpecificId](./enumerations/ttfnametableunicodeplatformspecificid/) | Representa la enumeración de ID específica de la plataforma Unicode. |
+| [TtfNameTableMacLanguageId](./enumerations/ttfnametablemaclanguageid/) | Enumeración MacLanguageId. |
+| [TtfNameTableMSLanguageId](./enumerations/ttfnametablemslanguageid/) | Enumeración MSLanguageId. |

--- a/spanish/nodejs-cpp/convert/_index.md
+++ b/spanish/nodejs-cpp/convert/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Funciones de conversión de fuentes"
+second_title: "Aspose.Font para Node.js mediante C++"
+description: "Funciones para convertir fuentes a formatos TrueType."
+type: docs
+url: /es/nodejs-cpp/convert/
+---
+
+## Convert functions
+
+| Función | Descripción |
+| -------- | ----------- |
+| [AsposeFontConvert](./asposefontconvert) | Convertir una fuente a formatos compatibles. |
+| [AsposeFontConvertToTTF](./asposefontconverttottf/) | Convertir una fuente al formato TTF. |
+| [AsposeFontConvertToWOFF](./asposefontconverttowoff/) | Convertir una fuente al formato WOFF. |
+| [AsposeFontConvertToWOFF2](./asposefontconverttowoff2/) | Convertir una fuente al formato WOFF2. |
+| [AsposeFontConvertToSVG](./asposefontconverttosvg/) | Convertir una fuente al formato SVG. |
+
+## Detailed Description
+
+Funciones para convertir fuentes a formatos TrueType.
+

--- a/spanish/nodejs-cpp/convert/asposefontconvert/_index.md
+++ b/spanish/nodejs-cpp/convert/asposefontconvert/_index.md
@@ -1,0 +1,73 @@
+---
+title: "AsposeFontConvert"
+second_title: "Aspose.Font para Node.js mediante C++"
+description: "Convierte la fuente a otro formato"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/convert/asposefontconvert/
+---
+## AsposeFontConvert function
+
+Convierte la fuente a otro formato.
+
+```js
+function AsposeFontConvert(
+    fileName,
+    fontType,
+    fontSavingFormat
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileName | string | Nombre de archivo. |
+| fontType | FontType | Tipo de fuente a convertir. |
+| fontSavingFormat | FontSavingFormats | Formato de fuente al que convertir. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto (\"\" sin error) |
+|  | fileNameResult | nombre de archivo de resultado |
+
+### Observaciones
+
+Nota: El tipo de fuente TTF ahora solo está soportado.
+
+### Ejemplos
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvert to convert font
+    const json = AsposeFontModule.AsposeFontConvert(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvert(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Ver también
+
+* enum [FontType](../../enumerations/fonttype/)
+* enum [FontSavingFormats](../../enumerations/fontsavingformats/)

--- a/spanish/nodejs-cpp/convert/asposefontconverttottf/_index.md
+++ b/spanish/nodejs-cpp/convert/asposefontconverttottf/_index.md
@@ -1,0 +1,60 @@
+---
+title: "AsposeFontConvertToTTF"
+second_title: "Aspose.Font para Node.js mediante C++"
+description: "Convierte la fuente al formato ttf"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/convert/asposefontconverttottf/
+---
+## AsposeFontConvertToTTF function
+
+Convierte la fuente al formato TTF.
+
+```js
+function AsposeFontConvertToTTF(
+    fileName,
+    fontType
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileName | string | Nombre de archivo. |
+| fontType | FontType | Tipo de fuente a convertir. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto (\"\" sin error) |
+|  | fileNameResult | nombre de archivo de resultado |
+
+### Ejemplos
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+const font_file = "./fonts/Lora-Regular.ttf";
+console.log('Aspose.Font for Node.js via C++ example');
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvert to convert font
+    const json = AsposeFontModule.AsposeFontConvertToTTF(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript/ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+const font_file ="./fonts/arial.ttf";
+const AsposeFontModule = await AsposeFont();
+console.log('Aspose.Font for Node.js via C++ example');
+const json = AsposeFontModule.AsposeFontConvertToTTF(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Ver también
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/spanish/nodejs-cpp/convert/asposefontconverttowoff/_index.md
+++ b/spanish/nodejs-cpp/convert/asposefontconverttowoff/_index.md
@@ -1,0 +1,67 @@
+---
+title: "AsposeFontConvertToWOFF"
+second_title: "Aspose.Font para Node.js mediante C++"
+description: "Convierte la fuente al formato woff"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/convert/asposefontconverttowoff/
+---
+## AsposeFontConvertToWOFF function
+
+Convierte la fuente al formato WOFF.
+
+```js
+function AsposeFontConvertToWOFF(
+    fileName,
+    fontType
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileName | string | Nombre de archivo. |
+| fontType | FontType | Tipo de fuente a convertir. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto (\"\" sin error) |
+|  | fileNameResult | nombre de archivo de resultado |
+
+### Ejemplos
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvertToWOFF to convert font
+    const json = AsposeFontModule.AsposeFontConvertToWOFF(font_file,AsposeFontModule.FontType.TTF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvertToWOFF(font_file,AsposeFontModule.FontType.TTF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Ver también
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/spanish/nodejs-cpp/convert/asposefontconverttowoff2/_index.md
+++ b/spanish/nodejs-cpp/convert/asposefontconverttowoff2/_index.md
@@ -1,0 +1,67 @@
+---
+title: "AsposeFontConvertToWOFF2"
+second_title: "Aspose.Font para Node.js mediante C++"
+description: "Convierte la fuente al formato woff2"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/convert/asposefontconverttowoff2/
+---
+## AsposeFontConvertToWOFF2 function
+
+Convierte la fuente al formato WOFF2.
+
+```js
+function AsposeFontConvertToWOFF2(
+    fileName,
+    fontType
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileName | string | Nombre de archivo. |
+| fontType | FontType | Tipo de fuente a convertir. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto (\"\" sin error) |
+|  | fileNameResult | nombre de archivo de resultado |
+
+### Ejemplos
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvertToWOFF2 to convert font
+    const json = AsposeFontModule.AsposeFontConvertToWOFF2(font_file,AsposeFontModule.FontType.TTF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvertToWOFF2(font_file,AsposeFontModule.FontType.TTF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Ver también
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/spanish/nodejs-cpp/convert/asposefontconverttowsvg/_index.md
+++ b/spanish/nodejs-cpp/convert/asposefontconverttowsvg/_index.md
@@ -1,0 +1,67 @@
+---
+title: "AsposeFontConvertToSVG"
+second_title: "Aspose.Font para Node.js mediante C++"
+description: "Convierte la fuente al formato svg"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/convert/asposefontconverttosvg/
+---
+## AsposeFontConvertToSVG function
+
+Convierte la fuente al formato SVG.
+
+```js
+function AsposeFontConvertToSVG(
+    fileName,
+    fontType
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileName | string | Nombre de archivo. |
+| fontType | FontType | Tipo de fuente a convertir. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto (\"\" sin error) |
+|  | fileNameResult | nombre de archivo de resultado |
+
+### Ejemplos
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvertToSVG to convert font
+    const json = AsposeFontModule.AsposeFontConvertToSVG(font_file,AsposeFontModule.FontType.TTF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvertToSVG(font_file,AsposeFontModule.FontType.TTF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Ver también
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/spanish/nodejs-cpp/enumerations/_index.md
+++ b/spanish/nodejs-cpp/enumerations/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Enumeraciones"
+second_title: "Aspose.Font para Node.js mediante C++"
+description: "Funciones para convertir fuentes a formatos TrueType."
+type: docs
+url: /es/nodejs-cpp/enumerations/
+---
+
+## Enumeraciones
+
+| Enumeración | Descripción |
+| ----------- | ----------- |
+| [FontSavingFormats](./fontsavingformats/) | Especifica el tipo de fuente. |
+| [FontType](./fonttype/) | Especifica el tipo de fuente. |
+| [TtfNameTableNameId](./ttfnametablenameid/) | Especifica NameId. |
+| [TtfNameTablePlatformId](./ttfnametableplatformid/) | Representa la enumeración PlatformId. |
+| [TtfNameTableMSPlatformSpecificId](./ttfnametableMSPlatformSpecificId/) | Representa la enumeración MSPlatformSpecificId. |
+| [TtfNameTableMacPlatformSpecificId](./ttfnametableMacPlatformSpecificId/) | Representa la enumeración MacPlatformSpecificId. |
+| [TtfNameTableUnicodePlatformSpecificId](./ttfnametableUnicodePlatformSpecificId/) | Representa la enumeración UnicodePlatformSpecificId. |
+| [TtfNameTableMacLanguageId](./ttfnametablemaclanguageid/) | Enumeración de identificador de idioma de la plataforma Macintosh. |
+| [TtfNameTableMSLanguageId](./ttfnametablemslanguageid/) | Enumeración de identificador de idioma de la plataforma Microsoft. |
+
+### Example of using enumarations
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    //define parameters for AsposeFontSetInfo
+    const nameId = AsposeFontModule.TtfNameTableNameId.Description;
+    const platformId = AsposeFontModule.TtfNameTablePlatformId.Microsoft;
+    const platformSpecificId = AsposeFontModule.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+    const langID = Module.TtfNameTableMSLanguageId.English_United_States.value;
+    const text = "Updated description";
+    
+    const json = AsposeFontSetInfo(font_file, nameId, platformId, platformSpecificId, langID, text);
+    console.log("AsposeFontSetInfo => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/spanish/nodejs-cpp/enumerations/fontsavingformats/_index.md
+++ b/spanish/nodejs-cpp/enumerations/fontsavingformats/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum FontSavingFormats"
+second_title: "Referencia de API de Aspose.Font para .NET"
+description: "Aspose.Font.FontSavingFormats enum. Especifica el tipo de fuente"
+type: docs
+weight: 110
+url: /es/nodejs-cpp/enumerations/fontsavingformats/
+---
+## FontSavingFormats enumeration
+
+Especifica el tipo de fuente.
+
+```csharp
+public enum FontSavingFormats
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+| TTF | `0` | Formato de fuente TTF (TrueType). |
+| WOFF | `1` | WOFF (Web Open Font Format). |
+| WOFF2 | `2` | Formato de archivo WOFF 2.0 |
+| SVG | `3` | Formato de fuente SVG (Scalable Vector Graphics) |
+| OTF | `4` | Formato de fuente OTF (OpenType) |

--- a/spanish/nodejs-cpp/enumerations/fonttype/_index.md
+++ b/spanish/nodejs-cpp/enumerations/fonttype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum FontType"
+second_title: "Referencia de API de Aspose.Font para .NET"
+description: "Aspose.Font.FontType enum. Especifica el tipo de fuente"
+type: docs
+weight: 100
+url: /es/nodejs-cpp/enumerations/fonttype/
+---
+## FontType enumeration
+
+Especifica el tipo de fuente.
+
+```csharp
+public enum FontType
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+| TTF | `0` | Tipo de fuente TTF (TrueType) y relacionados. |
+| Type1 | `1` | Tipo de fuente Type1. |
+| CFF | `2` | Tipo de fuente CFF (Compact font format). |
+| OTF | `3` | Fuente OpenType. El formato de fuente OpenType es una extensión del formato de fuente TrueType, añadiendo soporte para datos de fuentes PostScript. |
+

--- a/spanish/nodejs-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
+++ b/spanish/nodejs-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
@@ -1,0 +1,53 @@
+---
+title: "Enumeración TtfNameTableMacPlatformSpecificId"
+second_title: "Referencia de API de Aspose.Font para .NET"
+description: "Enumeración Aspose.Font.TtfNameTableMacPlatformSpecificId. Especifica MacPlatformSpecificId"
+type: docs
+weight: 131
+url: /es/nodejs-cpp/enumerations/ttfnametablemacplatformspecificid/
+---
+## TtfNameTableMacPlatformSpecificId enumeration
+
+Especifica MacPlatformSpecificId.
+
+```csharp
+ enum TtfNameTableMacPlatformSpecificId
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+|  | Roman | `0` | Valor específico de la plataforma romana. |
+|  | Japanese | `1` | Valor específico de la plataforma japonesa. |
+|  | Traditional_Chinese | `2` | Valor específico de la plataforma de chino tradicional. |
+|  | Korean | `3` | Valor específico de la plataforma coreana. |
+|  | Arabic | `4` | Valor específico de la plataforma árabe. |
+|  | Hebrew | `5` | Valor específico de la plataforma hebrea. |
+|  | Greek | `6` | Valor específico de la plataforma griega. |
+|  | Russian | `7` | Valor específico de la plataforma rusa. |
+|  | RSymbol | `8` | Valor específico de la plataforma RSymbol. |
+|  | Devanagari | `9` | Valor específico de la plataforma Devanagari. |
+|  | Gurmukhi | `10` | Valor específico de la plataforma Gurmukhi. |
+|  | Gujarati | `11` | Valor específico de la plataforma Gujarati. |
+|  | Oriya | `12` | Valor específico de la plataforma Oriya. |
+|  | Bengali | `13` | Valor específico de la plataforma Bengali. |
+|  | Tamil | `14` | Valor específico de la plataforma Tamil |
+|  | Telugu | `15` | Valor específico de la plataforma Telugu. |
+|  | Kannada | `16` | Valor específico de la plataforma Kannada. |
+|  | Malayalam | `17` | Valor específico de la plataforma Malayalam. |
+|  | Sinhalese | `18` | Valor específico de la plataforma Sinhalese. |
+|  | Burmese | `19` | Valor específico de la plataforma Burmese. |
+|  | Khmer | `20` | Valor específico de la plataforma Khmer. |
+|  | Thai | `21` | Valor específico de la plataforma Thai. |
+|  | Laotian | `22` | Valor específico de la plataforma Laotian. |
+|  | Georgian | `23` | Valor específico de la plataforma Georgian. |
+|  | Armenian | `24` | Valor específico de la plataforma Armenian. |
+|  | Simplified_Chinese | `25` | Valor específico de la plataforma Chino simplificado. |
+|  | Tibetan | `26` | Valor específico de la plataforma Tibetan. |
+|  | Mongolian | `27` | Valor específico de la plataforma Mongolian. |
+|  | Geez | `28` | Valor específico de la plataforma Geez. |
+|  | Slavic | `29` | Valor específico de la plataforma Slavic. |
+|  | Vietnamese | `30` | Valor específico de la plataforma Vietnamese. |
+|  | Sindhi | `31` | Valor específico de la plataforma Sindhi. |
+|  | Uninterpreted | `32` | Valor específico de la plataforma no interpretado. |

--- a/spanish/nodejs-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
+++ b/spanish/nodejs-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Enumeración TtfNameTableMSPlatformSpecificId"
+second_title: "Referencia de API de Aspose.Font para .NET"
+description: "Aspose.Font.TtfNameTableMSPlatformSpecificId enum. Especifica MSPlatformSpecificId."
+type: docs
+weight: 132
+url: /es/nodejs-cpp/enumerations/ttfnametablemsplatformspecificid/
+---
+## TtfNameTableMSPlatformSpecificId enumeration
+
+Especifica MSPlatformSpecificId.
+
+```csharp
+ enum TtfNameTableMSPlatformSpecificId
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+|  | Symbol | `0` | Símbolo MS PlatformSpecificId. |
+|  | Unicode_BMP_UCS2 | `1` | Unicode BMP (UCS2) MS PlatformSpecificId. |
+|  | ShiftJIS | `2` | ShiftJIS MS PlatformSpecificId. |
+|  | PRC | `3` | PRC MS PlatformSpecificId. |
+|  | Big5 | `4` | Big5 MS PlatformSpecificId. |
+|  | Wansung | `5` | Wansung MS PlatformSpecificId. |
+|  | Johab | `6` | Johab MS PlatformSpecificId. |
+|  | Reserved1 | `7` | Reserved1 MS PlatformSpecificId. |
+|  | Reserved2 | `8` | Reserved2 MS PlatformSpecificId. |
+|  | Reserved3 | `9` | Reserved3 MS PlatformSpecificId. |
+|  | Unicode_UCS4 | `10` | Unicode UCS4 MS PlatformSpecificId. |
+

--- a/spanish/nodejs-cpp/enumerations/ttfnametablenameid/_index.md
+++ b/spanish/nodejs-cpp/enumerations/ttfnametablenameid/_index.md
@@ -1,0 +1,46 @@
+---
+title: "Enumeración TtfNameTableNameId"
+second_title: "Referencia de API de Aspose.Font para .NET"
+description: "Enumeración Aspose.Font.TtfNameTableNameId. Especifica NameId"
+type: docs
+weight: 120
+url: /es/nodejs-cpp/enumerations/ttfnametablenameid/
+---
+## TtfNameTableNameId enumeration
+
+Especifica NameId.
+
+```csharp
+ enum TtfNameTableNameId
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+|  | CopyrightNotice | `0` | Aviso de derechos de autor. |
+|  | FontFamily | `1` | Familia de fuente. Esta cadena es el nombre de la familia de fuente que el usuario ve en plataformas Macintosh. |
+|  | FontSubfamily | `2` | Subfamilia de fuente. Esta cadena es la familia de fuente que el usuario ve en plataformas Macintosh. |
+|  | UniqueFontId | `3` | Identificación única de subfamilia (especificación de Apple). 3 Identificador único de fuente (especificación de MS). |
+|  | FullName | `4` | Nombre completo de la fuente. |
+|  | Version | `5` | Versión de la tabla de nombres. |
+|  | PostScriptName | `6` | Nombre PostScript de la fuente. Nota: Una fuente puede tener solo un nombre PostScript y ese nombre debe ser ASCII. |
+|  | TrademarkNotice | `7` | Aviso de marca registrada. |
+|  | ManufacturerName | `8` | Nombre del fabricante. |
+|  | DesignerName | `9` | Diseñador; nombre del diseñador del tipo de letra. |
+|  | Description | `10` | Descripción; descripción del tipo de letra. Puede contener información de revisión, recomendaciones de uso, historia, características, etc. |
+|  | UrlVendor | `11` | URL del proveedor de la fuente (con protocolo, p.ej., http://, ftp://). Si un número de serie único está incrustado en la URL, puede usarse para registrar la fuente. |
+|  | UrlDesigner | `12` | URL del diseñador de la fuente (con protocolo, p.ej., http://, ftp://) |
+|  | LicenseDescription | `13` | Descripción de la licencia; descripción de cómo puede usarse legalmente la fuente, o diferentes escenarios de ejemplo para uso licenciado. Este campo debe escribirse en lenguaje sencillo, no en jerga legal. |
+|  | LicenseInfoUrl | `14` | URL de información de la licencia, donde se puede encontrar información adicional de licencias. |
+|  | PreferredFamily | `16` | `15` Reservado `16` Familia preferida (solo Windows); En Windows, el nombre de la familia se muestra en el menú de fuentes; el nombre de la subfamilia se presenta como el nombre de estilo. Por razones históricas, las familias de fuentes han contenido un máximo de cuatro estilos, pero los diseñadores de fuentes pueden agrupar más de cuatro fuentes en una sola familia. Los IDs de Familia preferida y Subfamilia preferida permiten a los diseñadores de fuentes incluir los agrupamientos de familia/subfamilia preferidos. Estos IDs solo están presentes si son diferentes de los IDs 1 y 2. |
+|  | PreferredSubfamily | `17` | Subfamilia preferida (solo Windows); En Windows, el nombre de la familia se muestra en el menú de fuentes; el nombre de la subfamilia se presenta como el nombre de estilo. Por razones históricas, las familias de fuentes han contenido un máximo de cuatro estilos, pero los diseñadores de fuentes pueden agrupar más de cuatro fuentes en una sola familia. Los IDs de Familia preferida y Subfamilia preferida permiten a los diseñadores de fuentes incluir los agrupamientos de familia/subfamilia preferidos. Estos IDs solo están presentes si son diferentes de los IDs 1 y 2. |
+|  | CompatibleFull | `18` | Completo compatible (solo Macintosh); En Macintosh, el nombre del menú se construye usando el recurso de fuente. Esto usualmente coincide con el Nombre completo. Si deseas que el nombre de la fuente aparezca diferente al Nombre completo, puedes insertar el Nombre completo compatible en el ID 18. Este nombre no lo usa el propio Mac OS, pero puede ser usado por desarrolladores de aplicaciones (p.ej., Adobe). |
+|  | SampleText | `19` | Texto de muestra. Puede ser el nombre de la fuente, o cualquier otro texto que el diseñador considere el mejor ejemplo para mostrar cómo se ve la fuente. |
+|  | PostScriptCID | `20` | Su presencia en una fuente significa que el nameID 6 contiene un nombre de fuente PostScript que está destinado a usarse con la invocación "composefont" para invocar la fuente en un intérprete PostScript. |
+|  | WwsFamilyName | `21` | Usado para proporcionar un nombre de familia conforme a WWS en caso de que las entradas de los IDs 16 y 17 no se ajusten al modelo WWS. |
+|  | WwsSubfamilyName | `22` | Usado junto con el ID 21, este ID proporciona un nombre de subfamilia conforme a WWS (reflejando solo atributos de peso, ancho y pendiente) en caso de que las entradas de los IDs 16 y 17 no se ajusten al modelo WWS. |
+|  | LightBackground | `23` | Este ID, si se usa en la matriz de etiquetas de paleta de la tabla CPAL, especifica que la paleta de colores correspondiente en la tabla CPAL es adecuada para usar con la fuente al mostrarla sobre un fondo claro como blanco. |
+|  | DarkBackground | `24` | Este ID, si se usa en la matriz de etiquetas de paleta de la tabla CPAL, especifica que la paleta de colores correspondiente en la tabla CPAL es adecuada para usar con la fuente al mostrarla sobre un fondo oscuro como negro. |
+|  | VariationsPostScriptNamePrefix | `25` | Si está presente en una fuente variable, puede usarse como prefijo de familia en el algoritmo de generación de nombres PostScript para fuentes de variación. |
+

--- a/spanish/nodejs-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
+++ b/spanish/nodejs-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
@@ -1,0 +1,138 @@
+---
+title: "Enumeración TtfNameTableMacLanguageId"
+second_title: "Referencia de API de Aspose.Font para .NET"
+description: "Enumeración Aspose.Font.TtfNameTableMacLanguageId. Especifica MacLanguageId"
+type: docs
+weight: 140
+url: /es/nodejs-cpp/enumerations/ttfnametablemaclanguageid/
+---
+## TtfNameTableMacLanguageId enumeration
+
+Representa la enumeración MacLanguageId.
+
+```csharp
+ enum TtfNameTableMacLanguageId
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+|  | English | `0` | Valor de LanguageId en inglés |
+|  | French | `1` | Valor de LanguageId en francés |
+|  | German | `2` | Valor de LanguageId en alemán |
+|  | Italian | `3` | Valor de LanguageId en italiano |
+|  | Dutch | `4` | Valor de LanguageId en holandés |
+|  | Swedish | `5` | Valor de LanguageId en sueco |
+|  | Spanish | `6` | Valor de LanguageId en español |
+|  | Danish | `7` | Valor de LanguageId en danés |
+|  | Portuguese | `8` | Valor de LanguageId en portugués |
+|  | Norwegian | `9` | Valor de LanguageId en noruego |
+|  | Hebrew | `10` | Hebreo LanguageId valor |
+|  | Japanese | `11` | Japonés LanguageId valor |
+|  | Arabic | `12` | Árabe LanguageId valor |
+|  | Finnish | `13` | Finés LanguageId valor |
+|  | Greek | `14` | Griego LanguageId valor |
+|  | Icelandic | `15` | Islandés LanguageId valor |
+|  | Maltese | `16` | Maltés LanguageId valor |
+|  | Turkish | `17` | Turco LanguageId valor |
+|  | Croatian | `18` | Croata LanguageId valor |
+|  | Chinese_Traditional | `19` | Chino (Tradicional) LanguageId valor |
+|  | Urdu | `20` | Urdu LanguageId valor |
+|  | Hindi | `21` | Hindi LanguageId valor |
+|  | Thai | `22` | Tailandés LanguageId valor |
+|  | Korean | `23` | Coreano LanguageId valor |
+|  | Lithuanian | `24` | Lituano LanguageId valor |
+|  | Polish | `25` | Polaco LanguageId valor |
+|  | Hungarian | `26` | Húngaro LanguageId valor |
+|  | Estonian | `27` | Estonio LanguageId valor |
+|  | Latvian | `28` | Letón LanguageId valor |
+|  | Sami | `29` | Sami LanguageId valor |
+|  | Faroese | `30` | Feroés LanguageId valor |
+|  | Farsi_Persian | `31` | Farsi/Persa LanguageId valor |
+|  | Russian | `32` | Ruso LanguageId valor |
+|  | Chinese_Simplified | `33` | Chino (Simplificado) LanguageId valor |
+|  | Flemish | `34` | Flamenco LanguageId valor |
+|  | Irish_Gaelic | `35` | Irlandés gaélico LanguageId valor |
+|  | Albanian | `36` | Albanés LanguageId valor |
+|  | Romanian | `37` | Rumano LanguageId valor |
+|  | Czech | `38` | Checo LanguageId valor |
+|  | Slovak | `39` | Eslovaco LanguageId valor |
+|  | Slovenian | `40` | Esloveno LanguageId valor |
+|  | Yiddish | `41` | Yidis LanguageId valor |
+|  | Serbian | `42` | Serbio LanguageId valor |
+|  | Macedonian | `43` | Macedonio LanguageId valor |
+|  | Bulgarian | `44` | Búlgaro LanguageId valor |
+|  | Ukrainian | `45` | Ucraniano LanguageId valor |
+|  | Byelorussian | `46` | Bielorruso LanguageId valor |
+|  | Uzbek | `47` | Uzbeko LanguageId valor |
+|  | Kazakh | `48` | Kazajo LanguageId valor |
+|  | Azerbaijani_Cyrillic | `49` | Azerbaiyano (alfabeto cirílico) LanguageId valor |
+|  | Azerbaijani_Arabic | `50` | Azerbaiyano (alfabeto árabe) LanguageId valor |
+|  | Armenian | `51` | Armenio LanguageId valor |
+|  | Georgian | `52` | Georgiano LanguageId valor |
+|  | Moldavian | `53` | Moldavo LanguageId valor |
+|  | Kirghiz | `54` | Kirguís LanguageId valor |
+|  | Tajiki | `55` | Tayiko LanguageId valor |
+|  | Turkmen | `56` | Turcomano LanguageId valor |
+|  | Mongolian | `57` | Mongol (escritura mongola) LanguageId valor |
+|  | Mongolian_Cyrillic | `58` | Mongol (alfabeto cirílico) LanguageId valor |
+|  | Pashto | `59` | Pastún LanguageId valor |
+|  | Kurdish | `60` | Pastún LanguageId valor |
+|  | Kashmiri | `61` | Valor de LanguageId Kashmiri |
+|  | Sindhi | `62` | Valor de LanguageId Sindhi |
+|  | Tibetan | `63` | Valor de LanguageId Tibetan |
+|  | Nepali | `64` | Valor de LanguageId Nepali |
+|  | Sanskrit | `65` | Valor de LanguageId Sanskrit |
+|  | Marathi | `66` | Valor de LanguageId Marathi |
+|  | Bengali | `67` | Valor de LanguageId Bengali |
+|  | Assamese | `68` | Valor de LanguageId Assamese |
+|  | Gujarati | `69` | Valor de LanguageId Gujarati |
+|  | Punjabi | `70` | Valor de LanguageId Punjabi |
+|  | Oriya | `71` | Valor de LanguageId Oriya |
+|  | Malayalam | `72` | Valor de LanguageId Malayalam |
+|  | Kannada | `73` | Valor de LanguageId Kannada |
+|  | Tamil | `74` | Valor de LanguageId Tamil |
+|  | Telugu | `75` | Valor de LanguageId Telugu |
+|  | Sinhalese | `76` | Valor de LanguageId Sinhalese |
+|  | Burmese | `77` | Valor de LanguageId Burmese |
+|  | Khmer | `78` | Valor de LanguageId Khmer |
+|  | Lao | `79` | Valor de LanguageId Lao |
+|  | Vietnamese | `80` | Valor de LanguageId Vietnamese |
+|  | Indonesian | `81` | Valor de LanguageId Indonesian |
+|  | Tagalog | `82` | Valor de LanguageId Tagalog |
+|  | Malay_Roman | `83` | Valor de LanguageId Malay (script romano) |
+|  | Malay_Arabic | `84` | Valor de LanguageId Malay (script árabe) |
+|  | Amharic | `85` | Valor de LanguageId Amharic |
+|  | Tigrinya | `86` | Tigrinya LanguageId valor |
+|  | Galla | `87` | Galla LanguageId valor |
+|  | Somali | `88` | Somali LanguageId valor |
+|  | Swahili | `89` | Swahili LanguageId valor |
+|  | Kinyarwanda_Ruanda | `90` | Kinyarwanda/Ruanda LanguageId valor |
+|  | Rundi | `91` | Rundi LanguageId valor |
+|  | Nyanja_Chewa | `92` | Nyanja/Chewa LanguageId valor |
+|  | Malagasy | `93` | Malagasy LanguageId valor |
+|  | Esperanto | `94` | Esperanto LanguageId valor |
+|  | Welsh | `128` | Welsh LanguageId valor |
+|  | Basque | `129` | Basque LanguageId valor |
+|  | Catalan | `130` | Catalan LanguageId valor |
+|  | Latin | `131` | Latin LanguageId valor |
+|  | Quechua | `132` | Quechua LanguageId valor |
+|  | Guarani | `133` | Guarani LanguageId valor |
+|  | Aymara | `134` | Aymara LanguageId valor |
+|  | Tatar | `135` | Tatar LanguageId valor |
+|  | Uighur | `136` | Uighur LanguageId valor |
+|  | Dzongkha | `137` | Dzongkha LanguageId valor |
+|  | Javanese | `138` | Javanese (Roman script) LanguageId valor |
+|  | Sundanese | `139` | Sundanese (Roman script) LanguageId valor |
+|  | Galician | `140` | Galician LanguageId valor |
+|  | Afrikaans | `141` | Afrikaans LanguageId valor |
+|  | Breton | `142` | Breton LanguageId valor |
+|  | Inuktitut | `143` | Inuktitut LanguageId valor |
+|  | Scottish_Gaelic | `144` | Valor de LanguageId del gaélico escocés |
+|  | Manx_Gaelic | `145` | Valor de LanguageId del gaélico manés |
+|  | Irish_Gaelic_WDA | `146` | Valor de LanguageId del gaélico irlandés (con punto arriba) |
+|  | Tongan | `147` | Valor de LanguageId de tongano |
+|  | Greek_Polytonic | `148` | Valor de LanguageId de griego (polítono) |
+|  | Greenlandic | `149` | Valor de LanguageId de groenlandés |
+|  | Azerbaijani_Roman | `150` | Valor de LanguageId de azerí (alfabeto romano) |

--- a/spanish/nodejs-cpp/enumerations/ttfnametablenmslanguageid/_index.md
+++ b/spanish/nodejs-cpp/enumerations/ttfnametablenmslanguageid/_index.md
@@ -1,0 +1,225 @@
+---
+title: "Enumeración TtfNameTableMSLanguageId"
+second_title: "Referencia de API de Aspose.Font para .NET"
+description: "Enumeración Aspose.Font.TtfNameTableMSLanguageId. Especifica MSLanguageId"
+type: docs
+weight: 150
+url: /es/nodejs-cpp/enumerations/ttfnametablemslanguageid/
+---
+## TtfNameTableMSLanguageId enumeration
+
+Representa la enumeración MSLanguageId.
+
+```csharp
+ enum TtfNameTableMSLanguageId
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+|  | Afrikaans | `0x0436` | Valor LanguageId de Afrikaans (Región: Sudáfrica, SA) |
+|  | Albanian | `0x041c` | Valor LanguageId de Albanés (Región: Albania, SQI) |
+|  | Alsatian | `0x0484` | Alsaciano (Región: Francia) valor de LanguageId |
+|  | Amharic | `0x045E` | Amhárico (Región: Etiopía) valor de LanguageId |
+|  | Arabic_Algeria | `0x1401` | Árabe (Región: Argelia) valor de LanguageId |
+|  | Arabic_Bahrain | `0x3C01` | Árabe (Región: Baréin) valor de LanguageId |
+|  | Arabic_Egypt | `0x0C01` | Árabe (Región: Egipto) valor de LanguageId |
+|  | Arabic_Iraq | `0x0801` | Árabe (Región: Irak) valor de LanguageId |
+|  | Arabic_Jordan | `0x2C01` | Árabe (Región: Jordania) valor de LanguageId |
+|  | Arabic_Kuwait | `0x3401` | Árabe (Región: Kuwait) valor de LanguageId |
+|  | Arabic_Lebanon | `0x3001` | Árabe (Región: Líbano) valor de LanguageId |
+|  | Arabic_Libya | `0x1001` | Árabe (Región: Libia) valor de LanguageId |
+|  | Arabic_Morocco | `0x1801` | Árabe (Región: Marruecos) valor de LanguageId |
+|  | Arabic_Oman | `0x2001` | Árabe (Región: Omán) valor de LanguageId |
+|  | Arabic_Qatar | `0x4001` | Árabe (Región: Catar) valor de LanguageId |
+|  | Arabic_Saudi_Arabia | `0x0401` | Árabe (Región: Arabia Saudita) valor de LanguageId |
+|  | Arabic_Syria | `0x2801` | Árabe (Región: Siria) valor de LanguageId |
+|  | Arabic_Tunisia | `0x1C01` | Árabe (Región: Túnez) valor de LanguageId |
+|  | Arabic_U_A_E | `0x3801` | Árabe (Región: Emiratos Árabes Unidos) valor de LanguageId |
+|  | Arabic_Yemen | `0x2401` | Árabe (Región: Yemen) valor de LanguageId |
+|  | Armenian | `0x042B` | Armenio (Región: Armenia) valor de LanguageId |
+|  | Assamese | `0x044D` | Asamés (Región: India) valor de LanguageId |
+|  | Azeri_Cyrillic | `0x082C` | Azerí (Cirílico, Región: Azerbaiyán) valor de LanguageId |
+|  | Azeri_Latin | `0x042C` | Azerí (Latín, Región: Azerbaiyán) valor de LanguageId |
+|  | Bashkir | `0x046D` | Bashkir (Región: Rusia) valor de LanguageId |
+|  | Basque | `0x042D` | Vasco (Región: País Vasco, EUQ) valor de LanguageId |
+|  | Belarusian | `0x0423` | Bielorruso (Región: Bielorrusia,  BEL) valor de LanguageId |
+|  | Bengali_Bangladesh | `0x0845` | Bengalí (Región: Bangladesh) valor de LanguageId |
+|  | Bengali_India | `0x0445` | Bengalí (Región: India) valor de LanguageId |
+|  | Bosnian_Cyrillic | `0x201A` | Bosnio (Cirílico, Región: Bosnia y Herzegovina) valor de LanguageId |
+|  | Bosnian_Latin | `0x141A` | Bosnio (Latín, Región: Bosnia y Herzegovina) valor de LanguageId |
+|  | Breton | `0x047E` | Bretón (Región: Francia) valor de LanguageId |
+|  | Bulgarian | `0x0402` | Búlgaro (Región: Bulgaria, BGR) valor de LanguageId |
+|  | Catalan | `0x0403` | Catalán (Región: Catalán, CAT) valor de LanguageId |
+|  | Chinese_Hong_Kong | `0x0C04` | Chino (Región: Hong Kong S.A.R.) valor de LanguageId |
+|  | Chinese_Macao | `0x1404` | Chino (Región: Macao S.A.R.) valor de LanguageId |
+|  | Chinese_PRC | `0x0804` | Chino (Región: República Popular de China) valor de LanguageId |
+|  | Chinese_Singapore | `0x1004` | Chino (Región: Singapur) valor de LanguageId |
+|  | Chinese_Taiwan | `0x0404` | Chino (Región: Taiwán) valor de LanguageId |
+|  | Corsican | `0x0483` | Corso (Región: Francia) valor de LanguageId |
+|  | Croatian | `0x041A` | Croata (Región: Croacia, SHL) valor de LanguageId |
+|  | Croatian_Latin | `0x101A` | Croata (Latín, Región: Bosnia y Herzegovina) valor de LanguageId |
+|  | Czech | `0x0405` | Checo (Región: República Checa, CSY) valor de LanguageId |
+|  | Danish | `0x0406` | Danés (Región: Dinamarca, DAN) valor de LanguageId |
+|  | Dari | `0x048C` | Dari (Región: Afganistán) valor de LanguageId |
+|  | Divehi | `0x0465` | Divehi (Región: Maldivas) valor de LanguageId |
+|  | Dutch_Belgium | `0x0813` | Holandés (Flamenco, Región: Bélgica, NLB) valor de LanguageId |
+|  | Dutch_Netherlands | `0x0413` | Holandés (Estándar, Región: Países Bajos, NLD) valor de LanguageId |
+|  | English_Australia | `0x0C09` | Inglés (Australiano, Región: Australia, ENA) valor de LanguageId |
+|  | English_Belize | `0x2809` | Inglés (Región: Belice) valor de LanguageId |
+|  | English_Canada | `0x1009` | Inglés (Canadiense, Región: Canadá, ENC) valor de LanguageId |
+|  | English_Caribbean | `0x2409` | Inglés (Región: Caribe) valor de LanguageId |
+|  | English_India | `0x4009` | Inglés (Región: India) LanguageId valor |
+|  | English_Ireland | `0x1809` | Inglés (Región: Irlanda, ENI) LanguageId valor |
+|  | English_Jamaica | `0x2009` | Inglés (Región: Jamaica) LanguageId valor |
+|  | English_Malaysia | `0x4409` | Inglés (Región: Malasia) LanguageId valor |
+|  | English_New_Zealand | `0x1409` | Inglés (Región: Nueva Zelanda, ENZ) LanguageId valor |
+|  | English_ROP | `0x3409` | Inglés (Región: República de Filipinas, ROP) LanguageId valor |
+|  | English_Singapore | `0x4809` | Inglés (Región: Singapur) LanguageId valor |
+|  | English_South_Africa | `0x1C09` | Inglés (Región: Sudáfrica, SA) LanguageId valor |
+|  | English_TT | `0x2C09` | Inglés (Región: Trinidad y Tobago, TT) LanguageId valor |
+|  | English_United_Kingdom | `0x0809` | Inglés (Británico, Región: Reino Unido, ENG) LanguageId valor |
+|  | English_United_States | `0x0409` | Inglés (Americano, Región: Estados Unidos, ENU) LanguageId valor |
+|  | English_Zimbabwe | `0x3009` | Inglés (Región: Zimbabue) LanguageId valor |
+|  | Estonian | `0x0425` | Estonio (Región: Estonia, ETI) LanguageId valor |
+|  | Faroese | `0x0438` | Feroés (Región: Islas Feroe) LanguageId valor |
+|  | Filipino | `0x0464` | Filipino (Región: Filipinas) LanguageId valor |
+|  | Finnish | `0x040B` | Finlandés (Región: Finlandia, FIN) LanguageId valor |
+|  | French_Belgium | `0x080C` | Francés (Belga, Región: Bélgica, FRB) LanguageId valor |
+|  | French_Canada | `0x0C0C` | Francés (Canadiense, Región: Canadá, FRC) LanguageId valor |
+|  | French_France | `0x040C` | Francés (Estándar, Región: Francia, FRA) LanguageId valor |
+|  | French_Luxembourg | `0x140c` | Francés (Región: Luxemburgo, FRL) LanguageId valor |
+|  | French_MC | `0x180C` | Francés (Región: Principado de Mónaco, MC) LanguageId valor |
+|  | French_Switzerland | `0x100C` | Francés (Suizo, Región: Suiza, FRS) LanguageId valor |
+|  | Frisian | `0x0462` | Frisón (Región: Países Bajos, NLD) LanguageId valor |
+|  | Galician | `0x0456` | Gallego (Región: Galicia) LanguageId valor |
+|  | Georgian | `0x0437` | Georgiano (Región: Georgia) LanguageId valor |
+|  | German_Austria | `0x0C07` | Alemán (austríaco, Región: Austria, DEA) valor de LanguageId |
+|  | German_Germany | `0x0407` | Alemán (estándar, Región: Alemania, DEU) valor de LanguageId |
+|  | German_Liechtenstein | `0x1407` | Alemán (Región: Liechtenstein, DEC) valor de LanguageId |
+|  | German_Luxembourg | `0x1007` | Alemán (Región: Luxemburgo, DEL) valor de LanguageId |
+|  | German_Switzerland | `0x0807` | Alemán (suizo, Región: Suiza, DES) valor de LanguageId |
+|  | Greek | `0x0408` | Griego (Región: Grecia, ELL) valor de LanguageId |
+|  | Greenlandic | `0x046F` | Groenlandés (Región: Groenlandia) valor de LanguageId |
+|  | Gujarati | `0x0447` | Gujarati (Región: India) valor de LanguageId |
+|  | Hausa | `0x0468` | Hausa (latín, Región: Nigeria) valor de LanguageId |
+|  | Hebrew | `0x040D` | Hebreo (Región: Israel) valor de LanguageId |
+|  | Hindi | `0x0439` | Hindi (Región: India) valor de LanguageId |
+|  | Hungarian | `0x040E` | Húngaro (Región: Hungría, HUN) valor de LanguageId |
+|  | Icelandic | `0x040F` | Islandés (Región: Islandia, ISL) valor de LanguageId |
+|  | Igbo | `0x0470` | Igbo (Región: Nigeria) valor de LanguageId |
+|  | Indonesian | `0x0421` | Indonesio (Región: Indonesia) valor de LanguageId |
+|  | Inuktitut | `0x045D` | Inuktitut (Región: Canadá) valor de LanguageId |
+|  | Inuktitut_Latin | `0x085D` | Inuktitut (latín, Región: Canadá) valor de LanguageId |
+|  | Irish | `0x083C` | Irlandés (Región: Irlanda) valor de LanguageId |
+|  | isiXhosa | `0x0434` | isiXhosa (Región: Sudáfrica, SA) valor de LanguageId |
+|  | isiZulu | `0x0435` | isiZulu (Región: Sudáfrica, SA) valor de LanguageId |
+|  | Italian_Italy | `0x0410` | Italiano (estándar, Región: Italia, ITA) valor de LanguageId |
+|  | Italian_Switzerland | `0x0810` | Italiano (suizo, Región: Suiza, ITS) valor de LanguageId |
+|  | Japanese | `0x0411` | Japonés (Región: Japón) valor de LanguageId |
+|  | Kannada | `0x044B` | Kannada (Región: India) valor de LanguageId |
+|  | Kazakh | `0x043F` | Kazajo (Región: Kazajistán) valor de LanguageId |
+|  | Khmer | `0x0453` | Khmer (Región: Cambodia) LanguageId valor |
+|  | Kiche | `0x0486` | K�iche (Región: Guatemala) LanguageId valor |
+|  | Kinyarwanda | `0x0487` | Kinyarwanda (Región: Rwanda) LanguageId valor |
+|  | Kiswahili | `0x0441` | Kiswahili (Región: Kenya) LanguageId valor |
+|  | Konkani | `0x0457` | Konkani (Región: India) LanguageId valor |
+|  | Korean | `0x0412` | Korean (Región: Korea) LanguageId valor |
+|  | Kyrgyz | `0x0440` | Kyrgyz (Región: Kyrgyzstan) LanguageId valor |
+|  | Lao | `0x0454` | Lao (Región: Lao P.D.R.) LanguageId valor |
+|  | Latvian | `0x0426` | Latvian (Región: Latvia, LVI) LanguageId valor |
+|  | Lithuanian | `0x0427` | Lithuanian (Región: Lithuania, LTH) LanguageId valor |
+|  | Lower_Sorbian | `0x082E` | Lower Sorbian (Región: Germany) LanguageId valor |
+|  | Luxembourgish | `0x046E` | Luxembourgish (Región: Luxembourg) LanguageId valor |
+|  | Macedonian | `0x042F` | Macedonian (Región: North Macedonia) LanguageId valor |
+|  | Malay_Brunei_Darussalam | `0x083E` | Malay (Región: Brunei Darussalam) LanguageId valor |
+|  | Malay_Malaysia | `0x043E` | Malay (Región: Malaysia) LanguageId valor |
+|  | Malayalam | `0x044C` | Malayalam (Región: India) LanguageId valor |
+|  | Maltese | `0x043A` | Maltese (Región: Malta) LanguageId valor |
+|  | Maori | `0x0481` | Maori (Región: New Zealand) LanguageId valor |
+|  | Mapudungun | `0x047A` | Mapudungun (Región: Chile) LanguageId valor |
+|  | Marathi | `0x044E` | Marathi (Región: India) LanguageId valor |
+|  | Mohawk | `0x047C` | Mohawk (Región: Mohawk) LanguageId valor |
+|  | Mongolian_Cyrillic | `0x0450` | Mongolian (Cyrillic, Región: Mongolia) LanguageId valor |
+|  | Mongolian_Traditional | `0x0850` | Mongolian (Traditional, Región: People�s Republic of China) LanguageId valor |
+|  | Nepali | `0x0461` | Nepali (Región: Nepal) LanguageId valor |
+|  | Norwegian_Bokmal | `0x0414` | Norwegian (Bokmal, Región: Norway, NOR) LanguageId valor |
+|  | Norwegian_Nynorsk | `0x0814` | Noruego (Nynorsk, Región: Noruega, NON) valor de LanguageId |
+|  | Occitan | `0x0482` | Occitano (Región: Francia) valor de LanguageId |
+|  | Odia | `0x0448` | Odia (anteriormente Oriya, Región: India) valor de LanguageId |
+|  | Pashto | `0x0463` | Pastún (Región: Afganistán) valor de LanguageId |
+|  | Polish | `0x0415` | Polaco (Región: Polonia, PLK) valor de LanguageId |
+|  | Portuguese_Brazil | `0x0416` | Portugués (brasileño, Región: Brasil, PTB) valor de LanguageId |
+|  | Portuguese_Portugal | `0x0816` | Portugués (estándar, Región: Portugal, PTG) valor de LanguageId |
+|  | Punjabi | `0x0446` | Punjabi (Región: India) valor de LanguageId |
+|  | Quechua_Bolivia | `0x046B` | Quechua (Región: Bolivia) valor de LanguageId |
+|  | Quechua_Ecuador | `0x086B` | Quechua (Región: Ecuador) valor de LanguageId |
+|  | Quechua_Peru | `0x0C6B` | Quechua (Región: Perú) valor de LanguageId |
+|  | Romanian | `0x0418` | Rumano (Región: Rumania, ROM) valor de LanguageId |
+|  | Romansh | `0x0417` | Romanche (Región: Suiza) valor de LanguageId |
+|  | Russian | `0x0419` | Ruso (Región: Rusia, RUS) valor de LanguageId |
+|  | Sami_Inari | `0x243B` | Sami (Inari, Región: Finlandia) valor de LanguageId |
+|  | Sami_Lule_Norway | `0x103B` | Sami (Lule, Región: Noruega) valor de LanguageId |
+|  | Sami_Lule_Sweden | `0x143B` | Sami (Lule, Región: Suecia) valor de LanguageId |
+|  | Sami_Northern_Finland | `0x0C3B` | Sami (del norte, Región: Finlandia) valor de LanguageId |
+|  | Sami_Northern_Norway | `0x043B` | Sami (del norte, Región: Noruega) valor de LanguageId |
+|  | Sami_Northern_Sweden | `0x083B` | Sami (del norte, Región: Noruega) valor de LanguageId |
+|  | Sami_Skolt | `0x203B` | Sami (Skolt, Región: Finlandia) valor de LanguageId |
+|  | Sami_Southern_Norway | `0x183B` | Sami (del sur, Región: Noruega) valor de LanguageId |
+|  | Sami_Southern_Sweden | `0x1C3B` | Sami (del sur, Región: Suecia) valor de LanguageId |
+|  | Sanskrit | `0x044F` | Sánscrito (Región: India) valor de LanguageId |
+|  | Serbian_Cyrillic_BIH | `0x1C1A` | Serbio (Cirílico, Región: Bosnia y Herzegovina) valor de LanguageId |
+|  | Serbian_Cyrillic_Serbia | `0x0C1A` | Serbio (Cirílico, Región: Serbia) valor de LanguageId |
+|  | Serbian_Latin_BIH | `0x181A` | Serbio (Latin, Región: Bosnia y Herzegovina) LanguageId valor |
+|  | Serbian_Latin_Serbia | `0x081A` | Serbio (Latin, Región: Serbia) LanguageId valor |
+|  | Sesotho_Sa_Leboa | `0x046C` | Sesotho sa Leboa (Northern Sotho, Región: Sudáfrica, SA) LanguageId valor |
+|  | Setswana | `0x0432` | Setswana (Región: Sudáfrica, SA) LanguageId valor |
+|  | Sinhala | `0x045B` | Cingalés (Región: Sri Lanka) LanguageId valor |
+|  | Slovak | `0x041B` | Eslovaco (Región: Eslovaquia, SKY) LanguageId valor |
+|  | Slovenian | `0x0424` | Esloveno (Región: Eslovenia, SLV) LanguageId valor |
+|  | Spanish_Argentina | `0x2C0A` | Español (Región: Argentina) LanguageId valor |
+|  | Spanish_Bolivia | `0x400A` | Español (Región: Bolivia) LanguageId valor |
+|  | Spanish_Chile | `0x340A` | Español (Región: Chile) LanguageId valor |
+|  | Spanish_Colombia | `0x240A` | Español (Región: Colombia) LanguageId valor |
+|  | Spanish_Costa_Rica | `0x140A` | Español (Región: Costa Rica) LanguageId valor |
+|  | Spanish_Dominican_Republic | `0x1C0A` | Español (Región: República Dominicana) LanguageId valor |
+|  | Spanish_Ecuador | `0x300A` | Español (Región: República Dominicana) LanguageId valor |
+|  | Spanish_El_Salvador | `0x440A` | Español (Región: República Dominicana) LanguageId valor |
+|  | Spanish_Guatemala | `0x100A` | Español (Región: Guatemala) LanguageId valor |
+|  | Spanish_Honduras | `0x480A` | Español (Región: Honduras) LanguageId valor |
+|  | Spanish_Mexico | `0x080A` | Español (Mexicano, Región: México, ESM) LanguageId valor |
+|  | Spanish_Nicaragua | `0x4C0A` | Español (Región: Nicaragua) LanguageId valor |
+|  | Spanish_Panama | `0x180A` | Español (Región: Panamá) LanguageId valor |
+|  | Spanish_Paraguay | `0x3C0A` | Español (Región: Paraguay) LanguageId valor |
+|  | Spanish_Peru | `0x280A` | Español (Región: Perú) LanguageId valor |
+|  | Spanish_Puerto_Rico | `0x500A` | Español (Región: Puerto Rico) LanguageId valor |
+|  | Spanish_Modern_Sort | `0x0C0A` | Español (Orden Moderno, Región: España, ESN) LanguageId valor |
+|  | Spanish_Traditional_Sort | `0x040A` | Español (Orden Tradicional, Región: España, ESP) LanguageId valor |
+|  | Spanish_United_States | `0x540A` | Español (Región: Estados Unidos) LanguageId valor |
+|  | Spanish_Uruguay | `0x380A` | Español (Región: Uruguay) LanguageId valor |
+|  | Spanish_Venezuela | `0x200A` | Español (Región: Venezuela) valor de LanguageId |
+|  | Swedish_Finland | `0x081D` | Sueco (Región: Finlandia) valor de LanguageId |
+|  | Swedish_Sweden | `0x041D` | Sueco (Región: Suecia, SVE) valor de LanguageId |
+|  | Syriac | `0x045A` | Siríaco (Región: Siria) valor de LanguageId |
+|  | Tajik | `0x0428` | Tayiko (Cirílico, Región: Tayikistán) valor de LanguageId |
+|  | Tamazight | `0x085F` | Tamazight (Latín, Región: Argelia) valor de LanguageId |
+|  | Tamil | `0x0449` | Tamil (Región: India) valor de LanguageId |
+|  | Tatar | `0x0444` | Tártaro (Región: Rusia) valor de LanguageId |
+|  | Telugu | `0x044A` | Telugu (Región: India) valor de LanguageId |
+|  | Thai | `0x041E` | Tailandés (Región: Tailandia) valor de LanguageId |
+|  | Tibetan | `0x0451` | Tibetano (Región: RPC) valor de LanguageId |
+|  | Turkish | `0x041F` | Turco (Región: Turquía, TRK) valor de LanguageId |
+|  | Turkmen | `0x0442` | Turcomano (Región: Turkmenistán) valor de LanguageId |
+|  | Uighur | `0x0480` | Uigur (Región: RPC) valor de LanguageId |
+|  | Ukrainian | `0x0422` | Ucraniano (Región: Ucrania, UKR) valor de LanguageId |
+|  | Upper_Sorbian | `0x042E` | Alto sorabo (Región: Alemania) valor de LanguageId |
+|  | Urdu | `0x0420` | Urdu (Región: República Islámica de Pakistán) valor de LanguageId |
+|  | Uzbek_Cyrillic | `0x0843` | Uzbeko (Cirílico, Región: Uzbekistán) valor de LanguageId |
+|  | Uzbek_Latin | `0x0443` | Uzbeko (Latín, Región: Uzbekistán) valor de LanguageId |
+|  | Vietnamese | `0x042A` | Vietnamita (Región: Vietnam) valor de LanguageId |
+|  | Welsh | `0x0452` | Galés (Región: Reino Unido) valor de LanguageId |
+|  | Wolof | `0x0488` | Wolof (Región: Senegal) valor de LanguageId |
+|  | Yakut | `0x0485` | Yakuto (Región: Rusia) valor de LanguageId |
+|  | Yi | `0x0478` | Yi (Región: RPC) valor de LanguageId |
+| Yoruba | `0x046A` | Yoruba (Región: Nigeria) valor de LanguageId |

--- a/spanish/nodejs-cpp/enumerations/ttfnametableplatformid/_index.md
+++ b/spanish/nodejs-cpp/enumerations/ttfnametableplatformid/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Enum TtfNameTablePlatformId"
+second_title: "Referencia de API de Aspose.Font para .NET"
+description: "Aspose.Font.TtfNameTablePlatformId enum. Especifica PlatformId"
+type: docs
+weight: 130
+url: /es/nodejs-cpp/enumerations/ttfnametableplatformid/
+---
+## TtfNameTablePlatformId enumeration
+
+Especifica PlatformId.
+
+```cssharp
+ enum TtfNameTablePlatformId
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+|  | Unicode | `0` | Unicode |
+|  | Macintosh | `1` | Código del Administrador de Scripts de Macintosh. |
+|  | ISO | `2` | Especificación de Apple: (reservado; no usar) Especificación de MS: codificación ISO. Tenga en cuenta que la ID de plataforma 2 (ISO) ha sido obsoleta a partir de la Especificación OpenType v1.3. Se pretendía representar ISO/IEC 10646, en contraste con Unicode; ambos estándares tienen asignaciones de códigos de caracteres idénticas. |
+|  | Microsoft | `3` | Codificación de Microsoft. |

--- a/spanish/nodejs-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
+++ b/spanish/nodejs-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum TtfNameTableUnicodePlatformSpecificId"
+second_title: "Referencia de API de Aspose.Font para .NET"
+description: "Aspose.Font.TtfNameTableUnicodePlatformSpecificId enum. Especifica UnicodePlatformSpecificId"
+type: docs
+weight: 133
+url: /es/nodejs-cpp/enumerations/ttfnametableunicodeplatformspecificid/
+---
+## TtfNameTableUnicodePlatformSpecificId enumeration
+
+Especifica UnicodePlatformSpecificId.
+
+```csharp
+ enum TtfNameTableUnicodePlatformSpecificId
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| --- | --- | --- |
+|  | Default | `0` | Semántica predeterminada (Unicode 1.0). |
+|  | Unicode1_1 | `1` | Semántica Unicode 1.1. |
+|  | ISO10646_1993 | `2` | Semántica ISO 10646 1993 (obsoleta). |
+|  | Unicode2_0 | `3` | Semántica Unicode 2.0 o posterior. Solo BMP de Unicode. |
+|  | Unicode2_0_Full | `4Unicode 2.0 and onwards semantics (non-BMP characters allowed)` | Repertorio completo de Unicode. |

--- a/spanish/nodejs-cpp/metadata/_index.md
+++ b/spanish/nodejs-cpp/metadata/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Funciones de metadatos de fuente"
+second_title: "Aspose.Font para Node.js mediante C++"
+description: "Funciones para trabajar con archivos de metadatos de fuente"
+type: docs
+url: /es/nodejs-cpp/metadata/
+---
+
+## Metadata Font functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposeFontGetInfo](./asposefontgetinfo/) | Obtener información (metadatos) de un archivo de fuente. |
+| [AsposeFontSetInfo](./asposefontsetinfo/) | Establecer información (metadatos) en un archivo de fuente. |
+
+## Detailed Description
+
+Funciones para trabajar con archivos de fuentes de metadatos.
+

--- a/spanish/nodejs-cpp/metadata/asposefontgetinfo/_index.md
+++ b/spanish/nodejs-cpp/metadata/asposefontgetinfo/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposeFontGetInfo"
+second_title: "Aspose.Font para Node.js mediante C++"
+description: "Obtener información (metadatos) de un archivo de fuente."
+type: docs
+url: /es/nodejs-cpp/metadata/asposefontgetinfo/
+---
+## AsposeFontGetInfo function
+
+_Obtener información (metadatos) de un archivo de fuente._
+
+```js
+function AsposeFontGetInfo(
+    fileName
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileName | string | Nombre de archivo. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto (\"\" sin error) |
+|  | registros | Matriz de objetos JSON : |
+|  | * NameId | identificador de nombre |
+|  | * PlatformId | identificador de plataforma |
+|  | * PlatformSpecificId | identificador específico de plataforma |
+|  | * LanguageId | identificador de idioma |
+|  | * Información | contenido del registro de nombre |
+
+### Ejemplos
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    //AsposeFontGetInfo - get metadata information
+    const json = AsposeFontModule.AsposeFontGetInfo(font_file);
+    console.log("AsposeFontGetInfo => %O",  json.errorCode == 0 ? json.records.reduce((ret, a) => ret +
+        "\nNameId : " + a.NameId
+        + "; PlatformId : " + a.PlatformId
+        + "; PlatformSpecificId : " + a.PlatformSpecificId
+        + "; LanguageId : " + a.LanguageId
+        + "; Info : " + a.Info,"") : json.errorText);
+
+});
+```
+**ECMAScript\ES6 js modules:**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+//AsposeFontGetInfo - get metadata font information
+json = AsposeFontModule.AsposeFontGetInfo(font_file);
+console.log("AsposeFontGetInfo => %O",  json.errorCode == 0 ? json.records.reduce((ret, a) => ret +
+    "\nNameId : " + a.NameId
+  + "; PlatformId : " + a.PlatformId
+  + "; PlatformSpecificId : " + a.PlatformSpecificId
+  + "; LanguageId : " + a.LanguageId
+  + "; Info : " + a.Info,"") : json.errorText);
+```

--- a/spanish/nodejs-cpp/metadata/asposefontsetinfo/_index.md
+++ b/spanish/nodejs-cpp/metadata/asposefontsetinfo/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeFontSetInfo"
+second_title: "Aspose.Font para Node.js mediante C++"
+description: "Establecer información (metadatos) en un archivo de fuente."
+type: docs
+url: /es/nodejs-cpp/metadata/asposefontsetinfo/
+---
+## AsposeFontSetInfo function
+
+_Establecer información (metadatos) en un archivo de fuente._
+
+```js
+function AsposeFontSetInfo(
+    fileName,
+    nameId, 
+    platformId, 
+    platformSpecificId, 
+    languageId, 
+    text
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileName | string | Nombre de archivo. |
+| nameId | TtfNameTableNameId | Identificador de nombre, categoría lógica de cadena, especificado por la enumeración [`NameId`](../../enumerations/ttfnametablenameid/) |
+|  | platformId | TtfNameTablePlatformId | Identificador de plataforma |
+| platformSpecificId | int | Identificador de codificación específico de la plataforma. Por favor, use un valor de una de estas enumeraciones: [`UnicodePlatformSpecificId`](../../enumerations/ttfnametableunicodeplatformspecificid/), [`MacPlatformSpecificId`](../../ttfnametable.macplatformspecificid/), [`MSPlatformSpecificId`](../../enumerations/ttfnametablemsplatformspecificid/). Qué enumeración usar está definida por el contexto (*platformId* parámetro) |
+| languageId | int | Identificador de idioma. Por favor, use un valor de las enumeraciones [`MSLanguageId`](../../enumerations/ttfnametablemslanguageid/) o [`MacLanguageId`](../../enumerations/ttfnametablemaclanguageid/) que dependen del contexto, definido por el parámetro *platformId*. |
+|  | texto | string | Datos de cadena reales |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto (\"\" sin error) |
+|  | fileNameResult | nombre de archivo de resultado |
+
+### Ejemplos
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    //AsposeSetInfo - set metadata info into font
+    const nameId = AsposeFontModule.TtfNameTableNameId.Description;
+    const platformId = AsposeFontModule.TtfNameTablePlatformId.Microsoft;
+    const platformSpecificId = AsposeFontModule.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+    const langID = Module.TtfNameTableMSLanguageId.English_United_States.value;
+    const text = "Updated description";
+    
+    const json = AsposeFontSetInfo(font_file, nameId, platformId, platformSpecificId, langID, text);
+    console.log("AsposeFontSetInfo => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules:**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+//AsposeSetInfo - set metadata info into font
+const nameId = AsposeFontModule.TtfNameTableNameId.Description;
+const platformId = AsposeFontModule.TtfNameTablePlatformId.Microsoft;
+const platformSpecificId = AsposeFontModule.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+const langID = Module.TtfNameTableMSLanguageId.English_United_States.value;
+const text = "Updated description";
+
+const json = AsposeFontModule.AsposeFontSetInfo(font_file, nameId, platformId, platformSpecificId, langID, text);
+console.log("AsposeFontSetInfo => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Ver también
+
+* enum [TtfNameTableNameId](../../enumerations/ttfnametablenameid/)
+* enum [TtfNameTablePlatformId](../../enumerations/ttfnametableplatformid/)
+* enum [TtfNameTableMacPlatformSpecificId](../../enumerations/ttfnametablemacplatformspecificid/)
+* enum [TtfNameTableMSPlatformSpecificId](../../enumerations/ttfnametablemsplatformspecificid/)
+* enum [TtfNameTableUnicodePlatformSpecificId](../../enumerations/ttfnametableunicodeplatformspecificid/)
+* enum [TtfNameTableMacLanguageId](../../enumerations/ttfnametablemaclanguageid/)
+* enum [TtfNameTableMSLanguageId](../../enumerations/ttfnametablemslanguageid/)

--- a/spanish/nodejs-cpp/misc/_index.md
+++ b/spanish/nodejs-cpp/misc/_index.md
@@ -1,0 +1,17 @@
+---
+title: "Funciones misceláneas"
+second_title: "Aspose.Font para Node.js mediante C++"
+description: "Funciones secundarias para trabajar con archivos de fuentes."
+type: docs
+url: /es/nodejs-cpp/misc/
+---
+## Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposeFontAbout](./asposefontabout/) | Obtener información sobre el producto. |
+
+## Detailed Description
+
+Funciones secundarias para trabajar con archivos de fuentes.
+

--- a/spanish/nodejs-cpp/misc/asposefontabout/_index.md
+++ b/spanish/nodejs-cpp/misc/asposefontabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeFontAbout"
+second_title: "Aspose.Font para Node.js mediante C++"
+description: "Obtener información sobre el producto."
+type: docs
+url: /es/nodejs-cpp/misc/AsposeFontAbout/
+---
+
+## AsposeFontAbout function
+
+Obtener información sobre el producto.
+
+```js
+function AsposeFontAbout()
+```
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+| errorCode | error de código (0 sin error) |
+| errorText | error de texto (\"\" sin error) |
+| producto | Nombre del producto |
+| versión | Versión del producto |
+| Está licenciado | El producto está licenciado |
+
+
+## Ejemplo
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    json = AsposeFontModule.AsposeFontAbout();
+    console.log("AsposeFontAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules:**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+//AsposeFontAbout - Get info about Product
+const json = AsposeFontModule.AsposeFontAbout();
+console.log("AsposeFontAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+```


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **Spanish** (`es`) generated by RDA.

- Pages translated: 22/22
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `spanish/nodejs-cpp`

🤖 Generated by RDA