### PR TITLE
[auto] Translate NODEJS-CPP API Reference to Swedish

### DIFF
--- a/swedish/nodejs-cpp/_index.md
+++ b/swedish/nodejs-cpp/_index.md
@@ -1,0 +1,54 @@
+---
+title: "Aspose.Font för Node.js via C++"
+description: "Aspose.Font för Node.js via C++"
+keywords:  "Node.js via C++, Node.js Font toolkit"
+tags: ['font-to-ttf', 'font-to-woff',  'font-to-woff2', 'font-to-svg', 'font-convert', 'font-tools']
+weight: 40
+url: /sv/nodejs-cpp/
+type: docs
+is_root: true
+---
+
+> Aspose.Font for Node.js via C++ allows developers manipulate them Font files on server side web solutions.
+>
+> CommonJS and ECMAScript modules are aviable for any JavaScript solutions. 
+
+
+## Convert functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposeFontConvert](./convert/) | Konvertera ett teckensnitt till TrueType-teckensnitt. |
+| [AsposeFontConvertToTTF](./convert/asposefontconverttottf/) | Konvertera ett teckensnitt till TTF-format. |
+| [AsposeFontConvertToWOFF](./convert/asposefontconverttowoff/) | Konvertera ett teckensnitt till WOFF-format. |
+| [AsposeFontConvertToWOFF2](./convert/asposefontconverttowoff2/) | Konvertera ett teckensnitt till WOFF2-format. |
+| [AsposeFontConvertToSVG](./convert/asposefontconverttosvg/) | Konvertera ett teckensnitt till SVG-format. |
+
+
+## Metadata Font functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposeFontGetInfo](./metadata/asposefontgetinfo/) | Hämta information (metadata) från en teckensnittsfil. |
+| [AsposeFontSetInfo](./metadata/asposefontsetinfo/) | Ange information (metadata) i en teckensnittsfil. |
+
+
+## Miscellaneous
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposeFontAbout](./misc/asposefontabout/) | Hämta information om produkten. |
+
+## Enumerationer
+
+| Uppräkning | Beskrivning |
+| ----------- | ----------- |
+| [FontSavingFormats](./enumerations/fontsavingformats/) | Anger teckensnittstyp. |
+| [FontStyle](./enumerations/fontstyle/) | Anger teckensnittsstil. |
+| [TtfNameTableNameId](./enumerations/ttfnametablenameid/) | Anger NameId. |
+| [TtfNameTablePlatformId](./enumerations/ttfnametableplatformid/) | Representerar PlatformId-enumeration. |
+| [TtfNameTableMacPlatformSpecificId](./enumerations/ttfnametablemacplatformspecificid/) | Representerar Macintosh-plattformsspecifik id-enumeration. |
+| [TtfNameTableMSPlatformSpecificId](./enumerations/ttfnametablemsplatformspecificid/) | Representerar Microsoft-plattformsspecifik id-enumeration. |
+| [TtfNameTableUnicodePlatformSpecificId](./enumerations/ttfnametableunicodeplatformspecificid/) | Representerar Unicode-plattformsspecifik id-enumeration. |
+| [TtfNameTableMacLanguageId](./enumerations/ttfnametablemaclanguageid/) | MacLanguageId-enumeration. |
+| [TtfNameTableMSLanguageId](./enumerations/ttfnametablemslanguageid/) | MSLanguageId-enumeration. |

--- a/swedish/nodejs-cpp/convert/_index.md
+++ b/swedish/nodejs-cpp/convert/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Konvertera fontfunktioner"
+second_title: "Aspose.Font för Node.js via C++"
+description: "Funktioner för att konvertera fonter till TrueType-format."
+type: docs
+url: /sv/nodejs-cpp/convert/
+---
+
+## Convert functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposeFontConvert](./asposefontconvert) | Konvertera en font till stödda format. |
+| [AsposeFontConvertToTTF](./asposefontconverttottf/) | Konvertera ett teckensnitt till TTF-format. |
+| [AsposeFontConvertToWOFF](./asposefontconverttowoff/) | Konvertera ett teckensnitt till WOFF-format. |
+| [AsposeFontConvertToWOFF2](./asposefontconverttowoff2/) | Konvertera ett teckensnitt till WOFF2-format. |
+| [AsposeFontConvertToSVG](./asposefontconverttosvg/) | Konvertera ett teckensnitt till SVG-format. |
+
+## Detailed Description
+
+Funktioner för att konvertera fonter till TrueType-format.
+

--- a/swedish/nodejs-cpp/convert/asposefontconvert/_index.md
+++ b/swedish/nodejs-cpp/convert/asposefontconvert/_index.md
@@ -1,0 +1,73 @@
+---
+title: "AsposeFontConvert"
+second_title: "Aspose.Font för Node.js via C++"
+description: "Konverterar teckensnittet till ett annat format"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/convert/asposefontconvert/
+---
+## AsposeFontConvert function
+
+Konverterar teckensnittet till ett annat format.
+
+```js
+function AsposeFontConvert(
+    fileName,
+    fontType,
+    fontSavingFormat
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileName | string | Filnamn. |
+| fontType | FontType | Teckensnittstyp att konvertera. |
+| fontSavingFormat | FontSavingFormats | Teckensnittformat att konvertera till. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | felkod (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Anmärkningar
+
+Obs: TTF-teckensnittstyp stöds nu endast.
+
+### Exempel
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvert to convert font
+    const json = AsposeFontModule.AsposeFontConvert(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvert(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Se även
+
+* enum [FontType](../../enumerations/fonttype/)
+* enum [FontSavingFormats](../../enumerations/fontsavingformats/)

--- a/swedish/nodejs-cpp/convert/asposefontconverttottf/_index.md
+++ b/swedish/nodejs-cpp/convert/asposefontconverttottf/_index.md
@@ -1,0 +1,60 @@
+---
+title: "AsposeFontConvertToTTF"
+second_title: "Aspose.Font för Node.js via C++"
+description: "Konverterar teckensnittet till ttf-format"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/convert/asposefontconverttottf/
+---
+## AsposeFontConvertToTTF function
+
+Konverterar teckensnittet till TTF-format.
+
+```js
+function AsposeFontConvertToTTF(
+    fileName,
+    fontType
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileName | string | Filnamn. |
+| fontType | FontType | Teckensnittstyp att konvertera. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | felkod (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+const font_file = "./fonts/Lora-Regular.ttf";
+console.log('Aspose.Font for Node.js via C++ example');
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvert to convert font
+    const json = AsposeFontModule.AsposeFontConvertToTTF(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript/ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+const font_file ="./fonts/arial.ttf";
+const AsposeFontModule = await AsposeFont();
+console.log('Aspose.Font for Node.js via C++ example');
+const json = AsposeFontModule.AsposeFontConvertToTTF(font_file,AsposeFontModule.FontType.TTF,AsposeFontModule.FontSavingFormats.WOFF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Se även
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/swedish/nodejs-cpp/convert/asposefontconverttowoff/_index.md
+++ b/swedish/nodejs-cpp/convert/asposefontconverttowoff/_index.md
@@ -1,0 +1,67 @@
+---
+title: "AsposeFontConvertToWOFF"
+second_title: "Aspose.Font för Node.js via C++"
+description: "Konverterar teckensnittet till woff-format"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/convert/asposefontconverttowoff/
+---
+## AsposeFontConvertToWOFF function
+
+Konverterar teckensnittet till WOFF-format.
+
+```js
+function AsposeFontConvertToWOFF(
+    fileName,
+    fontType
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileName | string | Filnamn. |
+| fontType | FontType | Teckensnittstyp att konvertera. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | felkod (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvertToWOFF to convert font
+    const json = AsposeFontModule.AsposeFontConvertToWOFF(font_file,AsposeFontModule.FontType.TTF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvertToWOFF(font_file,AsposeFontModule.FontType.TTF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Se även
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/swedish/nodejs-cpp/convert/asposefontconverttowoff2/_index.md
+++ b/swedish/nodejs-cpp/convert/asposefontconverttowoff2/_index.md
@@ -1,0 +1,67 @@
+---
+title: "AsposeFontConvertToWOFF2"
+second_title: "Aspose.Font för Node.js via C++"
+description: "Konverterar teckensnittet till woff2-format"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/convert/asposefontconverttowoff2/
+---
+## AsposeFontConvertToWOFF2 function
+
+Konverterar teckensnittet till WOFF2-format.
+
+```js
+function AsposeFontConvertToWOFF2(
+    fileName,
+    fontType
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileName | string | Filnamn. |
+| fontType | FontType | Teckensnittstyp att konvertera. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | felkod (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvertToWOFF2 to convert font
+    const json = AsposeFontModule.AsposeFontConvertToWOFF2(font_file,AsposeFontModule.FontType.TTF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvertToWOFF2(font_file,AsposeFontModule.FontType.TTF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Se även
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/swedish/nodejs-cpp/convert/asposefontconverttowsvg/_index.md
+++ b/swedish/nodejs-cpp/convert/asposefontconverttowsvg/_index.md
@@ -1,0 +1,67 @@
+---
+title: "AsposeFontConvertToSVG"
+second_title: "Aspose.Font för Node.js via C++"
+description: "Konverterar teckensnittet till svg-format"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/convert/asposefontconverttosvg/
+---
+## AsposeFontConvertToSVG function
+
+Konverterar teckensnittet till SVG-format.
+
+```js
+function AsposeFontConvertToSVG(
+    fileName,
+    fontType
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileName | string | Filnamn. |
+| fontType | FontType | Teckensnittstyp att konvertera. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | felkod (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+AsposeFont().then(AsposeFontModule => {
+    //call AsposeFontConvertToSVG to convert font
+    const json = AsposeFontModule.AsposeFontConvertToSVG(font_file,AsposeFontModule.FontType.TTF);
+    console.log("AsposeFontConvert : %O",  json.errorCode == 0 ? font_file + ' => ' + json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+const json = AsposeFontModule.AsposeFontConvertToSVG(font_file,AsposeFontModule.FontType.TTF);
+console.log("AsposeFontConvert => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Se även
+
+* function [AsposeFontConvert](../asposefontconvert/)
+* enum [FontType](../../enumerations/fonttype/)

--- a/swedish/nodejs-cpp/enumerations/_index.md
+++ b/swedish/nodejs-cpp/enumerations/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Enumerationer"
+second_title: "Aspose.Font för Node.js via C++"
+description: "Funktioner för att konvertera fonter till TrueType-format."
+type: docs
+url: /sv/nodejs-cpp/enumerations/
+---
+
+## Enumerationer
+
+| Uppräkning | Beskrivning |
+| ----------- | ----------- |
+| [FontSavingFormats](./fontsavingformats/) | Anger teckensnittstyp. |
+| [FontType](./fonttype/) | Anger teckensnittstyp. |
+| [TtfNameTableNameId](./ttfnametablenameid/) | Anger NameId. |
+| [TtfNameTablePlatformId](./ttfnametableplatformid/) | Representerar PlatformId-enumeration. |
+| [TtfNameTableMSPlatformSpecificId](./ttfnametableMSPlatformSpecificId/) | Representerar MSPlatformSpecificId‑enumerationen. |
+| [TtfNameTableMacPlatformSpecificId](./ttfnametableMacPlatformSpecificId/) | Representerar MacPlatformSpecificId‑enumerationen. |
+| [TtfNameTableUnicodePlatformSpecificId](./ttfnametableUnicodePlatformSpecificId/) | Representerar UnicodePlatformSpecificId‑enumerationen. |
+| [TtfNameTableMacLanguageId](./ttfnametablemaclanguageid/) | Macintosh-plattformens språk‑id‑enumeration. |
+| [TtfNameTableMSLanguageId](./ttfnametablemslanguageid/) | Microsoft-plattformens språk‑id‑enumeration. |
+
+### Example of using enumarations
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    //define parameters for AsposeFontSetInfo
+    const nameId = AsposeFontModule.TtfNameTableNameId.Description;
+    const platformId = AsposeFontModule.TtfNameTablePlatformId.Microsoft;
+    const platformSpecificId = AsposeFontModule.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+    const langID = Module.TtfNameTableMSLanguageId.English_United_States.value;
+    const text = "Updated description";
+    
+    const json = AsposeFontSetInfo(font_file, nameId, platformId, platformSpecificId, langID, text);
+    console.log("AsposeFontSetInfo => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```

--- a/swedish/nodejs-cpp/enumerations/fontsavingformats/_index.md
+++ b/swedish/nodejs-cpp/enumerations/fontsavingformats/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum FontSavingFormats"
+second_title: "Aspose.Font för .NET API-referens"
+description: "Aspose.Font.FontSavingFormats enum. Anger teckensnittstyp"
+type: docs
+weight: 110
+url: /sv/nodejs-cpp/enumerations/fontsavingformats/
+---
+## FontSavingFormats enumeration
+
+Anger teckensnittstyp.
+
+```csharp
+public enum FontSavingFormats
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+| TTF | `0` | TTF (TrueType) Teckensnittformat. |
+| WOFF | `1` | WOFF (Web Open Font Format). |
+| WOFF2 | `2` | WOFF-filformat 2.0 |
+| SVG | `3` | SVG (Scalable Vector Graphics) Teckensnittformat |
+| OTF | `4` | OTF (OpenType) Teckensnittformat |

--- a/swedish/nodejs-cpp/enumerations/fonttype/_index.md
+++ b/swedish/nodejs-cpp/enumerations/fonttype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum FontType"
+second_title: "Aspose.Font för .NET API-referens"
+description: "Aspose.Font.FontType enum. Anger teckensnittstyp"
+type: docs
+weight: 100
+url: /sv/nodejs-cpp/enumerations/fonttype/
+---
+## FontType enumeration
+
+Anger teckensnittstyp.
+
+```csharp
+public enum FontType
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+| TTF | `0` | TTF (TrueType) Teckensnittstyp och relaterat. |
+| Type1 | `1` | Type1 Teckensnittstyp. |
+| CFF | `2` | CFF (Compact font format) Teckensnittstyp. |
+| OTF | `3` | OpenType Font. OpenType Font-format är en utökning av TrueType Font-formatet, som lägger till stöd för PostScript Font-data. |
+

--- a/swedish/nodejs-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
+++ b/swedish/nodejs-cpp/enumerations/ttfnametablemacplatformspecificid/_index.md
@@ -1,0 +1,53 @@
+---
+title: "Enum TtfNameTableMacPlatformSpecificId"
+second_title: "Aspose.Font för .NET API-referens"
+description: "Aspose.Font.TtfNameTableMacPlatformSpecificId enum. Anger MacPlatformSpecificId"
+type: docs
+weight: 131
+url: /sv/nodejs-cpp/enumerations/ttfnametablemacplatformspecificid/
+---
+## TtfNameTableMacPlatformSpecificId enumeration
+
+Anger MacPlatformSpecificId.
+
+```csharp
+ enum TtfNameTableMacPlatformSpecificId
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+|  | Roman | `0` | Romerskt plattformspecifikt värde. |
+|  | Japanese | `1` | Japanskt plattformspecifikt värde. |
+|  | Traditional_Chinese | `2` | Traditionellt kinesiskt plattformspecifikt värde. |
+|  | Korean | `3` | Koreanskt plattformspecifikt värde. |
+|  | Arabic | `4` | Arabiskt plattformspecifikt värde. |
+|  | Hebrew | `5` | Hebreiskt plattformspecifikt värde. |
+|  | Greek | `6` | Grekiskt plattformspecifikt värde. |
+|  | Russian | `7` | Ryskt plattformspecifikt värde. |
+|  | RSymbol | `8` | RSymbol plattformspecifikt värde. |
+|  | Devanagari | `9` | Devanagari plattformspecifikt värde. |
+|  | Gurmukhi | `10` | Gurmukhi plattformspecifikt värde. |
+|  | Gujarati | `11` | Gujarati plattformspecifikt värde. |
+|  | Oriya | `12` | Oriya plattformspecifikt värde. |
+|  | Bengali | `13` | Bengali plattformspecifikt värde. |
+|  | Tamil | `14` | Tamil plattformspecifikt värde. |
+|  | Telugu | `15` | Telugu-plattformspecifikt värde. |
+|  | Kannada | `16` | Kannada-plattformspecifikt värde. |
+|  | Malayalam | `17` | Malayalam-plattformspecifikt värde. |
+|  | Sinhalese | `18` | Sinhalese-plattformspecifikt värde. |
+|  | Burmese | `19` | Burmesisk plattformspecifikt värde. |
+|  | Khmer | `20` | Khmer-plattformspecifikt värde. |
+|  | Thai | `21` | Thailändsk plattformspecifikt värde. |
+|  | Laotian | `22` | Laotisk plattformspecifikt värde. |
+|  | Georgian | `23` | Georgisk plattformspecifikt värde. |
+|  | Armenian | `24` | Armenisk plattformspecifikt värde. |
+|  | Simplified_Chinese | `25` | Förenklad kinesisk plattformspecifikt värde. |
+|  | Tibetan | `26` | Tibetansk plattformspecifikt värde. |
+|  | Mongolian | `27` | Mongolisk plattformspecifikt värde. |
+|  | Geez | `28` | Geez-plattformspecifikt värde. |
+|  | Slavic | `29` | Slavisk plattformspecifikt värde. |
+|  | Vietnamese | `30` | Vietnamesisk plattformspecifikt värde. |
+|  | Sindhi | `31` | Sindhi-plattformspecifikt värde. |
+|  | Uninterpreted | `32` | Otolkad plattformspecifikt värde. |

--- a/swedish/nodejs-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
+++ b/swedish/nodejs-cpp/enumerations/ttfnametablemsplatformspecificid/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Enum TtfNameTableMSPlatformSpecificId"
+second_title: "Aspose.Font för .NET API-referens"
+description: "Aspose.Font.TtfNameTableMSPlatformSpecificId enum. Anger MSPlatformSpecificId"
+type: docs
+weight: 132
+url: /sv/nodejs-cpp/enumerations/ttfnametablemsplatformspecificid/
+---
+## TtfNameTableMSPlatformSpecificId enumeration
+
+Anger MSPlatformSpecificId.
+
+```csharp
+ enum TtfNameTableMSPlatformSpecificId
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+|  | Symbol | `0` | Symbol MS PlatformSpecificId. |
+|  | Unicode_BMP_UCS2 | `1` | Unicode BMP (UCS2) MS PlatformSpecificId. |
+|  | ShiftJIS | `2` | ShiftJIS MS PlatformSpecificId. |
+|  | PRC | `3` | PRC MS PlatformSpecificId. |
+|  | Big5 | `4` | Big5 MS PlatformSpecificId. |
+|  | Wansung | `5` | Wansung MS PlatformSpecificId. |
+|  | Johab | `6` | Johab MS PlatformSpecificId. |
+|  | Reserved1 | `7` | Reserved1 MS PlatformSpecificId. |
+|  | Reserved2 | `8` | Reserved2 MS PlatformSpecificId. |
+|  | Reserved3 | `9` | Reserved3 MS PlatformSpecificId. |
+|  | Unicode_UCS4 | `10` | Unicode UCS4 MS PlatformSpecificId. |
+

--- a/swedish/nodejs-cpp/enumerations/ttfnametablenameid/_index.md
+++ b/swedish/nodejs-cpp/enumerations/ttfnametablenameid/_index.md
@@ -1,0 +1,46 @@
+---
+title: "Enum TtfNameTableNameId"
+second_title: "Aspose.Font för .NET API-referens"
+description: "Aspose.Font.TtfNameTableNameId enum. Specificerar NameId"
+type: docs
+weight: 120
+url: /sv/nodejs-cpp/enumerations/ttfnametablenameid/
+---
+## TtfNameTableNameId enumeration
+
+Anger NameId.
+
+```csharp
+ enum TtfNameTableNameId
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+|  | CopyrightNotice | `0` | Upphovsrättsmeddelande. |
+|  | FontFamily | `1` | Font Family. Denna sträng är fontfamiljens namn som användaren ser på Macintosh-plattformar. |
+|  | FontSubfamily | `2` | Font Subfamily. Denna sträng är Font family som användaren ser på Macintosh-plattformar. |
+|  | UniqueFontId | `3` | Unik underfamiljeidentifiering (Apple-spec). 3 Unik Font-identifierare (MS-spec). |
+|  | FullName | `4` | Fullständigt namn på Fonten. |
+|  | Version | `5` | Version av namntabellen. |
+|  | PostScriptName | `6` | PostScript-namn för teckensnittet. Obs: Ett teckensnitt kan bara ha ett PostScript-namn och det namnet måste vara ASCII. |
+|  | TrademarkNotice | `7` | Varumärkesmeddelande. |
+|  | ManufacturerName | `8` | Tillverkarens namn. |
+|  | DesignerName | `9` | Designer; namn på designern av typsnittet. |
+|  | Description | `10` | Beskrivning; beskrivning av typsnittet. Kan innehålla revisionsinformation, användningsrekommendationer, historik, funktioner osv. |
+|  | UrlVendor | `11` | URL för teckensnittleverantören (med protokoll, t.ex. http://, ftp://). Om ett unikt serienummer är inbäddat i URL:en kan det användas för att registrera teckensnittet. |
+|  | UrlDesigner | `12` | URL för teckensnittdesignern (med protokoll, t.ex. http://, ftp://) |
+|  | LicenseDescription | `13` | Licensbeskrivning; beskrivning av hur teckensnittet får användas lagligt, eller olika exempel på scenarier för licensierad användning. Detta fält bör skrivas på klartext, inte i juridiskt språk. |
+|  | LicenseInfoUrl | `14` | URL för licensinformation, där ytterligare licensinformation kan hittas. |
+|  | PreferredFamily | `16` | `15` Reserverad `16` Föredragen familj (endast Windows); I Windows visas familjenamnet i teckensnittmenyn; subfamiljenamnet visas som stilnamn. Av historiska skäl har teckensnittsfamiljer innehållit högst fyra stilar, men teckensnittdesigners kan gruppera fler än fyra teckensnitt till en enda familj. De föredragna familje- och subfamilje-ID:n låter teckensnittdesigners inkludera de föredragna familje/subfamilje-grupperingarna. Dessa ID:n finns endast om de skiljer sig från ID:n 1 och 2. |
+|  | PreferredSubfamily | `17` | Föredragen subfamilj (endast Windows); I Windows visas familjenamnet i teckensnittmenyn; subfamiljenamnet visas som stilnamn. Av historiska skäl har teckensnittsfamiljer innehållit högst fyra stilar, men teckensnittdesigners kan gruppera fler än fyra teckensnitt till en enda familj. De föredragna familje- och subfamilje-ID:n låter teckensnittdesigners inkludera de föredragna familje/subfamilje-grupperingarna. Dessa ID:n finns endast om de skiljer sig från ID:n 1 och 2. |
+|  | CompatibleFull | `18` | Kompatibel full (endast Macintosh); På Macintosh konstrueras menynamnet med hjälp av teckensnittresursen. Detta matchar vanligtvis det fullständiga namnet. Om du vill att teckensnittets namn ska visas annorlunda än det fullständiga namnet kan du infoga det kompatibla fullständiga namnet i ID 18. Detta namn används inte av själva Mac OS, men kan användas av programutvecklare (t.ex. Adobe). |
+|  | SampleText | `19` | Exempeltext. Detta kan vara teckensnittets namn, eller någon annan text som designern anser vara den bästa exempeltexten för att visa hur teckensnittet ser ut. |
+|  | PostScriptCID | `20` | Dess närvaro i ett teckensnitt betyder att nameID 6 innehåller ett PostScript-teckensnittsnamn som är avsett att användas med "composefont"-anropet för att aktivera teckensnittet i en PostScript-tolk. |
+|  | WwsFamilyName | `21` | Används för att tillhandahålla ett WWS-konformt familjenamn om posterna för ID:n 16 och 17 inte följer WWS-modellen. |
+|  | WwsSubfamilyName | `22` | Används i kombination med ID 21, detta ID tillhandahåller ett WWS-konformt subfamiljenamn (som endast återspeglar vikt-, bredd- och lutningsattribut) om posterna för ID:n 16 och 17 inte följer WWS-modellen. |
+|  | LightBackground | `23` | Detta ID, om det används i CPAL-tabellens Palette Labels Array, anger att den motsvarande färgpaletten i CPAL-tabellen är lämplig att använda med teckensnittet när det visas på en ljus bakgrund, såsom vit. |
+|  | DarkBackground | `24` | Detta ID, om det används i CPAL-tabellens Palette Labels Array, anger att den motsvarande färgpaletten i CPAL-tabellen är lämplig att använda med teckensnittet när det visas på en mörk bakgrund, såsom svart. |
+|  | VariationsPostScriptNamePrefix | `25` | Om det finns i ett variabelt teckensnitt kan det användas som familjeprefix i algoritmen för PostScript-namngenerering för variationsfonter. |
+

--- a/swedish/nodejs-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
+++ b/swedish/nodejs-cpp/enumerations/ttfnametablenmaclanguageid/_index.md
@@ -1,0 +1,138 @@
+---
+title: "Enum TtfNameTableMacLanguageId"
+second_title: "Aspose.Font för .NET API-referens"
+description: "Aspose.Font.TtfNameTableMacLanguageId enum. Anger MacLanguageId"
+type: docs
+weight: 140
+url: /sv/nodejs-cpp/enumerations/ttfnametablemaclanguageid/
+---
+## TtfNameTableMacLanguageId enumeration
+
+Representerar MacLanguageId enumeration.
+
+```csharp
+ enum TtfNameTableMacLanguageId
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+|  | English | `0` | Engelsk LanguageId värde |
+|  | French | `1` | Fransk LanguageId värde |
+|  | German | `2` | Tysk LanguageId värde |
+|  | Italian | `3` | Italiensk LanguageId värde |
+|  | Dutch | `4` | Holländsk LanguageId värde |
+|  | Swedish | `5` | Svensk LanguageId värde |
+|  | Spanish | `6` | Spansk LanguageId värde |
+|  | Danish | `7` | Dansk LanguageId värde |
+|  | Portuguese | `8` | Portugisisk LanguageId värde |
+|  | Norwegian | `9` | Norsk LanguageId värde |
+|  | Hebrew | `10` | Hebreiska LanguageId värde |
+|  | Japanese | `11` | Japanska LanguageId värde |
+|  | Arabic | `12` | Arabiska LanguageId värde |
+|  | Finnish | `13` | Finska LanguageId värde |
+|  | Greek | `14` | Grekiska LanguageId värde |
+|  | Icelandic | `15` | Isländska LanguageId värde |
+|  | Maltese | `16` | Maltesiska LanguageId värde |
+|  | Turkish | `17` | Turkiska LanguageId värde |
+|  | Croatian | `18` | Kroatiska LanguageId värde |
+|  | Chinese_Traditional | `19` | Kinesiska (traditionell) LanguageId värde |
+|  | Urdu | `20` | Urdu LanguageId värde |
+|  | Hindi | `21` | Hindi LanguageId värde |
+|  | Thai | `22` | Thailändska LanguageId värde |
+|  | Korean | `23` | Koreanska LanguageId värde |
+|  | Lithuanian | `24` | Litauiska LanguageId värde |
+|  | Polish | `25` | Polska LanguageId värde |
+|  | Hungarian | `26` | Ungerska LanguageId värde |
+|  | Estonian | `27` | Estniska LanguageId värde |
+|  | Latvian | `28` | Lettiska LanguageId värde |
+|  | Sami | `29` | Samiska LanguageId värde |
+|  | Faroese | `30` | Färöiska LanguageId värde |
+|  | Farsi_Persian | `31` | Farsi/persiska LanguageId värde |
+|  | Russian | `32` | Ryska LanguageId värde |
+|  | Chinese_Simplified | `33` | Kinesiska (förenklad) LanguageId värde |
+|  | Flemish | `34` | Flamländska LanguageId värde |
+|  | Irish_Gaelic | `35` | Irish Gaelic LanguageId värde |
+|  | Albanian | `36` | Albanian LanguageId värde |
+|  | Romanian | `37` | Romanian LanguageId värde |
+|  | Czech | `38` | Czech LanguageId värde |
+|  | Slovak | `39` | Slovak LanguageId värde |
+|  | Slovenian | `40` | Slovenian LanguageId värde |
+|  | Yiddish | `41` | Yiddish LanguageId värde |
+|  | Serbian | `42` | Serbian LanguageId värde |
+|  | Macedonian | `43` | Macedonian LanguageId värde |
+|  | Bulgarian | `44` | Bulgarian LanguageId värde |
+|  | Ukrainian | `45` | Ukrainian LanguageId värde |
+|  | Byelorussian | `46` | Byelorussian LanguageId värde |
+|  | Uzbek | `47` | Uzbek LanguageId värde |
+|  | Kazakh | `48` | Kazakh LanguageId värde |
+|  | Azerbaijani_Cyrillic | `49` | Azerbaijani (Cyrillic script) LanguageId värde |
+|  | Azerbaijani_Arabic | `50` | Azerbaijani (Arabic script) LanguageId värde |
+|  | Armenian | `51` | Armenian LanguageId värde |
+|  | Georgian | `52` | Georgian LanguageId värde |
+|  | Moldavian | `53` | Moldavian LanguageId värde |
+|  | Kirghiz | `54` | Kirghiz LanguageId värde |
+|  | Tajiki | `55` | Tajiki LanguageId värde |
+|  | Turkmen | `56` | Turkmen LanguageId värde |
+|  | Mongolian | `57` | Mongolian (Mongolian script) LanguageId värde |
+|  | Mongolian_Cyrillic | `58` | Mongolian (Cyrillic script) LanguageId värde |
+|  | Pashto | `59` | Pashto LanguageId värde |
+|  | Kurdish | `60` | Pashto LanguageId värde |
+|  | Kashmiri | `61` | Kashmiri LanguageId värde |
+|  | Sindhi | `62` | Sindhi LanguageId värde |
+|  | Tibetan | `63` | Tibetan LanguageId värde |
+|  | Nepali | `64` | Nepali LanguageId värde |
+|  | Sanskrit | `65` | Sanskrit LanguageId värde |
+|  | Marathi | `66` | Marathi LanguageId värde |
+|  | Bengali | `67` | Bengali LanguageId värde |
+|  | Assamese | `68` | Assamese LanguageId värde |
+|  | Gujarati | `69` | Gujarati LanguageId värde |
+|  | Punjabi | `70` | Punjabi LanguageId värde |
+|  | Oriya | `71` | Oriya LanguageId värde |
+|  | Malayalam | `72` | Malayalam LanguageId värde |
+|  | Kannada | `73` | Kannada LanguageId värde |
+|  | Tamil | `74` | Tamil LanguageId värde |
+|  | Telugu | `75` | Telugu LanguageId värde |
+|  | Sinhalese | `76` | Sinhalese LanguageId värde |
+|  | Burmese | `77` | Burmese LanguageId värde |
+|  | Khmer | `78` | Khmer LanguageId värde |
+|  | Lao | `79` | Lao LanguageId värde |
+|  | Vietnamese | `80` | Vietnamese LanguageId värde |
+|  | Indonesian | `81` | Indonesian LanguageId värde |
+|  | Tagalog | `82` | Tagalog LanguageId värde |
+|  | Malay_Roman | `83` | Malay (Roman script) LanguageId värde |
+|  | Malay_Arabic | `84` | Malay (Arabic script) LanguageId värde |
+|  | Amharic | `85` | Amharic LanguageId värde |
+|  | Tigrinya | `86` | Tigrinya LanguageId värde |
+|  | Galla | `87` | Galla LanguageId värde |
+|  | Somali | `88` | Somali LanguageId värde |
+|  | Swahili | `89` | Swahili LanguageId värde |
+|  | Kinyarwanda_Ruanda | `90` | Kinyarwanda/Ruanda LanguageId värde |
+|  | Rundi | `91` | Rundi LanguageId värde |
+|  | Nyanja_Chewa | `92` | Nyanja/Chewa LanguageId värde |
+|  | Malagasy | `93` | Malagasy LanguageId värde |
+|  | Esperanto | `94` | Esperanto LanguageId värde |
+|  | Welsh | `128` | Welsh LanguageId värde |
+|  | Basque | `129` | Basque LanguageId värde |
+|  | Catalan | `130` | Catalan LanguageId värde |
+|  | Latin | `131` | Latin LanguageId värde |
+|  | Quechua | `132` | Quechua LanguageId värde |
+|  | Guarani | `133` | Guarani LanguageId värde |
+|  | Aymara | `134` | Aymara LanguageId värde |
+|  | Tatar | `135` | Tatar LanguageId värde |
+|  | Uighur | `136` | Uighur LanguageId värde |
+|  | Dzongkha | `137` | Dzongkha LanguageId värde |
+|  | Javanese | `138` | Javanese (Roman script) LanguageId värde |
+|  | Sundanese | `139` | Sundanese (Roman script) LanguageId värde |
+|  | Galician | `140` | Galician LanguageId värde |
+|  | Afrikaans | `141` | Afrikaans LanguageId värde |
+|  | Breton | `142` | Breton LanguageId värde |
+|  | Inuktitut | `143` | Inuktitut LanguageId värde |
+|  | Scottish_Gaelic | `144` | Skotsk gaeliska LanguageId-värde |
+|  | Manx_Gaelic | `145` | Manx-gaeliska LanguageId-värde |
+|  | Irish_Gaelic_WDA | `146` | Irländsk gaeliska (med prick ovan) LanguageId-värde |
+|  | Tongan | `147` | Tonganska LanguageId-värde |
+|  | Greek_Polytonic | `148` | Grekiska (polytoniska) LanguageId-värde |
+|  | Greenlandic | `149` | Grönländska LanguageId-värde |
+|  | Azerbaijani_Roman | `150` | Azerbajdzjanska (romanskt skriftsystem) LanguageId-värde |

--- a/swedish/nodejs-cpp/enumerations/ttfnametablenmslanguageid/_index.md
+++ b/swedish/nodejs-cpp/enumerations/ttfnametablenmslanguageid/_index.md
@@ -1,0 +1,225 @@
+---
+title: "Enum TtfNameTableMSLanguageId"
+second_title: "Aspose.Font för .NET API-referens"
+description: "Aspose.Font.TtfNameTableMSLanguageId enum. Anger MSLanguageId"
+type: docs
+weight: 150
+url: /sv/nodejs-cpp/enumerations/ttfnametablemslanguageid/
+---
+## TtfNameTableMSLanguageId enumeration
+
+Representerar MSLanguageId‑enumeration.
+
+```csharp
+ enum TtfNameTableMSLanguageId
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+|  | Afrikaans | `0x0436` | Afrikaans (Region: Sydafrika, SA) LanguageId‑värde |
+|  | Albanian | `0x041c` | Albanska (Region: Albanien, SQI) LanguageId‑värde |
+|  | Alsatian | `0x0484` | Alsatian (Region: Frankrike) LanguageId värde |
+|  | Amharic | `0x045E` | Amharic (Region: Etiopien) LanguageId värde |
+|  | Arabic_Algeria | `0x1401` | Arabic (Region: Algeriet) LanguageId värde |
+|  | Arabic_Bahrain | `0x3C01` | Arabic (Region: Bahrain) LanguageId värde |
+|  | Arabic_Egypt | `0x0C01` | Arabic (Region: Egypten) LanguageId värde |
+|  | Arabic_Iraq | `0x0801` | Arabic (Region: Irak) LanguageId värde |
+|  | Arabic_Jordan | `0x2C01` | Arabic (Region: Jordanien) LanguageId värde |
+|  | Arabic_Kuwait | `0x3401` | Arabic (Region: Kuwait) LanguageId värde |
+|  | Arabic_Lebanon | `0x3001` | Arabic (Region: Libanon) LanguageId värde |
+|  | Arabic_Libya | `0x1001` | Arabic (Region: Libyen) LanguageId värde |
+|  | Arabic_Morocco | `0x1801` | Arabic (Region: Marocko) LanguageId värde |
+|  | Arabic_Oman | `0x2001` | Arabic (Region: Oman) LanguageId värde |
+|  | Arabic_Qatar | `0x4001` | Arabic (Region: Qatar) LanguageId värde |
+|  | Arabic_Saudi_Arabia | `0x0401` | Arabic (Region: Saudiarabien) LanguageId värde |
+|  | Arabic_Syria | `0x2801` | Arabic (Region: Syrien) LanguageId värde |
+|  | Arabic_Tunisia | `0x1C01` | Arabic (Region: Tunisien) LanguageId värde |
+|  | Arabic_U_A_E | `0x3801` | Arabic (Region: Förenade Arabiska Emiraten) LanguageId värde |
+|  | Arabic_Yemen | `0x2401` | Arabic (Region: Jemen) LanguageId värde |
+|  | Armenian | `0x042B` | Armenian (Region: Armenien) LanguageId värde |
+|  | Assamese | `0x044D` | Assamese (Region: Indien) LanguageId värde |
+|  | Azeri_Cyrillic | `0x082C` | Azeri (Cyrillic, Region: Azerbajdzjan) LanguageId värde |
+|  | Azeri_Latin | `0x042C` | Azeri (Latin, Region: Azerbajdzjan) LanguageId värde |
+|  | Bashkir | `0x046D` | Bashkir (Region: Ryssland) LanguageId värde |
+|  | Basque | `0x042D` | Basque (Region: Baskien, EUQ) LanguageId värde |
+|  | Belarusian | `0x0423` | Belarusian (Region: Vitryssland,  BEL) LanguageId värde |
+|  | Bengali_Bangladesh | `0x0845` | Bengali (Region: Bangladesh) LanguageId värde |
+|  | Bengali_India | `0x0445` | Bengali (Region: India) LanguageId värde |
+|  | Bosnian_Cyrillic | `0x201A` | Bosniska (Cyrillic, Region: Bosnien och Hercegovina) LanguageId värde |
+|  | Bosnian_Latin | `0x141A` | Bosniska (Latin, Region: Bosnien och Hercegovina) LanguageId värde |
+|  | Breton | `0x047E` | Breton (Region: Frankrike) LanguageId värde |
+|  | Bulgarian | `0x0402` | Bulgariska (Region: Bulgarien, BGR) LanguageId värde |
+|  | Catalan | `0x0403` | Katalanska (Region: Katalonien, CAT) LanguageId värde |
+|  | Chinese_Hong_Kong | `0x0C04` | Kinesiska (Region: Hongkong S.A.R.) LanguageId värde |
+|  | Chinese_Macao | `0x1404` | Kinesiska (Region: Macau S.A.R.) LanguageId värde |
+|  | Chinese_PRC | `0x0804` | Kinesiska (Region: Folkrepubliken Kina) LanguageId värde |
+|  | Chinese_Singapore | `0x1004` | Kinesiska (Region: Singapore) LanguageId värde |
+|  | Chinese_Taiwan | `0x0404` | Kinesiska (Region: Taiwan) LanguageId värde |
+|  | Corsican | `0x0483` | Korsikanska (Region: Frankrike) LanguageId värde |
+|  | Croatian | `0x041A` | Kroatiska (Region: Kroatien, SHL) LanguageId värde |
+|  | Croatian_Latin | `0x101A` | Kroatiska (Latin, Region: Bosnien och Hercegovina) LanguageId värde |
+|  | Czech | `0x0405` | Tjeckiska (Region: Tjeckien, CSY) LanguageId värde |
+|  | Danish | `0x0406` | Danska (Region: Danmark, DAN) LanguageId värde |
+|  | Dari | `0x048C` | Dari (Region: Afghanistan) LanguageId värde |
+|  | Divehi | `0x0465` | Divehi (Region: Maldiverna) LanguageId värde |
+|  | Dutch_Belgium | `0x0813` | Nederländska (flamländska, Region: Belgien, NLB) LanguageId värde |
+|  | Dutch_Netherlands | `0x0413` | Nederländska (standard, Region: Nederländerna, NLD) LanguageId värde |
+|  | English_Australia | `0x0C09` | Engelska (australisk, Region: Australien, ENA) LanguageId värde |
+|  | English_Belize | `0x2809` | Engelska (Region: Belize) LanguageId värde |
+|  | English_Canada | `0x1009` | Engelska (kanadensisk, Region: Kanada, ENC) LanguageId värde |
+|  | English_Caribbean | `0x2409` | Engelska (Region: Karibien) LanguageId värde |
+|  | English_India | `0x4009` | Engelska (Region: Indien) LanguageId värde |
+|  | English_Ireland | `0x1809` | Engelska (Region: Irland, ENI) LanguageId värde |
+|  | English_Jamaica | `0x2009` | Engelska (Region: Jamaica) LanguageId värde |
+|  | English_Malaysia | `0x4409` | Engelska (Region: Malaysia) LanguageId värde |
+|  | English_New_Zealand | `0x1409` | Engelska (Region: Nya Zeeland, ENZ) LanguageId värde |
+|  | English_ROP | `0x3409` | Engelska (Region: Republiken Filippinerna, ROP) LanguageId värde |
+|  | English_Singapore | `0x4809` | Engelska (Region: Singapore) LanguageId värde |
+|  | English_South_Africa | `0x1C09` | Engelska (Region: Sydafrika, SA) LanguageId värde |
+|  | English_TT | `0x2C09` | Engelska (Region: Trinidad och Tobago, TT) LanguageId värde |
+|  | English_United_Kingdom | `0x0809` | Engelska (Brittiska, Region: Storbritannien, ENG) LanguageId värde |
+|  | English_United_States | `0x0409` | Engelska (Amerikanska, Region: USA, ENU) LanguageId värde |
+|  | English_Zimbabwe | `0x3009` | Engelska (Region: Zimbabwe) LanguageId värde |
+|  | Estonian | `0x0425` | Estniska (Region: Estland, ETI) LanguageId värde |
+|  | Faroese | `0x0438` | Färöiska (Region: Färöarna) LanguageId värde |
+|  | Filipino | `0x0464` | Filippinska (Region: Filippinerna) LanguageId värde |
+|  | Finnish | `0x040B` | Finska (Region: Finland, FIN) LanguageId värde |
+|  | French_Belgium | `0x080C` | Franska (Belgiska, Region: Belgien, FRB) LanguageId värde |
+|  | French_Canada | `0x0C0C` | Franska (Kanadensiska, Region: Kanada, FRC) LanguageId värde |
+|  | French_France | `0x040C` | Franska (Standard, Region: Frankrike, FRA) LanguageId värde |
+|  | French_Luxembourg | `0x140c` | Franska (Region: Luxemburg, FRL) LanguageId värde |
+|  | French_MC | `0x180C` | Franska (Region: Fyrstendömet Monaco, MC) LanguageId värde |
+|  | French_Switzerland | `0x100C` | Franska (Schweiziska, Region: Schweiz, FRS) LanguageId värde |
+|  | Frisian | `0x0462` | Frisiska (Region: Nederländerna, NLD) LanguageId värde |
+|  | Galician | `0x0456` | Galiciska (Region: Galicien) LanguageId värde |
+|  | Georgian | `0x0437` | Georgiska (Region: Georgien) LanguageId värde |
+|  | German_Austria | `0x0C07` | Tyska (österrikisk, Region: Österrike, DEA) LanguageId-värde |
+|  | German_Germany | `0x0407` | Tyska (standard, Region: Tyskland, DEU) LanguageId-värde |
+|  | German_Liechtenstein | `0x1407` | Tyska (Region: Liechtenstein, DEC) LanguageId-värde |
+|  | German_Luxembourg | `0x1007` | Tyska (Region: Luxemburg, DEL) LanguageId-värde |
+|  | German_Switzerland | `0x0807` | Tyska (schweizisk, Region: Schweiz, DES) LanguageId-värde |
+|  | Greek | `0x0408` | Grekiska (Region: Grekland, ELL) LanguageId-värde |
+|  | Greenlandic | `0x046F` | Grönländska (Region: Grönland) LanguageId-värde |
+|  | Gujarati | `0x0447` | Gujarati (Region: Indien) LanguageId-värde |
+|  | Hausa | `0x0468` | Hausa (latin, Region: Nigeria) LanguageId-värde |
+|  | Hebrew | `0x040D` | Hebreiska (Region: Israel) LanguageId-värde |
+|  | Hindi | `0x0439` | Hindi (Region: Indien) LanguageId-värde |
+|  | Hungarian | `0x040E` | Ungerska (Region: Ungern, HUN) LanguageId-värde |
+|  | Icelandic | `0x040F` | Isländska (Region: Island, ISL) LanguageId-värde |
+|  | Igbo | `0x0470` | Igbo (Region: Nigeria) LanguageId-värde |
+|  | Indonesian | `0x0421` | Indonesiska (Region: Indonesien) LanguageId-värde |
+|  | Inuktitut | `0x045D` | Inuktitut (Region: Kanada) LanguageId-värde |
+|  | Inuktitut_Latin | `0x085D` | Inuktitut (latin, Region: Kanada) LanguageId-värde |
+|  | Irish | `0x083C` | Irländska (Region: Irland) LanguageId-värde |
+|  | isiXhosa | `0x0434` | isiXhosa (Region: Sydafrika, SA) LanguageId-värde |
+|  | isiZulu | `0x0435` | isiZulu (Region: Sydafrika, SA) LanguageId-värde |
+|  | Italian_Italy | `0x0410` | Italienska (standard, Region: Italien, ITA) LanguageId-värde |
+|  | Italian_Switzerland | `0x0810` | Italienska (schweizisk, Region: Schweiz, ITS) LanguageId-värde |
+|  | Japanese | `0x0411` | Japanska (Region: Japan) LanguageId-värde |
+|  | Kannada | `0x044B` | Kannada (Region: Indien) LanguageId-värde |
+|  | Kazakh | `0x043F` | Kazakiska (Region: Kazakstan) LanguageId-värde |
+|  | Khmer | `0x0453` | Khmer (Region: Cambodia) LanguageId värde |
+|  | Kiche | `0x0486` | K�iche (Region: Guatemala) LanguageId värde |
+|  | Kinyarwanda | `0x0487` | Kinyarwanda (Region: Rwanda) LanguageId värde |
+|  | Kiswahili | `0x0441` | Kiswahili (Region: Kenya) LanguageId värde |
+|  | Konkani | `0x0457` | Konkani (Region: India) LanguageId värde |
+|  | Korean | `0x0412` | Korean (Region: Korea) LanguageId värde |
+|  | Kyrgyz | `0x0440` | Kyrgyz (Region: Kyrgyzstan) LanguageId värde |
+|  | Lao | `0x0454` | Lao (Region: Lao P.D.R.) LanguageId värde |
+|  | Latvian | `0x0426` | Latvian (Region: Latvia, LVI) LanguageId värde |
+|  | Lithuanian | `0x0427` | Lithuanian (Region: Lithuania, LTH) LanguageId värde |
+|  | Lower_Sorbian | `0x082E` | Lower Sorbian (Region: Germany) LanguageId värde |
+|  | Luxembourgish | `0x046E` | Luxembourgish (Region: Luxembourg) LanguageId värde |
+|  | Macedonian | `0x042F` | Macedonian (Region: North Macedonia) LanguageId värde |
+|  | Malay_Brunei_Darussalam | `0x083E` | Malay (Region: Brunei Darussalam) LanguageId värde |
+|  | Malay_Malaysia | `0x043E` | Malay (Region: Malaysia) LanguageId värde |
+|  | Malayalam | `0x044C` | Malayalam (Region: India) LanguageId värde |
+|  | Maltese | `0x043A` | Maltese (Region: Malta) LanguageId värde |
+|  | Maori | `0x0481` | Maori (Region: New Zealand) LanguageId värde |
+|  | Mapudungun | `0x047A` | Mapudungun (Region: Chile) LanguageId värde |
+|  | Marathi | `0x044E` | Marathi (Region: India) LanguageId värde |
+|  | Mohawk | `0x047C` | Mohawk (Region: Mohawk) LanguageId värde |
+|  | Mongolian_Cyrillic | `0x0450` | Mongolian (Cyrillic, Region: Mongolia) LanguageId värde |
+|  | Mongolian_Traditional | `0x0850` | Mongolian (Traditional, Region: People�s Republic of China) LanguageId värde |
+|  | Nepali | `0x0461` | Nepali (Region: Nepal) LanguageId värde |
+|  | Norwegian_Bokmal | `0x0414` | Norwegian (Bokmal, Region: Norway, NOR) LanguageId värde |
+|  | Norwegian_Nynorsk | `0x0814` | Norska (Nynorsk, Region: Norge, NON) LanguageId värde |
+|  | Occitan | `0x0482` | Occitanska (Region: Frankrike) LanguageId värde |
+|  | Odia | `0x0448` | Odia (tidigare Oriya, Region: Indien) LanguageId värde |
+|  | Pashto | `0x0463` | Pashto (Region: Afghanistan) LanguageId värde |
+|  | Polish | `0x0415` | Polska (Region: Polen, PLK) LanguageId värde |
+|  | Portuguese_Brazil | `0x0416` | Portugisiska (brasiliansk, Region: Brasilien, PTB) LanguageId värde |
+|  | Portuguese_Portugal | `0x0816` | Portugisiska (standard, Region: Portugal, PTG) LanguageId värde |
+|  | Punjabi | `0x0446` | Punjabi (Region: Indien) LanguageId värde |
+|  | Quechua_Bolivia | `0x046B` | Quechua (Region: Bolivia) LanguageId värde |
+|  | Quechua_Ecuador | `0x086B` | Quechua (Region: Ecuador) LanguageId värde |
+|  | Quechua_Peru | `0x0C6B` | Quechua (Region: Peru) LanguageId värde |
+|  | Romanian | `0x0418` | Rumänska (Region: Rumänien, ROM) LanguageId värde |
+|  | Romansh | `0x0417` | Rätoromanska (Region: Schweiz) LanguageId värde |
+|  | Russian | `0x0419` | Ryska (Region: Ryssland, RUS) LanguageId värde |
+|  | Sami_Inari | `0x243B` | Samiska (Inari, Region: Finland) LanguageId värde |
+|  | Sami_Lule_Norway | `0x103B` | Samiska (Lule, Region: Norge) LanguageId värde |
+|  | Sami_Lule_Sweden | `0x143B` | Samiska (Lule, Region: Sverige) LanguageId värde |
+|  | Sami_Northern_Finland | `0x0C3B` | Samiska (nordlig, Region: Finland) LanguageId värde |
+|  | Sami_Northern_Norway | `0x043B` | Samiska (nordlig, Region: Norge) LanguageId värde |
+|  | Sami_Northern_Sweden | `0x083B` | Samiska (nordlig, Region: Norge) LanguageId värde |
+|  | Sami_Skolt | `0x203B` | Samiska (Skolt, Region: Finland) LanguageId värde |
+|  | Sami_Southern_Norway | `0x183B` | Samiska (södra, Region: Norge) LanguageId värde |
+|  | Sami_Southern_Sweden | `0x1C3B` | Samiska (södra, Region: Sverige) LanguageId värde |
+|  | Sanskrit | `0x044F` | Sanskrit (Region: Indien) LanguageId värde |
+|  | Serbian_Cyrillic_BIH | `0x1C1A` | Serbiska (kyrillisk, Region: Bosnien och Hercegovina) LanguageId värde |
+|  | Serbian_Cyrillic_Serbia | `0x0C1A` | Serbiska (kyrillisk, Region: Serbien) LanguageId värde |
+|  | Serbian_Latin_BIH | `0x181A` | Serbiska (latin, Region: Bosnia and Herzegovina) LanguageId värde |
+|  | Serbian_Latin_Serbia | `0x081A` | Serbiska (latin, Region: Serbia) LanguageId värde |
+|  | Sesotho_Sa_Leboa | `0x046C` | Sesotho sa Leboa (nord-sotho, Region: South Africa, SA) LanguageId värde |
+|  | Setswana | `0x0432` | Setswana (Region: South Africa, SA) LanguageId värde |
+|  | Sinhala | `0x045B` | Singalesiska (Region: Sri Lanka) LanguageId värde |
+|  | Slovak | `0x041B` | Slovakiska (Region: Slovakia, SKY) LanguageId värde |
+|  | Slovenian | `0x0424` | Slovenska (Region: Slovenia, SLV) LanguageId värde |
+|  | Spanish_Argentina | `0x2C0A` | Spanska (Region: Argentina) LanguageId värde |
+|  | Spanish_Bolivia | `0x400A` | Spanska (Region: Bolivia) LanguageId värde |
+|  | Spanish_Chile | `0x340A` | Spanska (Region: Chile) LanguageId värde |
+|  | Spanish_Colombia | `0x240A` | Spanska (Region: Colombia) LanguageId värde |
+|  | Spanish_Costa_Rica | `0x140A` | Spanska (Region: Costa Rica) LanguageId värde |
+|  | Spanish_Dominican_Republic | `0x1C0A` | Spanska (Region: Dominikanska republiken) LanguageId värde |
+|  | Spanish_Ecuador | `0x300A` | Spanska (Region: Dominikanska republiken) LanguageId värde |
+|  | Spanish_El_Salvador | `0x440A` | Spanska (Region: Dominikanska republiken) LanguageId värde |
+|  | Spanish_Guatemala | `0x100A` | Spanska (Region: Guatemala) LanguageId värde |
+|  | Spanish_Honduras | `0x480A` | Spanska (Region: Honduras) LanguageId värde |
+|  | Spanish_Mexico | `0x080A` | Spanska (mexikansk, Region: Mexico, ESM) LanguageId värde |
+|  | Spanish_Nicaragua | `0x4C0A` | Spanska (Region: Nicaragua) LanguageId värde |
+|  | Spanish_Panama | `0x180A` | Spanska (Region: Panama) LanguageId värde |
+|  | Spanish_Paraguay | `0x3C0A` | Spanska (Region: Paraguay) LanguageId värde |
+|  | Spanish_Peru | `0x280A` | Spanska (Region: Peru) LanguageId värde |
+|  | Spanish_Puerto_Rico | `0x500A` | Spanska (Region: Puerto Rico) LanguageId värde |
+|  | Spanish_Modern_Sort | `0x0C0A` | Spanska (modern sortering, Region: Spain, ESN) LanguageId värde |
+|  | Spanish_Traditional_Sort | `0x040A` | Spanska (traditionell sortering, Region: Spain, ESP) LanguageId värde |
+|  | Spanish_United_States | `0x540A` | Spanska (Region: USA) LanguageId värde |
+|  | Spanish_Uruguay | `0x380A` | Spanska (Region: Uruguay) LanguageId värde |
+|  | Spanish_Venezuela | `0x200A` | Spanska (Region: Venezuela) LanguageId värde |
+|  | Swedish_Finland | `0x081D` | Svenska (Region: Finland) LanguageId värde |
+|  | Swedish_Sweden | `0x041D` | Svenska (Region: Sverige, SVE) LanguageId värde |
+|  | Syriac | `0x045A` | Syriska (Region: Syrien) LanguageId värde |
+|  | Tajik | `0x0428` | Tadzjikiska (Kyrilliska, Region: Tadzjikistan) LanguageId värde |
+|  | Tamazight | `0x085F` | Tamazight (Latinska, Region: Algeriet) LanguageId värde |
+|  | Tamil | `0x0449` | Tamil (Region: Indien) LanguageId värde |
+|  | Tatar | `0x0444` | Tatar (Region: Ryssland) LanguageId värde |
+|  | Telugu | `0x044A` | Telugu (Region: Indien) LanguageId värde |
+|  | Thai | `0x041E` | Thailändska (Region: Thailand) LanguageId värde |
+|  | Tibetan | `0x0451` | Tibetanska (Region: PRC) LanguageId värde |
+|  | Turkish | `0x041F` | Turkiska (Region: Turkiet, TRK) LanguageId värde |
+|  | Turkmen | `0x0442` | Turkmeniska (Region: Turkmenistan) LanguageId värde |
+|  | Uighur | `0x0480` | Uiguriska (Region: PRC) LanguageId värde |
+|  | Ukrainian | `0x0422` | Ukrainska (Region: Ukraina, UKR) LanguageId värde |
+|  | Upper_Sorbian | `0x042E` | Övre sorbiska (Region: Tyskland) LanguageId värde |
+|  | Urdu | `0x0420` | Urdu (Region: Islamiska republiken Pakistan) LanguageId värde |
+|  | Uzbek_Cyrillic | `0x0843` | Uzbekiska (Kyrilliska, Region: Uzbekistan) LanguageId värde |
+|  | Uzbek_Latin | `0x0443` | Uzbekiska (Latinska, Region: Uzbekistan) LanguageId värde |
+|  | Vietnamese | `0x042A` | Vietnamesiska (Region: Vietnam) LanguageId värde |
+|  | Welsh | `0x0452` | Walesiska (Region: Storbritannien) LanguageId värde |
+|  | Wolof | `0x0488` | Wolof (Region: Senegal) LanguageId värde |
+|  | Yakut | `0x0485` | Jakutiska (Region: Ryssland) LanguageId värde |
+|  | Yi | `0x0478` | Yi (Region: PRC) LanguageId värde |
+| Yoruba | `0x046A` | Yoruba (Region: Nigeria) LanguageId värde |

--- a/swedish/nodejs-cpp/enumerations/ttfnametableplatformid/_index.md
+++ b/swedish/nodejs-cpp/enumerations/ttfnametableplatformid/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Enum TtfNameTablePlatformId"
+second_title: "Aspose.Font för .NET API-referens"
+description: "Aspose.Font.TtfNameTablePlatformId enum. Anger PlatformId"
+type: docs
+weight: 130
+url: /sv/nodejs-cpp/enumerations/ttfnametableplatformid/
+---
+## TtfNameTablePlatformId enumeration
+
+Anger PlatformId.
+
+```cssharp
+ enum TtfNameTablePlatformId
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+|  | Unicode | `0` | Unicode |
+|  | Macintosh | `1` | Macintosh Script Manager‑kod. |
+|  | ISO | `2` | Apple-spec: (reserverad; får ej användas) MS-spec: ISO‑kodning. Observera att plattforms‑ID 2 (ISO) har avskrivits sedan OpenType Specification v1.3. Det var avsett att representera ISO/IEC 10646, i motsats till Unicode; båda standarderna har identiska teckenkodstilldelningar. |
+|  | Microsoft | `3` | Microsoft‑kodning. |

--- a/swedish/nodejs-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
+++ b/swedish/nodejs-cpp/enumerations/ttfnametableunicodeplatformspecificid/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum TtfNameTableUnicodePlatformSpecificId"
+second_title: "Aspose.Font för .NET API-referens"
+description: "Aspose.Font.TtfNameTableUnicodePlatformSpecificId enum. Anger UnicodePlatformSpecificId"
+type: docs
+weight: 133
+url: /sv/nodejs-cpp/enumerations/ttfnametableunicodeplatformspecificid/
+---
+## TtfNameTableUnicodePlatformSpecificId enumeration
+
+Anger UnicodePlatformSpecificId.
+
+```csharp
+ enum TtfNameTableUnicodePlatformSpecificId
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| --- | --- | --- |
+|  | Default | `0` | Standardsemantik (Unicode 1.0). |
+|  | Unicode1_1 | `1` | Unicode 1.1-semantik. |
+|  | ISO10646_1993 | `2` | ISO 10646 1993-semantik (föråldrad). |
+|  | Unicode2_0 | `3` | Unicode 2.0 eller senare semantik. Endast Unicode BMP. |
+|  | Unicode2_0_Full | `4Unicode 2.0 and onwards semantics (non-BMP characters allowed)` | Unicode fullständigt register. |

--- a/swedish/nodejs-cpp/metadata/_index.md
+++ b/swedish/nodejs-cpp/metadata/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Metadata-teckensnittsfunktioner"
+second_title: "Aspose.Font för Node.js via C++"
+description: "Funktioner för att arbeta med metadata-teckensnittsfiler"
+type: docs
+url: /sv/nodejs-cpp/metadata/
+---
+
+## Metadata Font functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposeFontGetInfo](./asposefontgetinfo/) | Hämta information (metadata) från en teckensnittsfil. |
+| [AsposeFontSetInfo](./asposefontsetinfo/) | Ställ in information (metadata) i en fontfil. |
+
+## Detailed Description
+
+Funktioner för att arbeta med metadata-fontfiler.
+

--- a/swedish/nodejs-cpp/metadata/asposefontgetinfo/_index.md
+++ b/swedish/nodejs-cpp/metadata/asposefontgetinfo/_index.md
@@ -1,0 +1,77 @@
+---
+title: "AsposeFontGetInfo"
+second_title: "Aspose.Font för Node.js via C++"
+description: "Hämta information (metadata) från en teckensnittsfil."
+type: docs
+url: /sv/nodejs-cpp/metadata/asposefontgetinfo/
+---
+## AsposeFontGetInfo function
+
+_Hämta information (metadata) från en Font-fil._
+
+```js
+function AsposeFontGetInfo(
+    fileName
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileName | string | Filnamn. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | felkod (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | poster | Array av JSON-objekt : |
+|  | * NameId | namnidentifierare |
+|  | * PlatformId | plattformidentifierare |
+|  | * PlatformSpecificId | plattformsspecifik identifierare |
+|  | * LanguageId | språkidentifierare |
+|  | * Info | innehåll i namnpost |
+
+### Exempel
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    //AsposeFontGetInfo - get metadata information
+    const json = AsposeFontModule.AsposeFontGetInfo(font_file);
+    console.log("AsposeFontGetInfo => %O",  json.errorCode == 0 ? json.records.reduce((ret, a) => ret +
+        "\nNameId : " + a.NameId
+        + "; PlatformId : " + a.PlatformId
+        + "; PlatformSpecificId : " + a.PlatformSpecificId
+        + "; LanguageId : " + a.LanguageId
+        + "; Info : " + a.Info,"") : json.errorText);
+
+});
+```
+**ECMAScript\ES6 js modules:**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+//AsposeFontGetInfo - get metadata font information
+json = AsposeFontModule.AsposeFontGetInfo(font_file);
+console.log("AsposeFontGetInfo => %O",  json.errorCode == 0 ? json.records.reduce((ret, a) => ret +
+    "\nNameId : " + a.NameId
+  + "; PlatformId : " + a.PlatformId
+  + "; PlatformSpecificId : " + a.PlatformSpecificId
+  + "; LanguageId : " + a.LanguageId
+  + "; Info : " + a.Info,"") : json.errorText);
+```

--- a/swedish/nodejs-cpp/metadata/asposefontsetinfo/_index.md
+++ b/swedish/nodejs-cpp/metadata/asposefontsetinfo/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeFontSetInfo"
+second_title: "Aspose.Font för Node.js via C++"
+description: "Ställ in information (metadata) i en fontfil."
+type: docs
+url: /sv/nodejs-cpp/metadata/asposefontsetinfo/
+---
+## AsposeFontSetInfo function
+
+_Ställ in information (metadata) i en fontfil._
+
+```js
+function AsposeFontSetInfo(
+    fileName,
+    nameId, 
+    platformId, 
+    platformSpecificId, 
+    languageId, 
+    text
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileName | string | Filnamn. |
+| nameId | TtfNameTableNameId | Namnidentifierare, logisk strängkategori, specificerad av [`NameId`](../../enumerations/ttfnametablenameid/)‑enumerationen |
+|  | platformId | TtfNameTablePlatformId | Plattformsidentifierare |
+| platformSpecificId | int | Plattformspecifik kodningsidentifierare. Använd ett värde från någon av dessa enumerationer – [`UnicodePlatformSpecificId`](../../enumerations/ttfnametableunicodeplatformspecificid/), [`MacPlatformSpecificId`](../../ttfnametable.macplatformspecificid/), [`MSPlatformSpecificId`](../../enumerations/ttfnametablemsplatformspecificid/). Vilken enumeration som ska användas bestäms av kontext (*platformId* parameter). |
+| languageId | int | Språkidentifierare. Använd ett värde från [`MSLanguageId`](../../enumerations/ttfnametablemslanguageid/) eller [`MacLanguageId`](../../enumerations/ttfnametablemaclanguageid/)‑enumerationerna beroende på kontext, definierad av *platformId*-parametern. |
+|  | text | string | Faktisk strängdata |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | felkod (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    //AsposeSetInfo - set metadata info into font
+    const nameId = AsposeFontModule.TtfNameTableNameId.Description;
+    const platformId = AsposeFontModule.TtfNameTablePlatformId.Microsoft;
+    const platformSpecificId = AsposeFontModule.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+    const langID = Module.TtfNameTableMSLanguageId.English_United_States.value;
+    const text = "Updated description";
+    
+    const json = AsposeFontSetInfo(font_file, nameId, platformId, platformSpecificId, langID, text);
+    console.log("AsposeFontSetInfo => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules:**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+//AsposeSetInfo - set metadata info into font
+const nameId = AsposeFontModule.TtfNameTableNameId.Description;
+const platformId = AsposeFontModule.TtfNameTablePlatformId.Microsoft;
+const platformSpecificId = AsposeFontModule.TtfNameTableMSPlatformSpecificId.Unicode_BMP_UCS2.value;
+const langID = Module.TtfNameTableMSLanguageId.English_United_States.value;
+const text = "Updated description";
+
+const json = AsposeFontModule.AsposeFontSetInfo(font_file, nameId, platformId, platformSpecificId, langID, text);
+console.log("AsposeFontSetInfo => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+```
+
+### Se även
+
+* enum [TtfNameTableNameId](../../enumerations/ttfnametablenameid/)
+* enum [TtfNameTablePlatformId](../../enumerations/ttfnametableplatformid/)
+* enum [TtfNameTableMacPlatformSpecificId](../../enumerations/ttfnametablemacplatformspecificid/)
+* enum [TtfNameTableMSPlatformSpecificId](../../enumerations/ttfnametablemsplatformspecificid/)
+* enum [TtfNameTableUnicodePlatformSpecificId](../../enumerations/ttfnametableunicodeplatformspecificid/)
+* enum [TtfNameTableMacLanguageId](../../enumerations/ttfnametablemaclanguageid/)
+* enum [TtfNameTableMSLanguageId](../../enumerations/ttfnametablemslanguageid/)

--- a/swedish/nodejs-cpp/misc/_index.md
+++ b/swedish/nodejs-cpp/misc/_index.md
@@ -1,0 +1,17 @@
+---
+title: "Diverse funktioner"
+second_title: "Aspose.Font för Node.js via C++"
+description: "Sekundära funktioner för att arbeta med fontfiler."
+type: docs
+url: /sv/nodejs-cpp/misc/
+---
+## Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposeFontAbout](./asposefontabout/) | Hämta information om produkten. |
+
+## Detailed Description
+
+Sekundära funktioner för att arbeta med fontfiler.
+

--- a/swedish/nodejs-cpp/misc/asposefontabout/_index.md
+++ b/swedish/nodejs-cpp/misc/asposefontabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeFontAbout"
+second_title: "Aspose.Font för Node.js via C++"
+description: "Hämta information om produkten."
+type: docs
+url: /sv/nodejs-cpp/misc/AsposeFontAbout/
+---
+
+## AsposeFontAbout function
+
+Hämta information om produkten.
+
+```js
+function AsposeFontAbout()
+```
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+| errorCode | felkod (0 inget fel) |
+| errorText | textfel ("" inget fel) |
+| produkt | Produktnamn |
+| version | Produktversion |
+| islicensed | Produkten är licensierad |
+
+
+## Exempel
+**Common js modules**:
+```js
+const AsposeFont = require('asposefontnodejs');
+
+const font_file = "./fonts/Lora-Regular.ttf";
+
+console.log("Aspose.Font for Node.js via C++ examples.");
+
+AsposeFont().then(AsposeFontModule => {
+
+    json = AsposeFontModule.AsposeFontAbout();
+    console.log("AsposeFontAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+});
+```
+**ECMAScript\ES6 js modules:**:
+```js
+import AsposeFont from 'asposefontnodejs';
+
+const font_file ="./fonts/arial.ttf";
+
+console.log('Aspose.Font for Node.js via C++ example');
+
+const AsposeFontModule = await AsposeFont();
+
+//AsposeFontAbout - Get info about Product
+const json = AsposeFontModule.AsposeFontAbout();
+console.log("AsposeFontAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+```


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **Swedish** (`sv`) generated by RDA.

- Pages translated: 22/22
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `swedish/nodejs-cpp`

🤖 Generated by RDA